### PR TITLE
Escaping % (percent sign) segment in Uri.AppendToPath 

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -960,6 +960,50 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
+        [Test]
+        public async Task GetAppendBlobClient_AsciiName()
+        {
+            //Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewBlobName();
+
+            //Act
+            AppendBlobClient blob = test.Container.GetAppendBlobClient(blobName);
+            await blob.CreateAsync();
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (BlobItem pathItem in test.Container.GetBlobsAsync())
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(blobName, names);
+        }
+
+        [Test]
+        public async Task GetAppendBlobClient_NonAsciiName()
+        {
+            //Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewNonAsciiBlobName();
+
+            //Act
+            AppendBlobClient blob = test.Container.GetAppendBlobClient(blobName);
+            await blob.CreateAsync();
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (BlobItem pathItem in test.Container.GetBlobsAsync())
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(blobName, names);
+        }
+
         private AppendBlobRequestConditions BuildDestinationAccessConditions(
             AccessConditionParameters parameters,
             bool lease = false,

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -46,7 +46,7 @@ namespace Azure.Storage.Test.Shared
         public string GetNewContainerName() => $"test-container-{Recording.Random.NewGuid()}";
         public string GetNewBlobName() => $"test-blob-{Recording.Random.NewGuid()}";
         public string GetNewBlockName() => $"test-block-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiBlobName() => $"test-β£©þ‽-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiBlobName() => $"test-β£©þ‽%3A-{Recording.Random.NewGuid()}";
 
         public BlobClientOptions GetOptions(bool parallelRange = false)
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -1694,6 +1694,59 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(blobSize, progress.List[progress.List.Count - 1]);
         }
 
+
+        [Test]
+        public async Task GetBlockBlobClient_AsciiName()
+        {
+            //Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewBlobName();
+
+            //Act
+            BlockBlobClient blob = test.Container.GetBlockBlobClient(blobName);
+            var data = GetRandomBuffer(Size);
+            using (var stream = new MemoryStream(data))
+            {
+                await blob.UploadAsync(content: stream);
+            }
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (BlobItem pathItem in test.Container.GetBlobsAsync())
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(blobName, names);
+        }
+
+        [Test]
+        public async Task GetBlockBlobClient_NonAsciiName()
+        {
+            //Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewNonAsciiBlobName();
+
+            //Act
+            BlockBlobClient blob = test.Container.GetBlockBlobClient(blobName);
+            var data = GetRandomBuffer(Size);
+            using (var stream = new MemoryStream(data))
+            {
+                await blob.UploadAsync(content: stream);
+            }
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (BlobItem pathItem in test.Container.GetBlobsAsync())
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(blobName, names);
+        }
+
         private RequestConditions BuildRequestConditions(AccessConditionParameters parameters)
             => new RequestConditions
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -2240,6 +2240,50 @@ namespace Azure.Storage.Blobs.Test
                 });
         }
 
+        [Test]
+        public async Task GetPageBlobClient_AsciiName()
+        {
+            //Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewBlobName();
+
+            //Act
+            PageBlobClient blob = test.Container.GetPageBlobClient(blobName);
+            await blob.CreateAsync(Constants.KB);
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (BlobItem pathItem in test.Container.GetBlobsAsync())
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(blobName, names);
+        }
+
+        [Test]
+        public async Task GetPageBlobClient_NonAsciiName()
+        {
+            //Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = GetNewNonAsciiBlobName();
+
+            //Act
+            PageBlobClient blob = test.Container.GetPageBlobClient(blobName);
+            await blob.CreateAsync(Constants.KB);
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (BlobItem pathItem in test.Container.GetBlobsAsync())
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(blobName, names);
+        }
+
         private PageBlobRequestConditions BuildAccessConditions(
             AccessConditionParameters parameters,
             bool lease = false,

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUri.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1f7d90d234477940b2649f4cd4b6c343-7c71977bf5a04d4a-00",
+        "traceparent": "00-94e49b219c50dc45bd523586ddc8bc4c-e6aea6df4151cd4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e8c3b6da-522b-add5-6486-9ab603dda849",
-        "x-ms-date": "Fri, 15 May 2020 23:29:37 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,15 +20,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:37 GMT",
-        "ETag": "\u00220x8D7F927D5C78F6C\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F008E2A6EC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e8c3b6da-522b-add5-6486-9ab603dda849",
-        "x-ms-request-id": "f79cb8c0-001e-0130-6410-2b8e64000000",
+        "x-ms-request-id": "ab64e0ee-801e-002e-0ad8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -40,14 +40,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "21",
         "Content-Type": "application/xml",
-        "traceparent": "00-da63d0be8b130a4ea8f09d6be8505cda-f8332e61f0251d4f-00",
+        "traceparent": "00-ac781b6e0473d8498e9675ce938b4f29-9f321e9759bcc64b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "5ad8457d-9286-c96b-1a4d-f9e854165569",
-        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,33 +55,33 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:37 GMT",
-        "ETag": "\u00220x8D7F927D5D71147\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F008F03817\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5ad8457d-9286-c96b-1a4d-f9e854165569",
-        "x-ms-request-id": "f79cb8f5-001e-0130-0c10-2b8e64000000",
+        "x-ms-request-id": "ab64e152-801e-002e-5fd8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D-3ebd17a8-2968-da4c-504e-be424a1e0d7d",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-3ebd17a8-2968-da4c-504e-be424a1e0d7d",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-86dcb8440668b948b0891a2e23cd9e81-27ac5270a120794b-00",
+        "traceparent": "00-6c86fbd78c7a2942b9806721f4adde8a-85d2a6ee6971d141-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "1f44b19c-36a0-1a1d-0e38-0f6fdcd40331",
-        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -89,33 +89,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D5F6222B\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F00901FBD9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1f44b19c-36a0-1a1d-0e38-0f6fdcd40331",
-        "x-ms-request-id": "f79cb955-001e-0130-5f10-2b8e64000000",
+        "x-ms-request-id": "ab64e1b8-801e-002e-3bd8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D-3ebd17a8-2968-da4c-504e-be424a1e0d7d?comp=appendblock",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-3ebd17a8-2968-da4c-504e-be424a1e0d7d?comp=appendblock",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-41283e638ee6ca4aa5a6ae8dd5b6049a-d6c624a59064d343-00",
+        "traceparent": "00-e5421fdbbd98bb4fadc3a0ab85c01041-007353376109f140-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "99a65e27-edd9-ecdd-6fda-232fcd797daf",
-        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -123,9 +123,9 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D6016EDA\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F0090CAC2D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -134,7 +134,7 @@
         "x-ms-blob-committed-block-count": "1",
         "x-ms-client-request-id": "99a65e27-edd9-ecdd-6fda-232fcd797daf",
         "x-ms-content-crc64": "BtUKF82b/EU=",
-        "x-ms-request-id": "f79cb96c-001e-0130-7210-2b8e64000000",
+        "x-ms-request-id": "ab64e200-801e-002e-7dd8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -146,14 +146,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-99e35063fe683149a4ad4c817352b825-324625a7ae60dd4a-00",
+        "traceparent": "00-1a3a680a5679cd46bbd52201018ca656-142dd30fa74bf340-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "e3c60ae6-8b2e-842e-4500-0e61fda07067",
-        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -161,15 +161,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D6095F81\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F009144EB0\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e3c60ae6-8b2e-842e-4500-0e61fda07067",
-        "x-ms-request-id": "f79cb97f-001e-0130-0410-2b8e64000000",
+        "x-ms-request-id": "ab64e22c-801e-002e-23d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -181,14 +181,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-2845750d042db54bbf10e2c860d261dc-c75d11c866602243-00",
+        "traceparent": "00-109bd07fbf6a3d46af5e0c45efc9a239-015c5e8df4d7d749-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "71563b79-c941-4c13-0bc2-392c5bf6f727",
-        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D-3ebd17a8-2968-da4c-504e-be424a1e0d7d",
-        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-3ebd17a8-2968-da4c-504e-be424a1e0d7d",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-source-range": "bytes=0-1023",
         "x-ms-version": "2019-07-07"
@@ -198,9 +198,9 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "\u002Bn7/nXi05mdgxXHOfeeNPA==",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D6445033\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F009276511\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -208,7 +208,7 @@
         "x-ms-blob-append-offset": "0",
         "x-ms-blob-committed-block-count": "1",
         "x-ms-client-request-id": "71563b79-c941-4c13-0bc2-392c5bf6f727",
-        "x-ms-request-id": "f79cb9ab-001e-0130-2410-2b8e64000000",
+        "x-ms-request-id": "ab64e24f-801e-002e-41d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -219,13 +219,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2bc40b2466cf3f458182727815e0d010-bf3b33b651358349-00",
+        "traceparent": "00-2726785d22ea1e4382ac790d6038f9c9-79ef9c08a4cd5648-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c1e77c2e-ff4a-6525-ce0b-886ec555893c",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -233,13 +233,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c1e77c2e-ff4a-6525-ce0b-886ec555893c",
-        "x-ms-request-id": "f79cba68-001e-0130-4110-2b8e64000000",
+        "x-ms-request-id": "ab64e29c-801e-002e-03d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUriAsync.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-5fcd11fdd5f04244bdb0b0f670d9e925-8e24d12de5a09a4b-00",
+        "traceparent": "00-62b14c2cb1ed4b4e924f46eea5384702-a19ad07595f89740-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "2a6483af-08eb-5ad5-89eb-d02227800d6b",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,15 +20,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D673A7A8\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009959C61\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "2a6483af-08eb-5ad5-89eb-d02227800d6b",
-        "x-ms-request-id": "f79cbab2-001e-0130-0410-2b8e64000000",
+        "x-ms-request-id": "ab64e453-801e-002e-63d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -40,14 +40,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "21",
         "Content-Type": "application/xml",
-        "traceparent": "00-86880d38a5db1344b06022e85c70ab06-d86457dc09e8f742-00",
+        "traceparent": "00-1fe87354ea90b74bae62096d34a18ce2-af536d575cc4c641-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "bad70431-6f85-a8d5-d094-6adfea57685f",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,33 +55,33 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D67DD187\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F0099DD587\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bad70431-6f85-a8d5-d094-6adfea57685f",
-        "x-ms-request-id": "f79cbac4-001e-0130-1310-2b8e64000000",
+        "x-ms-request-id": "ab64e499-801e-002e-20d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D-8ce92671-2776-2bbf-46a6-9829c330ba48",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-8ce92671-2776-2bbf-46a6-9829c330ba48",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-852f9a9526d1374b8ed359547ffbc963-589e5d72ef293d45-00",
+        "traceparent": "00-00f5946130d05e4199607e13679fc0d8-135bf02e6dca6a4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "71032535-2466-456a-4b3b-e8be99e229fc",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -89,33 +89,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:38 GMT",
-        "ETag": "\u00220x8D7F927D6869532\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009A5FADD\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "71032535-2466-456a-4b3b-e8be99e229fc",
-        "x-ms-request-id": "f79cbad5-001e-0130-2310-2b8e64000000",
+        "x-ms-request-id": "ab64e4d4-801e-002e-4dd8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D-8ce92671-2776-2bbf-46a6-9829c330ba48?comp=appendblock",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-8ce92671-2776-2bbf-46a6-9829c330ba48?comp=appendblock",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-28a49b77b8384b4cb44f28a0fc2daae9-f8e1e1889de65544-00",
+        "traceparent": "00-b32c4e99c640a6499ceb0c12e1e67a6e-ecd153697be97543-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9df4fc82-482d-59e2-fbf2-2009cee545be",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -123,9 +123,9 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D68EFB1B\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009ADEB91\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -134,7 +134,7 @@
         "x-ms-blob-committed-block-count": "1",
         "x-ms-client-request-id": "9df4fc82-482d-59e2-fbf2-2009cee545be",
         "x-ms-content-crc64": "fOT422XshIc=",
-        "x-ms-request-id": "f79cbae7-001e-0130-3310-2b8e64000000",
+        "x-ms-request-id": "ab64e4f8-801e-002e-6ed8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -146,14 +146,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-014db780926c0c49aed7877e41edbc65-6c81da6602cdd14e-00",
+        "traceparent": "00-5a330bbc42510b4e829f3d01fd39d62a-ffd11342000cab4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "83852cc5-4e8e-4177-7d41-57e5598520f9",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -161,15 +161,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D69712E2\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009B5B52B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "83852cc5-4e8e-4177-7d41-57e5598520f9",
-        "x-ms-request-id": "f79cbaf6-001e-0130-4010-2b8e64000000",
+        "x-ms-request-id": "ab64e51a-801e-002e-0dd8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -181,14 +181,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-4a94f6e4ae0b2d4bbec586f012fe25b1-233e36569e68cc48-00",
+        "traceparent": "00-62083f3149b4f04da2bf3e4ae50b9e70-79076d2bb6643f4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0d96515a-ea7c-f2a9-18f9-1eac34ea841d",
-        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D-8ce92671-2776-2bbf-46a6-9829c330ba48",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-8ce92671-2776-2bbf-46a6-9829c330ba48",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-source-range": "bytes=0-1023",
         "x-ms-version": "2019-07-07"
@@ -198,9 +198,9 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "FYBNS7tC6BOqRuliCdtdYQ==",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D69F9FEA\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009BE423B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -208,7 +208,7 @@
         "x-ms-blob-append-offset": "0",
         "x-ms-blob-committed-block-count": "1",
         "x-ms-client-request-id": "0d96515a-ea7c-f2a9-18f9-1eac34ea841d",
-        "x-ms-request-id": "f79cbb08-001e-0130-5010-2b8e64000000",
+        "x-ms-request-id": "ab64e53b-801e-002e-24d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -219,13 +219,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fc3c6f8c6d8cad4da2ded56f33920e92-e0ff315b9a1d3d4c-00",
+        "traceparent": "00-73e934a01793c04da7ea0db8681668fc-aa35115b1430fb4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "078ae5f0-13ef-9a7d-3fd5-26b08a232299",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -233,13 +233,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "078ae5f0-13ef-9a7d-3fd5-26b08a232299",
-        "x-ms-request-id": "f79cbb21-001e-0130-6910-2b8e64000000",
+        "x-ms-request-id": "ab64e55d-801e-002e-3fd8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_AsciiName.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1aab13ef-1474-43bb-3d27-f2aaf28eddec?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a904e8bae21e1d468d5cd2b4ce218a83-4072857eb239ac4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "15fd3c53-a3d6-4ca7-7fe8-09d542976872",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F0094683C7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "15fd3c53-a3d6-4ca7-7fe8-09d542976872",
+        "x-ms-request-id": "ab64e302-801e-002e-59d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1aab13ef-1474-43bb-3d27-f2aaf28eddec/test-blob-84b82e4c-06b4-3c61-92e5-816f44e3e303",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "318b5d9c-4580-4c30-dbc1-82f12137079b",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "ETag": "\u00220x8D803F009502A19\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "318b5d9c-4580-4c30-dbc1-82f12137079b",
+        "x-ms-request-id": "ab64e32e-801e-002e-78d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1aab13ef-1474-43bb-3d27-f2aaf28eddec?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e7d38161-b158-1883-dd0a-dad0452593d4",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "e7d38161-b158-1883-dd0a-dad0452593d4",
+        "x-ms-request-id": "ab64e353-801e-002e-16d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-1aab13ef-1474-43bb-3d27-f2aaf28eddec\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-84b82e4c-06b4-3c61-92e5-816f44e3e303\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:55 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F009502A19\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1aab13ef-1474-43bb-3d27-f2aaf28eddec?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-28046a63a1259143b77eab2df38e2dc7-2342402632b97842-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a08f9a2f-1f64-5243-825f-5736d8113ef2",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a08f9a2f-1f64-5243-825f-5736d8113ef2",
+        "x-ms-request-id": "ab64e37e-801e-002e-38d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2039935516",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_AsciiNameAsync.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7b7d25db-b1b3-87dd-bb53-05d530d3f4be?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-14d51232d7776b44921a4e5fdd664392-69ef785f111ecb41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e9d19030-aac9-37d8-09e0-992a4cfcdad5",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009D19EC8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e9d19030-aac9-37d8-09e0-992a4cfcdad5",
+        "x-ms-request-id": "ab64e582-801e-002e-5cd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7b7d25db-b1b3-87dd-bb53-05d530d3f4be/test-blob-c2a539ec-119d-85b0-f8ec-39137447bacd",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "93aa67c4-7648-1f33-e04c-f0dc70c5c3c2",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009D94937\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "93aa67c4-7648-1f33-e04c-f0dc70c5c3c2",
+        "x-ms-request-id": "ab64e5ac-801e-002e-7ad8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7b7d25db-b1b3-87dd-bb53-05d530d3f4be?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0d4ef4a8-269c-a484-0084-bfb61a19e0b2",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0d4ef4a8-269c-a484-0084-bfb61a19e0b2",
+        "x-ms-request-id": "ab64e5d7-801e-002e-1cd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-7b7d25db-b1b3-87dd-bb53-05d530d3f4be\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-c2a539ec-119d-85b0-f8ec-39137447bacd\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:56 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:56 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F009D94937\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7b7d25db-b1b3-87dd-bb53-05d530d3f4be?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6179e644ac30484cbc3f35bc140e8c42-ce6a3ef3bad37b4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "7b34fa84-b576-ff25-476b-18d37b1cc52b",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7b34fa84-b576-ff25-476b-18d37b1cc52b",
+        "x-ms-request-id": "ab64e60a-801e-002e-48d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "203401775",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_NonAsciiName.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-bf5c3076-85e5-f73c-8c49-cd09d981d561?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-46fa6e8f42bc664b9d562c661d99c61e-112bd06c6618e648-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "365c492d-514d-e135-5315-e8f47415ae12",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F00973412A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "365c492d-514d-e135-5315-e8f47415ae12",
+        "x-ms-request-id": "ab64e3ab-801e-002e-59d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-bf5c3076-85e5-f73c-8c49-cd09d981d561/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-81d87ff0-47b6-56ce-070f-cd9591ea3e2d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "3961e1a1-7e86-e5f0-7a06-2f3e849f5068",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F0097AEB64\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3961e1a1-7e86-e5f0-7a06-2f3e849f5068",
+        "x-ms-request-id": "ab64e3c2-801e-002e-6cd8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-bf5c3076-85e5-f73c-8c49-cd09d981d561?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "aff3f036-0488-caa6-35f6-151e6fd4db28",
+        "x-ms-date": "Fri, 29 May 2020 16:47:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "aff3f036-0488-caa6-35f6-151e6fd4db28",
+        "x-ms-request-id": "ab64e3e2-801e-002e-04d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-bf5c3076-85e5-f73c-8c49-cd09d981d561\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-\u03B2\u00A3\u00A9\u00FE\u203D%3A-81d87ff0-47b6-56ce-070f-cd9591ea3e2d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:55 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F0097AEB64\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-bf5c3076-85e5-f73c-8c49-cd09d981d561?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0d929e3013f96c40a1492d7537f0a63c-f25ed8fc988bd749-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "94075ce6-a1ac-d2e0-15e0-194207cee296",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94075ce6-a1ac-d2e0-15e0-194207cee296",
+        "x-ms-request-id": "ab64e401-801e-002e-21d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "920200097",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/GetAppendBlobClient_NonAsciiNameAsync.json
@@ -1,0 +1,135 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-aab4b727-6eb4-474c-9c8e-710714c27554?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b06fe28471cf9643b5e3a2479bf47e89-68fbe03b6d577e48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "7f4391bb-90f1-9442-fa68-b4b3a67e59ca",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009F559D3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7f4391bb-90f1-9442-fa68-b4b3a67e59ca",
+        "x-ms-request-id": "ab64e641-801e-002e-74d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-aab4b727-6eb4-474c-9c8e-710714c27554/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-982b8a49-2fcf-2b03-5ce1-7845d596668e",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "576bce15-f0e2-8c1b-8d17-230f17fcbf63",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:55 GMT",
+        "ETag": "\u00220x8D803F009FD045A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "576bce15-f0e2-8c1b-8d17-230f17fcbf63",
+        "x-ms-request-id": "ab64e66b-801e-002e-19d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-aab4b727-6eb4-474c-9c8e-710714c27554?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0730c5b4-0e2a-15ac-6abf-f466d2547ecf",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0730c5b4-0e2a-15ac-6abf-f466d2547ecf",
+        "x-ms-request-id": "ab64e6a5-801e-002e-4cd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-aab4b727-6eb4-474c-9c8e-710714c27554\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-\u03B2\u00A3\u00A9\u00FE\u203D%3A-982b8a49-2fcf-2b03-5ce1-7845d596668e\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:56 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:56 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F009FD045A\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-aab4b727-6eb4-474c-9c8e-710714c27554?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-cd876e8ae442514c8e8d954c164eef63-d333297b152d6144-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "515a6e33-b8cc-f338-7898-b573e2e581d2",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "515a6e33-b8cc-f338-7898-b573e2e581d2",
+        "x-ms-request-id": "ab64e6e5-801e-002e-01d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "821555269",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_AsciiName.json
@@ -1,0 +1,137 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-d7021ad5-fdc9-bbe7-01a3-ebb14c23e9a8?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ed003ec0743f4749ba829c383148232b-c8f2db7041a5014d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "1dbf6300-310f-ce6e-9e47-78eb6ebc7798",
+        "x-ms-date": "Fri, 29 May 2020 16:47:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A16A372\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1dbf6300-310f-ce6e-9e47-78eb6ebc7798",
+        "x-ms-request-id": "ab64e712-801e-002e-24d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-d7021ad5-fdc9-bbe7-01a3-ebb14c23e9a8/test-blob-23ce8186-e60d-96d0-048e-547368285145",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "f45af5a0-7556-f98e-15c8-e8dbcdd16a42",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "9hKx6GPLmFsrmbAExSoFxd38OOntissZkykYgdz6ZXb1M/VcC481uuhz93Q2y9DaiI6WbO9oV2tHl1Q6sxd\u002BMDM6DpE1qbpNxn4AeZJW48hYPvhOZPmGjdyJFXM7\u002BwfQ9cdA\u002B7w\u002BpN/USKVxZ93Y8LOM4XQeMMw5s4G1q5NHEst2MITLFegLGZoZeRtUFCb\u002BsCS/rxmTscX6Bkc7iPhLjDXZ\u002BzdZDdrLgMjaBbaw5Z5bt/tuh2Oy436/0A\u002Bg0JChzu3lehnupKNK8y5QuKwOSiGo4NH93AXSJhe4mjzLK7A3OTbJymuFbBJXJJM1YirRsIbt9\u002B\u002B/o/HnE1MBNQpnf8h\u002BGX91RX\u002B1I3S\u002BprhxncTt5um13TPAeJVE4bcYgzYI8KXLtkmqXGoHONR7Af05dnaOFE8gsaGUvaDqMGTHnaA9tbYSpeZ7Q4p/rqVfRHeYC2pBiW/n5z4DN/mowCsFP5o0PktHJtCQEtHEoAP8NHgpUSX6hhQxVs53D27t04JeeW4KKwYsUeSZsXadIkc7BwKAfm4GC7mGA\u002Bd8zxdhoj5OZSeU8Qly/QBBYNWdkzOHOwhsbVUUWG61hCger4HMOA43T7wfphX4DoBuxKvj6W\u002B09ZMP9TXpOQ24323hU05\u002BdSjHZUN2Z5Tyc17UppPC0Zu4arnuvULYThWvZ8eoF7ox70\u002BDHIMsPY7\u002BHIHWFZN59Q3RKeiVkLfl7hYuxv/NSlykorZEP7QXjCwq76DBATmBNnG61u3RnF\u002BXnS5s/XeOMdEkMnLdNLZYup28a6AXI\u002B3drJCOE3Ru0gZXraGGqo61m77PnM7GpAG6YRtQFTG\u002BgHlBj1DmAB5dtWBrhYcU0g8OB8/iSIceFgiP07JYHrzVmCwnRRs9z5ufceZuWx55po4MQg5h2zjyInhIVixsBZejlu1a7Yz00Tc0Qtagr7vpFS0jTNyuc7z0NCKj9XhvM2xPysQxHrkCF3HWLJhhUnO8XkH\u002BSbi79SIwZrhpUdu/xQ9pUeT3uPd0IDRr10YkkuKv5pY3cOqzk9WhALgBmMaVFmeJ9wGOxaZJiiiEUB7bDNPVumpFiFQktr0PVbc/c4hu1sDfmprhICDv7ebCL0O2xvTkK91bT44TZEFDf2/vChafFXpd/HE585pJVpttYoZ6WI/CWkeqE4YyyzZYnaGxAOLPIhrJWcmDqjdDEfnzpQK7ySbgLK/P9QLzKzE74Fb5mFW4nj9ssf/FP68PZwGNPiU0nNR60NQyAC0X1S2YSMrhSnijOgfCTxgnGu3/v40AZewLBkOCfsiBhp0SVNvRLfblLhyJ6gQdcU27U7XmMkCfFm9BjEGGX8uvIbRpr/s9Vez2GpFxd3vo7ZT2xisSmlNdcj1skKG1X85Q2chPs8FSfv3J8BiuLp/zWJ6skJignYZgDD290cVLQbvCIJ2zmDrSpEgtSao7rkSdeDcCCM42sDtB76eElK04fa9d7A4BQL9k2exQc1TcJV74H1iNSTjsjHBicamTTg\u002Bb9Mz73sE2nDd4nS7i5jznZclIjHRUqzN2cGCen88V0YvctX6H4EecwoMhFawJCqUzegvfSsGbRkmYhW1hl/xoYsujBTG9X4WCrMnwM5WHbGa6aiXDNYfJQW407lvZOiqHubLgZgR0dRqGXZ74qhO0ERgHpyzXpCxE2cTCiXApqXGeaXripwZiRvUKPNjp0ZZbgN1D0pP\u002BrxSGm4w/seypXbMsWUGZ0WoRpGA3zGhTWwcuZwiT5tfdoLlmXAt5I5UIYd8kvHhUwq9yMS0yxuOrMkCFEEnjFXfcTrmIM3RemIHLLmuJLp\u002BP2qVZILSpqtnWuinL9BNLJUtoR22/zI86FJmsZ5d3IgSg9jWkivXCM6TfsnhLk6RugAkgIeYx0A0WHgwb/UNCXpclKv7dpppVpRTJ4BoW74D0PeaOVwEdbyUojmzopjVgnVPhJWimkdluynvSaO/z/y6MJr9csweWCLvYtRgubf/faUPGNckXTqwNH4yGSgY2NI49XH92A\u002BlMSh2tzdzAQF188/\u002BsLMpldNcST5R6EL20ooCK8BB/aGVZeuqsaoHQTN4vCVcHiQfD2OioY7NV0Tpg\u002BCtbNk9M/YqZU7LfuAlWQQO1SgZlrRh5xhgo1gWyBKiwS3JVdRWP4wzNbjVV4x/fUSGwoIcz\u002B0oT4W83IyaE504JL22WAcztJWf6lz/iJOL4SYXjAmQhfFAnQpOmV7/mSYbnS7SySE9VwnofOWMLML2NPtqgoOXq57Mcb784R86nE064\u002B9guRgA1jj/qAULtGxHVGBnlRaih/GMAldmQHHuseCUVUzTlXvjaaxKlAOZxL1OtYy60ws6lFv90LrAnpXHEPokc18jd8LohCtqW/Pt9jmaG47lM97VXbzw0cDBHs8ag4cJcVVeKz3J0k7f0DxoD959KoMG4d0bTxWiMqH\u002BJ2lcT9Ro5ITkO\u002BxNG12P\u002BYl8hMXmQ/BIE6Gp7iJDu/ify6rlf4BkAytZmPKWucZ/i1WIIancG\u002Bd1FDw2wvZipH/3sVO2qnoJFIWajKcBtVXbKmLMt5ZSv7PHbGtEMTw0\u002BvRynwh2yODbgw0gRY88d2LmX5STkezlpPGf7z4SwOdJZZGyjxZNZGGB8TSJLnogivUEXdWnoWULiPoa1tmiyL4l2uP5iehImPc3DZy0WHZ3f2RFCmcRocAsqwIcMpGH3yh6Y1eaKv0Mu8DebJfEUyyDo1t1Xb5XFDUfzOLmLGZlsy50Pfki3VRnOFKiMzEsZFvRmJM2DoFuI08eeloeJoteeL1lUBE3YMYHDiFvsOEH82SLFJfXL6CtCh6qAGL6SRXHR7pzxxRGmjfJMvxj/m5qGob1lxHzi0kYtEn2jWBnCMULpG0qkCxQQHpgCfikTQusQ\u002BXYALYH07xtWw7OUAzXZio7VFn9Q4papVKXk31MdGs\u002BRkl6iwQPB9CwuTUdgexpjKPSaPStswBffV9jbEA/IOKnjA3DWN8iKEyFTIZRPSNiLgLZfgtyjJdJGwmoq5uQcZhWdfXipjPEsECoKGJ6DkA8AUI9YaLbMP92ej3ReXy09Nrt/scpf4fPFM3KymQwzwzJaKpZUxP1f0T2aC/19zbD9zOLjBN5EoG\u002BbkzVDGabRasxCAzWX6HK9IOCNxNX2SGXCtcwqUL9TFoknuTDHG7iXyaEwOsl6ZeRvJeP\u002Bt9uZpEvQgGPZphkM7\u002B2rby9B9gQn9fszxQ2bSE/ouirbVF6ujRTl9ptUvSKHJEvcz/a1Li/f1sHgZt49NTgU8ezvMJqO/eIaXP9p0zjYq6HCvnhZM4z7\u002B36dzSc1p8FiQMs2mPOwTdETmtEvdgKJB7o9e3a/ur5f8zUc8S\u002B75bU\u002BBpNsohKuEXGnRpi6y4V7FMZs\u002BCtKooUM1qS\u002BlFyiWLQc8HBvHGWnj2kEGHQlpSevoNxpTu2J82MOX8tu730VBO7kntsUDPhgxWjCRYoR5zF9DvN/OQnHkvwMYbyZOZ/s7xOGQQZMmpTkCImEx67Z/Hia8OGJlsvkHAzeCKo7xovJ1lZ2i6UrMHNfmjCAQ8tOM2RE/0i\u002BYllIoSX6bpLpqUH9uvFXYnHTbsBtKvuaZNlAj9RG98ZCCnP9LumAMMHgdfDugoja9tDycZCIUDhdrj1Mud\u002B\u002Bo7J7urB9WjSIUj3\u002BjbULq\u002BFQZpgDU4Y1uro7n3\u002BrNHfiItE\u002Bc8fYXJycah5SicOCUgJb\u002B1JGulArRQD1Qrq03B7GG2rjzDgaeAr8Z\u002Bhn4jH3uE19TzgknGiBEy7H4hrh540AjG1Yn4bKQYNISlJnxGLO/oltN4zloX8CYrgJU5XwG39bZ1bEnxnHsw613FEVGk7L\u002BOSQdLAAG\u002BrtVj3NwO7tWC/TDFwMCl9vpYN\u002BL8Ut7EdpPlqwX6bOWktr1kjc\u002BvIgx4MiQQ7yv\u002B6FIM4sguslv2n1Y4KTPfmIBLERoDQWk6qRXWdBC6s5d35rKz7XodhgRhbf55dwjIqKmjxc4B\u002B6b40kmySE47S\u002BvOsDKBG6sGPZsFodNqwTINHct3Bu3JdfsbyxswWz22JhISusbGR40OnZgzDEnTjgEHtTpytDT99UpHZVCPxdJtX3uxSBZrNsZOeGlFlnmhSD0KKKYDQ2HdFLWMjtI8fte11azeEjX6nH5kNEvbuF7Qli0jdZ0sWgwJ1DNQ7rf0EfmRj8DM0yX3H4w3nx8mAWxWu/i1CPk6mXugxE4Cqb3GcCJCOiieE7L3LGYA9Mrs48LG\u002BjK/PwkAZvZVHA7n5GXecS7809dDyKg1zdyDKZSgw\u002BB7S697BzEZQcMiOPekD0fwMoOb8B/rgzGaeXEsfU1hpFgufKjGU2nt05IUEY\u002Bggb6UgucBFNPAj8ht4I3P/MR1wJSvhZKfOd8prhyN12Gx6feyl/pWUJ90XezgaHLcLebNnlD68Qwb9VkX52bHQqhWu/aWDVTaL2/1Kye1vtFsXXAlsEkQxujrppKRTnkovRs0max8NiCB837g9dXkZkaHq5nmkZJvNfUNulbCOND23G4ccSUk8Bdfk8zaP9ETBzBMGZLvQit41VO3bovJz7qd6hlnx\u002BUhUrtylw3FhQYj\u002BqMmhi8\u002BF5pCk6vBfYGbhdQCPEW3uz9bGrbnbKsdo0Bdk3PYozmbX9KPJTQ5b\u002BUp5xE5w1iwfD9jy3toVrrvJOBrc\u002BodstKadtxzKJYLEbrRvXWJ4\u002B/3nRc0ZOfOIwknr/BD3fwLHCQ\u002Bn0x8PUOpaLmwlqk1VTEAc9bC6U363FPTW3iVtzPOxpFRS1STe2/DiwwuDYxf4krPQ2oVODLmQ7L4qOHbE6F18cAH5AncbPh2/15BzM7Hc2k91nPZqZ5ueweRqtJ9\u002BGdauBu8WA4w4uZhrkjUlHb0MSV4nU09nFgxmWkCSsIl\u002BPbm9xSzCxta/POdd/tFmdaArWmtBWsqHRvDir6VPpgkO7VB7Z1iMSYKHaBJoCRc7A\u002BScZ1YiPObvNoI/4Bstc5baTxGA6xJLmxDkue64HznZp6vAr0Ky6KxtiCzWUGlrWfR/jboFuhjSUMhBPYb0NxtEYjhvaMBQJ2JhE17hdUareV/2OI1/1\u002B2S7lp2ca8pdVERje4s/\u002B00K2ZboKa58N\u002BBmcAm/f6NxI5O2Hpl3bW3O54Jz\u002BdYen1ywhEnJDNG2P1\u002B8NfrBntWh8lj4iNyzkmsoGkIsCT4KSNGtD/tZqBbBAN86uzhyDUis0QZ9Jhd//PHdoPKOijYgse0pE4/aR0pBNof9eNcztg35fzc3jSG6LRIKewckM3apGglKSPm50oq8O/CPgoMZqurklQr\u002B6CPLb\u002BZ80MtCHQMQU17O6G0UP6yselIxKqqO8NEcP51rqjHlf9gSPQG\u002BeR3tfi8lSsF80FVeUW3RmkU87t/5Jt1lpKkt6GmUAQKr7gA0RKt7aKUQoG9IDVjDE\u002BST1k4hxFM/h9qF\u002BGJX585Ts2NtnVaZwIU56YZuHZdQaQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "YB7meKYrNdjr/Er7Zgvu9w==",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A21F833\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f45af5a0-7556-f98e-15c8-e8dbcdd16a42",
+        "x-ms-content-crc64": "8pfjpdmiZ3A=",
+        "x-ms-request-id": "ab64e74d-801e-002e-59d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-d7021ad5-fdc9-bbe7-01a3-ebb14c23e9a8?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "27cdcd30-5b3c-5f12-f607-15eca14ddf22",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "27cdcd30-5b3c-5f12-f607-15eca14ddf22",
+        "x-ms-request-id": "ab64e76a-801e-002e-73d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-d7021ad5-fdc9-bbe7-01a3-ebb14c23e9a8\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-23ce8186-e60d-96d0-048e-547368285145\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:56 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:56 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00A21F833\u003C/Etag\u003E\u003CContent-Length\u003E4096\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EYB7meKYrNdjr/Er7Zgvu9w==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-d7021ad5-fdc9-bbe7-01a3-ebb14c23e9a8?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4b4867a7c148ae4a9b8adcd88fc55ec4-6a6c6675236a9549-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "00aaf1b3-4203-d906-7c2d-dcde8db288ec",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "00aaf1b3-4203-d906-7c2d-dcde8db288ec",
+        "x-ms-request-id": "ab64e7a6-801e-002e-26d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "13474771",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_AsciiNameAsync.json
@@ -1,0 +1,137 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c0d4417-6621-e146-7d2b-c711a6d132e7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-df40fbe0a4e4cb43890abdd5d9fd701a-fe36e6d8209b1149-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "abd405be-7cd3-6b81-b82c-9a4e33160f5a",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A897728\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "abd405be-7cd3-6b81-b82c-9a4e33160f5a",
+        "x-ms-request-id": "ab64e948-801e-002e-14d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c0d4417-6621-e146-7d2b-c711a6d132e7/test-blob-1c834f03-40c7-f146-d0d8-68273c8d99f5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ac2c952d-d985-c89e-c9f3-1a1e6c4d2b91",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "pwBSoPyHFKMkkkjLiiUBnerPtfcEaP5\u002Bv\u002BLb\u002BhRZLiqSpKcyxG5dezvf9zX4emeq1so9bNii8T4C1OEarBmOy2MdOOV9z9l8cjm8JHDJhkR7MCNKHMJS8LNpMO\u002BMQ88hUCzR2kKBLAfwwfqe5s3OOU6cn3v2RK\u002Bhy0cyFJ/p7y9qmtNE96sC\u002BQQcWVvIswrlmveh8KRTKwx9MA/6ThdnBtHLNEv6iUGimqV32etT2Bg9TXqoSP\u002BKFm7Hx8acCKrstVKJ/H6\u002B6xG1/lX\u002B3FIgKVf3vQGdvr7SQB7dMsJ7BpL6iiSYytuZfmJo80mpjDocpp5upEqpT/aTtrxg4bhPOfjDA1Ith158XT\u002BfNMt0KbPkwIwkDGFHUTouBBMfOZypGblR5Yjo7x8/8kcLCRoqH40IeyEsKyyWfLEX/4JKXCSi9hsSI0Qr\u002B9Fs5BoaO0gfA\u002BWGFr16fe6MumjX0O\u002Bc9JUiaRP/GPtJ3X9Qv0YSe0Bp9/ycxEZmJ3gthWjbUyvh0PCF99I1IOvqPTg9Kr2oej8nbtnzADBPu0Ga0pKTbolUbu9VjYNuNNcRsoYNKfy7hAsps\u002BVR7tDANTyRmk1YV8\u002Bv6LzOUuy7uToC4U2pQpJE302GabqkAn8flVdH3ZmJuFu3XkBA7TIfbvmrTw2CF/OpTLsA0u0UCuU9rr2Vc9ygeCny8eRRBPIbZ/vA\u002BLNynH1knpDeiOZuo1NbAz50ifodCtbjkCYPWEjI5GrxUxEyyhE/MdVLwvBChE6Q9gCzpt0Bo\u002B7cjgxXVEZIFaN7fE9BKDgsNFgl0kjmoAzXfmFHFT6N8LAjVjwF6NyPAqxMxwf\u002BT83IhnKE29Cl9e0Af9XkAQBl7oyeHdL8J0x8ltCbmtkE2C\u002BUfo7LCBTgfmBOBGgGqgGs5tl7YDH7y18mCEUACVsU/KemUIJxmuV3vp9xriPjduvO77MAiXj\u002BmbIvpQDP33QFOgjBYFp\u002BOkzzA6KSiR07QpFZMRqnE3Iup7fPQvTlqN4qbHMbIhaRULRnDIbWbA\u002BV82Nuda5aXiaVkrijr/dXDlrDZx2qIB97yOFlPwbsWDunOk6RdjMvzw1NhZBd7aC8D/4sEgTy69ND8q3N9R8fqTp8\u002B3SpxZcmk5cPXJqPHdpAqC8IwEU3tE97ToOGYtruLdxV4fIsE0lmBX5s4444s9TSjE3vF\u002Bj0REYlLXcUoDC9IC\u002B\u002BOTzoFJTlobvGytHBQpuus9aM/xbzYZyrBubSUmRNrsJeenmY6ni4CXUtLXl1ZOrcZe1aMCEZytifPA2uEk9XeBwOYsghFchd0/WgxjQiNaL79ux2832hRbCh\u002Ba1rCvYl1rRdZgEiuk8l/V0reAOjfAdqshxj4IWebR0XgBwa8sj\u002BevB/xc6h2DucUfUgdcys/XymAFjawvUuv/nkCjozCguULf4TI7c4ydngxo\u002BQffdQa4Kfc/FwI7f6UQbUvM4BaUbqjEfOmNnFbjd\u002B\u002BfxmnkEClJ\u002B3k5caIwlGGdKxYw0L3l1IpvGvgtKo2gW68im7k7LF0iguStav0Gk\u002Bh38HFAopchufHvhPUhLNDriRXzDfioYf65Hl3JSHmdaIcfpSocb6kH8OHHW6dX8WYTsdHXA4Xvz55yh5RJWGGIQix\u002BEXem3yl8\u002Bx0G4RZHYRzntZaXtlTxP9WbmdgEvpiATwmK2e/ufNKoahh42O6IKxaHUaLK4JvHfNGiCzVBaDx0hqIMzIc9CTjD/1xMiGb3E36xjVzlxV5tw10OTHGtVwHb9EI8e26fWlh6BvFPevR6qufGn9rfjrFDrvkqLszHFphKcIQUuqgAIjMEe75tLlhog5GJ5scnDGWA\u002BMxlZSubouBY9QpgZfBPtm2X2xMC1nCgsZsrTT/BE2Qeg7Hbmr0XaMjeFClOCC2ROiBZnzFSjhJbxKOAYGWgh9GWQeI\u002BdBuggGJKJMJXUrl9igMfd4Qyy/Wvj9YZhwhTLYxHt8ZLYsYUqQ7PCGlf9GH6EtZikRBdU4XsnuQ1lvlZ9wc2D6rzIic8\u002Bs51Y7OcT4tkH3Qh8Ix7\u002BmRAXsPR3xIFZRFSGfTHBuC/JaZR1\u002B/CQE9owYeFOAZ6yhVGotNTWxu8YA6SOjWWrRiTYsrmGiJ0fg6EeQ2KgD0a50/vgFQdW8qKpWfhMBYZwiRu4dU7hL/ywjTE3uIOIe/Bd1Lltxy0hgbwa3S6k034aqbpK65n71Kf7M4vWIzofHOIH7jDNBsXumvOOyk7OD7mzHQ7JQYxaZfwRcpelT2KF\u002B7xMnOFNSabwWEymaQ5ZLSPOIwIrVd9RqYQwu5QySU\u002BNCNKOgXLYYdNr1OU/s/zxuEFz1yhcWqHg\u002BvNdHI4OwhMBGVw7yq\u002Bw9b0yv3z6EfmLQwNSwnIjMK4srYZ/e0VBWRbWPpqcte2VvuFrLZ8k6uj51d2OvAOc4eiyCx0pNXp77WJmJ9de6okVuQOQtAMTC8adhaVrtp0XNVix7qrMbIlm8zw4vscRmutUdQL8DCnlowNai6/RDDrFUu56rPveRUx6LcTG1kkDi\u002Bq\u002BFz2aFykuyE\u002BrdeDZkeMBc2vUlunvdjO2hd5lHsi6WwPFFvj5LzvFS\u002BCsMs9vnJvhwWbdKvD8zp0N45FKya2G8R7hFHrmCEAwD0sJQ0dgSuVCg1lh2SwOxEhf70uqfoI3KUGwiogg/7kirRul949ZqZioBEZQIRfy1lAyihz4hZDI1hYBs7xdIYegQygQZMy5BkGu/nY74wQtvbQ77nGcKiuK3SF1W/ncTuLCs93r3m2DdYfbSYcakPMR0/IEITcSBBkAiYevR6pL0rOXeTMmQd9KtHTtwNygbEwuZ4QH2CmvrKvE61Tl0DHZk3rThxfD65IWvWi\u002BJEc4XBk7fNwmR/aF68iHYVqGYOBDFC1lzOk0bnvx7R7A7YhkiIs/rldRs0\u002BETZ9LPIo7jFiEexAV1o8wBxJkNFbXxPpAHtTPSrKM8WDh3YNJ6THxumDCOHZ4UrH4C6dA7X74rISlBx2xaEGp\u002B4mvM/UP5hngcn3yEYyHy8gm10MLTAPl6TD6pOIQQE4fGEDoyR647CGNYHsBBpr4HT9VjpUCnq\u002BFxUrEEUE70DIv0vlPmwKpaecdfeuE5OKaAoemvrG5HH2RZwfX9NrgUZBI0TehrIY8qCCt4RzD/NxoLhK5kRF8crZ7ujf61XUIPShbPBOu9FH9ahKRCztg0WYna8bIJrx\u002ByGJ9JfJSQdKvoafwZMDIvTW8uCr\u002B72d7GuTN02muQBZv2HexLdJfryQ/4WWXbGilXq6RC2qVf9z7Bg8NhG5o/WGNhIhNF49jXQ0CvwoB56p4KHS7GTSv1lyWuivHUiq11uQEBevcWEcfLa5dkrzS\u002BR5gkVv5reAs4a4vtllnnA7mSOgl\u002Bd3Cm9Atm\u002B\u002BKTkOfx8EJYsDOvCUD1yQ5sKHpu42je0nUrP9AofWLzBH0ppNqk/KYXjlKF4zDJia5hOsuQ\u002BBd5tb5xxbFxMDLRuwTCzCQ0xyzUVlUVWO5EYrYhx0KWYwxlr\u002B8cMjb0pV4gtCgsBryJLHOfu6LCZF3QLGP7UGnvOlj4XR01GJT237D29KPGGFv5mJrP96dpo0qRTAbS\u002BVX1MHrPM6mfVBTeqNzxy3C5CRMIAbfOH0KwjrnSo8uOI\u002BVbAcMp9uWyWkSF8U7LeNfa10LyyvidJhA3H6XvzbBIT4X2lsmskBMuVadzSC7z5Rbi98yJnFntvduz8ddAwo2TPKHJ1OENLkcuxHRRKt3iQzmPDNXkv7MrCdnu\u002BZ487pIa3wyMKhE01MmEWtflnJL90K6esbW3r33unssIHjWo8tXhNkvRVhkoWjgMX2TbRm1G8SjwnT3cYi\u002BOnoxFK7WT3GcCA2VHK3qUdVZ9q1AZEldewS0Mt1SYBNQbQ7eN4i6CeIL82UMH/8WuWyjnX7bfdYw05mqIhyQTaf6RLOjCB5Mn\u002BzPNHDgUVsFnXlsssaUdO84rWPvE\u002BvBd6XBEdtPd61SUv2SDEVhTH5CoICjJ5rhZc/Aal66XYgBCbzPIz\u002BDuinIHl/FBmSl11zlrG9rIlAO36wLiw1Sl/VxjQKIki0\u002BvuZW1wU7GF9nGpL91K0YmetowEOTdC8ceYpqU3lmHUEzpu2FEEtO08dMpHB6UL9EWPMbH9Hpr0q7Ol160MTmAPlNzjHDl4mcHex8QtO\u002BoijPJfqGSwFzSfeizdXt0AMCaqN3LIaJgMFpewHhbWh6/Jgwr67KY7X73oQ6HMWzskntedgsR3GmQaE1GNP/jdiPK9E5uSRUNArtf1ICU2f/tcS38/OQTrUqjm4NkUbh\u002BEyrrvT0efUhmUXRQsQjo/I5OWcLR5no/t0YEy66SqLAC4MBVqBzCz/PklqpvwvtBup70Fvj2rCywrAX2GbKa1KnDTtFHk1NyjInP7FDPz/RKwxAPnZK4DDOTpfwWy7ZASsIBrHQq\u002BidKgoluJr/c4NwRq1aiijYXCkGds\u002B1XW8DTjqKNzSJ/IMjoxBsISuVzt8UfBCBfnr\u002BL6qIzjEY68ybJmpgdThK5kYuNucUaDr9cKfwoN1agdO/jAuOATJOCrtH1P7BMVmiyZnOV0uT5cdvi1mNJEbzPKCaoOkwvOEX3Cgr0Jc8PENKUddHjC6IK6ZEHnnYvOZ0UJhaKoxwbgy0tncfaBEwM0saQtJzr6x2EnlC7KJrPx9Ft3/65hWy2efKjtm3aMORE\u002B8uvn4QBKTv4BgXLX1qTXtX2bCRNUk1Z2jupRzWvqW1rdi3OHyhMbLbDwH9n6hmXEFeY5MO/96h\u002BVsVJV\u002BIFSFyYX\u002BktxD\u002BtqQBuipLO8u8iETbeF8SprH\u002BFT8hiAxTTvXgiz4owaUwX6zrDUW0VsGPWJ0WsJzGX7rNpqHR2Sqbrm8wZqyNk8ajqxiuK5loRb59kjNvPJ5VGiuDXxsDXoKGT17ag/ARAcTWdwWEFDQdYWDnVEb3LHHM30yBCjSvnEiWK9g\u002BkcHOaJBumMWU0QH3Zfm6HAo7kyLpCaSjj/uQKtq87exb4tOfGOu2iJOsOApKjaA\u002B8YBCXpi1UYgZKtiU3m3u2\u002BMRm4MqHwMihQqPPNGeVQJXVTVaepNXoo1HgfIPIaolvVwnNPIdFNZ9I9mSKhS2ftHaPYk4lF1TvfT14pkRE2dcaX9xdxwMNjxe2Vq5xXh4jQMcMOAg6Sj\u002B13r9KzI5bAxyMbyVRQuxygtI2bsGmfh4eVGZ8OKDO3xScqOlEwsOIWlKR5O/50v7ambY2BNx\u002BDmCgLHgo38t7vo8QtJoDLr8OrRRuFZkvJIFooZ7ql9s4HpmJo5ZKYHuHFSVf6B5j12v2J1fID/jGcAf2wD0tkSa02JUAeoopxE2Y5wBz0DxjBMoz82\u002BDcA\u002BgwjKOU589WoT\u002Bqg\u002BIYl3gzWMJLyf4UqDLk7xz\u002Bp22MGiGYLdXmnCuW418dCUs26FtUiYMekDnp2\u002BSw8DiymDnR3mnAQKliDPyW9SafN56ng==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "fI9Y/UyLGYzITtHztgNOZg==",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A91BE22\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ac2c952d-d985-c89e-c9f3-1a1e6c4d2b91",
+        "x-ms-content-crc64": "I98Eu4QYtfo=",
+        "x-ms-request-id": "ab64e96c-801e-002e-36d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c0d4417-6621-e146-7d2b-c711a6d132e7?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e76c438f-ceb1-de18-7c3d-dd838f98ba51",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "e76c438f-ceb1-de18-7c3d-dd838f98ba51",
+        "x-ms-request-id": "ab64e988-801e-002e-52d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-1c0d4417-6621-e146-7d2b-c711a6d132e7\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-1c834f03-40c7-f146-d0d8-68273c8d99f5\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:57 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:57 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00A91BE22\u003C/Etag\u003E\u003CContent-Length\u003E4096\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfI9Y/UyLGYzITtHztgNOZg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c0d4417-6621-e146-7d2b-c711a6d132e7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-142218c759d3094a9a6d20c6d0a87428-2cdb8f661ac4d44e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "298ed897-43e0-49e0-0c2a-4b87dbec0d2a",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "298ed897-43e0-49e0-0c2a-4b87dbec0d2a",
+        "x-ms-request-id": "ab64e9a4-801e-002e-6dd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1001043166",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_NonAsciiName.json
@@ -1,0 +1,137 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9fe64900-d10e-c3a7-752e-6d690e0ee211?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b24a27b6ecbf2841b703781b8e992a4d-6f95213e8b751c4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "be44debe-804e-4214-9a94-0be3f46b5464",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A3B490B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "be44debe-804e-4214-9a94-0be3f46b5464",
+        "x-ms-request-id": "ab64e7d0-801e-002e-4dd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9fe64900-d10e-c3a7-752e-6d690e0ee211/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-498505f2-d4d6-5caa-7e7d-269fae546eeb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a30f8ce9-55e6-fda9-ce84-ba2c61231abd",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "d8qrL8kjwtxJdXi7mOZ1DRq/YU8EbMzqM\u002Bg/0Vp0lEYmIGspwCSazkKoAGFb7sOYBxmE7vIf5wr\u002BwPzg4/GC1OAylXh6S0z2JJIMW2xqjkUlp8lB8KVTBzlhK/8ouutQJiyBKFlLHbzMjcpgEouekzG2uzwoQeM6344\u002BGSBNzmmnvDRA6Wbr2YkNdGLa8/Stw5jNcf6uKOVIRknKDASbfr9huFVWXanLyuKyG8yBX\u002BuZkVWIf1xr\u002BJRP96McIcyEcfWjeTqeVmXuAqYc/AwZx\u002BZdMHuuE/9i9r/BB2UGrqkVLarW3eaw\u002BzvwmX22TvyHNjC8v/BR1V32QIN73U//6FP8Bs5iQukArDU/vnqBrKfDOtE1Se\u002B4w1dM351iNR7s8LApuUctJfNHuxK7ERfjdJTct6J\u002Byp5kREN2FWNMnnYXU87JWPJflRTd7o7c/bFAaWoIhn57biURxXUEthCQ\u002Bh2co75IGRyifCGOoNwQh0aRNqv4Qxf4nOWpt5J9W98ETfNwQFnz\u002BE9NZglc7M1JAT0uc4Bkl7cFowfYn2GJJSFCilPpoEftnT1cqtwOnLAYX7ZVTuhen7U7a51SG1jtxEHoGWJ5YGH1QdVCCO3b9wZWwD\u002BrNNY54\u002BqerTWqmoLlbuaaJYJNnv9VXw0SHJfHYHOW\u002B1oZQpBrrzV327IsS6ZTXZkGQNGECSJAVtTJJsdS1kzBFJ4nzCtWL3ZN1sJMKRRmv779wCCiEvI42Oy7oohuJARmajcIK5BusBBbNjJf8y2/YmcIVBYsHwGr7/M/mo3t37G\u002B5r7dXpMtjxAPRtvA2eW//D8hZc/uOUs1XDydLhaDbVeBoQxv4gTT2sUFHdgm6xYNf55NzHnhz6xypwFXkGD5i9mDPjfYUBk7TYoK6BxzD3Amj693NaHen9Ff/DsCfEpkDJH\u002BoqzeNS\u002BEEn7v1uaQ/piRMQCxglY3pZ9meFPeOdFAptyLdGzDR1p/8yMj78jqz/2jcEtJsok6xv0NeLzcpdmsrjAKBYorzumlMo4zFLbWe6lVO8iG9vNSUK1vtc\u002Beo01JdkCY4Mpzd6JipID7B7JHNvwShmoRJrg9t7TcvBgZB49B6Z52Pprf4sMlI1JyV0j7KH7SixzjOE\u002BHWigVlruKSZzxuh4T0PhhM6Sm6wNmymBs4ZSZRntyXbBP7uNyyksIm9q1gZ0p6FeGcFh4PE1MIZDIqLUn8AIhf1xuw\u002BIU72hYnk8osEnDQvk8E9Ui\u002BSFiA81TqiGW4KvYkwJBuyR0cYHvIJ79I3BGBWa86t0t/oU6C8AUwEVHwr2kUBxHgofUyKFUMtiCZd9dDaW72fbOqpV8Bq9kX7E7qF7hWdNT/4Le5yI72MusuKbgt7Ogi\u002BjG1qWHy3zXcGjvGIp6oQsLCQ0i3PLUktLJz00Ig6j\u002Bmxx2GoIuyzQGB3e6TMBBMhea1K2lfq/28kTTvvsuzuzA8XxtA4aI3T7ZG9V6GkURiJw2ba76WB1tgCg\u002BWw042DiL\u002BVpE0y6REvdvzGLae9j\u002BwTZf\u002BGE9xZlfAINeSoIwoUKc7yDrzbRtpVu3ioy6kgRPP5nX2ODXTTTA5NOrMsd0PisgPYy4EvSB8VMFhjoNpG1/DgrpWchixaLrKujgwnKUQkxhmlR4li2kVeeN0sb5s0BlLCS8i\u002BRivXjqzOcMoC7hcEPurAoZB3jdRATg1fPb8neoe5ZN17dn/tzcjclFl7S4q2GCCgc1TCSs30bgguiED9pwZCWXk5mMh60tPHmul61PJymSWOdwci9xofhwhnz0V37v1TOPIBjI9YNZCA\u002Br/keZkVq\u002B8rbyAPL2JvGhHAAxOOX7vsJ5wAYRymJkFmkfxqOw1vUhNmTH/NRBmfomJ9mDKM8psD\u002BFH9BTrShTjumI1l9O8EUKDwKAM8HtOCcM6qKJ4e6a9hVkK7clzok7c27qucKb2DaTeBjMqX19l\u002BaoR8KFyq377eBJ6sWO5UB5Rb9TAn9kcBFs9WjVzU2Y5pPQfIfGtanA78viUe5wBZLXU2O9KpRnRNawGdVEJR\u002BTsQMyvWm5so8WkhO0gR8j\u002B\u002B/W/nrp27v\u002BaTexFZzUfMmrT6DqPkgoHqDUp5iBs8K2jR3lbielqdZIM1QxCJzzQRZKCDJ/OL2nrd/ZFTMifbV1\u002Boh/7g2hBaXKoQrz9xUD4WWCN6qQN1RfPcFIzJSiJbaevA4Uc1MIqAKMtJays7bJ1TTNoEYL5cI0H7BMWTgRJ3xUVDoH720Seo6nA4K9rIkLfvdg1IVwk9dM4FSiu0/Ke40aXl57wuXGuya3Y\u002BE/dnImQdtBsFL25MFjuw8YcL4\u002B3Yj1o04qj7sRmRleuC/1DGnhe3p0iMo6I3qdFwbWrUpoeYVZSdMj/LEfLxY4lyuRbq6lN/RDylW9u3/UjXi1O\u002BzO9j6qnMOWvX/JVVi0AYtOC6lYMHZVJK8wnI5TT244afQqaqHs59LrDnl1enT8CLnzhYHPXQp1eNKPef80Q24QkOtkiZfqYSTWbCL94Ko6NJPVX8nsaQzptfHOXW7St8sKZemJmH8hCSRd\u002BPDod5gnVUVsX\u002BOkIyfeetSmGwS2BLVW8nvAsZsUs1alj3AbAD1YpwgoZVfnZkHCqh6qe\u002B0fp/Q7koUdZ6OpWKyN/pO2w3mWTnT8jZ5db4w5/gd9aTdpheh84G64Oj9kfg2rWmetDOekEy14IxpV3iL45GmcLO90I3irOeIL3hM0lw6RshUki/Eg2VUK8GLOJwJLv1bWx1IeNjbuAtMEmDUZQ4sLxCsN1Fh3fFOZajMW3RHgvx68XdC7cnzfNYkeG0Ag8KzWwmLWPuv\u002BX0v\u002BhMsC2CXBI9kWXea7UFGvLp7OWWATeXqGPxquCoAzvv6EvO6w3F1kXPdmCpPGG3IRJhBMMAbq6wtRfJgKEhlY4p7nNpNj/1FBafxprG/nwCSoneNw5474mtHiX2DEWkreDSf03uTerie\u002BCsYJgT\u002BcarxzYnQ16PsQ75zCgJ/xfQ\u002Bxip5H8uFAye\u002B8sdzH7hmRRfWkUffVqCQs5O9IHC2HzI23WPagVHfaM5iFeTceSACDMDqqTSsX2\u002BF5Gw7x96zCNORPEJYi8PB9yR1eUC/tDZvvxezy3H9hn3wVJzlp6Tvsw0RTzzhpYD9KLYQOuIuxjA5yATLA0Fdl7XAaDMm3E9/ico3qmj5ihmSsqK/6U\u002BfwY5or9ugJK/Ls7uHITlR2khmkLEX\u002BxvHPEHvOFCeoapqIKakujB332Eaa/qxdmjcQNhWVVieh8pyoW\u002BZtOhfKRIRHPyWrRwb8rVP\u002BY8hFcnVDvd4SEhNy5zcMhTA2ip4vz7koFVoSZe4OmajUoo7UY\u002BlwKX05uDFw1FjtnsHWxSO1z5QOHVwaMVjvA3hrnkSoOCJGxmEg9heIt0ECJMYtONSFH9P6xUWMVfckSrW5BDUTRWaej//ClNl9hmYbGA2Swcqk5X9xrXLdunBp/KxizrIL795fjqnVw4v6fT7fcT3pkYjqFB62oZfzwdWOWJctG7ezDygvMjMhziL0dzAz/kgzgGojd7qTVU1Ga8zTRmvzzWKHLGIUul9UyEX8wipnwMOMW9csCaP9H7na6MZmTYi3AKrNrNLmHsYLz690l5Mj36sJR\u002BuTx8S/iQ2oOtKY7Xq9RMGAmRPxpj0RIDn0iYcmtwgbXQacJDnmDiLFPeT0cuE0tlLRo0WXGKCugqaKygCFgoLJfZB0ISCImYrxLGlZHa1Xv9I0VBTDg0Vm7aKSW0MhP7phK/VRwJUySAm6puw3VWT4MgsuUS1uBfpKDTN\u002B9T5H0Oyu9/K4Bf89AgsLCN1YLpg9mig48u6N8iX6BrJhs1PKc9b/iF1yPy0M8U4hY/wd8t\u002BbQVsVDt3\u002BIQTMvf5M3E64QJUHWaU6ylr7LAGfa48o3RTTxXL3tWT4AGdYpYEuwBT/aSNnFpg5YXYBGeLbX7Z1pODqeBbcwYowDlg\u002B4SXYzWvtnwFswMd8mmP79ZuCHaGx4wGhREf\u002BI6eYNwdA\u002BoBRKUx27r\u002B0COMYbt6z4cvurvC2jf0jNokk73xa1Im/O5/jqsxPCy/i/NoeidZoSkLbqYgXiW2CLfLCUf9CWjRZWTI/zzb/nqLA05AiBa2zvKQ6fioAp7IyYHzajbkwn6KmxDCjKHsL3AvmV7XcXydED5VaCNsKWLGADW\u002B5JRHpjzTufEF9D5MoLqEfGlD8VQBVlX0k1ZfGnGx\u002BIxsMUbf5/ceB7ePmxwABMtk56j1gg7duZI\u002BTxLqdKODV/ut3HNzqJR2Jemcdbs19I6O9jLEuHqBkne0nZTgN5MUCEcgUiRX8T8Qg1glPUfXCFqAW35svpuBLE3/vw8DkfJWiGlwFaJmOwD3sDUeWFEv3ZU\u002BX9gQp02royXWVDYwEO1pzrTeZva0Ghx9eQ5mYtP4z911wTIWQeEbyHJ8k\u002BLKw59LsImcUXqiikW/lypDRTxR3YhUulO7V4jTwp6AN4o9srVvGq5GXHpm1zbsWq622IMyKrJacglLjF0AyJLcHla7feRw0C6OC30N8ecYzvjeGOYbTgjX4zysI4pNRZPrhrTgNNjGRghUoCM1SIAiMsFkIrOowNBJ45qnxKygPMXtJm8yNJYgF9bdxqnpopq8jfDI6SLgPsHkmlU\u002BIn1btGNZRCYQ8/ovRArYzv4mXD0D6zq/11ejDOepSZ5A4fVVhhJKjF5wq5n2naUUB3PHwjoUOjdGn90Pujs\u002BZ6Zf6mIVh0jv38/ikz\u002BcxTmuiwl35YtkKKe\u002BDuY1OtYjMkPzmrNHAoAm2\u002BJqNar3qdqjYS8xyoIa\u002B8G6V3RitqD5v1z7rSqKa4SFTQ2o\u002Bfb4ymUPkdmq8WvB1KLxiK8LxCE9cHZN//ysGPmmqHl0cf3KvY0PVyTLTs3xOdSLmN7ZfYjoa4mArspoY3jcAEjuTWKlJssd\u002BHD4diGoWMIkJHwazS7wiApwRhLCpvOr606BAuxx5nIXu4EX7/Fr2FIIQD74xTcd/cFYMNy4X1V9UIrXJ1XVtkIOBxGp2JgVCG28uma0syYbZwUrGbGRW1wvmp9qlLT8Mo387sIhcCEpQyRy\u002B6TuxKFgu7xQrpiMfKu1fkH4rne4wIfUu8Rn9fLj/dqNHmO3PNH\u002BBdj0r4fxbG4Wa/XjMJCstjsdFgzY/MXJbKzB/15L/j1v\u002BqSewBED50tWTYn9AM1J3GgkmibFIQkTLz7XM3ETzm24dzXoEfYmHTLBhrM7zG/jeCL2I2QWptWfi5TWKLPaRn8cRImXXc5x/nz0B55V12LS97tOHa8FocxgSIZdU/B\u002B50AwH4fiSBpUgCDrIqM7RbQyAzT4jCjQFqK9NxFEEK6MdRxeJbva8Kuc\u002BZmKHn8pJQbSL0y7hlsbXATlIRUJDG92Wq2C3SP4WxKNW5KPSfgjkA4OdeVd1O7FQsWy9c\u002BSl\u002B0uE8PRpkvi1dA\u002BKi7EiBYMwY0G/paGGIXCvZpeSWVG\u002BsQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "5u7vs/EKjpPaOOpxZvCZuw==",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A42F3A5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a30f8ce9-55e6-fda9-ce84-ba2c61231abd",
+        "x-ms-content-crc64": "ehgHTkyGtB8=",
+        "x-ms-request-id": "ab64e7fc-801e-002e-74d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9fe64900-d10e-c3a7-752e-6d690e0ee211?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "cca8eb38-1b42-94cb-ae50-be90c04429c4",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "cca8eb38-1b42-94cb-ae50-be90c04429c4",
+        "x-ms-request-id": "ab64e82a-801e-002e-19d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-9fe64900-d10e-c3a7-752e-6d690e0ee211\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-\u03B2\u00A3\u00A9\u00FE\u203D%3A-498505f2-d4d6-5caa-7e7d-269fae546eeb\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:57 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:57 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00A42F3A5\u003C/Etag\u003E\u003CContent-Length\u003E4096\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E5u7vs/EKjpPaOOpxZvCZuw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9fe64900-d10e-c3a7-752e-6d690e0ee211?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-dd68fd27f8deff4c9d18f4278b58f7d7-d32cecd0da92304c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "76f30bc4-4d7a-b07b-0e34-1c66368b288c",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76f30bc4-4d7a-b07b-0e34-1c66368b288c",
+        "x-ms-request-id": "ab64e842-801e-002e-30d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2064558603",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/GetBlockBlobClient_NonAsciiNameAsync.json
@@ -1,0 +1,137 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-976ed893-ecdb-5443-f70d-7db5c1542c34?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-dbc6cbc78b90b8439b127be9c96e0bbf-a53c85ee5560e245-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c6dd02c9-540a-3acb-e0a8-fe62177f01db",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00AAA4B79\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c6dd02c9-540a-3acb-e0a8-fe62177f01db",
+        "x-ms-request-id": "ab64e9ce-801e-002e-16d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-976ed893-ecdb-5443-f70d-7db5c1542c34/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-04a263be-5c8d-e768-af08-9e92ce1845c8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "4096",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a8e81c3c-d683-bb9d-e5fd-111fe92f202b",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "PdnsvnZmKVE8BLEYrsZOeUdCbKuNyxZtmfYWAbU5bMdiNiU9k0NkVzlRyIiqUDjouSRKi6yZO3HDfySATyibA5jptXihEOYE3hRxOwONwki9LkiQ7uAbyPuzehMe5AgRtcXvwJvAR6k\u002BRq2XJ/9uNbzbwiHfChS3zux97ZbS5voMYIY\u002BnQGt/eafUqgzg6D7RURXQiHmMaqxOPKuQ1oSbGCyi8d5MJe6LcQ7QLhrhEtMgadRe6PYJi7bjWUP/7qLjOZIgPjYghWtnBRcq/HyRbSnYcGzwfG82mWZnqIxqy4Kr7TSIgNSc/6RpN6Oe3o96UexaJ742Mr1i6aTP\u002BRye/HmUvs8HyKxVO7CIR0SLV7qXLRbgEKQEdbp3ZdcvzMaHyjsqCl\u002BAMkkABSvNret4l5IqOMvF/qvVkAlU0KLVJS6qAL0JoU0a1vrNn8u4NsfPPs4ExZQ6wctPVLpWa2Hmat/9I61ubzYFD2HROF7gHVkBRZGUkF9arz6xugzSxGuY53TruxNaYM/YP/ZyKcmsrzchFOWQEZqAonRuvLTpcgr2OBEp9KJF5uTB/JBpKIV1BMrVse9GCJWaaxifK\u002BQa7o2re/G4QvqUmy3AjlTKF3nu\u002BXfp04BbsC97T0mJ5rsAps3C/ayT/IIQQRaBRXpAkBOesHJscRsNT8uCfTNxCvRywCdGx1mNGvz12VKp2ir0\u002Bv916zZI1HXy9a3g0X\u002BOn3YiDoVTOYi50ZV1tpeIY3XgzYJ0Ox\u002B\u002BKiuxVBHr7Am9JzocR4tlocE2u9mhEx3ealI4AAP9WqQWZCSZoaW2jiVLuE9dbBvqe2uBPX9GHRbN0ym/86wF/8yWBeNmi8AbQC20FVrOQP52DYTYPB1kkEcNy858Ntq5RfhCxyZ4Q69rZb1Rkge7/5IrCeXnLYPvMXWcWMAx30kTOo9iS3mYPYnVbJZgEz4/Ugx8EO00khh0k5Xwm\u002BrveYZ0Pld4WXQYkwwb0YDtTx53XQbz9Y5cHqh27bej52GfJjMQK9SmhziYI73hGICXh0S3eT7kO4Q319/uwWv8tKuqfOuN3WNJkJYOG5HQuwXn32ZzLG4i\u002Buqu2BP098WMm68SdtvVCaohbeho1d/yJ1zZxyIFiYh9R4HA3sUPVNjQQYAi/kRqEtX8Uf6F\u002BeTK/PD3GvCjhxIm1O8Z1Crk0hjPWJRfj2kYb/QMCTeJt42c9iIUWDoobPpuPClVEH7q13/ltmFQqy1Hnqr8l33aXR1hvN4IkHne5yuaMVN/g1\u002B1YXG35AFsTEr0jLlPK5W8U97MM5NgogcFxs81trmaB9tLR3YMYnkcNTBTFAOAT7uWHd20c4/MFL8qsh0yNtXRWoSeA6RfsDGl7/5izY4DRXdTX5icJZRLf3K24bBb6f5agfl\u002B4kvXdq2sDoPRaQcw5yyl3pc9NTUwUoRxqI5BCcYACEuUxKMrfCkrL9cQuhYrhjqDtgsnHUyETk\u002BHpY3fKsS9kSC7XCKJumKuEgVd39iuBiJT/ZO7GSr/ELYTY9abC8USUuj1sCoX\u002BfvouMtHZm53GV9ri20wwrg1vAtsdlaL0wYAC40vuJX4O8PX0mAft\u002BoHnEp3L0CX4ZBwv/Peq4NlXKXFBxrhR2CJc09pWPAYFgRhZJoMFKOFqCn8/zjh2ZBAcrX6GrCPZlTprbwxLoigGKnvvUbpWUgCf17w5Ihn55n\u002B6SZ6XftT0f5FImbnlLmhXKZPMlwJltltt9sRnoHMgcYiMkViZfquW6uIpHbhGurlT4fh2PU9tVIMzKYgQjN8eGBghWJ0PzbroJbwgPKiTJ0wbE856ujRJLzzVVkUjdl4TCvWQFVIcRBRNjgeTPRfqr/JL9XkAk23j6ClQOmdlxK9eHSGy8wHp/t\u002BqPSwsteIU\u002BrZS54DlAneHvD04zAm818lYRS/mJ6zwUgapZlYxtyJHO0\u002BxEu0uaRq6K0bUsTLF/VVixHDCPsMJUoV6S6wRRfUa4YDJ\u002B8TcOdwFPAxmK6DT03jw3vKxdQyMp7BnpC1\u002BqNVBuc\u002BiC/GQhpqUvPLGozbUpmgjEHcCWWyEPVQUdIW\u002BloMnFGHhIdeHYEhoHMgJtgR5gv21S4huT2BTLc6tjBIE5hZ/r47U44SQq7AuqkykendPmuGICVsKuNUBngQI6dQ2UzahmhaFpK95JJ/YP6UTrqNHXfEgjOzLZOap01Vwh8Hb\u002BEcF8tBQufZCHtS7Ink/7e9QsYvjBdZZ5iU/28FJ\u002BJzeDEdeHbvC5qQK7n4IAEJtefV2L8ZF6PJwvAyrIN4k\u002BBZH7SYx4cAjjdrn6BdYQeXiwmHb09jGiBNU3VGvF8XF1eZXsBMcO5glQpH7bfDbGGomyG58WSRNcVUC7QR\u002BdGYFIgIxAJHCxpbZpoE2yyoiebTniF9XSYzCGj6\u002BGU6Dps4r5kvuqhfYY/HXoqKTBrY64GNfhvwWrdiFfvZTBL1IRf/DCtTuM9\u002BdHyRtj6bqLwOIgzjrNC/CFUhjaTshdV80j1yi3/vRTLyTsnfXqS4hm0/i2nGEbRHf8OWcesqke5nFKPBKR08Hp0Z8R3G3\u002BnwaQd3rPqrdsCJKwu8WNMHh7zbeAoAt11Pw6yM7CBWQJ/Z5cjjsyUzu52jOD3Rv8WJ0mlg62efr/GqJ6kOHorgcqpronMKY9SX57xsXX8ffgPmwtn29ZV4ejYXeYt8JZ0SwsWTph1Sv65UyQOrM1KySullZ1uw6bzVMyh88upJG4IfWVq5i5fmVANroexRjQajpO7h1r4BYhlIvnM1FcyDy61BS9o3\u002BP8RftNYRUeQg2YhmU47p0UEHjdBMM1k8X52p5Z\u002B0EFsq6wvkJeq6RyRuDrM07x\u002BiGRofW3i9ofx7E2U4Z3xEbMktO3iC9btWTTar7jSWB3B\u002BB9yFpMTifTkPeQKFcd\u002B4KZH6B6OnLxNuyQ4yAcPH1Rv0yl\u002BfzsgESs4/c4y4wNtm48Siq//Mxui5Juu2oGtlN6PmkLdwGFrJ9czlZ6uWtfgiyx4PJTksJ/N25pfsTZpS2jvowjAT5ttp2KYy519NInDjk\u002BVdVhJqumi0CTGy3bgikp1vveO4DuRCpUyC\u002BUCUOcQm\u002BLm1BXQpfhfXb\u002B2Zpwr\u002BAFSx3WSNO4UBCrDF17EYL899m9T\u002BbZ0pRj/L0K72qQ5BhOj70mxfmc00s/rDU5ZWvzAeLBsl/6LHmIc0wVrWClGihELILF1jLfIXybmSZfKZZSF\u002B2IzzK5VGJEnlGthibqmZEN9DnoLiuv4ZDjX5JSKEm1w5VzHEv1i9cfgDjgMZtWsP\u002BVUjRdaenC2e2i1fXQ8XUI\u002BMKQd31GF2lhyK3zz6/1jK6SvdUUV1qssENdU7biT4/C1znYxjiCTjvL/KA7zwo9rElGPTSg9KBo48c56cOzf3keMPd2HMZ2D26aSFu5cOE5H6ZsmxJaIuOZcOJxSWV3GH0nHZ4Tx5CC0C3GBatFrnPlAMkdRuRmww4T3KvkBcYIIy/dklJDJlcV6srklBw3U8Fui0icWdKZwFqP/\u002BvknstmvuJ7ZxwgotpyB1sZgi/y3IjqdXl\u002BbMldRNH4syZsMUv/ftY6u\u002BukTeluKVJ2fz4rnSJi\u002BilR6FEYHiNKKO\u002BzBtYQGgRYtyCcRSeQEEJ25sSTzBUDCTcirZWEIZ3IWiT5uiN8ZmU50uUCxbQBwdcPojdft1zZr/yf7Wxu1JaD1OsCllUe\u002BoBeWfovAUSCIey9dH9laaLIIAsn3Xn5y/5PfvDJ/iqC8ae2AF1iqq23HMx/sF8XHWtIOXZK9hwHZY774IJTuCLCO4PXrmhFZnVdcMCseRueN2GFgcSzN/qLr5vPZsorY2SpvXTbQG4CAtMA7YZcWutyXKghzjddDgOJTP/NdQCrMQxcArymw/fygn7xs0pzLlSvXAkiCZUsTK5xUvRvNYzSVbt6/1cuzJmwLku4bFu5Fh2qHRn2iSd3L7YONHADg03xHl2O\u002BS78gY9wcdtJc\u002BBTtzzWxBdz3MyTA9ChIJcorav\u002Bx039Kh3urZyJhRdMLbvWun00LL41fUKR\u002B/ZeW2H3SMQwS6ySVYwf6BZ76la0RtUUymUa84DsyEkLbC8nkFE6kT1THOIPQ2XwFUSoupPr3LQgSZH73VRDQ4Jih\u002Blc91fEQFgZYSryBYYAKd08Qw62H497BkbAP7ToD9hfrLt7lB3s43k60nuJLUMK\u002B7N2BwB0rGdZ4PEQBAGkMFFRk1jKhJW/UGCUe00T8tgDtkMAcQjY6wBUIbMs2993lqEpN5rrP3cdt7ef3zAaRu4ZDU2\u002BpL5IeadXdmLik3SAHOWs6bo9F3bL4rpROAvQOdvEEs2RufHj4b7yk8gVOyNCHsNKblw02/bW8sED90CchzyGHoCm72PzyAj8SoSutqeXDxpIhst/kDfXusYw3\u002Bl9VgyLjh2imy9gVqVTOJBxKDsaa\u002BgmVABxB45JzjScw\u002BkffvR3IiiJ9XPq5y8mLFemZZKLFXMBVwELGoePWMz7w5K8NLqb\u002BgYTkHZ1O2zRSts2ommhEa51HSbzaweh\u002Bpym7iScafidCmuLd4X9jBuUOtCsWbVjWbLkRxaTqI7/cpXazkxINODjmJj9Fpkod5EKXjE39aHmQpVxuCLhCWLdjAXvI73PSwbvycAdZkMZu8\u002BEiUlcx33084y313u\u002BAY42IIqUOVTUOxIrSCzhyNtSWPxTXYAYgMSI\u002Bi8wF3SKMccx50a4hYF7sE43MX9REiqwZX9/aqMOHqDFCz4koyOeoRZkr\u002BGVmdJ62Kwy4U5EN\u002BcEgLL0CsYjIsml8nlDVg0qmJBo7GJJGsusBJL33D1RgdRWICJwqZZQQI0Y76ZZN4GfB0i\u002B20qEumXmSAUzLEaMVHGk7DXque/5GKzVMSolUs0QV9T0kqaK0WW9iWGQHRNGi5s1tUtMtU1ZxcOdr4k6wfU4ItVxl8LLGhrQLC\u002BNaPuZj6WP8J2CxKGGmszj7CLcgshrWPo91PTZaZswfIkdy1zHBCDjq9FYtl006/z16C339KlnIhAAW7qxtoYCUUgYaM9wG\u002BgC\u002BNf2EqKcCen344FtOYfftqhMx6hlMvRKVmQVHIIthcxF9fvScA9uY1LQutIElBjAOLImI1Q/nMXiq7w9h\u002B1myV60KEOMDUWY3mNWlHchRcFMVOPQB2F4BVg178RTMNxlavB0UGzUNCttjUXw6QdOwWX68TIJlsL8OyLqVh2ARa2H8CqGrPVVdyC3Y3kciBtR5y5fWD\u002BpW9QueBRJ6d4N7EeYafjdxxRwpXkSUjJI37MGmW7vIe1t3ZVWWDPgC41BqnYxhB4jdCAZ7rPGlgmh5plhQlBvHctaKotjhm/gj5nr0Ki8FluU4yVO1TI5pkeLtHGaf8k90oyq11mTv\u002B2xOV8Z28Vh5M8\u002BzF4qIUiZIIRE19L9RQ/Qrf4bEj8BASQ3nJzTIMuBKtCiXLNqE7BDEbbVT\u002BcbtPNPSS3GRdKQPMo68oSrxQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "oLdq1\u002B1IB0Gd3WSr5WWfsg==",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00AB29286\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a8e81c3c-d683-bb9d-e5fd-111fe92f202b",
+        "x-ms-content-crc64": "OPQ\u002Bnnim6VQ=",
+        "x-ms-request-id": "ab64e9fb-801e-002e-3ad8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-976ed893-ecdb-5443-f70d-7db5c1542c34?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d6fe1710-039c-2942-1a07-c70349ca7335",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "d6fe1710-039c-2942-1a07-c70349ca7335",
+        "x-ms-request-id": "ab64ea11-801e-002e-4dd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-976ed893-ecdb-5443-f70d-7db5c1542c34\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-\u03B2\u00A3\u00A9\u00FE\u203D%3A-04a263be-5c8d-e768-af08-9e92ce1845c8\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:57 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:57 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00AB29286\u003C/Etag\u003E\u003CContent-Length\u003E4096\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EoLdq1\u002B1IB0Gd3WSr5WWfsg==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-976ed893-ecdb-5443-f70d-7db5c1542c34?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-98546435d0b41a4b96f03fefacb7ab8e-c377e9740ad41d4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d10e0a2c-4931-948f-098b-02857215103f",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d10e0a2c-4931-948f-098b-02857215103f",
+        "x-ms-request-id": "ab64ea32-801e-002e-69d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1982420725",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUri.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-259e98ed118c7a4c8ad561f900df9e64-27cd2babfa4ff742-00",
+        "traceparent": "00-e6f9eec2496e3b4fae66ba6f4a95de1b-5b9cab2c0ae5e945-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "cb7b9eb7-8075-6b75-1e9f-09d0b08dd783",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D6B1A6D7\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A5C4477\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "cb7b9eb7-8075-6b75-1e9f-09d0b08dd783",
-        "x-ms-request-id": "f79cbb3b-001e-0130-0110-2b8e64000000",
+        "x-ms-request-id": "ab64e872-801e-002e-57d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-\u03B2\u00A3\u00A9\u00FE\u203D-beb23120-ae34-3397-00e7-727f8e893ceb",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-beb23120-ae34-3397-00e7-727f8e893ceb",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-af63f8af61fbc44ab369f4df90b6b5a9-ffde6e20910c1a48-00",
+        "traceparent": "00-76d231f64f0d674f93fa390e569d8264-e2efc5368b9a214a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "3b203075-6e17-f16e-0c27-69ed729d7115",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,16 +55,16 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "/kAZ62gQ2W2WN7BTJAgisA==",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D6C55719\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
+        "ETag": "\u00220x8D803F00A6CF170\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "3b203075-6e17-f16e-0c27-69ed729d7115",
         "x-ms-content-crc64": "KVEVv0M5cK8=",
-        "x-ms-request-id": "f79cbb74-001e-0130-3010-2b8e64000000",
+        "x-ms-request-id": "ab64e8b2-801e-002e-0ed8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -76,14 +76,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-5bf52bd642b1184e8202fe17458b059c-7f077f5cf8c1f141-00",
+        "traceparent": "00-a67030fa11e9304d83d99fca6a474885-9d4813d52cc61e41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8cbca68b-1392-85ac-55f4-2940f66ad19a",
-        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-\u03B2\u00A3\u00A9\u00FE\u203D-beb23120-ae34-3397-00e7-727f8e893ceb",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-beb23120-ae34-3397-00e7-727f8e893ceb",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-source-range": "bytes=0-",
         "x-ms-version": "2019-07-07"
@@ -92,14 +92,14 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8cbca68b-1392-85ac-55f4-2940f66ad19a",
         "x-ms-content-crc64": "KVEVv0M5cK8=",
-        "x-ms-request-id": "f79cbb93-001e-0130-4b10-2b8e64000000",
+        "x-ms-request-id": "ab64e8d9-801e-002e-34d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -110,13 +110,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8af36f321f9b8144b23f746909e63458-633ef322012adb41-00",
+        "traceparent": "00-bdfb5b7112070d45ac0b56e42fe4275e-a8610f8f8b27c347-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4b32f9b9-e418-97dc-b4d5-19c2c69a389e",
-        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -124,13 +124,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4b32f9b9-e418-97dc-b4d5-19c2c69a389e",
-        "x-ms-request-id": "f79cbbab-001e-0130-6210-2b8e64000000",
+        "x-ms-request-id": "ab64e912-801e-002e-63d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUriAsync.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-388340dda387ad449d8e8a88ed4b58fe-bfc0b50d92332846-00",
+        "traceparent": "00-e7ed8e8dddf5464388c3e8cf1c7879bf-ce0056ce2bc0a24c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "f4ccba32-62ef-278b-a3f4-82066b9d3530",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D6E3E3F8\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00ACA5C5F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f4ccba32-62ef-278b-a3f4-82066b9d3530",
-        "x-ms-request-id": "f79cbbc5-001e-0130-7710-2b8e64000000",
+        "x-ms-request-id": "ab64ea6d-801e-002e-1bd8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-\u03B2\u00A3\u00A9\u00FE\u203D-b078a817-cb29-8be4-c443-ffe2ad92158d",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-b078a817-cb29-8be4-c443-ffe2ad92158d",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-5c7baa73e5975444945a9d4d781621db-7aa8ed03121b964f-00",
+        "traceparent": "00-c2a82f11206e2148b8a443586691bd38-4f38646e8517a847-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "52a65e0e-19db-716f-33be-9b888d483a65",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,16 +55,16 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "yhkIOBpSog8MI\u002BLH4loskw==",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D6EC952B\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00AD1E00A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "52a65e0e-19db-716f-33be-9b888d483a65",
         "x-ms-content-crc64": "fjJoEaeZ1fo=",
-        "x-ms-request-id": "f79cbbe3-001e-0130-0e10-2b8e64000000",
+        "x-ms-request-id": "ab64ea97-801e-002e-40d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -76,14 +76,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-bd173d4c91310c44a09dae4c255f7440-446fdd3281b3a845-00",
+        "traceparent": "00-c90177fa4aafbf4892d2af6d5486c30a-7c4085407e07544f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "71ae887a-ea74-da79-f61a-4d66e1083328",
-        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-\u03B2\u00A3\u00A9\u00FE\u203D-b078a817-cb29-8be4-c443-ffe2ad92158d",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-b078a817-cb29-8be4-c443-ffe2ad92158d",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-source-range": "bytes=0-",
         "x-ms-version": "2019-07-07"
@@ -92,14 +92,14 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "71ae887a-ea74-da79-f61a-4d66e1083328",
         "x-ms-content-crc64": "fjJoEaeZ1fo=",
-        "x-ms-request-id": "f79cbbef-001e-0130-1710-2b8e64000000",
+        "x-ms-request-id": "ab64eab9-801e-002e-60d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -110,13 +110,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-54c7d8ff259bdd4d88e843f20c45f160-5979001f0b7bee4e-00",
+        "traceparent": "00-69c43d3c67772a408c9d7e64703cde75-a70db762ab76574b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9bcbfc47-ae4d-8e10-0978-a76a04410e06",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -124,13 +124,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9bcbfc47-ae4d-8e10-0978-a76a04410e06",
-        "x-ms-request-id": "f79cbc02-001e-0130-2810-2b8e64000000",
+        "x-ms-request-id": "ab64eaea-801e-002e-08d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0853d02fe68088468df2c02d0853bc91-be339d7ed810ee4f-00",
+        "traceparent": "00-08c55e82ad27cd44a66666b05b461ea0-5c62c0b30fb1d842-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "b0a6b0a0-505f-2516-fd44-437cd324e80b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:29 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:28 GMT",
-        "ETag": "\u00220x8D77DEEF0DDA3FF\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330956DA5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:29 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b0a6b0a0-505f-2516-fd44-437cd324e80b",
-        "x-ms-request-id": "db366ca4-d01e-0015-66d7-af8588000000",
+        "x-ms-request-id": "821ae47c-f01e-0021-25dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-2d102e05e5d3fa4bbb893830952f3bcf-0cca0ac59161fb49-00",
+        "traceparent": "00-16fd758a6f4d384bae0336ac89852e86-62295d7559fb4c46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "277a500b-1b1b-000c-27d5-1457cb024034",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:28 GMT",
-        "ETag": "\u00220x8D77DEEF0EA0789\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330AE1A59\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "277a500b-1b1b-000c-27d5-1457cb024034",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366ca7-d01e-0015-68d7-af8588000000",
+        "x-ms-request-id": "821ae4ab-f01e-0021-4bdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-79ffa1aec393914380b409ed57250c11-6bc507c5601bfd4a-00",
+        "traceparent": "00-0c89b28b25192b4192c29961561ad696-024faf9ea64e834b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "5bed0121-067c-34f4-ae6b-5a9bc0f8471c",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:28 GMT",
-        "ETag": "\u00220x8D77DEEF0F63C8D\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330B60B03\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5bed0121-067c-34f4-ae6b-5a9bc0f8471c",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366ca8-d01e-0015-69d7-af8588000000",
+        "x-ms-request-id": "821ae4c0-f01e-0021-5fdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-23cea22c99e67d48b535576b9260eeaa-6b7efe99e8091546-00",
+        "traceparent": "00-3deefa57cc002d449e14c9963b87c0a6-6020c029900b2b42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ca361287-e514-a2b7-591f-f902222b07b9",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF1024A88\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330BDAD90\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ca361287-e514-a2b7-591f-f902222b07b9",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366ca9-d01e-0015-6ad7-af8588000000",
+        "x-ms-request-id": "821ae4d9-f01e-0021-73dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-f9033dbe59ed23449f15715f52839724-ee2edc6def66d047-00",
+        "traceparent": "00-69e4e7fcca285148a446956f266cd5a6-6753913389d19a4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ae145771-7cc2-1f07-d8c9-ae5b71736a5e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF10E589E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330C74C38\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ae145771-7cc2-1f07-d8c9-ae5b71736a5e",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366caa-d01e-0015-6bd7-af8588000000",
+        "x-ms-request-id": "821ae4ef-f01e-0021-04dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-675d574cd041b948ad4bb419dc885db1-17a09ccad289604c-00",
+        "traceparent": "00-a80a5322a213c74baa01f290c19c4e1b-5ae5d54f4e324e47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "cb90aae7-5916-33f7-fc88-9fee972b4318",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF11A6662\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330CEEEC1\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "cb90aae7-5916-33f7-fc88-9fee972b4318",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366cab-d01e-0015-6cd7-af8588000000",
+        "x-ms-request-id": "821ae507-f01e-0021-18dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-d541c7fe7aea0f499fa4a3d0a919ae97-dd32d0c032114648-00",
+        "traceparent": "00-6945a269b9716e43b187273363ec4eb8-1e2f23a36002fb45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "c77425b9-9fe2-5247-c340-fb2de25ba860",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF1269B93\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330D66A2E\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c77425b9-9fe2-5247-c340-fb2de25ba860",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366cac-d01e-0015-6dd7-af8588000000",
+        "x-ms-request-id": "821ae51f-f01e-0021-2ddc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-6b9a81d536918f4f87e7d987113c255e-cebc3a9d5342f044-00",
+        "traceparent": "00-b1177d1e746c894f93e25cd66652e91d-4da525a4124c544f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "7235b57c-7cb7-5536-2bca-131c446a0db1",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF132A96A\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330DE0CAE\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7235b57c-7cb7-5536-2bca-131c446a0db1",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366cad-d01e-0015-6ed7-af8588000000",
+        "x-ms-request-id": "821ae535-f01e-0021-41dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-5721371e98833d4bbdd813a806ef3dd3-2c5434be5837f74e-00",
+        "traceparent": "00-99084fe2ccce3b4fabe3ba066c157746-e3cb8db0b3acde42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "2db1524a-3626-c1a8-ef6a-7305250f61a6",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "F13DoSQAbMJPd1QyW7397Q==",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF13EB764\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330E5AF32\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "2db1524a-3626-c1a8-ef6a-7305250f61a6",
         "x-ms-content-crc64": "wq8GkwAptG4=",
-        "x-ms-request-id": "db366cae-d01e-0015-6fd7-af8588000000",
+        "x-ms-request-id": "821ae54b-f01e-0021-55dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4592f4d6671b2341b4e15ef31566d3e8-5d0115e2066fe044-00",
+        "traceparent": "00-d3e96ac4c2249c44b486fc655bfaa7b2-fb0eff02a3683c48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f2d106ae-e0b9-f38a-1943-2828f9135be9",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:30 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
-        "ETag": "\u00220x8D77DEEF14B88CF\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:30 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
+        "ETag": "\u00220x8D803F330F05F85\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f2d106ae-e0b9-f38a-1943-2828f9135be9",
-        "x-ms-request-id": "db366caf-d01e-0015-70d7-af8588000000",
+        "x-ms-request-id": "821ae560-f01e-0021-65dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0?restype=container\u0026comp=list",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0?restype=container\u0026comp=list",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1e564cf6-6f3d-b2ed-8224-5a6eb4ed1588",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:30 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "1e564cf6-6f3d-b2ed-8224-5a6eb4ed1588",
-        "x-ms-request-id": "db366cb0-d01e-0015-71d7-af8588000000",
+        "x-ms-request-id": "821ae572-f01e-0021-76dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF0F63C8D\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF1024A88\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/bar/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF13EB764\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF1269B93\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF132A96A\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF0EA0789\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF11A6662\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF14B88CF\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330B60B03\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330BDAD90\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/bar/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330E5AF32\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330D66A2E\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330DE0CAE\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330AE1A59\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330CEEEC1\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:30 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F330F05F85\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EF13DoSQAbMJPd1QyW7397Q==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8f72eef5-9d1d-47cb-9af4-b1af432e2eb0?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4622059ea1e9104f9717e76862a43697-2ae074d9e5366c42-00",
+        "traceparent": "00-f504192d181e5942b7135d004862c029-aeac1314bbed494d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ad312c48-3cbc-fcab-21fd-52c74decb94e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:30 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:29 GMT",
+        "Date": "Fri, 29 May 2020 17:10:29 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ad312c48-3cbc-fcab-21fd-52c74decb94e",
-        "x-ms-request-id": "db366cb1-d01e-0015-72d7-af8588000000",
+        "x-ms-request-id": "821ae59e-f01e-0021-1cdc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "205919400",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsyncAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsyncAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6c6b7b35d55c354a90a01d0f535d05b7-24e6e90a574a6e4b-00",
+        "traceparent": "00-6b62054a29d4fc42966d866ca4a696d3-dbe20368912a194c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "11e39909-b340-f8b4-446f-a9174ab53147",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:03 GMT",
-        "ETag": "\u00220x8D77DEF05980D44\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3622B1D3E\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "11e39909-b340-f8b4-446f-a9174ab53147",
-        "x-ms-request-id": "db366f3e-d01e-0015-5cd7-af8588000000",
+        "x-ms-request-id": "821b6844-f01e-0021-6bdc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-85d28cad109ae142a77eae3fdd5d4509-b741c69f4dcf3b4e-00",
+        "traceparent": "00-9cace92f84fec54084a95264f66e24d8-7f464f8bfb4c0149-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "29f8c68a-729b-066e-4721-48f860940516",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:03 GMT",
-        "ETag": "\u00220x8D77DEF05A477B5\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F362471FEA\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "29f8c68a-729b-066e-4721-48f860940516",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f40-d01e-0015-5dd7-af8588000000",
+        "x-ms-request-id": "821b6897-f01e-0021-38dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-9654807a6962544db202e8331aa70e1d-f96f7bc151cc0842-00",
+        "traceparent": "00-72b31c68bf8b424d9c7c32219e80e28e-ae827248f6146a45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b6e3f334-c314-a63f-18da-3be6d5db566e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:03 GMT",
-        "ETag": "\u00220x8D77DEF05B08582\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3624FACF4\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b6e3f334-c314-a63f-18da-3be6d5db566e",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f41-d01e-0015-5ed7-af8588000000",
+        "x-ms-request-id": "821b68ab-f01e-0021-48dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-bbb5e0c41835e54d9995ccb657758bc6-52b7944882cbc341-00",
+        "traceparent": "00-39cebaa803ffae4bb2d021b5c924b13e-a6d6d24190af1040-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "6dc41e3e-4eb1-1f02-e936-ca8a5fa78253",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:03 GMT",
-        "ETag": "\u00220x8D77DEF05BC9393\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F362574F74\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6dc41e3e-4eb1-1f02-e936-ca8a5fa78253",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f42-d01e-0015-5fd7-af8588000000",
+        "x-ms-request-id": "821b68c1-f01e-0021-5edc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-939ae4d70d5a4349b9db6b871192b0a2-b187283d69ef0146-00",
+        "traceparent": "00-33b43f8c6cd6684d81db1077cb9543e2-3f018a694a54aa47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b7a8cf8a-e916-34bd-313a-03e4c8979092",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:03 GMT",
-        "ETag": "\u00220x8D77DEF05C8EF88\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3625F1910\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b7a8cf8a-e916-34bd-313a-03e4c8979092",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f43-d01e-0015-60d7-af8588000000",
+        "x-ms-request-id": "821b68d4-f01e-0021-70dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-6ac362aa3f0577469d260a308c6f417c-ecb2109cb5614b4a-00",
+        "traceparent": "00-20a81ddafdbd584bb93782d0733b2198-6022a545ea548943-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "90ff8993-cbfe-ad3c-43e0-5148f12ad83a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
-        "ETag": "\u00220x8D77DEF05D4FDA7\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3626709C2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "90ff8993-cbfe-ad3c-43e0-5148f12ad83a",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f44-d01e-0015-61d7-af8588000000",
+        "x-ms-request-id": "821b68ef-f01e-0021-0bdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0f8aa4f74b33f941846947a55c559cac-b9356cc970880643-00",
+        "traceparent": "00-99a92f8d8e70224cbc8f65dea79467f2-c85e387d13de1a45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "3f51abe3-0097-5293-6b69-c0e17ca156e4",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
-        "ETag": "\u00220x8D77DEF05E10B67\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3626EAC53\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "3f51abe3-0097-5293-6b69-c0e17ca156e4",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f45-d01e-0015-62d7-af8588000000",
+        "x-ms-request-id": "821b690d-f01e-0021-27dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-ebbf3bd1c7bacf428168fe14a8f57b70-a52f18bfd8588b44-00",
+        "traceparent": "00-aa9ca7c98c19a842819f33862f057a61-045c03de50ea1b49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "4664ae7e-99d9-63a3-5703-b410df9e4044",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
-        "ETag": "\u00220x8D77DEF05ED4080\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3627675E2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4664ae7e-99d9-63a3-5703-b410df9e4044",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f46-d01e-0015-63d7-af8588000000",
+        "x-ms-request-id": "821b692b-f01e-0021-43dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-d0f85550f1b9894e8938cff384377555-03b5821009d03e41-00",
+        "traceparent": "00-a8b60d83da06114f8ce5ad7e361fcb6d-c2e55387c4b0e24a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ce627c0a-103c-b20a-bcf6-903581cc136b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "VSR5dTHMgHnqVMZGecEPIw==",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
-        "ETag": "\u00220x8D77DEF05F94E68\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F3627DF14F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ce627c0a-103c-b20a-bcf6-903581cc136b",
         "x-ms-content-crc64": "B3Mq8wnVFUo=",
-        "x-ms-request-id": "db366f47-d01e-0015-64d7-af8588000000",
+        "x-ms-request-id": "821b693f-f01e-0021-54dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-58a5b331be323f4187be73fb30211145-6280828e5890f943-00",
+        "traceparent": "00-cbc39cb1af421e4887b07c223e2e7831-aa59e963d3a3b44c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "620692d5-723b-f807-b9f4-30aee9332b01",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
-        "ETag": "\u00220x8D77DEF06058375\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
+        "ETag": "\u00220x8D803F36287DE2E\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "620692d5-723b-f807-b9f4-30aee9332b01",
-        "x-ms-request-id": "db366f48-d01e-0015-65d7-af8588000000",
+        "x-ms-request-id": "821b6966-f01e-0021-76dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528?restype=container\u0026comp=list",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528?restype=container\u0026comp=list",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ee602de9-b1c6-912f-5d9e-a6ad40ee1a11",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:52 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "ee602de9-b1c6-912f-5d9e-a6ad40ee1a11",
-        "x-ms-request-id": "db366f49-d01e-0015-66d7-af8588000000",
+        "x-ms-request-id": "821b6981-f01e-0021-0fdc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-19d99494-29d2-996e-3ddb-e0b080d27528\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05B08582\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05BC9393\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/bar/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05F94E68\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05E10B67\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05ED4080\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05A477B5\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF05D4FDA7\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF06058375\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-19d99494-29d2-996e-3ddb-e0b080d27528\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3624FACF4\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F362574F74\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/bar/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3627DF14F\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3626EAC53\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz/foo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3627675E2\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F362471FEA\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3626709C2\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:53 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F36287DE2E\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EVSR5dTHMgHnqVMZGecEPIw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-19d99494-29d2-996e-3ddb-e0b080d27528?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c8fc1d4317ca2046aa23dcac3373389b-a0321cee5dc69e48-00",
+        "traceparent": "00-83dfa0d1cbeb454e8389c2895d2a6cb6-520ec57fbddb034e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bcc5c4a6-3dd3-983b-99bf-91bf27d258f0",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:04 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bcc5c4a6-3dd3-983b-99bf-91bf27d258f0",
-        "x-ms-request-id": "db366f4b-d01e-0015-68d7-af8588000000",
+        "x-ms-request-id": "821b69bb-f01e-0021-44dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "129689593",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync_MaxResultsAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync_MaxResultsAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0aed8fc53fefd3489e94c7b6d13374b1-f034acc4ec50ec4b-00",
+        "traceparent": "00-5d0d13f30bc53b42be9b57cbe74b1fef-bce473eab1988349-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "8432b3e8-34a5-58ec-0d10-863ae0927db9",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06755F11\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362BC0600\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8432b3e8-34a5-58ec-0d10-863ae0927db9",
-        "x-ms-request-id": "db366f55-d01e-0015-6ed7-af8588000000",
+        "x-ms-request-id": "821b6a00-f01e-0021-04dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-2928a2a35c8d534695fa7154b834615f-71f0536d46d13d40-00",
+        "traceparent": "00-84338d5d3edf0a4789190c67c189af17-9dad68029bd36b44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "936bdc39-8fea-5e14-e9a5-40f7887c507b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF0681B8C3\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362C3E0AE\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "936bdc39-8fea-5e14-e9a5-40f7887c507b",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f5a-d01e-0015-72d7-af8588000000",
+        "x-ms-request-id": "821b6a1a-f01e-0021-19dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-2f64a2700b7d274b86f17605d42feba5-94bc19b534ddf340-00",
+        "traceparent": "00-62786aedc033ac438e1aad84f67f252b-debc882d0032a04f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a08df232-6a24-7dbd-8b87-25d3fcee0c4b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF068DEDB4\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362CDA676\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a08df232-6a24-7dbd-8b87-25d3fcee0c4b",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f5b-d01e-0015-73d7-af8588000000",
+        "x-ms-request-id": "821b6a38-f01e-0021-35dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-080d9219b881c84f81d98cbef115c411-f5c302abc507334e-00",
+        "traceparent": "00-381e4db99beeb046861041552265f654-6517e27c383b6f45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "96c4efe6-afee-c457-065e-7ca343bca281",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF0699FB97\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362D521E3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "96c4efe6-afee-c457-065e-7ca343bca281",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f5c-d01e-0015-74d7-af8588000000",
+        "x-ms-request-id": "821b6a4f-f01e-0021-4cdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-86da62d1f4f2c743ac8afe56d49da2a1-d40a0465b69a684f-00",
+        "traceparent": "00-a845b88e84655b41929f84201b8b4a9b-c775468da1afda42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "0ded93e0-762a-de5c-b104-eec442058d8f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06A6099F\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362DC9D50\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0ded93e0-762a-de5c-b104-eec442058d8f",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f5d-d01e-0015-75d7-af8588000000",
+        "x-ms-request-id": "821b6a61-f01e-0021-5ddc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-e2d26a42c7142140b8831de952b982b2-2a87dc17e3d65a46-00",
+        "traceparent": "00-68ab976fe2a36a46a1202e47b557e7ba-37b4909375c8244f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "afc21cb3-95cf-e357-167c-fc89dc6a3143",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06B23E87\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362E6B146\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "afc21cb3-95cf-e357-167c-fc89dc6a3143",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f5e-d01e-0015-76d7-af8588000000",
+        "x-ms-request-id": "821b6a7d-f01e-0021-75dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-6a5988bafe0a1e4ea64bb50a27bdba72-a57b0aa195cfe149-00",
+        "traceparent": "00-ab0aae49dbb2494bb862765fdadbb9cc-298ff6a452ba5848-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "26102286-dd43-94c0-4b46-4954fb7a3f56",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06BE737D\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362EE53CB\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "26102286-dd43-94c0-4b46-4954fb7a3f56",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f64-d01e-0015-7ad7-af8588000000",
+        "x-ms-request-id": "821b6a8e-f01e-0021-05dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-ec6cc4db5cf2c049add81fc94fb42c70-058c51654d997341-00",
+        "traceparent": "00-04ad5134adf5a249b6390039ed8b69ca-5781cce6879aaf4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b9024af9-0b59-5000-0399-57ca023aed15",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06CAF6A3\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362F5F64F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b9024af9-0b59-5000-0399-57ca023aed15",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f65-d01e-0015-7bd7-af8588000000",
+        "x-ms-request-id": "821b6aa1-f01e-0021-17dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0a78c2ea3e4e3148bdbd6375d9ad0f0b-78d401621a795043-00",
+        "traceparent": "00-fe7759b4cd1e944385aa2e83a3e824ad-d72b7690bfca2d45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b15b5c8d-8578-12fc-09b4-933783f06552",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "wLm21VTFjw\u002BXe5AVbO8U7w==",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06D7049E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F362FD71BC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b15b5c8d-8578-12fc-09b4-933783f06552",
         "x-ms-content-crc64": "Gpe4MIHbfqU=",
-        "x-ms-request-id": "db366f67-d01e-0015-7dd7-af8588000000",
+        "x-ms-request-id": "821b6ab7-f01e-0021-2cdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b5f3cf7b4b2b9f4aac630fd1095a29bf-2b67188514028845-00",
+        "traceparent": "00-52ef0422fa20d4408df5b56969e948e2-a264038f1f6d0140-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a63d884d-3bdf-0d9d-f9a9-167058a82976",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
-        "ETag": "\u00220x8D77DEF06E339B3\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F36304ED29\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a63d884d-3bdf-0d9d-f9a9-167058a82976",
-        "x-ms-request-id": "db366f68-d01e-0015-7ed7-af8588000000",
+        "x-ms-request-id": "821b6acd-f01e-0021-41dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8?restype=container\u0026comp=list\u0026maxresults=2",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8?restype=container\u0026comp=list\u0026maxresults=2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "faea5221-bfb3-b073-6e5d-59178157b5c1",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "faea5221-bfb3-b073-6e5d-59178157b5c1",
-        "x-ms-request-id": "db366f69-d01e-0015-7fd7-af8588000000",
+        "x-ms-request-id": "821b6ae0-f01e-0021-53dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8\u0022\u003E\u003CMaxResults\u003E2\u003C/MaxResults\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:05 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:05 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF068DEDB4\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EwLm21VTFjw\u002BXe5AVbO8U7w==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:05 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:05 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF0699FB97\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EwLm21VTFjw\u002BXe5AVbO8U7w==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!76!MDAwMDExIWJhei9iYXIvZm9vITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8\u0022\u003E\u003CMaxResults\u003E2\u003C/MaxResults\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F362CDA676\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EwLm21VTFjw\u002BXe5AVbO8U7w==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F362D521E3\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EwLm21VTFjw\u002BXe5AVbO8U7w==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!76!MDAwMDExIWJhei9iYXIvZm9vITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-9c28c0cc-7a09-7ba8-6c26-35ad861dd1b8?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-78297054bbb53f47bc468b37be22524c-4dba1d2bb8c35046-00",
+        "traceparent": "00-1acde9f8697390448b03bf1beffa35b2-f86efa2e5d1cb84a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "054fa409-2ebe-83c2-d2cb-44fba0f5723d",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:05 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "054fa409-2ebe-83c2-d2cb-44fba0f5723d",
-        "x-ms-request-id": "db366f6a-d01e-0015-80d7-af8588000000",
+        "x-ms-request-id": "821b6af5-f01e-0021-67dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "714752713",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync_Prefix.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync_Prefix.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1449ad084555134b96cfa5fdbbba78b3-7fa6920265093944-00",
+        "traceparent": "00-cc4f44fbf545f04292fe477dd0004f22-25ae2a0aa0492c4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "4a122db7-b11e-aac6-8bd7-27982557dc31",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:30 GMT",
-        "ETag": "\u00220x8D77DEEF1F8A25F\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:02 GMT",
+        "ETag": "\u00220x8D803F320D37F05\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4a122db7-b11e-aac6-8bd7-27982557dc31",
-        "x-ms-request-id": "db366cc1-d01e-0015-7dd7-af8588000000",
+        "x-ms-request-id": "e253308b-f01e-00e6-3edb-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-d5659634a541774fa1ac8bc51d8eb257-86beeec936dc464e-00",
+        "traceparent": "00-c59a98eebde54242a2c63284cf3f61aa-4c6f7d7d89614243-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "d76f6852-f30a-a0c5-7f77-b5b7585d9ac3",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:30 GMT",
-        "ETag": "\u00220x8D77DEEF205150E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:02 GMT",
+        "ETag": "\u00220x8D803F320EA2E3F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d76f6852-f30a-a0c5-7f77-b5b7585d9ac3",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc3-d01e-0015-7ed7-af8588000000",
+        "x-ms-request-id": "e25330cf-f01e-00e6-7ddb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-53b5b4ae18421b44acf9389a419ff349-10f7386f57cbf049-00",
+        "traceparent": "00-cd111c144575bd46bf94d9ab1bde934a-9dfb59a938193643-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "3daa0985-f342-216d-9470-da0d3fc6ba74",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:30 GMT",
-        "ETag": "\u00220x8D77DEEF2114A31\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:02 GMT",
+        "ETag": "\u00220x8D803F320F21EF6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "3daa0985-f342-216d-9470-da0d3fc6ba74",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc4-d01e-0015-7fd7-af8588000000",
+        "x-ms-request-id": "e25330f8-f01e-00e6-1edb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0aa855970546004aa7f3f9209d8fd6f3-e3c22a4c99e2ab4f-00",
+        "traceparent": "00-58385e2c1bd17e4abca3325f5c8f34ef-2f005abca8a95046-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "4f312f85-5db3-a680-f940-a92bb0af510f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:30 GMT",
-        "ETag": "\u00220x8D77DEEF21D5822\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:02 GMT",
+        "ETag": "\u00220x8D803F320F9C176\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4f312f85-5db3-a680-f940-a92bb0af510f",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc5-d01e-0015-80d7-af8588000000",
+        "x-ms-request-id": "e253311c-f01e-00e6-3cdb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a2cfbeed3a422f49bcadcaeb654128c5-596ef6a7f827d249-00",
+        "traceparent": "00-5ca3a60e2fff9045950236ef5f9f6b44-63b83dee742d1041-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "10875765-6a95-d6c1-41e5-9dfa6f1317fc",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:30 GMT",
-        "ETag": "\u00220x8D77DEEF22C9A6E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:02 GMT",
+        "ETag": "\u00220x8D803F32101B228\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "10875765-6a95-d6c1-41e5-9dfa6f1317fc",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc6-d01e-0015-01d7-af8588000000",
+        "x-ms-request-id": "e2533131-f01e-00e6-51db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-1773012cb77f3741a8d57a1f65edb15d-84e59565ff147648-00",
+        "traceparent": "00-6e6d4b7e64995f4c871cf51c75c5cee3-bb177b1d6d44da4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "58c64b79-4127-1e7a-6284-9289bd50feb6",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
-        "ETag": "\u00220x8D77DEEF238A876\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
+        "ETag": "\u00220x8D803F3210954AC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "58c64b79-4127-1e7a-6284-9289bd50feb6",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc7-d01e-0015-02d7-af8588000000",
+        "x-ms-request-id": "e253315a-f01e-00e6-75db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-e3d014a12c369549bb89794c5b6b6485-8c7aeeb58181d54f-00",
+        "traceparent": "00-8bdea406a05f7f45b5fe87fd4fbf8493-4b8a0cb011c1c648-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "23804931-be4d-4bd5-771e-d356a58a6e94",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:03 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
-        "ETag": "\u00220x8D77DEEF245047D\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
+        "ETag": "\u00220x8D803F32110F735\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "23804931-be4d-4bd5-771e-d356a58a6e94",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc8-d01e-0015-03d7-af8588000000",
+        "x-ms-request-id": "e253317c-f01e-00e6-15db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a05a58d069963442898f87cfa5b0829c-51c46472b9a29c43-00",
+        "traceparent": "00-240122c381a7e349bd1f48027b410cd6-791ef3508d91c347-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "73576c7a-dacf-0c68-bf8b-894bbc2c88b8",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
-        "ETag": "\u00220x8D77DEEF2511273\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
+        "ETag": "\u00220x8D803F32119AB57\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:04 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "73576c7a-dacf-0c68-bf8b-894bbc2c88b8",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366cc9-d01e-0015-04d7-af8588000000",
+        "x-ms-request-id": "e2533192-f01e-00e6-29db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0dcc36f990917643a0682a6201478033-c92dec11b049bf41-00",
+        "traceparent": "00-3802500b1398694fb6f9cb61ec4bcd5f-b1c8533af741bb40-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "38dc63e4-fb32-ebc4-66f8-78b8299e2c9c",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "lHBDhkhYIZJ/eGFzWm4ucA==",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
-        "ETag": "\u00220x8D77DEEF25D2045\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
+        "ETag": "\u00220x8D803F3212174F6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:04 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "38dc63e4-fb32-ebc4-66f8-78b8299e2c9c",
         "x-ms-content-crc64": "DeGSd96/NIM=",
-        "x-ms-request-id": "db366ccb-d01e-0015-06d7-af8588000000",
+        "x-ms-request-id": "e25331b4-f01e-00e6-4adb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8a3d654b35c8b64f860e056e677a5091-5adf28503b24e444-00",
+        "traceparent": "00-76bb0d610338ef4a93820bd1ffaeecc4-b4e5a890662a904e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5867bb55-504f-f285-d21f-aef5592854c2",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:04 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
-        "ETag": "\u00220x8D77DEEF269554C\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
+        "ETag": "\u00220x8D803F3212B61D5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:10:04 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5867bb55-504f-f285-d21f-aef5592854c2",
-        "x-ms-request-id": "db366ccd-d01e-0015-08d7-af8588000000",
+        "x-ms-request-id": "e25331da-f01e-00e6-6cdb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c?restype=container\u0026comp=list\u0026prefix=foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c?restype=container\u0026comp=list\u0026prefix=foo",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6e62c395-d437-bf4c-d7eb-ab7f758e4f63",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "6e62c395-d437-bf4c-d7eb-ab7f758e4f63",
-        "x-ms-request-id": "db366cce-d01e-0015-09d7-af8588000000",
+        "x-ms-request-id": "e25331fa-f01e-00e6-09db-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-763e9087-72f7-5d57-7086-f89f3aa6017c\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:31 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:31 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF205150E\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ElHBDhkhYIZJ/eGFzWm4ucA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:31 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:31 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF238A876\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ElHBDhkhYIZJ/eGFzWm4ucA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:31 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:31 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF269554C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ElHBDhkhYIZJ/eGFzWm4ucA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-763e9087-72f7-5d57-7086-f89f3aa6017c\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:03 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:03 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F320EA2E3F\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ElHBDhkhYIZJ/eGFzWm4ucA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:03 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:03 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3210954AC\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ElHBDhkhYIZJ/eGFzWm4ucA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:10:03 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:10:04 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3212B61D5\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ElHBDhkhYIZJ/eGFzWm4ucA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-763e9087-72f7-5d57-7086-f89f3aa6017c?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e8ffa9dfe1fd484c976ca69c63ac6152-f4ad715aac899d40-00",
+        "traceparent": "00-47a4a1fcbbd65e4da7fd724150c314d9-b55c0d376e82ed40-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "955ffbb2-e5c5-968a-72e6-74410bb04a52",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:32 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:10:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:31 GMT",
+        "Date": "Fri, 29 May 2020 17:10:03 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "955ffbb2-e5c5-968a-72e6-74410bb04a52",
-        "x-ms-request-id": "db366ccf-d01e-0015-0ad7-af8588000000",
+        "x-ms-request-id": "e253323d-f01e-00e6-44db-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "1425492991",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync_PrefixAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsFlatSegmentAsync_PrefixAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6fbdc9ac9df5ad41bdb63cc93ca2a396-be34edd3cdde1d4f-00",
+        "traceparent": "00-1b490edcdcee2e459d0e5155f914f9e5-0b8c928e5b03d843-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "be774420-6751-1479-657c-39c7868ba26a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF0739CED0\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F3631CFC5A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "be774420-6751-1479-657c-39c7868ba26a",
-        "x-ms-request-id": "db366f71-d01e-0015-06d7-af8588000000",
+        "x-ms-request-id": "821b6b0b-f01e-0021-7cdc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-4a443ff82b3600478fbecc9c8c0b39c9-68256d9463d6ee4c-00",
+        "traceparent": "00-c68448abac002d47b6cc3d7e49f4dcca-e3182f1e8cf60f4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "1774c2bd-a264-f4d3-6070-14967d91086a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF0746416B\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F36324D70A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1774c2bd-a264-f4d3-6070-14967d91086a",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f73-d01e-0015-07d7-af8588000000",
+        "x-ms-request-id": "821b6b16-f01e-0021-06dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a308841fd014f24a80e9070278e9069e-167bf8c797d8db42-00",
+        "traceparent": "00-465b2c3f325ffc4c9a36aa4cafa44203-d40ec298d0552346-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "7f32e654-24fc-9a88-7c05-29d9624de96d",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF07524F61\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:06 GMT",
+        "Date": "Fri, 29 May 2020 17:11:53 GMT",
+        "ETag": "\u00220x8D803F3632C5277\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7f32e654-24fc-9a88-7c05-29d9624de96d",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f75-d01e-0015-09d7-af8588000000",
+        "x-ms-request-id": "821b6b28-f01e-0021-17dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-666274b2b554b141b90cac8aa167f8de-953437660a96f04f-00",
+        "traceparent": "00-7c9ba1572bb359488e2b69ae8a5e30ca-724cf599470a7841-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "96426b00-885f-fa6e-8c42-85e88722f6dc",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF075EAB52\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F36333CDE9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "96426b00-885f-fa6e-8c42-85e88722f6dc",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f76-d01e-0015-0ad7-af8588000000",
+        "x-ms-request-id": "821b6b3d-f01e-0021-2cdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-7dd9ff3ca9ae9e4f807f885469d22f4d-fad8f3407fa3a843-00",
+        "traceparent": "00-b9110f795b476e41a36b63e22229a455-ff5795fa152f5f48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f6d903db-520a-410d-90ec-2ec947f384a3",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF076BCAB2\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F3633E300D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f6d903db-520a-410d-90ec-2ec947f384a3",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f77-d01e-0015-0bd7-af8588000000",
+        "x-ms-request-id": "821b6b5a-f01e-0021-47dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-7672bc84cd0f024f86b11d7d227cafdf-32f0726d4fd52147-00",
+        "traceparent": "00-d19db9fbd75c3242ab36462819437f06-5dd7a4da665a4644-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "840da435-ff49-7cd1-9a2c-3a6785d43e17",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF077826F0\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F36345F9A9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "840da435-ff49-7cd1-9a2c-3a6785d43e17",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f78-d01e-0015-0cd7-af8588000000",
+        "x-ms-request-id": "821b6b6c-f01e-0021-58dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-8b37ddc9ec705548b7f3057c5b2ffff6-024505fd8b509b43-00",
+        "traceparent": "00-4df676251f7a594fb534a0ebc8148536-064b3dd34dd8d844-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a3947f28-00e5-2559-415f-4a02246ac7fa",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF078434FC\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F3634D9C2D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a3947f28-00e5-2559-415f-4a02246ac7fa",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f79-d01e-0015-0dd7-af8588000000",
+        "x-ms-request-id": "821b6b85-f01e-0021-71dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-d5a328d5bd66f34e95e7b0f3e75d0737-5f64c1f7bb98be42-00",
+        "traceparent": "00-f711da226a1cf44c858c8c8c56a6d3ff-4456edf3bf3d7040-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "063e36ba-9b3f-a032-bc96-e2a0ddae57c7",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF07901BDC\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363553EAD\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "063e36ba-9b3f-a032-bc96-e2a0ddae57c7",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f7a-d01e-0015-0ed7-af8588000000",
+        "x-ms-request-id": "821b6b99-f01e-0021-05dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-e131baca33cc4549853f48e6a0482954-fd5d24abf6e4974c-00",
+        "traceparent": "00-b855dc41eb4a8d4a824266cc3e02a3f2-2e6f8f4553081e4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ee4885aa-c02b-e0ba-41f7-fc3abd0f2f45",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gblHjFQFuD0ij/HeGDf7Iw==",
-        "Date": "Wed, 11 Dec 2019 04:03:06 GMT",
-        "ETag": "\u00220x8D77DEF079C50FE\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F3635D2F5F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ee4885aa-c02b-e0ba-41f7-fc3abd0f2f45",
         "x-ms-content-crc64": "Ley3Sl5O760=",
-        "x-ms-request-id": "db366f7b-d01e-0015-0fd7-af8588000000",
+        "x-ms-request-id": "821b6bb0-f01e-0021-1cdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9ba2cdf1e51b1b4d959c2e07ede2a00f-f2c15d02c0caae4c-00",
+        "traceparent": "00-417b735b78ef4f40ac4509abf3cda5ff-3185367c65991a4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "58f52347-6965-049b-74f1-1044bdf8cbc0",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:07 GMT",
-        "ETag": "\u00220x8D77DEF07A85ED0\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F36364D1EC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "58f52347-6965-049b-74f1-1044bdf8cbc0",
-        "x-ms-request-id": "db366f7c-d01e-0015-10d7-af8588000000",
+        "x-ms-request-id": "821b6bc1-f01e-0021-2ddc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f?restype=container\u0026comp=list\u0026prefix=foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f?restype=container\u0026comp=list\u0026prefix=foo",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "99f3dc05-d719-d1e0-eef2-33bf5244430b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "99f3dc05-d719-d1e0-eef2-33bf5244430b",
-        "x-ms-request-id": "db366f7d-d01e-0015-11d7-af8588000000",
+        "x-ms-request-id": "821b6bdd-f01e-0021-45dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF0746416B\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EgblHjFQFuD0ij/HeGDf7Iw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:07 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:07 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF077826F0\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EgblHjFQFuD0ij/HeGDf7Iw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:07 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:07 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF07A85ED0\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EgblHjFQFuD0ij/HeGDf7Iw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F36324D70A\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EgblHjFQFuD0ij/HeGDf7Iw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F36345F9A9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EgblHjFQFuD0ij/HeGDf7Iw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:54 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F36364D1EC\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EgblHjFQFuD0ij/HeGDf7Iw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-21b5ddad-6ee0-87a6-f9bc-0b99dce73b6f?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c3de71a5a41a794d94392189e3587696-9a04cca9d07e7149-00",
+        "traceparent": "00-c22b5d85a2f47846a7c58062618721fc-e9c53b08e9b5dc48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e13eadfd-3204-80a6-8848-35b2734ff4b7",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:07 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e13eadfd-3204-80a6-8848-35b2734ff4b7",
-        "x-ms-request-id": "db366f7f-d01e-0015-13d7-af8588000000",
+        "x-ms-request-id": "821b6c0a-f01e-0021-6ddc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "533742588",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fe82ed9108820e41ab8a34d4abf447c8-8a5ac64629eea44e-00",
+        "traceparent": "00-da8acc1f7a2e844ba626667eef9a96e1-952cae806095fa42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "de930545-ad71-129e-eddc-95d011809f37",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:33 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF39A8822\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:33 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F3082B1905\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "de930545-ad71-129e-eddc-95d011809f37",
-        "x-ms-request-id": "db366cf4-d01e-0015-28d7-af8588000000",
+        "x-ms-request-id": "e252d829-f01e-00e6-7cdb-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-238a1ae831f681489f6d0e232e974ec9-711df5f6e7857543-00",
+        "traceparent": "00-e549624ed3670541bdc8248041f1d6c1-6c44ea75ea21444f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "4f28f373-8be8-a5d7-ef40-5c866bd0aa3f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:33 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3A75479\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:33 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F308475B42\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4f28f373-8be8-a5d7-ef40-5c866bd0aa3f",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cf6-d01e-0015-29d7-af8588000000",
+        "x-ms-request-id": "e252d875-f01e-00e6-40db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-60d8aaada78c9d45a22d74feb7820460-002f32cebf7ccf4c-00",
+        "traceparent": "00-bafdb15e7f629843a53f8e8688b3852c-ffee9da36719744a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "85a1b26e-af6e-6f3d-ddf1-3f8dcc1ea053",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3B3897C\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F308505D92\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "85a1b26e-af6e-6f3d-ddf1-3f8dcc1ea053",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cf7-d01e-0015-2ad7-af8588000000",
+        "x-ms-request-id": "e252d894-f01e-00e6-59db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0672fe5c4f1270438bb4a509227241b7-7845353729d6f245-00",
+        "traceparent": "00-38a1a14c58b9374f9c3aff3c31c89457-fcbc3bf78d1b4647-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b8188307-242e-cdd0-2e4a-34ebe6f57c40",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3BFBE56\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F308582732\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b8188307-242e-cdd0-2e4a-34ebe6f57c40",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cfa-d01e-0015-2dd7-af8588000000",
+        "x-ms-request-id": "e252d8ab-f01e-00e6-6cdb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-e927dd6210690f48afe826c138cc3841-896e0fdccb57d447-00",
+        "traceparent": "00-b57b31aa258e3f45ad4ec529cffd46fc-6012ff620c35b94e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "498641ae-e806-4025-ac22-c094924d677a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3CBF38F\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F3085FC9B6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "498641ae-e806-4025-ac22-c094924d677a",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cfb-d01e-0015-2ed7-af8588000000",
+        "x-ms-request-id": "e252d8b8-f01e-00e6-79db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-11abfb7bfcb3c0408e48870fa1837807-7056e17672ea6143-00",
+        "traceparent": "00-54f12b89ad423b409062d7f9666ccd7b-fa6f8b005b83d546-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a43ddb23-336f-ff3a-caad-37e08965152d",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3D84F65\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F30867BA64\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a43ddb23-336f-ff3a-caad-37e08965152d",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cfc-d01e-0015-2fd7-af8588000000",
+        "x-ms-request-id": "e252d8d4-f01e-00e6-12db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a88550e89647e04aaa4055007850c1d0-84ea7fbe64325c44-00",
+        "traceparent": "00-e310ef933edbe34ebc9ac729fcd90c38-5377dbe81b4c5144-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b6717014-c30f-2e0b-7577-8de9271b3423",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3E4849A\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F3086FAB1B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b6717014-c30f-2e0b-7577-8de9271b3423",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cfe-d01e-0015-31d7-af8588000000",
+        "x-ms-request-id": "e252d8f2-f01e-00e6-2ddb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-85e6c7a474399e479948783df68e157f-42bcaa05f2273e4a-00",
+        "traceparent": "00-fe613c934c5c3b4d857a028af60a36a2-50f95ebff2741941-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "18cbcb7c-5ef4-281d-8efe-9af041d7272a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3F0E0C5\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F3087774B2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "18cbcb7c-5ef4-281d-8efe-9af041d7272a",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366cff-d01e-0015-32d7-af8588000000",
+        "x-ms-request-id": "e252d90e-f01e-00e6-49db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-5eaff21ce681c643ba72d47d5fea3b00-56340f8aea0f2b43-00",
+        "traceparent": "00-40402c70cca3074381e3087a1a7d4ee8-bf1eefdda947fa47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "5b6d0d22-1b4f-fc2f-f2c5-e61464f71243",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "fEl916NO5loNVYBdtiqiTw==",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF3FD3CF1\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F3087F1732\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5b6d0d22-1b4f-fc2f-f2c5-e61464f71243",
         "x-ms-content-crc64": "kaaAtX9PLoM=",
-        "x-ms-request-id": "db366d00-d01e-0015-33d7-af8588000000",
+        "x-ms-request-id": "e252d920-f01e-00e6-5adb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e12255cb21cf6f409e942346c2822b83-755d8c8e1229b247-00",
+        "traceparent": "00-dcf5b756b2678e47a419c0b3d95aa5bd-eceb21718dca9f4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "34cec944-cc6a-79db-6c3e-a796d644b190",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:33 GMT",
-        "ETag": "\u00220x8D77DEEF409BF94\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:21 GMT",
+        "ETag": "\u00220x8D803F30889C789\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "34cec944-cc6a-79db-6c3e-a796d644b190",
-        "x-ms-request-id": "db366d01-d01e-0015-34d7-af8588000000",
+        "x-ms-request-id": "e252d93c-f01e-00e6-71db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585?restype=container\u0026comp=list\u0026delimiter=%2F",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585?restype=container\u0026comp=list\u0026delimiter=%2F",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9acfbd01-dd29-fad9-5898-6b2a138de92e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "9acfbd01-dd29-fad9-5898-6b2a138de92e",
-        "x-ms-request-id": "db366d02-d01e-0015-35d7-af8588000000",
+        "x-ms-request-id": "e252d959-f01e-00e6-0cdb-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585\u0022\u003E\u003CDelimiter\u003E/\u003C/Delimiter\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:34 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:34 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF3B3897C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfEl916NO5loNVYBdtiqiTw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:34 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:34 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF3BFBE56\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfEl916NO5loNVYBdtiqiTw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Ebaz/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:33 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:33 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF3A75479\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfEl916NO5loNVYBdtiqiTw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Efoo/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585\u0022\u003E\u003CDelimiter\u003E/\u003C/Delimiter\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:09:22 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:09:22 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F308505D92\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfEl916NO5loNVYBdtiqiTw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:09:22 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:09:22 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F308582732\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfEl916NO5loNVYBdtiqiTw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Ebaz/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:09:22 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:09:22 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F308475B42\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EfEl916NO5loNVYBdtiqiTw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Efoo/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-94d491c6-a67f-cae6-145a-c0a3f1d65585?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-864d205fe79ce841ba4b8dd048eb2a3e-e288d0f146e43e46-00",
+        "traceparent": "00-bda9b634416d254c8f4382704fb988ca-4a8675b29122d341-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1895b005-1775-2d67-7f60-d8bc773c535a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:34 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1895b005-1775-2d67-7f60-d8bc773c535a",
-        "x-ms-request-id": "db366d03-d01e-0015-36d7-af8588000000",
+        "x-ms-request-id": "e252d9a5-f01e-00e6-55db-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "102017201",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsyncAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsyncAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b7c6fab7ad083d4f81fb5603bdcf7b36-4022b69af4411944-00",
+        "traceparent": "00-7c530c931790a54e9e7235a56c47b68e-4680c590fa04f645-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "452f5882-ee4b-e8f3-9cb7-2964b6e873e7",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:08 GMT",
-        "ETag": "\u00220x8D77DEF08DAA39A\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F36383C031\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "452f5882-ee4b-e8f3-9cb7-2964b6e873e7",
-        "x-ms-request-id": "db366fa6-d01e-0015-32d7-af8588000000",
+        "x-ms-request-id": "821b6c21-f01e-0021-04dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-400958f571f3e449b22f44f5658e4e96-c0a051b20742ec4e-00",
+        "traceparent": "00-2afa12900eb9994cab01ede09f3a5a10-47503525d1ee2840-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "fc464748-acd1-9b03-c298-0f33df40c6fa",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF08E72104\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F3638B9AD9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fc464748-acd1-9b03-c298-0f33df40c6fa",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fa9-d01e-0015-34d7-af8588000000",
+        "x-ms-request-id": "821b6c34-f01e-0021-16dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-579009b996c8634eac98c636e1ed7e47-f9af1a7f8e57f64a-00",
+        "traceparent": "00-c71b71134faa034ebf6573ee40a22b39-eeccb53d251b1148-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "0bad7fd6-e652-76b6-5108-aa4211770961",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF08F355F0\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363938B88\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0bad7fd6-e652-76b6-5108-aa4211770961",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366faa-d01e-0015-35d7-af8588000000",
+        "x-ms-request-id": "821b6c58-f01e-0021-3adc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-2908329b0cb07f4e9fe3f7791b7a7c0d-8b4749260ab4c84e-00",
+        "traceparent": "00-90d666797b0c124296001b5f8d20d750-9a1a190302b7d343-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "605d502a-bb92-8aa8-80db-7c6f3cfe7d8f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF08FFB20E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F3639B06F9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "605d502a-bb92-8aa8-80db-7c6f3cfe7d8f",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fab-d01e-0015-36d7-af8588000000",
+        "x-ms-request-id": "821b6c7c-f01e-0021-5adc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-46e26f85a600fa47bad6f0bd63ffba7d-4e6e56b7ef095043-00",
+        "traceparent": "00-6f16f6f4d497c247b2552624f555fe8b-ecb687efa6c6924b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "c017e829-a91a-5acf-3700-0f6262152407",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF090BBFF2\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363A28266\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c017e829-a91a-5acf-3700-0f6262152407",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fad-d01e-0015-37d7-af8588000000",
+        "x-ms-request-id": "821b6c91-f01e-0021-6fdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-20403ad2983590459831457d4a13fbdf-3bc17688bf6ca143-00",
+        "traceparent": "00-3176c0c2ec335b4aa8ed7a93b06c4c25-82c30304cdf6044d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "534595ef-bde6-3b75-f027-a574ce1f94e4",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF0917F4DA\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363A9FDD3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "534595ef-bde6-3b75-f027-a574ce1f94e4",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fb1-d01e-0015-39d7-af8588000000",
+        "x-ms-request-id": "821b6ca4-f01e-0021-80dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a1b855d2d1964d459a9afb5bbe085ab7-05df2732898bcd40-00",
+        "traceparent": "00-cdf9fcb8896c5b4e903e64a2f6a07fcd-c6377ad9e89f274b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "cc736367-d0cf-7c20-f1c3-dac15cd77eaf",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF09249F17\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363B2159D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "cc736367-d0cf-7c20-f1c3-dac15cd77eaf",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fb2-d01e-0015-3ad7-af8588000000",
+        "x-ms-request-id": "821b6cc1-f01e-0021-1adc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-bfadfaecd9f03046aec8bf61f4928463-5047a6223449954e-00",
+        "traceparent": "00-068255cf99d8ea459985fc2e6988b858-c06d5d79b91f3143-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "6a0d7c82-c8ac-5815-dce3-9811463ccac4",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF0930FB59\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363BAC9C3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6a0d7c82-c8ac-5815-dce3-9811463ccac4",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fb6-d01e-0015-3cd7-af8588000000",
+        "x-ms-request-id": "821b6cd8-f01e-0021-31dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a653a159451f07458f81f53212801dbe-bc6533a36709bf4d-00",
+        "traceparent": "00-8b5ef37e2ad15541a09e9097e8985e72-84b68a258438a745-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "df3f74cb-13ca-0803-6bc4-dcca76c7865b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "9LylMPdRBLeB2LOTvB0/GA==",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF093D3038\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363C2935A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "df3f74cb-13ca-0803-6bc4-dcca76c7865b",
         "x-ms-content-crc64": "q6ESwD0zrOQ=",
-        "x-ms-request-id": "db366fb9-d01e-0015-3fd7-af8588000000",
+        "x-ms-request-id": "821b6cf3-f01e-0021-48dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a91e80ea9292c141add8b6eec916d8ce-1a908081d9709749-00",
+        "traceparent": "00-f4f0c9cf9dc11a48ade4529a3b9ea2ea-f9511708e7d3f446-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d2456933-eafc-3afa-3dd9-56a910afe1c3",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
-        "ETag": "\u00220x8D77DEF09498C99\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "Date": "Fri, 29 May 2020 17:11:54 GMT",
+        "ETag": "\u00220x8D803F363CA0EC7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d2456933-eafc-3afa-3dd9-56a910afe1c3",
-        "x-ms-request-id": "db366fba-d01e-0015-40d7-af8588000000",
+        "x-ms-request-id": "821b6d03-f01e-0021-56dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9?restype=container\u0026comp=list\u0026delimiter=%2F",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9?restype=container\u0026comp=list\u0026delimiter=%2F",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0d970484-b481-6a5e-f993-4e05df4e8553",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "0d970484-b481-6a5e-f993-4e05df4e8553",
-        "x-ms-request-id": "db366fbb-d01e-0015-41d7-af8588000000",
+        "x-ms-request-id": "821b6d1f-f01e-0021-6ddc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-18cbc38f-93e8-b528-9201-74550519c9f9\u0022\u003E\u003CDelimiter\u003E/\u003C/Delimiter\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:09 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:09 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF08F355F0\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E9LylMPdRBLeB2LOTvB0/GA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:09 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:09 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF08FFB20E\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E9LylMPdRBLeB2LOTvB0/GA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Ebaz/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:09 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:09 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF08E72104\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E9LylMPdRBLeB2LOTvB0/GA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Efoo/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-18cbc38f-93e8-b528-9201-74550519c9f9\u0022\u003E\u003CDelimiter\u003E/\u003C/Delimiter\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F363938B88\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E9LylMPdRBLeB2LOTvB0/GA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3639B06F9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E9LylMPdRBLeB2LOTvB0/GA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Ebaz/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:11:55 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3638B9AD9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003E9LylMPdRBLeB2LOTvB0/GA==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlobPrefix\u003E\u003CName\u003Efoo/\u003C/Name\u003E\u003C/BlobPrefix\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-18cbc38f-93e8-b528-9201-74550519c9f9?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-17968af2260d2c44aab9669a58385a61-1c30727e05c2e64c-00",
+        "traceparent": "00-f5f3c9a569f1a8408de661332eec98b0-8826c01a17ab6c42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0b244e65-d318-6942-79f1-2ca3d54ab62d",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:11:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:09 GMT",
+        "Date": "Fri, 29 May 2020 17:11:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0b244e65-d318-6942-79f1-2ca3d54ab62d",
-        "x-ms-request-id": "db366fbd-d01e-0015-42d7-af8588000000",
+        "x-ms-request-id": "821b6d59-f01e-0021-19dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "1542115839",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync_MaxResultsAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync_MaxResultsAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-06be47d8773a68499a95b5b05eab85b1-b2e22558f182e04c-00",
+        "traceparent": "00-7e4b1b84d1e57a4d9c720370c17a92e8-4de963f612df7e4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e4b53493-9e72-58d8-57af-5a441c2a703f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF09B7CF13\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:10 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F387EDBD0D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e4b53493-9e72-58d8-57af-5a441c2a703f",
-        "x-ms-request-id": "db366fc7-d01e-0015-48d7-af8588000000",
+        "x-ms-request-id": "821bd226-f01e-0021-11dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-7b96e3a000dc8542a4d08dffd8e5ae27-29bfc8f36da7c646-00",
+        "traceparent": "00-ef3853d8ee4dd64fba426a87f2e8550c-1dbff838626c0d40-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ccb2720d-d4c2-d275-fab3-280cd80202dd",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF09C3ECC1\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F388085B64\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ccb2720d-d4c2-d275-fab3-280cd80202dd",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fc9-d01e-0015-49d7-af8588000000",
+        "x-ms-request-id": "821bd286-f01e-0021-60dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0aebf75bca1bd944850545ad7ceb5d6e-3b3b6af8ab6fb545-00",
+        "traceparent": "00-6375785a48b5d94e9580b59e1dd4a61d-b19703d4937c9e47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "dcf813ac-6d9c-450a-fd14-1c620f0e87e7",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF09D048D5\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F388115DB8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "dcf813ac-6d9c-450a-fd14-1c620f0e87e7",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fcb-d01e-0015-4bd7-af8588000000",
+        "x-ms-request-id": "821bd2ab-f01e-0021-7fdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-6b3ebc15f8cd7b4cad551537005ad733-0b6cd7b3cc90754c-00",
+        "traceparent": "00-3feefd101ca21748a3c42278cee8d8cf-ebc6b10370b38f41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "c55f1cd4-2509-b440-f7f9-200583355cdb",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF09DCA4F3\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F388194E6A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c55f1cd4-2509-b440-f7f9-200583355cdb",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fcc-d01e-0015-4cd7-af8588000000",
+        "x-ms-request-id": "821bd2c7-f01e-0021-17dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-e573e914275e9648b4d06b6a291856d7-d9684b3c1fed5d43-00",
+        "traceparent": "00-59a5b6a093a8ed4d893d3366ddd314a8-16dbc8974b705940-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f38de208-c1af-80dd-d54f-24daecf0e9a4",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF09E8B31B\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F38820C9DC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f38de208-c1af-80dd-d54f-24daecf0e9a4",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fcd-d01e-0015-4dd7-af8588000000",
+        "x-ms-request-id": "821bd2ee-f01e-0021-3adc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-51955b365a25a34889f5d906b4392623-40f7a0703edcbc47-00",
+        "traceparent": "00-0fe5a633d2691b45b8635ee63cc6ff0d-d8ae8bd92b6d114b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a0fdfed1-69a7-f02c-f274-db6c9e5eb22b",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF09F4C0BF\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F388292FCF\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a0fdfed1-69a7-f02c-f274-db6c9e5eb22b",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fd0-d01e-0015-4fd7-af8588000000",
+        "x-ms-request-id": "821bd2fd-f01e-0021-49dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-67feface4f3a794eb793cac2eceab054-4362a0b922031647-00",
+        "traceparent": "00-8df1f72f65803643a3c82333a1130042-3b73d3a32e7e0745-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ee09ae26-48f3-81fd-dbe5-59717e107285",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF0A00F5E2\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:56 GMT",
+        "ETag": "\u00220x8D803F38830D254\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ee09ae26-48f3-81fd-dbe5-59717e107285",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fd1-d01e-0015-50d7-af8588000000",
+        "x-ms-request-id": "821bd325-f01e-0021-6cdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-fdfe6762f752d74584ad3bb951b63ae4-ad05570476088444-00",
+        "traceparent": "00-93df32fe3899414698d85d1f4fce5075-15c3caa1e7bf9246-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f046f217-c354-5938-5fe9-a7c681ca2f55",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:10 GMT",
-        "ETag": "\u00220x8D77DEF0A0D7951\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F3883B5B8F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f046f217-c354-5938-5fe9-a7c681ca2f55",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fd2-d01e-0015-51d7-af8588000000",
+        "x-ms-request-id": "821bd351-f01e-0021-12dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-6162620decf3684a8c4f25de6da87c34-06107c7c5cc93e48-00",
+        "traceparent": "00-18793981a71ccd44b2fcf2bd83996409-287ad4f0051a3545-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "8c59c60e-82ca-4a30-4482-6697ff0374f7",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "KIIDEQcdpxTLiCPa1emZqw==",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
-        "ETag": "\u00220x8D77DEF0A19FC38\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388434C46\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8c59c60e-82ca-4a30-4482-6697ff0374f7",
         "x-ms-content-crc64": "d9lCzVqMkRs=",
-        "x-ms-request-id": "db366fd3-d01e-0015-52d7-af8588000000",
+        "x-ms-request-id": "821bd373-f01e-0021-31dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6c55a36b90896242a60f6f86d6ca48b8-30773c011bf2d842-00",
+        "traceparent": "00-eeaf5aa08c53344a99b24b38b257d283-7797ce25b6350a45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bbb808c1-a371-878a-5996-580030d180e0",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
-        "ETag": "\u00220x8D77DEF0A260A33\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F3884D6038\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bbb808c1-a371-878a-5996-580030d180e0",
-        "x-ms-request-id": "db366fd4-d01e-0015-53d7-af8588000000",
+        "x-ms-request-id": "821bd393-f01e-0021-4cdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be?restype=container\u0026comp=list\u0026delimiter=%2F\u0026maxresults=2",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be?restype=container\u0026comp=list\u0026delimiter=%2F\u0026maxresults=2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f6d6d836-b94b-7b86-5b9a-76c5e00f4fb8",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "f6d6d836-b94b-7b86-5b9a-76c5e00f4fb8",
-        "x-ms-request-id": "db366fd5-d01e-0015-54d7-af8588000000",
+        "x-ms-request-id": "821bd3ba-f01e-0021-71dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be\u0022\u003E\u003CMaxResults\u003E2\u003C/MaxResults\u003E\u003CDelimiter\u003E/\u003C/Delimiter\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:11 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:11 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF09D048D5\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EKIIDEQcdpxTLiCPa1emZqw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:11 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:11 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF09DCA4F3\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EKIIDEQcdpxTLiCPa1emZqw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!76!MDAwMDExIWJhei9iYXIvZm9vITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be\u0022\u003E\u003CMaxResults\u003E2\u003C/MaxResults\u003E\u003CDelimiter\u003E/\u003C/Delimiter\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Ebar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:12:56 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:12:56 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F388115DB8\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EKIIDEQcdpxTLiCPa1emZqw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Ebaz\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:12:56 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:12:56 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F388194E6A\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EKIIDEQcdpxTLiCPa1emZqw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker\u003E2!76!MDAwMDExIWJhei9iYXIvZm9vITAwMDAyOCE5OTk5LTEyLTMxVDIzOjU5OjU5Ljk5OTk5OTlaIQ--\u003C/NextMarker\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-a749997c-0d35-bec6-9802-2e4d7c6a36be?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-12f00493f1a3ad40b8223bdf9cb1c0c8-571f00a80c081b4f-00",
+        "traceparent": "00-3b1231489a2c194c887a70b8e0e83aab-b766f088ce31ff4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "58c9a7e4-89fb-e695-ae0a-cb15e17cf3a6",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "58c9a7e4-89fb-e695-ae0a-cb15e17cf3a6",
-        "x-ms-request-id": "db366fd6-d01e-0015-55d7-af8588000000",
+        "x-ms-request-id": "821bd3e7-f01e-0021-16dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "763495",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync_Prefix.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync_Prefix.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-5a5e41ec910bc040903d08131d9c5368-a9a039e9e483b842-00",
+        "traceparent": "00-64c4a91d6fa43e4fb0356166ee2ced28-aca454e26793e547-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "a4a5286b-8aa2-8544-3805-b8b0e3aa7533",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:34 GMT",
-        "ETag": "\u00220x8D77DEEF4AFB67C\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308C30942\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a4a5286b-8aa2-8544-3805-b8b0e3aa7533",
-        "x-ms-request-id": "db366d14-d01e-0015-42d7-af8588000000",
+        "x-ms-request-id": "e252da0c-f01e-00e6-31db-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-2fe5becf6b6d5746a60e0ed40d12e35c-6651516a6da5fc43-00",
+        "traceparent": "00-dd09d3470335d04b8a880e32f0893abb-d5c4723c5bdc8949-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "181cb0c4-02d5-badf-3540-31bf2bf89ad7",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF4BBD1FA\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308CBE5A6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "181cb0c4-02d5-badf-3540-31bf2bf89ad7",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d1a-d01e-0015-45d7-af8588000000",
+        "x-ms-request-id": "e252da2c-f01e-00e6-4cdb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-37b84b60e9277c46a271e238967129d6-c391a0752dfd7649-00",
+        "traceparent": "00-b97f2b118238d84d8518bebd0288d0c4-a8c2e79b68b39b48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "538e1019-67ed-ff0d-be16-f59f012151d8",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF4C7DFF5\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308D3882F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "538e1019-67ed-ff0d-be16-f59f012151d8",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d1b-d01e-0015-46d7-af8588000000",
+        "x-ms-request-id": "e252da46-f01e-00e6-64db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-cbc2b0c8b801244eb700e5e0cc9f106f-01f8dc432ed89e45-00",
+        "traceparent": "00-602c6467c4eba34888044ea8f5ed7a3c-393d8316aa8c1b45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "1ba5b478-4669-fce9-7b37-041797e341d0",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF4D43BF3\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308DB51C6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1ba5b478-4669-fce9-7b37-041797e341d0",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d1e-d01e-0015-48d7-af8588000000",
+        "x-ms-request-id": "e252da5c-f01e-00e6-7adb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a6166abc72a8be4d84f910ebe51013e6-19aaa41f85b88d4b-00",
+        "traceparent": "00-0674e7d0ade06d40afdb534817ae51ca-ddc0f68c4be9ad4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "4d266cca-367c-166e-e5df-eb222da4a04a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF4E0981E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308E2F44E\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4d266cca-367c-166e-e5df-eb222da4a04a",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d1f-d01e-0015-49d7-af8588000000",
+        "x-ms-request-id": "e252da78-f01e-00e6-14db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-95ed3fbd98fa624e864b739d2520a99b-14b9ca2e45fb9849-00",
+        "traceparent": "00-ada8d169c5726b4b8137f18199c496fb-f4dfe07361aa5746-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "2b4c83de-f4bc-9154-152f-b8f27500baaf",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF4ECCD06\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308EA96CE\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "2b4c83de-f4bc-9154-152f-b8f27500baaf",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d21-d01e-0015-4bd7-af8588000000",
+        "x-ms-request-id": "e252da94-f01e-00e6-2fdb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-e852c071b6818444abd1bebf174810fb-4956cb81843e2846-00",
+        "traceparent": "00-0335ec94d8762944b65ac4ef257ccceb-2f50601528c19846-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a943c124-7458-a38e-0160-0dc9f3c5a390",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF4F8B449\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308F2606A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a943c124-7458-a38e-0160-0dc9f3c5a390",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d22-d01e-0015-4cd7-af8588000000",
+        "x-ms-request-id": "e252daaf-f01e-00e6-4adb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-0f7075c24eb0b7499c22a9690ea9b4ca-8021000d3af44d49-00",
+        "traceparent": "00-658261274af94241bd3fe9c9b8c2876a-f0b0f6a4e500e34a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b3cea739-10bd-4257-4dd9-e9ff28bf29ef",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF5051008\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F308F9DBD7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b3cea739-10bd-4257-4dd9-e9ff28bf29ef",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d23-d01e-0015-4dd7-af8588000000",
+        "x-ms-request-id": "e252dad4-f01e-00e6-6adb-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-a1c88cab50312d4ab93b1f9b44cbe81f-1fa4f4f7ff4d8241-00",
+        "traceparent": "00-ef40bda5f382974b8fd6e9c3cfce17a5-9c5c73662e996549-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "4b90543f-eff7-f3d3-bf18-f77ee5ca7f3a",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "bri4anPkYXJeuIHDtkjhcw==",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF5116C3D\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F309017E5B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4b90543f-eff7-f3d3-bf18-f77ee5ca7f3a",
         "x-ms-content-crc64": "75ceE6ZwLGM=",
-        "x-ms-request-id": "db366d24-d01e-0015-4ed7-af8588000000",
+        "x-ms-request-id": "e252daee-f01e-00e6-03db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0a22fdc3b23beb4e93ae5ec430e24786-59d1e9729f649b49-00",
+        "traceparent": "00-2089af68e78f5d47b8287a7b19448e9a-e314ea56cd4ad84e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d4bf7e6f-dd2f-7bf7-57c6-9ae8b93b6f2d",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
-        "ETag": "\u00220x8D77DEEF51DC852\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
+        "ETag": "\u00220x8D803F3090920DF\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:09:23 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d4bf7e6f-dd2f-7bf7-57c6-9ae8b93b6f2d",
-        "x-ms-request-id": "db366d25-d01e-0015-4fd7-af8588000000",
+        "x-ms-request-id": "e252db04-f01e-00e6-19db-3583eb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a?restype=container\u0026comp=list\u0026prefix=foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a?restype=container\u0026comp=list\u0026prefix=foo",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "670e8bd4-aa0a-270b-8fc5-b6152ed0cfb3",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "670e8bd4-aa0a-270b-8fc5-b6152ed0cfb3",
-        "x-ms-request-id": "db366d26-d01e-0015-50d7-af8588000000",
+        "x-ms-request-id": "e252db2c-f01e-00e6-3adb-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:35 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:35 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF4BBD1FA\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003Ebri4anPkYXJeuIHDtkjhcw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:36 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:36 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF4ECCD06\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003Ebri4anPkYXJeuIHDtkjhcw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:02:36 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:02:36 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEEF51DC852\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003Ebri4anPkYXJeuIHDtkjhcw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:09:23 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:09:23 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F308CBE5A6\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003Ebri4anPkYXJeuIHDtkjhcw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:09:23 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:09:23 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F308EA96CE\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003Ebri4anPkYXJeuIHDtkjhcw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:09:23 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:09:23 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3090920DF\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003Ebri4anPkYXJeuIHDtkjhcw==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fbb48304-f58e-a9d4-0a7f-2f7a11dc4a4a?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f11378a05e11314ca39628250f90ece5-fe45cd35d8538644-00",
+        "traceparent": "00-4cd56325e7b7c741bfe4620104c3ce92-0d3dff73d147b54d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2e130933-082c-7122-6afc-e6d9a67948cb",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:36 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:35 GMT",
+        "Date": "Fri, 29 May 2020 17:09:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "2e130933-082c-7122-6afc-e6d9a67948cb",
-        "x-ms-request-id": "db366d27-d01e-0015-51d7-af8588000000",
+        "x-ms-request-id": "e252db58-f01e-00e6-65db-3583eb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "475093929",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync_PrefixAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListBlobsHierarchySegmentAsync_PrefixAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-085e17e4ff51464d9b695ef8cfc1cc96-d2862cacaa861d4e-00",
+        "traceparent": "00-a1c293013506384c87b23385551f0446-7491fe060fac7c4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "84c5b90d-12a3-9164-9a64-150a0d9f9910",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
-        "ETag": "\u00220x8D77DEF0A7C3F3B\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F38883FDF8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "84c5b90d-12a3-9164-9a64-150a0d9f9910",
-        "x-ms-request-id": "db366fdf-d01e-0015-5cd7-af8588000000",
+        "x-ms-request-id": "821bd46d-f01e-0021-0edc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-547819566cd2c64da7481879dc96ed77-8f78e1a094a2074d-00",
+        "traceparent": "00-bec502887916284e86803041bf600942-200bc23a7b019845-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "6e97b49b-a205-65dd-d611-2814c7edc86e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,35 +55,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
-        "ETag": "\u00220x8D77DEF0A88C3A4\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F3888CE5CC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6e97b49b-a205-65dd-d611-2814c7edc86e",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fe2-d01e-0015-5dd7-af8588000000",
+        "x-ms-request-id": "821bd49b-f01e-0021-39dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-66552893fbc6b649ac625c4f8ffba5a2-f1c24c3c90891940-00",
+        "traceparent": "00-22916a53c274c84a9e53caa2fe81f6c7-3e85e4f1722a6e48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "96f3e71f-c8f0-656d-e87e-4241c74e1f99",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -92,35 +92,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
-        "ETag": "\u00220x8D77DEF0A94F8AB\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F38894AF6B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "96f3e71f-c8f0-656d-e87e-4241c74e1f99",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fe3-d01e-0015-5ed7-af8588000000",
+        "x-ms-request-id": "821bd4c9-f01e-0021-65dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-902f6c99d628b84fae049856a0ecfc30-b75c25c6162c904d-00",
+        "traceparent": "00-59741c50e5fd184d8d6a78654a735aa2-10f42b6fccc2e24c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "e0f53712-31fa-247e-3d84-b96b22f0b022",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -129,35 +129,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:11 GMT",
-        "ETag": "\u00220x8D77DEF0AA106B8\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F3889C51EB\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e0f53712-31fa-247e-3d84-b96b22f0b022",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fe4-d01e-0015-5fd7-af8588000000",
+        "x-ms-request-id": "821bd4f0-f01e-0021-07dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-ba4536cd034d384bb52b503f3fa387df-a8b534e102cd9f40-00",
+        "traceparent": "00-38e6d9b392276a48b1da966395e6063a-0232a4de003fd545-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "902e2a2e-3f59-df9e-3407-591e65461492",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -166,35 +166,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
-        "ETag": "\u00220x8D77DEF0AAD89E7\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388A3F46B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "902e2a2e-3f59-df9e-3407-591e65461492",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fe5-d01e-0015-60d7-af8588000000",
+        "x-ms-request-id": "821bd508-f01e-0021-1bdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-ae46e21bc205f148b5b6e01f8923bf4e-342faa1e425f2e4a-00",
+        "traceparent": "00-942072c16fadb545b18cd9b5ee72896a-47fd118cef6bc441-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f73dbb4e-20c1-c8c8-3b02-2d8b0e2e9bee",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,35 +203,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
-        "ETag": "\u00220x8D77DEF0AB9BEBD\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388ABE522\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f73dbb4e-20c1-c8c8-3b02-2d8b0e2e9bee",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fe8-d01e-0015-62d7-af8588000000",
+        "x-ms-request-id": "821bd534-f01e-0021-45dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-1d82736c32d13b40a0efbff9911c5522-a9b4263687fad445-00",
+        "traceparent": "00-5d4e4cc88f92104f80c658b21fb30007-9e47bc63c0d1eb49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "aad0acad-1d08-4ed0-130b-1906c0f89cbb",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -240,35 +240,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
-        "ETag": "\u00220x8D77DEF0AC66927\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388B387A6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "aad0acad-1d08-4ed0-130b-1906c0f89cbb",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fe9-d01e-0015-63d7-af8588000000",
+        "x-ms-request-id": "821bd561-f01e-0021-6fdc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz/foo/bar",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz/foo/bar",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-6ce9b20f4aaf3b43aa535eca4e6a842b-b8f92fea722a944a-00",
+        "traceparent": "00-91fff9375d13d1459d58195a7f6c0f87-f9e70d7ad6151e4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "61dda540-f05e-8ae5-b014-dbb0c8ed7fad",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -277,35 +277,35 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
-        "ETag": "\u00220x8D77DEF0AD29E26\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388BB0318\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "61dda540-f05e-8ae5-b014-dbb0c8ed7fad",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366fea-d01e-0015-64d7-af8588000000",
+        "x-ms-request-id": "821bd576-f01e-0021-02dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz/bar/foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/baz/bar/foo",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-b53c1123a51b6f44835bf3d75838bf59-ba4310c169583e4d-00",
+        "traceparent": "00-9f220844f41b6340a84db96cfa38040b-4d57353c12d31c4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "1bc53ed8-3b1b-685c-d60b-eb368f40a5d9",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -314,33 +314,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "TnS/nIMWmut1OF8LATLI/g==",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
-        "ETag": "\u00220x8D77DEF0ADED336\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388C2A59C\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1bc53ed8-3b1b-685c-d60b-eb368f40a5d9",
         "x-ms-content-crc64": "z1lEDAVvhRY=",
-        "x-ms-request-id": "db366feb-d01e-0015-65d7-af8588000000",
+        "x-ms-request-id": "821bd597-f01e-0021-20dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo/foo?comp=metadata",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61/foo/foo?comp=metadata",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-935623f6083c7f46a6d6a6baa996038b-35ec729e377afa46-00",
+        "traceparent": "00-db2fa67982cbad4899c7abd14c5e46e5-5cf5e6bb0e239d4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8ad82c40-6327-ab92-8ea3-01be3a07b37c",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:57 GMT",
         "x-ms-meta-Capital": "letter",
         "x-ms-meta-foo": "bar",
         "x-ms-meta-meta": "data",
@@ -352,31 +352,31 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
-        "ETag": "\u00220x8D77DEF0AEB0830\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:03:13 GMT",
+        "Date": "Fri, 29 May 2020 17:12:57 GMT",
+        "ETag": "\u00220x8D803F388CA2105\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:12:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8ad82c40-6327-ab92-8ea3-01be3a07b37c",
-        "x-ms-request-id": "db366fef-d01e-0015-67d7-af8588000000",
+        "x-ms-request-id": "821bd5b4-f01e-0021-39dc-35ff2a000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61?restype=container\u0026comp=list\u0026prefix=foo",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61?restype=container\u0026comp=list\u0026prefix=foo",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "62f5cd4d-1a67-1bb1-11ac-00b45952e161",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:13 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -384,31 +384,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "62f5cd4d-1a67-1bb1-11ac-00b45952e161",
-        "x-ms-request-id": "db366ff1-d01e-0015-68d7-af8588000000",
+        "x-ms-request-id": "821bd5db-f01e-0021-5bdc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:12 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:12 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF0A88C3A4\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ETnS/nIMWmut1OF8LATLI/g==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:12 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:12 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF0AB9BEBD\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ETnS/nIMWmut1OF8LATLI/g==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 04:03:12 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 04:03:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEF0AEB0830\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ETnS/nIMWmut1OF8LATLI/g==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61\u0022\u003E\u003CPrefix\u003Efoo\u003C/Prefix\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Efoo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:12:57 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:12:57 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F3888CE5CC\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ETnS/nIMWmut1OF8LATLI/g==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/bar\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:12:57 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:12:57 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F388ABE522\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ETnS/nIMWmut1OF8LATLI/g==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Efoo/foo\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 17:12:57 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 17:12:57 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F388CA2105\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003ETnS/nIMWmut1OF8LATLI/g==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-3aa3854f-2c52-25c7-8b01-40b0bd4f1d61?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7a7bf6c805a1ff4cb1931d5eb0ea8256-a3084993d0c5c84e-00",
+        "traceparent": "00-9b88338e71cfec45ac2c9c0cc2babf43-d40c17d6a501d14a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6c700548-5011-a314-5970-178e45a322da",
-        "x-ms-date": "Wed, 11 Dec 2019 04:03:13 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:12:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -416,13 +415,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:03:12 GMT",
+        "Date": "Fri, 29 May 2020 17:12:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6c700548-5011-a314-5970-178e45a322da",
-        "x-ms-request-id": "db366ff2-d01e-0015-69d7-af8588000000",
+        "x-ms-request-id": "821bd620-f01e-0021-19dc-35ff2a000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -430,6 +429,6 @@
   ],
   "Variables": {
     "RandomSeed": "821987787",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_AsciiName.json
@@ -1,0 +1,136 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c75305b-f289-a751-22c9-6ec0a7c8d204?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-606a6cc95794bc42ad0d65da72b8c4bc-862eddb650d02d47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "eb5d37a3-213c-2e66-10c3-8f6da48c08e5",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00AEC696C\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "eb5d37a3-213c-2e66-10c3-8f6da48c08e5",
+        "x-ms-request-id": "ab64eb13-801e-002e-2cd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c75305b-f289-a751-22c9-6ec0a7c8d204/test-blob-f6a347a7-8bcd-a142-232e-d9b8bef28b90",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "d4b74dc8-5fef-1735-f5bb-c80e48ad6f1d",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00AF7BE71\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d4b74dc8-5fef-1735-f5bb-c80e48ad6f1d",
+        "x-ms-request-id": "ab64eb47-801e-002e-5ad8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c75305b-f289-a751-22c9-6ec0a7c8d204?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "70f0228a-b73a-12a1-3506-7baf1eb807d1",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "70f0228a-b73a-12a1-3506-7baf1eb807d1",
+        "x-ms-request-id": "ab64eb6d-801e-002e-7ed8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-1c75305b-f289-a751-22c9-6ec0a7c8d204\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-f6a347a7-8bcd-a142-232e-d9b8bef28b90\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:58 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:58 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00AF7BE71\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003Cx-ms-blob-sequence-number\u003E0\u003C/x-ms-blob-sequence-number\u003E\u003CBlobType\u003EPageBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-1c75305b-f289-a751-22c9-6ec0a7c8d204?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f97c5a4e4ac9b4a8608cfe3e35904ae-e147a0aef319d34d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "25844543-febd-80e2-5de7-03681ccaa1c8",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "25844543-febd-80e2-5de7-03681ccaa1c8",
+        "x-ms-request-id": "ab64eb8c-801e-002e-17d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "382982676",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_AsciiNameAsync.json
@@ -1,0 +1,136 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-6a00cb9a-e6ad-4c92-1c32-a017b7309ee5?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-430d6b06541ecc4fa37ea72b9bd79da2-3c20cb1d7ddc3649-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "376cda0d-c1fb-5199-c72a-72aa5237dab7",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B77D286\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "376cda0d-c1fb-5199-c72a-72aa5237dab7",
+        "x-ms-request-id": "ab64ed51-801e-002e-28d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-6a00cb9a-e6ad-4c92-1c32-a017b7309ee5/test-blob-e925c30e-8eb5-5ea7-f3ef-20822939b1c6",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "d74a0551-2c31-7f7e-330d-440ba016288e",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B7F7DBF\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d74a0551-2c31-7f7e-330d-440ba016288e",
+        "x-ms-request-id": "ab64ed67-801e-002e-3cd8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-6a00cb9a-e6ad-4c92-1c32-a017b7309ee5?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "23300e31-daee-f094-ee89-aab522de8f94",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "23300e31-daee-f094-ee89-aab522de8f94",
+        "x-ms-request-id": "ab64ed82-801e-002e-55d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-6a00cb9a-e6ad-4c92-1c32-a017b7309ee5\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-e925c30e-8eb5-5ea7-f3ef-20822939b1c6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:59 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:59 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00B7F7DBF\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003Cx-ms-blob-sequence-number\u003E0\u003C/x-ms-blob-sequence-number\u003E\u003CBlobType\u003EPageBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-6a00cb9a-e6ad-4c92-1c32-a017b7309ee5?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-87eb79c903a2bd4390958d30addce1be-3348223b06bfbb43-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "92da7d78-04e6-9e9f-179e-f7a4523e84fa",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "92da7d78-04e6-9e9f-179e-f7a4523e84fa",
+        "x-ms-request-id": "ab64ed96-801e-002e-69d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "850360884",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_NonAsciiName.json
@@ -1,0 +1,136 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-77d9c325-d77a-b629-dc8c-6937ff1b19ee?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a0e0c22fc4951d439c8fc465c54c6a58-759771ab9d09d44c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "b5f7b69b-cb27-30b9-9a18-35531c7570fe",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00B115D38\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b5f7b69b-cb27-30b9-9a18-35531c7570fe",
+        "x-ms-request-id": "ab64eba5-801e-002e-2dd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-77d9c325-d77a-b629-dc8c-6937ff1b19ee/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-25b1a2f2-8f75-d5d6-8fe3-55f99fa6daed",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "39903910-cf3d-0c63-df22-254476bf91f3",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00B190826\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "39903910-cf3d-0c63-df22-254476bf91f3",
+        "x-ms-request-id": "ab64ebc0-801e-002e-46d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-77d9c325-d77a-b629-dc8c-6937ff1b19ee?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "66e8a808-a016-c6af-2b8e-69013e82b618",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "66e8a808-a016-c6af-2b8e-69013e82b618",
+        "x-ms-request-id": "ab64ebdb-801e-002e-5dd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-77d9c325-d77a-b629-dc8c-6937ff1b19ee\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-\u03B2\u00A3\u00A9\u00FE\u203D%3A-25b1a2f2-8f75-d5d6-8fe3-55f99fa6daed\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:58 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:58 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00B190826\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003Cx-ms-blob-sequence-number\u003E0\u003C/x-ms-blob-sequence-number\u003E\u003CBlobType\u003EPageBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-77d9c325-d77a-b629-dc8c-6937ff1b19ee?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f8d0a323ea4aa34480bc04dab2c4f2ae-d2c396b70bfabe45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "cd3b7567-2bd7-9ddd-98f6-604abed95057",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cd3b7567-2bd7-9ddd-98f6-604abed95057",
+        "x-ms-request-id": "ab64ebf2-801e-002e-72d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "592426638",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/GetPageBlobClient_NonAsciiNameAsync.json
@@ -1,0 +1,136 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-134b539c-603a-3828-e49f-8fc559f0fda1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-70c7b6f642708d4f909b7ee88b912daa-6830f35320132247-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "7e1d5616-d32b-7312-28a5-6f78ef8d7f62",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B98A6D2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7e1d5616-d32b-7312-28a5-6f78ef8d7f62",
+        "x-ms-request-id": "ab64edb6-801e-002e-07d8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-134b539c-603a-3828-e49f-8fc559f0fda1/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-2d670347-1ab3-eb06-7d08-c0caf16fe20d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "52710bf0-986f-fbe2-5031-0023134781b9",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00BA07942\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52710bf0-986f-fbe2-5031-0023134781b9",
+        "x-ms-request-id": "ab64edc9-801e-002e-19d8-3512dc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-134b539c-603a-3828-e49f-8fc559f0fda1?restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e6dafab4-8ffe-409d-16b4-b1a17e525b27",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "e6dafab4-8ffe-409d-16b4-b1a17e525b27",
+        "x-ms-request-id": "ab64ede0-801e-002e-2cd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-134b539c-603a-3828-e49f-8fc559f0fda1\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-\u03B2\u00A3\u00A9\u00FE\u203D%3A-2d670347-1ab3-eb06-7d08-c0caf16fe20d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 29 May 2020 16:47:59 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 29 May 2020 16:47:59 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D803F00BA07942\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003Cx-ms-blob-sequence-number\u003E0\u003C/x-ms-blob-sequence-number\u003E\u003CBlobType\u003EPageBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-134b539c-603a-3828-e49f-8fc559f0fda1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5840a840a129b6498b88717c6eb04f41-72da625a390c344a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "186ee087-9a6c-34ba-c45d-e028cbee4a3b",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "186ee087-9a6c-34ba-c45d-e028cbee4a3b",
+        "x-ms-request-id": "ab64ee1d-801e-002e-5fd8-3512dc000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "789592400",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUri.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e8bd6e7540cc1443b8d34e992c994f03-b95cc63f960dff43-00",
+        "traceparent": "00-37b0746c25a6954e8ca0fbca834114c9-f81bbc667cccc842-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "7a572549-a167-4250-f748-6fde8bc28d50",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,15 +20,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D70862DC\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:57 GMT",
+        "ETag": "\u00220x8D803F00B319531\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7a572549-a167-4250-f748-6fde8bc28d50",
-        "x-ms-request-id": "f79cbc25-001e-0130-4710-2b8e64000000",
+        "x-ms-request-id": "ab64ec0f-801e-002e-0fd8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -40,14 +40,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "21",
         "Content-Type": "application/xml",
-        "traceparent": "00-02fec6186b69d5408e51eb07604a530f-67f76f15b897704a-00",
+        "traceparent": "00-2f6c156ce15d404ab6646a5f85e8c83f-56ff899dafd1ab4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "76dc84ec-dcb3-25b6-3df4-b8206722d50c",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,34 +55,34 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:39 GMT",
-        "ETag": "\u00220x8D7F927D70FCD2D\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B390B15\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "76dc84ec-dcb3-25b6-3df4-b8206722d50c",
-        "x-ms-request-id": "f79cbc3c-001e-0130-5a10-2b8e64000000",
+        "x-ms-request-id": "ab64ec2d-801e-002e-2ad8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D-7789343c-6dc4-628a-2c47-c7dff770ab05",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-7789343c-6dc4-628a-2c47-c7dff770ab05",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-4f3deb45e5621f4bad90c97cca737e36-652ac56482730249-00",
+        "traceparent": "00-a83cdf113f5e274f9340149545e4d9b6-f1b169d06135324d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "b64996ce-960b-7e46-fa7a-4a6c15d72dcc",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -90,33 +90,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D726E97C\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B496FC9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b64996ce-960b-7e46-fa7a-4a6c15d72dcc",
-        "x-ms-request-id": "f79cbc91-001e-0130-2210-2b8e64000000",
+        "x-ms-request-id": "ab64ec5d-801e-002e-58d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D-7789343c-6dc4-628a-2c47-c7dff770ab05?comp=page",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-7789343c-6dc4-628a-2c47-c7dff770ab05?comp=page",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-eeb24f626d65854f93f604883dbee166-a348ccc0a8df764d-00",
+        "traceparent": "00-349422eca4ba454d9aa8f1ab3a7fea61-9e07d6703cf05d44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "60119fc2-f427-19fa-811e-266ef71a1921",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-page-write": "update",
         "x-ms-range": "bytes=0-1023",
         "x-ms-return-client-request-id": "true",
@@ -126,9 +126,9 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D73395F1\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B535CA8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -136,7 +136,7 @@
         "x-ms-blob-sequence-number": "0",
         "x-ms-client-request-id": "60119fc2-f427-19fa-811e-266ef71a1921",
         "x-ms-content-crc64": "ArqHnhhPzi8=",
-        "x-ms-request-id": "f79cbcb2-001e-0130-4310-2b8e64000000",
+        "x-ms-request-id": "ab64ec91-801e-002e-06d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -148,15 +148,15 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-99847742a44ea24488b19c3bad3f9735-42ab3594ea4fd543-00",
+        "traceparent": "00-ed16ed5cdafbd9498cb987bb057592c7-a46232337e62cf43-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "ba895c3f-7037-dda4-fdf8-edd7eb4801cb",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -164,15 +164,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D73B869C\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B5BC2A0\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ba895c3f-7037-dda4-fdf8-edd7eb4801cb",
-        "x-ms-request-id": "f79cbcc9-001e-0130-5510-2b8e64000000",
+        "x-ms-request-id": "ab64ecb5-801e-002e-24d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -184,14 +184,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-bc1dc6493aefc148aded83bf48c08689-c24e787c03d0cd4d-00",
+        "traceparent": "00-26b1a117ad9ca441a017f5aa5b632dc3-41153ec65d717c4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bb71764b-162d-7986-f4cc-78cddfcd6970",
-        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D-7789343c-6dc4-628a-2c47-c7dff770ab05",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-7789343c-6dc4-628a-2c47-c7dff770ab05",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-page-write": "update",
         "x-ms-range": "bytes=0-1023",
         "x-ms-return-client-request-id": "true",
@@ -203,16 +203,16 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "gZvsSO4/SMIHEPj59c9Qmg==",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D760C887\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00B670F4F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
         "x-ms-client-request-id": "bb71764b-162d-7986-f4cc-78cddfcd6970",
-        "x-ms-request-id": "f79cbcef-001e-0130-7710-2b8e64000000",
+        "x-ms-request-id": "ab64ed04-801e-002e-67d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -223,13 +223,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f18bb95f169a154f935b0789c4ed46b4-501b7ca06b384943-00",
+        "traceparent": "00-760dc77a1d6e1c4aa2b1fb2cedb375c4-80f9c921c76c174a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "758c2f6e-46d7-379e-e109-68a52c8d5a7f",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -237,13 +237,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "758c2f6e-46d7-379e-e109-68a52c8d5a7f",
-        "x-ms-request-id": "f79cbd50-001e-0130-4810-2b8e64000000",
+        "x-ms-request-id": "ab64ed30-801e-002e-09d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUriAsync.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ec8a73265b2e5c4ba762444ddadcd3e4-c27c98f7de23874e-00",
+        "traceparent": "00-9927c2fd8d0b9447ada42346929e041c-b77c80539241e14a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "19592718-1153-8d9b-ac50-f4aa94dca964",
-        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,15 +20,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D776F12B\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00BC515F4\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "19592718-1153-8d9b-ac50-f4aa94dca964",
-        "x-ms-request-id": "f79cbd70-001e-0130-6310-2b8e64000000",
+        "x-ms-request-id": "ab64ee42-801e-002e-02d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -40,14 +40,14 @@
         "Authorization": "Sanitized",
         "Content-Length": "21",
         "Content-Type": "application/xml",
-        "traceparent": "00-e3b40ce84c2c0e408a058550c15a6bd1-db07876007d69d46-00",
+        "traceparent": "00-447a705f1de7944c89124a9eac5b6e14-4cf20aef803a5b45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "4b0d6802-41b2-2110-2104-3a24a3330f11",
-        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,34 +55,34 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D77E5B8B\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Date": "Fri, 29 May 2020 16:47:58 GMT",
+        "ETag": "\u00220x8D803F00BCC6502\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4b0d6802-41b2-2110-2104-3a24a3330f11",
-        "x-ms-request-id": "f79cbd92-001e-0130-8010-2b8e64000000",
+        "x-ms-request-id": "ab64ee6a-801e-002e-22d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D-6940b86a-e7a8-4049-b27e-bfc223d8b093",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-6940b86a-e7a8-4049-b27e-bfc223d8b093",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-b3517afba102824c868e657437c830cd-01bd3a4d23767946-00",
+        "traceparent": "00-181d5c1c63e7de46986fcdf0326ffb82-e06cbe67e755f74a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "bf190cf6-3ec2-1aed-1fcd-9833824dfd49",
-        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -90,33 +90,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D786F4FD\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Date": "Fri, 29 May 2020 16:47:59 GMT",
+        "ETag": "\u00220x8D803F00BD43CE5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bf190cf6-3ec2-1aed-1fcd-9833824dfd49",
-        "x-ms-request-id": "f79cbdbd-001e-0130-2610-2b8e64000000",
+        "x-ms-request-id": "ab64ee8f-801e-002e-42d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D-6940b86a-e7a8-4049-b27e-bfc223d8b093?comp=page",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-6940b86a-e7a8-4049-b27e-bfc223d8b093?comp=page",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-1385ed84871bb34089768139397d4392-9d5dba949fe7e847-00",
+        "traceparent": "00-7aadaa5ec99d604a834ccec9ea9ae0d0-fd2bbb8dff267e4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "16cc08c3-f0bf-92d1-3654-189412f5a663",
-        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-page-write": "update",
         "x-ms-range": "bytes=0-1023",
         "x-ms-return-client-request-id": "true",
@@ -126,9 +126,9 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D78FA920\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Date": "Fri, 29 May 2020 16:47:59 GMT",
+        "ETag": "\u00220x8D803F00BDC067C\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -136,7 +136,7 @@
         "x-ms-blob-sequence-number": "0",
         "x-ms-client-request-id": "16cc08c3-f0bf-92d1-3654-189412f5a663",
         "x-ms-content-crc64": "n5hijHPKiEA=",
-        "x-ms-request-id": "f79cbdd0-001e-0130-3510-2b8e64000000",
+        "x-ms-request-id": "ab64eeb2-801e-002e-5cd8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -148,15 +148,15 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-b914cf3afc20f946a3da0353fec06ba0-6764e78a0fb7a644-00",
+        "traceparent": "00-900fdf01e5f8d04bab191d5eb4f8992c-7fe9491e09714144-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "c0f55470-d793-86cc-17ad-b965c0260c99",
-        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:47:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -164,15 +164,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D797C0DA\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Date": "Fri, 29 May 2020 16:47:59 GMT",
+        "ETag": "\u00220x8D803F00BE41E4A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c0f55470-d793-86cc-17ad-b965c0260c99",
-        "x-ms-request-id": "f79cbde0-001e-0130-4210-2b8e64000000",
+        "x-ms-request-id": "ab64eecc-801e-002e-75d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -184,14 +184,14 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-45fbaef00e80fb4aa9aabb5ac321f19c-c206176f130af34a-00",
+        "traceparent": "00-4fef76507b5ad340bef31e93916f8508-ca502b7decc8af45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "323a96ae-a9a7-bec7-36ea-63d42d24a1af",
-        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D-6940b86a-e7a8-4049-b27e-bfc223d8b093",
-        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D%253A-6940b86a-e7a8-4049-b27e-bfc223d8b093",
+        "x-ms-date": "Fri, 29 May 2020 16:48:00 GMT",
         "x-ms-page-write": "update",
         "x-ms-range": "bytes=0-1023",
         "x-ms-return-client-request-id": "true",
@@ -203,16 +203,16 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "6rrcTL/ffUQuqK64/r/hlg==",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
-        "ETag": "\u00220x8D7F927D7A074F9\u0022",
-        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Date": "Fri, 29 May 2020 16:47:59 GMT",
+        "ETag": "\u00220x8D803F00BECAB55\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:48:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-blob-sequence-number": "0",
         "x-ms-client-request-id": "323a96ae-a9a7-bec7-36ea-63d42d24a1af",
-        "x-ms-request-id": "f79cbdeb-001e-0130-4d10-2b8e64000000",
+        "x-ms-request-id": "ab64eef0-801e-002e-14d8-3512dc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -223,13 +223,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d23e321ce4c097478726884415204022-e2d65b070cc58145-00",
+        "traceparent": "00-e530fd4089a43442bbc4f7857cb1ccff-7f8cc2e5947eac46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "29b6754c-d9ec-40f1-f641-d99bc90d4640",
-        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-date": "Fri, 29 May 2020 16:48:00 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -237,13 +237,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "Date": "Fri, 29 May 2020 16:47:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "29b6754c-d9ec-40f1-f641-d99bc90d4640",
-        "x-ms-request-id": "f79cbe0c-001e-0130-6610-2b8e64000000",
+        "x-ms-request-id": "ab64ef18-801e-002e-34d8-3512dc000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -69,6 +69,9 @@ namespace Azure.Storage
         public const string Https = "https";
         public const string Http = "http";
 
+        public const string PercentSign = "%";
+        public const string EncodedPercentSign = "%25";
+
         /// <summary>
         /// Storage Connection String constant values.
         /// </summary>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
@@ -25,6 +25,9 @@ namespace Azure.Storage
             var builder = new UriBuilder(uri);
             var path = builder.Path;
             var seperator = (path.Length == 0 || path[path.Length - 1] != '/') ? "/" : "";
+            // In URLs, the percent sign is used to encode special characters, so if the segment
+            // has a percent sign in their URL path, we have to encode it before adding it to the path
+            segment = segment.Replace(Constants.PercentSign, Constants.EncodedPercentSign);
             builder.Path += seperator + segment;
             return builder.Uri;
         }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -42,7 +42,9 @@ namespace Azure.Storage.Files.DataLake.Tests
         public string GetGarbageLeaseId() => Recording.Random.NewGuid().ToString();
         public string GetNewFileSystemName() => $"test-filesystem-{Recording.Random.NewGuid()}";
         public string GetNewDirectoryName() => $"test-directory-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiDirectoryName() => $"test-dire¢t Ø®ϒ%3A-{Recording.Random.NewGuid()}";
         public string GetNewFileName() => $"test-file-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiFileName() => $"test-ƒ¡£€‽%3A-{Recording.Random.NewGuid()}";
 
         public DataLakeClientOptions GetOptions(bool parallelRange = false)
         {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -2318,5 +2318,93 @@ namespace Azure.Storage.Files.DataLake.Tests
                 InstrumentClient(directory.GetDataLakeLeaseClient()).BreakAsync(),
                 e => Assert.AreEqual("BlobNotFound", e.ErrorCode));
         }
+
+        [Test]
+        public async Task GetDirectoryClientAsync_AsciiName()
+        {
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            string directoryName = GetNewDirectoryName();
+            DataLakeDirectoryClient directory = test.FileSystem.GetDirectoryClient(directoryName);
+            await directory.CreateAsync();
+
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(directoryName, names);
+        }
+
+        [Test]
+        public async Task GetDirectoryClientAsync_NonAsciiName()
+        {
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            string directoryName = GetNewNonAsciiDirectoryName();
+            DataLakeDirectoryClient file = test.FileSystem.GetDirectoryClient(directoryName);
+            await file.CreateAsync();
+
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(directoryName, names);
+        }
+
+        [Test]
+        public async Task GetSubDirectoryClientAsync_AsciiName()
+        {
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            string directoryName = GetNewDirectoryName();
+            string subDirectoryName = GetNewDirectoryName();
+            string fullPathName = string.Join("/", directoryName, subDirectoryName);
+            DataLakeDirectoryClient directory = test.FileSystem.GetDirectoryClient(directoryName);
+            DataLakeDirectoryClient subdirectory = directory.GetSubDirectoryClient(subDirectoryName);
+
+            await subdirectory.CreateAsync();
+
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(2, names.Count);
+            Assert.Contains(fullPathName, names);
+        }
+
+        [Test]
+        public async Task GetSubDirectoryClientAsync_NonAsciiName()
+        {
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            string directoryName = GetNewDirectoryName();
+            string subDirectoryName = GetNewNonAsciiDirectoryName();
+            string fullPathName = string.Join("/", directoryName, subDirectoryName);
+            DataLakeDirectoryClient directory = test.FileSystem.GetDirectoryClient(directoryName);
+            DataLakeDirectoryClient subdirectory = directory.GetSubDirectoryClient(subDirectoryName);
+
+            await subdirectory.CreateAsync();
+
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(2, names.Count);
+            Assert.Contains(fullPathName, names);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -2927,5 +2927,99 @@ namespace Azure.Storage.Files.DataLake.Tests
             await file.ReadToAsync(actual);
             TestHelper.AssertSequenceEqual(data, actual.ToArray());
         }
+
+        [Test]
+        public async Task GetFileClient_FromFileSystemAsciiName()
+        {
+            //Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+            string fileName = GetNewFileName();
+
+            //Act
+            DataLakeFileClient file = test.FileSystem.GetFileClient(fileName);
+            await file.CreateAsync();
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(fileName, names);
+        }
+
+        [Test]
+        public async Task GetFileClient_FromFileSystemNonAsciiName()
+        {
+            //Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+            string fileName = GetNewNonAsciiFileName();
+
+            //Act
+            DataLakeFileClient file = test.FileSystem.GetFileClient(fileName);
+            await file.CreateAsync();
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(fileName, names);
+        }
+
+        [Test]
+        public async Task GetFileClient_FromDirectoryAsciiName()
+        {
+            //Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+            string directoryName = GetNewDirectoryName();
+            string fileName = GetNewFileName();
+            DataLakeDirectoryClient directory = await test.FileSystem.CreateDirectoryAsync(directoryName);
+
+            // Act
+            DataLakeFileClient file = directory.GetFileClient(fileName);
+            await file.CreateAsync();
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            string fullPathName = string.Join("/", directoryName, fileName);
+            Assert.AreEqual(2, names.Count);
+            Assert.Contains(fullPathName, names);
+        }
+
+        [Test]
+        public async Task GetFileClient_FromDirectoryNonAsciiName()
+        {
+            //Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+            string directoryName = GetNewDirectoryName();
+            string fileName = GetNewNonAsciiFileName();
+            DataLakeDirectoryClient directory = await test.FileSystem.CreateDirectoryAsync(directoryName);
+
+            // Act
+            DataLakeFileClient file = directory.GetFileClient(fileName);
+            await file.CreateAsync();
+
+            //Assert
+            List<string> names = new List<string>();
+            await foreach (PathItem pathItem in test.FileSystem.GetPathsAsync(recursive: true))
+            {
+                names.Add(pathItem.Name);
+            }
+            // Verify the file name exists in the filesystem
+            string fullPathName = string.Join("/", directoryName, fileName);
+            Assert.AreEqual(2, names.Count);
+            Assert.Contains(fullPathName, names);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiName.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e26fe53ba1b12548846afef9b32928dd-74a8b31517c24641-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "6f07e92a-b4bc-eea6-b23e-0c35751df410",
+        "x-ms-date": "Fri, 29 May 2020 00:05:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "ETag": "\u00220x8D80363F3434DD6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6f07e92a-b4bc-eea6-b23e-0c35751df410",
+        "x-ms-request-id": "83c44d6b-501e-00c0-084c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d/test-directory-03711db3-f9a8-3719-a408-fdc7bd52fdf1?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "38626c48-3711-30a5-cfcf-cbb4b6df305f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "ETag": "\u00220x8D80363F357A9F4\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38626c48-3711-30a5-cfcf-cbb4b6df305f",
+        "x-ms-request-id": "7539ed3c-e01f-000e-4d4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "517e7375-c4f0-c1e0-180f-5f8a2ccd9f37",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "517e7375-c4f0-c1e0-180f-5f8a2ccd9f37",
+        "x-ms-request-id": "7539ed3d-e01f-000e-4e4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F357A9F4",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:09 GMT",
+            "name": "test-directory-03711db3-f9a8-3719-a408-fdc7bd52fdf1"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c159c3d0e8be5243986c7509ac8a313f-15319c7a72d3684a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "433eddd6-df60-7d6f-3b7c-9fce662c90cf",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "433eddd6-df60-7d6f-3b7c-9fce662c90cf",
+        "x-ms-request-id": "83c44dc1-501e-00c0-4f4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "470932305",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiNameAsync.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e87f4378c387e14ea52cbc2d21eefbbb-dd92b824f34bc74c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "1137f5da-33d0-cebf-7cb5-00d3c30b7915",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F434C651\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1137f5da-33d0-cebf-7cb5-00d3c30b7915",
+        "x-ms-request-id": "83c44e9e-501e-00c0-7a4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520/test-directory-104361a3-d89d-22c9-81d6-444a1d200977?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0a320266-e6f3-01fb-2b14-8ff9ef74b15b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F440E30D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a320266-e6f3-01fb-2b14-8ff9ef74b15b",
+        "x-ms-request-id": "7539ed45-e01f-000e-564c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1be30775-ffed-cf84-7a31-645834557fae",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "1be30775-ffed-cf84-7a31-645834557fae",
+        "x-ms-request-id": "7539ed46-e01f-000e-574c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F440E30D",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-104361a3-d89d-22c9-81d6-444a1d200977"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-076d68a28e75014c86d53706d17312c3-41e31ee67352584e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e78406bb-9591-ad6e-054d-d2a6844eaabc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e78406bb-9591-ad6e-054d-d2a6844eaabc",
+        "x-ms-request-id": "83c44ec4-501e-00c0-164c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "743471578",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiName.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1bb12b8349115643bc9f523da48e016c-77fd5a3acf97d449-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "320ea34e-f672-ce88-ddc5-65ded75f6dea",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F39DB8E4\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "320ea34e-f672-ce88-ddc5-65ded75f6dea",
+        "x-ms-request-id": "83c44ddf-501e-00c0-6a4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-18294ffa-650d-10a8-c204-3574679319f5?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d2ef06c8-1e31-e9fd-fafd-6f6ec014674a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F3A93939\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2ef06c8-1e31-e9fd-fafd-6f6ec014674a",
+        "x-ms-request-id": "7539ed3e-e01f-000e-4f4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "60ab50b9-46a3-53c3-0ffe-f4656248ca3f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "60ab50b9-46a3-53c3-0ffe-f4656248ca3f",
+        "x-ms-request-id": "7539ed3f-e01f-000e-504c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F3A93939",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:09 GMT",
+            "name": "test-dire\u00A2t \u00D8\u00AE\u03D2%3A-18294ffa-650d-10a8-c204-3574679319f5"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f5412b1ea214a4dbec77cad495b1038-7ecfb1d6ce277447-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6fb4d378-0668-65a7-ac18-bb788a22c550",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6fb4d378-0668-65a7-ac18-bb788a22c550",
+        "x-ms-request-id": "83c44e08-501e-00c0-064c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "409565269",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiNameAsync.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5d39224cf1afb14d90a16c0b72465c4e-1bc1b70e2f92444b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "dc469eac-169f-d4ec-d0a2-358cfbcf4216",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F467A289\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dc469eac-169f-d4ec-d0a2-358cfbcf4216",
+        "x-ms-request-id": "83c44ed5-501e-00c0-244c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-6491b0f7-14fa-ac10-189d-11b300dbb88e?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "94b0239f-ec9f-978a-8d9a-c4010438d3f5",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F472FBB0\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94b0239f-ec9f-978a-8d9a-c4010438d3f5",
+        "x-ms-request-id": "7539ed47-e01f-000e-584c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dd138bd3-242a-28ee-b47d-69ef813999bf",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "dd138bd3-242a-28ee-b47d-69ef813999bf",
+        "x-ms-request-id": "7539ed48-e01f-000e-594c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F472FBB0",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-dire\u00A2t \u00D8\u00AE\u03D2%3A-6491b0f7-14fa-ac10-189d-11b300dbb88e"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-67a6aa281d4e7841bd2cbcdace857045-302877a415cafe4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "782d175c-f525-c6cb-b850-073be29e303b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "782d175c-f525-c6cb-b850-073be29e303b",
+        "x-ms-request-id": "83c44f0d-501e-00c0-4e4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "442423822",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiName.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d76e6c980179ba4f8febb3cd958aadde-52416320f7269546-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d314c582-072a-d30f-9c06-866ff1ddd634",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F3D06DE9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d314c582-072a-d30f-9c06-866ff1ddd634",
+        "x-ms-request-id": "83c44e1c-501e-00c0-134c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a/test-directory-f0a56a24-a014-f12a-2708-b5fdbc2142b8/test-directory-7a74f125-27bc-a570-3ebd-18fe11897429?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ff49cdc3-5b69-fd78-fa00-b257872bdf9d",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F3DD2714\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ff49cdc3-5b69-fd78-fa00-b257872bdf9d",
+        "x-ms-request-id": "7539ed40-e01f-000e-514c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "443b9ca7-7440-f4c0-8dc2-164f30825a6e",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "443b9ca7-7440-f4c0-8dc2-164f30825a6e",
+        "x-ms-request-id": "7539ed41-e01f-000e-524c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F3DC8AAE",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-f0a56a24-a014-f12a-2708-b5fdbc2142b8"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F3DD2714",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-f0a56a24-a014-f12a-2708-b5fdbc2142b8/test-directory-7a74f125-27bc-a570-3ebd-18fe11897429"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1dede5f3a407c94ca3fdf900de5d89d5-ba118a03bc8f3b48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ebb086ac-9bf0-1f5c-cbb8-299d1a191295",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ebb086ac-9bf0-1f5c-cbb8-299d1a191295",
+        "x-ms-request-id": "83c44e53-501e-00c0-3d4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1326272744",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiNameAsync.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f34be58f292e240bdbf7956d5a2c29b-f053141a3d9c674b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "43473107-5cc3-e5e4-9f71-1459fbfab0eb",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F497BEF7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43473107-5cc3-e5e4-9f71-1459fbfab0eb",
+        "x-ms-request-id": "83c44f1c-501e-00c0-5b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4/test-directory-5e1057f4-caf3-dd25-b8f4-e320d5af510a/test-directory-0a69c85d-efbd-de30-9034-3da57d21e884?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "33fb0a1f-a690-042e-2731-cdbf8c7f6096",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F4A402A1\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "33fb0a1f-a690-042e-2731-cdbf8c7f6096",
+        "x-ms-request-id": "7539ed49-e01f-000e-5a4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "73864d23-b526-fff3-d720-8142d125b08c",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "73864d23-b526-fff3-d720-8142d125b08c",
+        "x-ms-request-id": "7539ed4a-e01f-000e-5b4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4A38D54",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-5e1057f4-caf3-dd25-b8f4-e320d5af510a"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4A402A1",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-5e1057f4-caf3-dd25-b8f4-e320d5af510a/test-directory-0a69c85d-efbd-de30-9034-3da57d21e884"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f7cee348107fdd4a9e940008c03fcf62-c99e50901aabe14e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3f9b00cb-edf9-566f-6b7b-f7692752ecbd",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3f9b00cb-edf9-566f-6b7b-f7692752ecbd",
+        "x-ms-request-id": "83c44f45-501e-00c0-014c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "52368560",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiName.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8768dd29a6e5f044bcea6152a544320c-1cdf0d92338dfd4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d9f5fff4-d24a-67ec-ffae-855505f40a4a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F4025F74\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d9f5fff4-d24a-67ec-ffae-855505f40a4a",
+        "x-ms-request-id": "83c44e65-501e-00c0-4b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f/test-directory-d89389d3-8b10-589a-5fca-72e2bf7a5f4c/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-1203f328-0a20-8f35-ae91-3b444860ffa2?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "112d384f-f8f0-c829-5303-297f4f5510fe",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F40E7C33\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "112d384f-f8f0-c829-5303-297f4f5510fe",
+        "x-ms-request-id": "7539ed43-e01f-000e-544c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0ff5b7e8-ee33-b8b1-46db-f70ff18e1a0f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0ff5b7e8-ee33-b8b1-46db-f70ff18e1a0f",
+        "x-ms-request-id": "7539ed44-e01f-000e-554c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F40E06EB",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-d89389d3-8b10-589a-5fca-72e2bf7a5f4c"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F40E7C33",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-d89389d3-8b10-589a-5fca-72e2bf7a5f4c/test-dire\u00A2t \u00D8\u00AE\u03D2%3A-1203f328-0a20-8f35-ae91-3b444860ffa2"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d08efd672a70c04a93006bad667eed82-ce9b6973f54f0046-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "979684d4-0060-ddca-1d79-09fb1c2a1c56",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "979684d4-0060-ddca-1d79-09fb1c2a1c56",
+        "x-ms-request-id": "83c44e88-501e-00c0-664c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1368634928",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiNameAsync.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d61d18754d355d46ba1dddc00a1abd55-273203ea0f3ceb49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "97579df9-919a-011c-6c94-071c6f25bf2d",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F4C850B5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "97579df9-919a-011c-6c94-071c6f25bf2d",
+        "x-ms-request-id": "83c44f55-501e-00c0-104c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703/test-directory-2802d4cb-a0a3-e67b-9b94-9196f8dbe4ef/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-88b94936-f0fe-0169-c6d1-acbb05d77b36?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "26e617b0-366b-db2f-6b01-62d2f4bfe1c3",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F4D49440\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "26e617b0-366b-db2f-6b01-62d2f4bfe1c3",
+        "x-ms-request-id": "7539ed4c-e01f-000e-5d4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ed0b1bc8-55f1-14ca-c010-9cfacee96462",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "ed0b1bc8-55f1-14ca-c010-9cfacee96462",
+        "x-ms-request-id": "7539ed4d-e01f-000e-5e4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4D3F7DF",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-2802d4cb-a0a3-e67b-9b94-9196f8dbe4ef"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4D49440",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-2802d4cb-a0a3-e67b-9b94-9196f8dbe4ef/test-dire\u00A2t \u00D8\u00AE\u03D2%3A-88b94936-f0fe-0169-c6d1-acbb05d77b36"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5e9c9b6efce99a469eecfb77bfb17855-3fd5837ec94d204e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d80921ff-f3b4-c3d2-9035-48e040f936a4",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d80921ff-f3b4-c3d2-9035-48e040f936a4",
+        "x-ms-request-id": "83c44f9a-501e-00c0-454c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1548058516",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiName.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4d68f2705b22b445aff1da0db99eaddd-b4f71f6a190c7548-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f3a6e2c3-21a6-d31b-28b4-2d3e1b31ed76",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F4F9A5EA\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3a6e2c3-21a6-d31b-28b4-2d3e1b31ed76",
+        "x-ms-request-id": "83c44fac-501e-00c0-544c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb/test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5f4af5842b893347946b46f3b6f05990-f8824e5a45f5dc4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "61524f1e-09e6-c5ef-ed13-e6f3054b9161",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F5054D02\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61524f1e-09e6-c5ef-ed13-e6f3054b9161",
+        "x-ms-request-id": "7539ed4e-e01f-000e-5f4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb/test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de/test-file-e34bbaec-5287-dc25-0d95-484e3a0e9b9b?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "eb2f0c74-3abc-3fb5-5524-89122bf870fc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F51136C5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "eb2f0c74-3abc-3fb5-5524-89122bf870fc",
+        "x-ms-request-id": "7539ed4f-e01f-000e-604c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f87e815d-a61c-05a5-a9eb-17de94a5afd6",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "f87e815d-a61c-05a5-a9eb-17de94a5afd6",
+        "x-ms-request-id": "7539ed50-e01f-000e-614c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5054D02",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F51136C5",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de/test-file-e34bbaec-5287-dc25-0d95-484e3a0e9b9b"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a7436f73ed73624889a30b989d4c0cdc-5c0b8dc1be0be449-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a9b4f72e-7779-a1e0-7b83-1d939d5b6cf2",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a9b4f72e-7779-a1e0-7b83-1d939d5b6cf2",
+        "x-ms-request-id": "83c44fde-501e-00c0-7d4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "110400654",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiNameAsync.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-68e993210047484db4b041dfe74ac2a6-996cbc1b690e4e4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "50db8106-99e2-faf5-9d47-03f95ff5b36a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5D743AD\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "50db8106-99e2-faf5-9d47-03f95ff5b36a",
+        "x-ms-request-id": "83c450e5-501e-00c0-574c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9/test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d81c55790b8a444a9599a742ec3c3a7c-555385b6ae654043-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9b8d3d76-a3fc-5b00-97dd-4dd04267869b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5E2EA92\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9b8d3d76-a3fc-5b00-97dd-4dd04267869b",
+        "x-ms-request-id": "7539ed5c-e01f-000e-6a4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9/test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6/test-file-10f8c46b-0769-a7c7-62e1-ba50e9317eb7?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "acda9a26-e3a4-8abb-a9ee-ed828330c762",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F5EE861E\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "acda9a26-e3a4-8abb-a9ee-ed828330c762",
+        "x-ms-request-id": "7539ed5d-e01f-000e-6b4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a7aafd56-da8c-c6f6-052b-eb465fe21793",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "a7aafd56-da8c-c6f6-052b-eb465fe21793",
+        "x-ms-request-id": "7539ed5e-e01f-000e-6c4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5E2EA92",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5EE861E",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6/test-file-10f8c46b-0769-a7c7-62e1-ba50e9317eb7"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ac51a1704e475c448f700760e516af1f-165390dd1940ee4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "852c6117-1f85-09d5-f14a-5a313ba5c9f4",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "852c6117-1f85-09d5-f14a-5a313ba5c9f4",
+        "x-ms-request-id": "83c45120-501e-00c0-064c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "494872270",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiName.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1885764c21865d4da731848b8b1b60c6-6c0919c24ee38549-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cdac5acd-a2e0-4c3d-5d3f-c09de22826f4",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F5375A3C\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cdac5acd-a2e0-4c3d-5d3f-c09de22826f4",
+        "x-ms-request-id": "83c44ff1-501e-00c0-0b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a/test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-32163589c02e9e4082b00da0d43ab653-e2bfb84ae4aa8b47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5cdb0062-b163-e3ae-4c38-1bf570f9716d",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F5430135\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5cdb0062-b163-e3ae-4c38-1bf570f9716d",
+        "x-ms-request-id": "7539ed52-e01f-000e-624c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a/test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-74c486c1-3f46-f359-aa47-c034d3b9fba1?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d2d12ed1-9fde-923d-b30f-03df515a2c32",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F54E4E96\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2d12ed1-9fde-923d-b30f-03df515a2c32",
+        "x-ms-request-id": "7539ed53-e01f-000e-634c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4224b5ad-9e27-3f8f-5b23-c0c888c702dc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "4224b5ad-9e27-3f8f-5b23-c0c888c702dc",
+        "x-ms-request-id": "7539ed54-e01f-000e-644c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5430135",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F54E4E96",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf/test-\u0192\u00A1\u00A3\u20AC\u203D%3A-74c486c1-3f46-f359-aa47-c034d3b9fba1"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-54150c71cd34e64681c66325e687fd84-711395957acde14e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9c320ac6-ea35-560b-a7e7-756a41f04d92",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c320ac6-ea35-560b-a7e7-756a41f04d92",
+        "x-ms-request-id": "83c45052-501e-00c0-5f4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "670912280",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiNameAsync.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-54aaea5603531240964589f58143e826-aa82dcb94c65344b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "16efcc3d-f4fe-8787-5d76-dce50223be7a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F612AD72\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16efcc3d-f4fe-8787-5d76-dce50223be7a",
+        "x-ms-request-id": "83c4512c-501e-00c0-114c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3/test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-49ad54e694b3b34abd2d206e966bef9b-988f9c169710784d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "06e5ea9f-4bf2-7b9e-ed18-d03245b6640a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F61E2D3D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "06e5ea9f-4bf2-7b9e-ed18-d03245b6640a",
+        "x-ms-request-id": "7539ed5f-e01f-000e-6d4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3/test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-7330fb00-52dc-a9a4-9226-17a3c8ffbca0?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dd03b81c-b61a-91ae-0b87-6e101c719bbc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F6297A9A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dd03b81c-b61a-91ae-0b87-6e101c719bbc",
+        "x-ms-request-id": "7539ed60-e01f-000e-6e4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8d16fd58-87b2-cff0-bc59-c8730cb7f6e5",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "8d16fd58-87b2-cff0-bc59-c8730cb7f6e5",
+        "x-ms-request-id": "7539ed61-e01f-000e-6f4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F61E2D3D",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F6297A9A",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1/test-\u0192\u00A1\u00A3\u20AC\u203D%3A-7330fb00-52dc-a9a4-9226-17a3c8ffbca0"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7a6937c038a3b945826c2b2adf51731f-61d28393de2d5b4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1fb76952-0d5b-d609-1065-c27b6ff0176b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1fb76952-0d5b-d609-1065-c27b6ff0176b",
+        "x-ms-request-id": "83c4517a-501e-00c0-4c4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "300069817",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiName.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0c123c582866ca4b8b8b70bb1acf63bd-1cbe72977ea1434b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "19e886a9-d716-0773-40fb-ba72d161bfb9",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5770AD2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "19e886a9-d716-0773-40fb-ba72d161bfb9",
+        "x-ms-request-id": "83c45062-501e-00c0-6f4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b/test-file-640f6b0c-8e6e-59f7-dab8-e7a8c6ed4cd3?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "95c95ecc-925b-1a3c-8e8f-3f5eefcb4152",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5828A95\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "95c95ecc-925b-1a3c-8e8f-3f5eefcb4152",
+        "x-ms-request-id": "7539ed57-e01f-000e-664c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "67dbe677-b723-7c77-e5ec-8c8851c64674",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "67dbe677-b723-7c77-e5ec-8c8851c64674",
+        "x-ms-request-id": "7539ed58-e01f-000e-674c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5828A95",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-file-640f6b0c-8e6e-59f7-dab8-e7a8c6ed4cd3"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-88a74dd2dbbc3045975507c4261672c3-237807f1ccdfcb4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "09e6a22f-daef-f72f-6ee5-c96e18182980",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "09e6a22f-daef-f72f-6ee5-c96e18182980",
+        "x-ms-request-id": "83c4509b-501e-00c0-1b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "633551975",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiNameAsync.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f6f5e5fb9d6aa14ab9f94c1cb4fe1a18-a4cc318b7c764b44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5c700f78-7814-ad15-413d-3a2236cf273c",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F64EDAA8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5c700f78-7814-ad15-413d-3a2236cf273c",
+        "x-ms-request-id": "83c4518a-501e-00c0-5a4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67/test-file-9d411be1-01df-f22c-a11a-a59b9f7facd2?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "154f95cd-4092-7695-e27d-bafad2790ec2",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F65A3358\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "154f95cd-4092-7695-e27d-bafad2790ec2",
+        "x-ms-request-id": "7539ed62-e01f-000e-704c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "09ce95fd-962f-0940-2425-2ae83358d57f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "09ce95fd-962f-0940-2425-2ae83358d57f",
+        "x-ms-request-id": "7539ed63-e01f-000e-714c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F65A3358",
+            "lastModified": "Fri, 29 May 2020 00:05:14 GMT",
+            "name": "test-file-9d411be1-01df-f22c-a11a-a59b9f7facd2"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0b0b872cfa13e5488748d7cd305aec7e-11aa6dbc268f3a42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3cfd5871-05ab-fa92-27ce-580df0edbf70",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3cfd5871-05ab-fa92-27ce-580df0edbf70",
+        "x-ms-request-id": "83c451b0-501e-00c0-774c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "949313137",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiName.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-910926da80f76e4681e250b0b2a794db-9b210104cb5e8646-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "00790507-ed04-9b8a-cdbe-a11173312cb7",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5A70026\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "00790507-ed04-9b8a-cdbe-a11173312cb7",
+        "x-ms-request-id": "83c450ae-501e-00c0-2b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-91c34577-ef16-0d15-6bd4-660711495b35?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f3b7ca47-c318-17b3-ef6b-943087828a83",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5B27FEB\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3b7ca47-c318-17b3-ef6b-943087828a83",
+        "x-ms-request-id": "7539ed59-e01f-000e-684c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "46c07acf-6891-c21c-1e50-c04abee9fef9",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "46c07acf-6891-c21c-1e50-c04abee9fef9",
+        "x-ms-request-id": "7539ed5a-e01f-000e-694c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5B27FEB",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-\u0192\u00A1\u00A3\u20AC\u203D%3A-91c34577-ef16-0d15-6bd4-660711495b35"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5b338584b1014447b197397ca2043907-ea11be9e7cddfa4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0c60bc72-43c2-faf1-50c9-8378bcb66742",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0c60bc72-43c2-faf1-50c9-8378bcb66742",
+        "x-ms-request-id": "83c450d5-501e-00c0-4b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1268590554",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiNameAsync.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-549e46a0b9a82f46a35f9fc04c1b08d2-2b844a461d766f47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "bd343d99-798e-c956-82de-bb0a08dd4cca",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F67E5A9B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd343d99-798e-c956-82de-bb0a08dd4cca",
+        "x-ms-request-id": "83c451ba-501e-00c0-014c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-1576c511-1dac-62d7-1df0-562cee90651e?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1184fc62-3f68-7b8e-66d1-a09e2329dbf2",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:14 GMT",
+        "ETag": "\u00220x8D80363F689B349\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1184fc62-3f68-7b8e-66d1-a09e2329dbf2",
+        "x-ms-request-id": "7539ed64-e01f-000e-724c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f1ca1218-540b-68b5-d121-687cab57af72",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "f1ca1218-540b-68b5-d121-687cab57af72",
+        "x-ms-request-id": "7539ed65-e01f-000e-734c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F689B349",
+            "lastModified": "Fri, 29 May 2020 00:05:14 GMT",
+            "name": "test-\u0192\u00A1\u00A3\u20AC\u203D%3A-1576c511-1dac-62d7-1df0-562cee90651e"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-36ec6ee55330974cbed1cd93d1956320-089f3aa42f347e44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "11859ced-ea5f-24e6-e7fa-d61e15ff1978",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "11859ced-ea5f-24e6-e7fa-d61e15ff1978",
+        "x-ms-request-id": "83c451e0-501e-00c0-1e4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "337560350",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -808,5 +808,85 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.ThrowsAsync<RequestFailedException>(
                 async () => await file.GetPropertiesAsync());
         }
+
+        [Test]
+        public async Task GetDirectoryAsync_AsciiName()
+        {
+            await using DisposingShare test = await GetTestShareAsync();
+            string name = GetNewDirectoryName();
+
+            ShareDirectoryClient subdir = InstrumentClient(test.Share.GetDirectoryClient(name));
+            await subdir.CreateAsync();
+
+            // Assert
+            List<string> names = new List<string>();
+            ShareDirectoryClient rootDirectory = InstrumentClient(test.Share.GetRootDirectoryClient());
+            await foreach (ShareFileItem item in rootDirectory.GetFilesAndDirectoriesAsync())
+            {
+                names.Add(item.Name);
+            }
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(name, names);
+        }
+
+        [Test]
+        public async Task GetDirectoryAsync_NonAsciiName()
+        {
+            await using DisposingShare test = await GetTestShareAsync();
+            string name = GetNewNonAsciiDirectoryName();
+
+            ShareDirectoryClient subdir = InstrumentClient(test.Share.GetDirectoryClient(name));
+            await subdir.CreateAsync();
+
+            // Assert
+            List<string> names = new List<string>();
+            ShareDirectoryClient rootDirectory = InstrumentClient(test.Share.GetRootDirectoryClient());
+            await foreach (ShareFileItem item in rootDirectory.GetFilesAndDirectoriesAsync())
+            {
+                names.Add(item.Name);
+            }
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(name, names);
+        }
+
+        [Test]
+        public async Task GetSubdirectoryAsync_AsciiName()
+        {
+            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            ShareDirectoryClient dir = test.Directory;
+            string name = GetNewDirectoryName();
+
+            ShareDirectoryClient subdir = InstrumentClient(dir.GetSubdirectoryClient(name));
+            await subdir.CreateAsync();
+
+            // Assert
+            List<string> names = new List<string>();
+            await foreach (ShareFileItem item in test.Directory.GetFilesAndDirectoriesAsync())
+            {
+                names.Add(item.Name);
+            }
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(name, names);
+        }
+
+        [Test]
+        public async Task GetSubdirectoryAsync_NonAsciiName()
+        {
+            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            ShareDirectoryClient dir = test.Directory;
+            string name = GetNewDirectoryName();
+
+            ShareDirectoryClient subdir = InstrumentClient(dir.GetSubdirectoryClient(name));
+            await subdir.CreateAsync();
+
+            // Assert
+            List<string> names = new List<string>();
+            await foreach (ShareFileItem item in test.Directory.GetFilesAndDirectoriesAsync())
+            {
+                names.Add(item.Name);
+            }
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(name, names);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -2552,6 +2552,50 @@ namespace Azure.Storage.Files.Shares.Test
                 e => Assert.AreEqual("ResourceNotFound", e.ErrorCode));
         }
 
+        [Test]
+        public async Task GetFileClient_AsciiName()
+        {
+            // Arrange
+            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            ShareDirectoryClient directory = test.Directory;
+
+            // Act
+            var name = GetNewFileName();
+            ShareFileClient file = InstrumentClient(directory.GetFileClient(name));
+            Response<ShareFileInfo> response = await file.CreateAsync(maxSize: Constants.MB);
+
+            // Assert
+            List<string> names = new List<string>();
+            await foreach (ShareFileItem item in test.Directory.GetFilesAndDirectoriesAsync())
+            {
+                names.Add(item.Name);
+            }
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(name, names);
+        }
+
+        [Test]
+        public async Task GetFileClient_NonAsciiName()
+        {
+            // Arrange
+            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            ShareDirectoryClient directory = test.Directory;
+
+            // Act
+            var name = GetNewNonAsciiFileName();
+            ShareFileClient file = InstrumentClient(directory.GetFileClient(name));
+            Response<ShareFileInfo> response = await file.CreateAsync(maxSize: Constants.MB);
+
+            // Assert
+            List<string> names = new List<string>();
+            await foreach (ShareFileItem item in test.Directory.GetFilesAndDirectoriesAsync())
+            {
+                names.Add(item.Name);
+            }
+            Assert.AreEqual(1, names.Count);
+            Assert.Contains(name, names);
+        }
+
         private async Task WaitForCopy(ShareFileClient file, int milliWait = 200)
         {
             CopyStatus status = CopyStatus.Pending;

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -32,8 +32,9 @@ namespace Azure.Storage.Files.Shares.Tests
 
         public string GetNewShareName() => $"test-share-{Recording.Random.NewGuid()}";
         public string GetNewDirectoryName() => $"test-directory-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiDirectoryName() => $"test-dire¢t Ø®ϒ%3A-{Recording.Random.NewGuid()}";
         public string GetNewFileName() => $"test-file-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiFileName() => $"test-ƒ¡£€‽-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiFileName() => $"test-ƒ¡£€‽%3A-{Recording.Random.NewGuid()}";
 
         public ShareClientOptions GetOptions()
         {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_AsciiName.json
@@ -1,0 +1,146 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-85c587b0-a4c5-1d40-9fdc-caa5ecf94fa0?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2bd4cd37cad8cc448a76e30faa012085-bce3857c8918f642-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9ebfe2e6-bc24-29f0-3ef3-2dc661a7accc",
+        "x-ms-date": "Fri, 29 May 2020 16:50:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:48 GMT",
+        "ETag": "\u00220x8D803F070F806B6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9ebfe2e6-bc24-29f0-3ef3-2dc661a7accc",
+        "x-ms-request-id": "7a949b7c-001a-00bc-27d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-85c587b0-a4c5-1d40-9fdc-caa5ecf94fa0/test-directory-ae2a7f87-0b0c-898e-07cd-e15a011c5b52?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a6a9e6ddc6adbf43bb9f4a65e4e45a06-a877400fe3a6b14c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "429cd5be-3222-da50-5436-9656db952722",
+        "x-ms-date": "Fri, 29 May 2020 16:50:49 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:48 GMT",
+        "ETag": "\u00220x8D803F0710C4CEA\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "429cd5be-3222-da50-5436-9656db952722",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:49.6591082Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:49.6591082Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:49.6591082Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b81-001a-00bc-2ad9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-85c587b0-a4c5-1d40-9fdc-caa5ecf94fa0/?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "2c9ce437-197f-ca30-1ce4-b5031a25fc52",
+        "x-ms-date": "Fri, 29 May 2020 16:50:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "2c9ce437-197f-ca30-1ce4-b5031a25fc52",
+        "x-ms-request-id": "7a949b82-001a-00bc-2bd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-85c587b0-a4c5-1d40-9fdc-caa5ecf94fa0\u0022 DirectoryPath=\u0022\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-directory-ae2a7f87-0b0c-898e-07cd-e15a011c5b52\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-85c587b0-a4c5-1d40-9fdc-caa5ecf94fa0?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4b6ee749d85d74cb01182e5129c3a8f-dbed9169b597ea46-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f61f4aa5-fbf8-7fa2-aaff-d704ec8fbcdd",
+        "x-ms-date": "Fri, 29 May 2020 16:50:49 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f61f4aa5-fbf8-7fa2-aaff-d704ec8fbcdd",
+        "x-ms-request-id": "7a949b83-001a-00bc-2cd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "116450055",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_AsciiNameAsync.json
@@ -1,0 +1,146 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-490ddf61-3051-c424-3483-493ba6e7b40f?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b0a3053bac150443ab5b5656f0885173-e9a31fa3dea84a4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b4f4c466-e83f-4bdf-4af0-b703285b1c3b",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F071AF6A30\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b4f4c466-e83f-4bdf-4af0-b703285b1c3b",
+        "x-ms-request-id": "7a949b96-001a-00bc-3bd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-490ddf61-3051-c424-3483-493ba6e7b40f/test-directory-1e0cbf9b-29e6-cb6a-2506-2ac1e9024354?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-480a60b7dbde9f4785b090ddce4c2c05-82864e99e1f4ec46-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c2860b72-cdd2-3c57-5a28-8e39be1e6148",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F071BAFBFC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c2860b72-cdd2-3c57-5a28-8e39be1e6148",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:50.8039164Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:50.8039164Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:50.8039164Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b98-001a-00bc-3cd9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-490ddf61-3051-c424-3483-493ba6e7b40f/?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dd4e6628-807c-c982-b397-87ca7197da6c",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "dd4e6628-807c-c982-b397-87ca7197da6c",
+        "x-ms-request-id": "7a949b9a-001a-00bc-3dd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-490ddf61-3051-c424-3483-493ba6e7b40f\u0022 DirectoryPath=\u0022\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-directory-1e0cbf9b-29e6-cb6a-2506-2ac1e9024354\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-490ddf61-3051-c424-3483-493ba6e7b40f?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-04afaf1574145942a5253a9ae3ad2694-73b1b0eeaa964946-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "58111f3c-83cf-2ccb-e0a3-6aeeb37c2957",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "58111f3c-83cf-2ccb-e0a3-6aeeb37c2957",
+        "x-ms-request-id": "7a949b9b-001a-00bc-3ed9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "958487204",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_NonAsciiName.json
@@ -1,0 +1,146 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1053f8c8-7066-2897-f570-b0308b36e424?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8896adf9ac990344bc46051028bca3ec-9a2c0ee1bbfab442-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "585e3cd8-8253-d0b9-9ba0-b4d6fcc3b343",
+        "x-ms-date": "Fri, 29 May 2020 16:50:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F07139FDB1\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "585e3cd8-8253-d0b9-9ba0-b4d6fcc3b343",
+        "x-ms-request-id": "7a949b85-001a-00bc-2dd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1053f8c8-7066-2897-f570-b0308b36e424/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-6ec97b61-1988-5619-748c-372482044c6e?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-13298d1bd63af543911dd2b957e29412-5fa7289bc9fa1448-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6031aa8e-a0bd-bfb6-2207-e4c74b954e96",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F07142A8FD\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6031aa8e-a0bd-bfb6-2207-e4c74b954e96",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:50.0153597Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:50.0153597Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:50.0153597Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b87-001a-00bc-2ed9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1053f8c8-7066-2897-f570-b0308b36e424/?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d79622c0-ecd2-c1b0-bb98-2ccfa708584f",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "d79622c0-ecd2-c1b0-bb98-2ccfa708584f",
+        "x-ms-request-id": "7a949b88-001a-00bc-2fd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-1053f8c8-7066-2897-f570-b0308b36e424\u0022 DirectoryPath=\u0022\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-dire\u00A2t \u00D8\u00AE\u03D2%3A-6ec97b61-1988-5619-748c-372482044c6e\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1053f8c8-7066-2897-f570-b0308b36e424?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab6518975cb9fd47a2bc3057eebc12e9-ae450566e5bc3c40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "28061e6d-76ff-66c3-95b2-ced3379b2da2",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "28061e6d-76ff-66c3-95b2-ced3379b2da2",
+        "x-ms-request-id": "7a949b89-001a-00bc-30d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1632593104",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryAsync_NonAsciiNameAsync.json
@@ -1,0 +1,146 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-392bed07-dff7-f5a8-f45f-f637a31e2a28?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ccaef4e3a1014c47baa2f120125ea20c-98de731e0a0df740-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1327957b-db55-a3d1-79fa-a1a42e2b815d",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F071D6CF7F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1327957b-db55-a3d1-79fa-a1a42e2b815d",
+        "x-ms-request-id": "7a949b9c-001a-00bc-3fd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-392bed07-dff7-f5a8-f45f-f637a31e2a28/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-dd2b78a5-cd87-01f5-b6cd-9a7af233b809?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-50a2dfa4d55da347849fa6f9d47a5eea-d9a62b65c02cd649-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c3cf8ffb-07bf-ae01-9f25-5d884156b145",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F071DFEFCE\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c3cf8ffb-07bf-ae01-9f25-5d884156b145",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.0460878Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.0460878Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.0460878Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b9e-001a-00bc-40d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-392bed07-dff7-f5a8-f45f-f637a31e2a28/?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "627f269e-f464-724a-6b0e-6ed1b84959b6",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "627f269e-f464-724a-6b0e-6ed1b84959b6",
+        "x-ms-request-id": "7a949b9f-001a-00bc-41d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-392bed07-dff7-f5a8-f45f-f637a31e2a28\u0022 DirectoryPath=\u0022\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-dire\u00A2t \u00D8\u00AE\u03D2%3A-dd2b78a5-cd87-01f5-b6cd-9a7af233b809\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-392bed07-dff7-f5a8-f45f-f637a31e2a28?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-389499b3f9babe44b22c4337c6d7ea78-4b2e9d42a3a34c49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1ae93b89-4fd7-4ce1-4db7-54600495d55c",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ae93b89-4fd7-4ce1-4db7-54600495d55c",
+        "x-ms-request-id": "7a949ba0-001a-00bc-42d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1091992156",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiName.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e26fe53ba1b12548846afef9b32928dd-74a8b31517c24641-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "6f07e92a-b4bc-eea6-b23e-0c35751df410",
+        "x-ms-date": "Fri, 29 May 2020 00:05:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "ETag": "\u00220x8D80363F3434DD6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6f07e92a-b4bc-eea6-b23e-0c35751df410",
+        "x-ms-request-id": "83c44d6b-501e-00c0-084c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d/test-directory-03711db3-f9a8-3719-a408-fdc7bd52fdf1?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "38626c48-3711-30a5-cfcf-cbb4b6df305f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "ETag": "\u00220x8D80363F357A9F4\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38626c48-3711-30a5-cfcf-cbb4b6df305f",
+        "x-ms-request-id": "7539ed3c-e01f-000e-4d4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "517e7375-c4f0-c1e0-180f-5f8a2ccd9f37",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "517e7375-c4f0-c1e0-180f-5f8a2ccd9f37",
+        "x-ms-request-id": "7539ed3d-e01f-000e-4e4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F357A9F4",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:09 GMT",
+            "name": "test-directory-03711db3-f9a8-3719-a408-fdc7bd52fdf1"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-a50f9183-3a04-5369-7333-0b6a1861673d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c159c3d0e8be5243986c7509ac8a313f-15319c7a72d3684a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "433eddd6-df60-7d6f-3b7c-9fce662c90cf",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:08 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "433eddd6-df60-7d6f-3b7c-9fce662c90cf",
+        "x-ms-request-id": "83c44dc1-501e-00c0-4f4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "470932305",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_AsciiNameAsync.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e87f4378c387e14ea52cbc2d21eefbbb-dd92b824f34bc74c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "1137f5da-33d0-cebf-7cb5-00d3c30b7915",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F434C651\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1137f5da-33d0-cebf-7cb5-00d3c30b7915",
+        "x-ms-request-id": "83c44e9e-501e-00c0-7a4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520/test-directory-104361a3-d89d-22c9-81d6-444a1d200977?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0a320266-e6f3-01fb-2b14-8ff9ef74b15b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F440E30D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a320266-e6f3-01fb-2b14-8ff9ef74b15b",
+        "x-ms-request-id": "7539ed45-e01f-000e-564c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1be30775-ffed-cf84-7a31-645834557fae",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "1be30775-ffed-cf84-7a31-645834557fae",
+        "x-ms-request-id": "7539ed46-e01f-000e-574c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F440E30D",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-104361a3-d89d-22c9-81d6-444a1d200977"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8dfb4ded-342a-75f6-aead-0f0d85a5d520?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-076d68a28e75014c86d53706d17312c3-41e31ee67352584e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e78406bb-9591-ad6e-054d-d2a6844eaabc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e78406bb-9591-ad6e-054d-d2a6844eaabc",
+        "x-ms-request-id": "83c44ec4-501e-00c0-164c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "743471578",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiName.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1bb12b8349115643bc9f523da48e016c-77fd5a3acf97d449-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "320ea34e-f672-ce88-ddc5-65ded75f6dea",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F39DB8E4\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "320ea34e-f672-ce88-ddc5-65ded75f6dea",
+        "x-ms-request-id": "83c44ddf-501e-00c0-6a4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-18294ffa-650d-10a8-c204-3574679319f5?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d2ef06c8-1e31-e9fd-fafd-6f6ec014674a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F3A93939\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2ef06c8-1e31-e9fd-fafd-6f6ec014674a",
+        "x-ms-request-id": "7539ed3e-e01f-000e-4f4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "60ab50b9-46a3-53c3-0ffe-f4656248ca3f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "60ab50b9-46a3-53c3-0ffe-f4656248ca3f",
+        "x-ms-request-id": "7539ed3f-e01f-000e-504c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F3A93939",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:09 GMT",
+            "name": "test-dire\u00A2t \u00D8\u00AE\u03D2%3A-18294ffa-650d-10a8-c204-3574679319f5"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-7926c602-58aa-3a7d-50a9-173792710428?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f5412b1ea214a4dbec77cad495b1038-7ecfb1d6ce277447-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6fb4d378-0668-65a7-ac18-bb788a22c550",
+        "x-ms-date": "Fri, 29 May 2020 00:05:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6fb4d378-0668-65a7-ac18-bb788a22c550",
+        "x-ms-request-id": "83c44e08-501e-00c0-064c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "409565269",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetDirectoryClientAsync_NonAsciiNameAsync.json
@@ -1,0 +1,142 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5d39224cf1afb14d90a16c0b72465c4e-1bc1b70e2f92444b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "dc469eac-169f-d4ec-d0a2-358cfbcf4216",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F467A289\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dc469eac-169f-d4ec-d0a2-358cfbcf4216",
+        "x-ms-request-id": "83c44ed5-501e-00c0-244c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-6491b0f7-14fa-ac10-189d-11b300dbb88e?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "94b0239f-ec9f-978a-8d9a-c4010438d3f5",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F472FBB0\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94b0239f-ec9f-978a-8d9a-c4010438d3f5",
+        "x-ms-request-id": "7539ed47-e01f-000e-584c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dd138bd3-242a-28ee-b47d-69ef813999bf",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "dd138bd3-242a-28ee-b47d-69ef813999bf",
+        "x-ms-request-id": "7539ed48-e01f-000e-594c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F472FBB0",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-dire\u00A2t \u00D8\u00AE\u03D2%3A-6491b0f7-14fa-ac10-189d-11b300dbb88e"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-66631150-3b95-fd83-bf65-c3c294d022d9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-67a6aa281d4e7841bd2cbcdace857045-302877a415cafe4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "782d175c-f525-c6cb-b850-073be29e303b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "782d175c-f525-c6cb-b850-073be29e303b",
+        "x-ms-request-id": "83c44f0d-501e-00c0-4e4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "442423822",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiName.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d76e6c980179ba4f8febb3cd958aadde-52416320f7269546-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d314c582-072a-d30f-9c06-866ff1ddd634",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F3D06DE9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d314c582-072a-d30f-9c06-866ff1ddd634",
+        "x-ms-request-id": "83c44e1c-501e-00c0-134c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a/test-directory-f0a56a24-a014-f12a-2708-b5fdbc2142b8/test-directory-7a74f125-27bc-a570-3ebd-18fe11897429?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ff49cdc3-5b69-fd78-fa00-b257872bdf9d",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F3DD2714\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ff49cdc3-5b69-fd78-fa00-b257872bdf9d",
+        "x-ms-request-id": "7539ed40-e01f-000e-514c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "443b9ca7-7440-f4c0-8dc2-164f30825a6e",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "443b9ca7-7440-f4c0-8dc2-164f30825a6e",
+        "x-ms-request-id": "7539ed41-e01f-000e-524c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F3DC8AAE",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-f0a56a24-a014-f12a-2708-b5fdbc2142b8"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F3DD2714",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-f0a56a24-a014-f12a-2708-b5fdbc2142b8/test-directory-7a74f125-27bc-a570-3ebd-18fe11897429"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-bc6e1f89-f724-bd06-adf9-e0f63fd1fb9a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1dede5f3a407c94ca3fdf900de5d89d5-ba118a03bc8f3b48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ebb086ac-9bf0-1f5c-cbb8-299d1a191295",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ebb086ac-9bf0-1f5c-cbb8-299d1a191295",
+        "x-ms-request-id": "83c44e53-501e-00c0-3d4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1326272744",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_AsciiNameAsync.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0f34be58f292e240bdbf7956d5a2c29b-f053141a3d9c674b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "43473107-5cc3-e5e4-9f71-1459fbfab0eb",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F497BEF7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43473107-5cc3-e5e4-9f71-1459fbfab0eb",
+        "x-ms-request-id": "83c44f1c-501e-00c0-5b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4/test-directory-5e1057f4-caf3-dd25-b8f4-e320d5af510a/test-directory-0a69c85d-efbd-de30-9034-3da57d21e884?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "33fb0a1f-a690-042e-2731-cdbf8c7f6096",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F4A402A1\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "33fb0a1f-a690-042e-2731-cdbf8c7f6096",
+        "x-ms-request-id": "7539ed49-e01f-000e-5a4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "73864d23-b526-fff3-d720-8142d125b08c",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "73864d23-b526-fff3-d720-8142d125b08c",
+        "x-ms-request-id": "7539ed4a-e01f-000e-5b4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4A38D54",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-5e1057f4-caf3-dd25-b8f4-e320d5af510a"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4A402A1",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-5e1057f4-caf3-dd25-b8f4-e320d5af510a/test-directory-0a69c85d-efbd-de30-9034-3da57d21e884"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-62d93370-c777-52c8-8f5b-a2703b0432f4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f7cee348107fdd4a9e940008c03fcf62-c99e50901aabe14e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3f9b00cb-edf9-566f-6b7b-f7692752ecbd",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3f9b00cb-edf9-566f-6b7b-f7692752ecbd",
+        "x-ms-request-id": "83c44f45-501e-00c0-014c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "52368560",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiName.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8768dd29a6e5f044bcea6152a544320c-1cdf0d92338dfd4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d9f5fff4-d24a-67ec-ffae-855505f40a4a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F4025F74\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d9f5fff4-d24a-67ec-ffae-855505f40a4a",
+        "x-ms-request-id": "83c44e65-501e-00c0-4b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f/test-directory-d89389d3-8b10-589a-5fca-72e2bf7a5f4c/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-1203f328-0a20-8f35-ae91-3b444860ffa2?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "112d384f-f8f0-c829-5303-297f4f5510fe",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "ETag": "\u00220x8D80363F40E7C33\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "112d384f-f8f0-c829-5303-297f4f5510fe",
+        "x-ms-request-id": "7539ed43-e01f-000e-544c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0ff5b7e8-ee33-b8b1-46db-f70ff18e1a0f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0ff5b7e8-ee33-b8b1-46db-f70ff18e1a0f",
+        "x-ms-request-id": "7539ed44-e01f-000e-554c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F40E06EB",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-d89389d3-8b10-589a-5fca-72e2bf7a5f4c"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F40E7C33",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:10 GMT",
+            "name": "test-directory-d89389d3-8b10-589a-5fca-72e2bf7a5f4c/test-dire\u00A2t \u00D8\u00AE\u03D2%3A-1203f328-0a20-8f35-ae91-3b444860ffa2"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-09ce1526-799e-34f2-f31b-12f71216e47f?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d08efd672a70c04a93006bad667eed82-ce9b6973f54f0046-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "979684d4-0060-ddca-1d79-09fb1c2a1c56",
+        "x-ms-date": "Fri, 29 May 2020 00:05:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "979684d4-0060-ddca-1d79-09fb1c2a1c56",
+        "x-ms-request-id": "83c44e88-501e-00c0-664c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1368634928",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubDirectoryClientAsync_NonAsciiNameAsync.json
@@ -1,0 +1,149 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d61d18754d355d46ba1dddc00a1abd55-273203ea0f3ceb49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "97579df9-919a-011c-6c94-071c6f25bf2d",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:10 GMT",
+        "ETag": "\u00220x8D80363F4C850B5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "97579df9-919a-011c-6c94-071c6f25bf2d",
+        "x-ms-request-id": "83c44f55-501e-00c0-104c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703/test-directory-2802d4cb-a0a3-e67b-9b94-9196f8dbe4ef/test-dire\u00A2t \u00D8\u00AE\u03D2%253A-88b94936-f0fe-0169-c6d1-acbb05d77b36?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "26e617b0-366b-db2f-6b01-62d2f4bfe1c3",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F4D49440\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "26e617b0-366b-db2f-6b01-62d2f4bfe1c3",
+        "x-ms-request-id": "7539ed4c-e01f-000e-5d4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ed0b1bc8-55f1-14ca-c010-9cfacee96462",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "ed0b1bc8-55f1-14ca-c010-9cfacee96462",
+        "x-ms-request-id": "7539ed4d-e01f-000e-5e4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4D3F7DF",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-2802d4cb-a0a3-e67b-9b94-9196f8dbe4ef"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F4D49440",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:11 GMT",
+            "name": "test-directory-2802d4cb-a0a3-e67b-9b94-9196f8dbe4ef/test-dire\u00A2t \u00D8\u00AE\u03D2%3A-88b94936-f0fe-0169-c6d1-acbb05d77b36"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-ed808ef3-15a1-c093-ed90-a9b225558703?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5e9c9b6efce99a469eecfb77bfb17855-3fd5837ec94d204e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d80921ff-f3b4-c3d2-9035-48e040f936a4",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d80921ff-f3b4-c3d2-9035-48e040f936a4",
+        "x-ms-request-id": "83c44f9a-501e-00c0-454c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1548058516",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_AsciiName.json
@@ -1,0 +1,190 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a49f246c-1572-3772-7cf1-bd757a1e7ed6?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7404008f23e0cc4db61f2cc566ef108a-70990df37d016940-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9f376962-4039-c346-2012-8fdbaef681b3",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F0715B4768\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9f376962-4039-c346-2012-8fdbaef681b3",
+        "x-ms-request-id": "7a949b8a-001a-00bc-31d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a49f246c-1572-3772-7cf1-bd757a1e7ed6/test-directory-6cfdfefe-3b45-5bf2-633d-f2c240ae00d9?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-787f502a87ea0b4c9b01f03b23c5570b-6c1d8833bf6cef48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "39c4212e-85a5-26bd-76db-3bfc4e848271",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F0716467E7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "39c4212e-85a5-26bd-76db-3bfc4e848271",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:50.2365159Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:50.2365159Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:50.2365159Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b8c-001a-00bc-32d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a49f246c-1572-3772-7cf1-bd757a1e7ed6/test-directory-6cfdfefe-3b45-5bf2-633d-f2c240ae00d9/test-directory-f3dcb512-70e4-1fcc-61eb-7e54d8c5da7e?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-82a0c8bb95a55f4c98df5d2def795b8e-2b884439aaaf0241-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "cb1af06e-c008-bdd7-54a4-d7b906694db1",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F0716C3183\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb1af06e-c008-bdd7-54a4-d7b906694db1",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:50.2875523Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:50.2875523Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:50.2875523Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b8d-001a-00bc-33d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a49f246c-1572-3772-7cf1-bd757a1e7ed6/test-directory-6cfdfefe-3b45-5bf2-633d-f2c240ae00d9?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e8e51528-0faa-c875-60d6-cb45ef7a7294",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "e8e51528-0faa-c875-60d6-cb45ef7a7294",
+        "x-ms-request-id": "7a949b8e-001a-00bc-34d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-a49f246c-1572-3772-7cf1-bd757a1e7ed6\u0022 DirectoryPath=\u0022test-directory-6cfdfefe-3b45-5bf2-633d-f2c240ae00d9\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-directory-f3dcb512-70e4-1fcc-61eb-7e54d8c5da7e\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a49f246c-1572-3772-7cf1-bd757a1e7ed6?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c00da88d9a9bd04d82366c23fecdfcb4-3716a50a6a3d3b45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f0911627-6583-f106-47a9-b61997425b07",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f0911627-6583-f106-47a9-b61997425b07",
+        "x-ms-request-id": "7a949b8f-001a-00bc-35d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "903050876",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_AsciiNameAsync.json
@@ -1,0 +1,190 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1d92bd04-1520-4e90-b013-8f2d03b21d82?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e321a8a2c01dd441b9ee668e423a7f3e-b4f5cab70f1ad347-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c1de0798-42ac-367e-181b-a44e450445a4",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F071F8B589\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1de0798-42ac-367e-181b-a44e450445a4",
+        "x-ms-request-id": "7a949ba1-001a-00bc-43d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1d92bd04-1520-4e90-b013-8f2d03b21d82/test-directory-97c6d26c-2223-a8dd-ef21-f94a4a32075e?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-16911a6ce158924090d4eef0a6437685-db6d6e9a7b9d2747-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "74f12690-298b-7562-2935-d18a4834ece5",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F07201396A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "74f12690-298b-7562-2935-d18a4834ece5",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.2642410Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.2642410Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.2642410Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949ba3-001a-00bc-44d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1d92bd04-1520-4e90-b013-8f2d03b21d82/test-directory-97c6d26c-2223-a8dd-ef21-f94a4a32075e/test-directory-3cfb4513-486e-10cf-fbb8-b8f20a57f070?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8f2e0f1e549d42448138aa478e5047c8-e5eb731669ec354f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "71723344-ee83-48b0-57e0-78d371706bd1",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F0720C37EF\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "71723344-ee83-48b0-57e0-78d371706bd1",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.3362927Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.3362927Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.3362927Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949ba4-001a-00bc-45d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1d92bd04-1520-4e90-b013-8f2d03b21d82/test-directory-97c6d26c-2223-a8dd-ef21-f94a4a32075e?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d6ad0df2-7fe4-07ed-2971-cc6119ffb735",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "d6ad0df2-7fe4-07ed-2971-cc6119ffb735",
+        "x-ms-request-id": "7a949ba5-001a-00bc-46d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-1d92bd04-1520-4e90-b013-8f2d03b21d82\u0022 DirectoryPath=\u0022test-directory-97c6d26c-2223-a8dd-ef21-f94a4a32075e\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-directory-3cfb4513-486e-10cf-fbb8-b8f20a57f070\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-1d92bd04-1520-4e90-b013-8f2d03b21d82?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6812d085cc8b774687d24fe1272e84ae-020682a2f5387e4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "64e0c85a-94c3-c5ed-728c-4409fd416772",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "64e0c85a-94c3-c5ed-728c-4409fd416772",
+        "x-ms-request-id": "7a949ba6-001a-00bc-47d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "283301135",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_NonAsciiName.json
@@ -1,0 +1,190 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a526a3e1-135c-690a-29ef-dbac3b823892?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-3543546be11ebf42b2f3650fe67ae16a-7278f4aae2214a48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f6602021-3f9f-6e93-b2ae-a9de9da061c9",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F07184CFFB\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f6602021-3f9f-6e93-b2ae-a9de9da061c9",
+        "x-ms-request-id": "7a949b90-001a-00bc-36d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a526a3e1-135c-690a-29ef-dbac3b823892/test-directory-a6735e48-400c-c20f-ef2a-18138c06e593?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-101f093759fde348ab66c36a274b9136-14fad2a457d7f943-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "25bcbde7-1c23-e173-119d-0775267fe2ac",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F0718DF068\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "25bcbde7-1c23-e173-119d-0775267fe2ac",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:50.5087080Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:50.5087080Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:50.5087080Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b92-001a-00bc-37d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a526a3e1-135c-690a-29ef-dbac3b823892/test-directory-a6735e48-400c-c20f-ef2a-18138c06e593/test-directory-40b115c8-4616-06a7-6bb0-2dc04af14d19?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f3d411dedce4474d8b6303de81653ac3-9412404637823747-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5f554969-1e24-a1d5-16b5-b972eeb39620",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "ETag": "\u00220x8D803F071956BD3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5f554969-1e24-a1d5-16b5-b972eeb39620",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:50.5577427Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:50.5577427Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:50.5577427Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949b93-001a-00bc-38d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a526a3e1-135c-690a-29ef-dbac3b823892/test-directory-a6735e48-400c-c20f-ef2a-18138c06e593?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "01563413-ed9b-acf5-568b-b99406fd2136",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "01563413-ed9b-acf5-568b-b99406fd2136",
+        "x-ms-request-id": "7a949b94-001a-00bc-39d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-a526a3e1-135c-690a-29ef-dbac3b823892\u0022 DirectoryPath=\u0022test-directory-a6735e48-400c-c20f-ef2a-18138c06e593\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-directory-40b115c8-4616-06a7-6bb0-2dc04af14d19\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a526a3e1-135c-690a-29ef-dbac3b823892?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-91a31a83fd618d4f9b6ec932b59d1692-06daad6b7ea7b346-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ba5fcae9-955c-6384-f7ff-a3c75acd02a8",
+        "x-ms-date": "Fri, 29 May 2020 16:50:50 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:49 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ba5fcae9-955c-6384-f7ff-a3c75acd02a8",
+        "x-ms-request-id": "7a949b95-001a-00bc-3ad9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1122309295",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/GetSubdirectoryAsync_NonAsciiNameAsync.json
@@ -1,0 +1,190 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-b11dfeb8-e9e4-eeb4-1bf9-489c84b1d783?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-cb2d5cf89318f44ea62f717caf2a3bcf-daca14384d704d4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e9f682bd-1cb5-d3cf-b38f-d15bbd01d065",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F072234FC3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e9f682bd-1cb5-d3cf-b38f-d15bbd01d065",
+        "x-ms-request-id": "7a949ba7-001a-00bc-48d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-b11dfeb8-e9e4-eeb4-1bf9-489c84b1d783/test-directory-f046af74-e679-4174-897d-a1dc5e79ec87?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6605f1cb3fc7a047a2c4bc2c6d6d1504-22f53be2d3167a42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "51c62537-374d-d7ee-0eb4-60377bf3753a",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F0722D5A78\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "51c62537-374d-d7ee-0eb4-60377bf3753a",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.5534456Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.5534456Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.5534456Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949ba9-001a-00bc-49d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-b11dfeb8-e9e4-eeb4-1bf9-489c84b1d783/test-directory-f046af74-e679-4174-897d-a1dc5e79ec87/test-directory-dc8a49a2-ce22-86aa-e26f-0f79444a9c6f?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4ffa5202a7dd94b9be22a7937f183f6-9facbba5dd4b1a4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5c86678a-068f-68eb-7b40-6fdd277592c3",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "ETag": "\u00220x8D803F07234FCF5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5c86678a-068f-68eb-7b40-6fdd277592c3",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.6034805Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.6034805Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.6034805Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949baa-001a-00bc-4ad9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-b11dfeb8-e9e4-eeb4-1bf9-489c84b1d783/test-directory-f046af74-e679-4174-897d-a1dc5e79ec87?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dcee2113-3fc3-93e0-a73d-be712a5c727c",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:50 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "dcee2113-3fc3-93e0-a73d-be712a5c727c",
+        "x-ms-request-id": "7a949bab-001a-00bc-4bd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-b11dfeb8-e9e4-eeb4-1bf9-489c84b1d783\u0022 DirectoryPath=\u0022test-directory-f046af74-e679-4174-897d-a1dc5e79ec87\u0022\u003E\u003CEntries\u003E\u003CDirectory\u003E\u003CName\u003Etest-directory-dc8a49a2-ce22-86aa-e26f-0f79444a9c6f\u003C/Name\u003E\u003CProperties /\u003E\u003C/Directory\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-b11dfeb8-e9e4-eeb4-1bf9-489c84b1d783?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a1bb75981e5a5d47b4384dccd3581e0e-f9a43b6f93f20f40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "05c92347-b586-d8ff-1009-40107d16ddb1",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "05c92347-b586-d8ff-1009-40107d16ddb1",
+        "x-ms-request-id": "7a949bac-001a-00bc-4cd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "510646393",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_AsciiName.json
@@ -5,13 +5,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a13063e11d4e944abcf87a5074a9077e-f888874740f9f542-00",
+        "traceparent": "00-083505482302b340ad593a36aec98500-7e9e9469cc933344-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8ed15bf5-9222-758e-a76c-b124798270d9",
-        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:28:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,15 +19,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 16:50:51 GMT",
-        "ETag": "\u00220x8D803F0724D4D97\u0022",
-        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "ETag": "\u00220x8D803FE112675D2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:28:21 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8ed15bf5-9222-758e-a76c-b124798270d9",
-        "x-ms-request-id": "7a949baf-001a-00bc-4dd9-35856a000000",
+        "x-ms-request-id": "f348ed7e-a01a-0010-3fe6-35a4fd000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -37,13 +37,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-451066a80a63a54b9aca05e4afbf822f-4e94404a84e5b64a-00",
+        "traceparent": "00-71dd9da2dc0e624a9a909c1d9faba650-178bac569e5bc247-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "38f85c14-0c3b-d074-a756-7a1f89508ebc",
-        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:28:21 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,22 +55,22 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 16:50:51 GMT",
-        "ETag": "\u00220x8D803F07255F86F\u0022",
-        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "ETag": "\u00220x8D803FE113F10F6\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:28:21 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "38f85c14-0c3b-d074-a756-7a1f89508ebc",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-29T16:50:51.8196335Z",
-        "x-ms-file-creation-time": "2020-05-29T16:50:51.8196335Z",
+        "x-ms-file-change-time": "2020-05-29T18:28:21.8847478Z",
+        "x-ms-file-creation-time": "2020-05-29T18:28:21.8847478Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-29T16:50:51.8196335Z",
+        "x-ms-file-last-write-time": "2020-05-29T18:28:21.8847478Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "7a949bb1-001a-00bc-4ed9-35856a000000",
+        "x-ms-request-id": "f348ed81-a01a-0010-40e6-35a4fd000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -81,14 +81,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-739f51e52ae4084ca8769c335e562741-98d7ffa0d04cf343-00",
+        "traceparent": "00-6e9769519f44af439b77b60235d52e67-463d0b269e9fdf44-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "01538560-ad8b-667f-6de9-d7d98ee6ec4a",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -101,22 +101,22 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 16:50:51 GMT",
-        "ETag": "\u00220x8D803F0726600E5\u0022",
-        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "ETag": "\u00220x8D803FE11524E53\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "01538560-ad8b-667f-6de9-d7d98ee6ec4a",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-29T16:50:51.9247077Z",
-        "x-ms-file-creation-time": "2020-05-29T16:50:51.9247077Z",
+        "x-ms-file-change-time": "2020-05-29T18:28:22.0108371Z",
+        "x-ms-file-creation-time": "2020-05-29T18:28:22.0108371Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-29T16:50:51.9247077Z",
+        "x-ms-file-last-write-time": "2020-05-29T18:28:22.0108371Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "7a949bb3-001a-00bc-4fd9-35856a000000",
+        "x-ms-request-id": "f348ed82-a01a-0010-41e6-35a4fd000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -132,7 +132,7 @@
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5e2dfe92-2a08-99f1-c8c3-1c0957507d0f",
-        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -141,14 +141,14 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Content-Type": "application/xml",
-        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Date": "Fri, 29 May 2020 18:28:21 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "5e2dfe92-2a08-99f1-c8c3-1c0957507d0f",
-        "x-ms-request-id": "7a949bb4-001a-00bc-50d9-35856a000000",
+        "x-ms-request-id": "f348ed83-a01a-0010-42e6-35a4fd000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1\u0022 DirectoryPath=\u0022test-directory-4ebb0f15-257c-7ab4-1403-093ee7eb6765\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-file-0e0c4b04-ae41-0eef-6062-7e8de45c2c7c\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
@@ -158,13 +158,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1b1b6beefa12974ca337127fae234771-cc7307692e5c944d-00",
+        "traceparent": "00-50d4b15c4d2f674c84753cea70317133-e656bb91d408f747-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8f460668-8db9-ff42-0b3f-7863e6bf7cd1",
-        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -173,13 +173,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Date": "Fri, 29 May 2020 18:28:21 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8f460668-8db9-ff42-0b3f-7863e6bf7cd1",
-        "x-ms-request-id": "7a949bb5-001a-00bc-51d9-35856a000000",
+        "x-ms-request-id": "f348ed84-a01a-0010-43e6-35a4fd000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_AsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_AsciiName.json
@@ -1,0 +1,192 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a13063e11d4e944abcf87a5074a9077e-f888874740f9f542-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8ed15bf5-9222-758e-a76c-b124798270d9",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "ETag": "\u00220x8D803F0724D4D97\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8ed15bf5-9222-758e-a76c-b124798270d9",
+        "x-ms-request-id": "7a949baf-001a-00bc-4dd9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1/test-directory-4ebb0f15-257c-7ab4-1403-093ee7eb6765?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-451066a80a63a54b9aca05e4afbf822f-4e94404a84e5b64a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "38f85c14-0c3b-d074-a756-7a1f89508ebc",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "ETag": "\u00220x8D803F07255F86F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38f85c14-0c3b-d074-a756-7a1f89508ebc",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.8196335Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.8196335Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.8196335Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949bb1-001a-00bc-4ed9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1/test-directory-4ebb0f15-257c-7ab4-1403-093ee7eb6765/test-file-0e0c4b04-ae41-0eef-6062-7e8de45c2c7c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-739f51e52ae4084ca8769c335e562741-98d7ffa0d04cf343-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "01538560-ad8b-667f-6de9-d7d98ee6ec4a",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "ETag": "\u00220x8D803F0726600E5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "01538560-ad8b-667f-6de9-d7d98ee6ec4a",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-05-29T16:50:51.9247077Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:51.9247077Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:51.9247077Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "7a949bb3-001a-00bc-4fd9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1/test-directory-4ebb0f15-257c-7ab4-1403-093ee7eb6765?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5e2dfe92-2a08-99f1-c8c3-1c0957507d0f",
+        "x-ms-date": "Fri, 29 May 2020 16:50:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "5e2dfe92-2a08-99f1-c8c3-1c0957507d0f",
+        "x-ms-request-id": "7a949bb4-001a-00bc-50d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1\u0022 DirectoryPath=\u0022test-directory-4ebb0f15-257c-7ab4-1403-093ee7eb6765\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-file-0e0c4b04-ae41-0eef-6062-7e8de45c2c7c\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-4c39cf78-1ec3-aff8-5d73-5b371ebb95d1?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1b1b6beefa12974ca337127fae234771-cc7307692e5c944d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8f460668-8db9-ff42-0b3f-7863e6bf7cd1",
+        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8f460668-8db9-ff42-0b3f-7863e6bf7cd1",
+        "x-ms-request-id": "7a949bb5-001a-00bc-51d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "708241521",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_AsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_AsciiNameAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ea5be194-6715-e258-fbcf-b1c11aec0196?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c29b78dcb08e1549be8d91f60898d4ee-18945e7ec4b8fe46-00",
+        "traceparent": "00-67c46aefac4ea74f85a8dce4e89a18ac-5fe2a7e2207c3445-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "279b96a5-a863-73a2-7929-ffc122556ecf",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "46abd2a3-efa0-ca48-2322-a0571e6246f9",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
-        "ETag": "\u00220x8D803FE11885693\u0022",
-        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
+        "Date": "Fri, 29 May 2020 18:14:30 GMT",
+        "ETag": "\u00220x8D803FC2217A483\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "279b96a5-a863-73a2-7929-ffc122556ecf",
-        "x-ms-request-id": "f348ed86-a01a-0010-44e6-35a4fd000000",
+        "x-ms-client-request-id": "46abd2a3-efa0-ca48-2322-a0571e6246f9",
+        "x-ms-request-id": "9ca3cc98-c01a-0083-09e4-3532b6000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978?restype=directory",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ea5be194-6715-e258-fbcf-b1c11aec0196/test-directory-9306f251-7851-dca7-6b33-3bf21f642186?restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-31a2724eece48c429c33e5e074dbbc61-e0646bea14278049-00",
+        "traceparent": "00-aa9ff290caa275428c32a62ad5e62315-ddae987cc2802241-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a1822b17-c79a-6e3f-fbd0-be267451dd27",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "cfa24fdb-d16e-2b90-2ace-da6db455abbf",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,40 +55,40 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
-        "ETag": "\u00220x8D803FE11909B2E\u0022",
-        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
+        "Date": "Fri, 29 May 2020 18:14:30 GMT",
+        "ETag": "\u00220x8D803FC22289735\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a1822b17-c79a-6e3f-fbd0-be267451dd27",
+        "x-ms-client-request-id": "cfa24fdb-d16e-2b90-2ace-da6db455abbf",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-29T18:28:22.4191278Z",
-        "x-ms-file-creation-time": "2020-05-29T18:28:22.4191278Z",
+        "x-ms-file-change-time": "2020-05-29T18:14:31.2652597Z",
+        "x-ms-file-creation-time": "2020-05-29T18:14:31.2652597Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-29T18:28:22.4191278Z",
+        "x-ms-file-last-write-time": "2020-05-29T18:14:31.2652597Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "f348ed88-a01a-0010-45e6-35a4fd000000",
+        "x-ms-request-id": "9ca3cc9a-c01a-0083-0ae4-3532b6000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-1e4a873f-06e6-cd67-f422-d5983c0ae0d8",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ea5be194-6715-e258-fbcf-b1c11aec0196/test-directory-9306f251-7851-dca7-6b33-3bf21f642186/test-file-4fec1a01-fe45-97b7-fce0-ee75f6d8c54d",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-66439a83eaf77744ae68716a332cf632-5eb6f2de5da50e4b-00",
+        "traceparent": "00-d4f36c4d620e8241ac9b074a262695cd-2d614b1dfc137c4d-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6351d316-9f45-1060-c3b4-ad77f2a631f1",
+        "x-ms-client-request-id": "fcccc230-b931-dc07-970b-d38de31a3552",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -101,29 +101,29 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
-        "ETag": "\u00220x8D803FE11988BE1\u0022",
-        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
+        "Date": "Fri, 29 May 2020 18:14:30 GMT",
+        "ETag": "\u00220x8D803FC2239FF7A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6351d316-9f45-1060-c3b4-ad77f2a631f1",
+        "x-ms-client-request-id": "fcccc230-b931-dc07-970b-d38de31a3552",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-29T18:28:22.4711649Z",
-        "x-ms-file-creation-time": "2020-05-29T18:28:22.4711649Z",
+        "x-ms-file-change-time": "2020-05-29T18:14:31.3793402Z",
+        "x-ms-file-creation-time": "2020-05-29T18:14:31.3793402Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-29T18:28:22.4711649Z",
+        "x-ms-file-last-write-time": "2020-05-29T18:14:31.3793402Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "f348ed89-a01a-0010-46e6-35a4fd000000",
+        "x-ms-request-id": "9ca3cc9b-c01a-0083-0be4-3532b6000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978?restype=directory\u0026comp=list",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ea5be194-6715-e258-fbcf-b1c11aec0196/test-directory-9306f251-7851-dca7-6b33-3bf21f642186?restype=directory\u0026comp=list",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
@@ -131,8 +131,8 @@
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6881fc05-7db9-df92-8c28-a71c9a66bd1e",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "33449e6f-c90b-701b-e73a-38b67d89b524",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -141,30 +141,30 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Content-Type": "application/xml",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "6881fc05-7db9-df92-8c28-a71c9a66bd1e",
-        "x-ms-request-id": "f348ed8a-a01a-0010-47e6-35a4fd000000",
+        "x-ms-client-request-id": "33449e6f-c90b-701b-e73a-38b67d89b524",
+        "x-ms-request-id": "9ca3cc9c-c01a-0083-0ce4-3532b6000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4\u0022 DirectoryPath=\u0022test-directory-ffb33523-378b-ca9b-683c-34519652e978\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-\u0192\u00A1\u00A3\u20AC\u203D%3A-1e4a873f-06e6-cd67-f422-d5983c0ae0d8\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-ea5be194-6715-e258-fbcf-b1c11aec0196\u0022 DirectoryPath=\u0022test-directory-9306f251-7851-dca7-6b33-3bf21f642186\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-file-4fec1a01-fe45-97b7-fce0-ee75f6d8c54d\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ea5be194-6715-e258-fbcf-b1c11aec0196?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b44857abfc09d246943eae359fc73ac0-d1daf045d5a42a46-00",
+        "traceparent": "00-63bd45dd05ef9840b927414df3054c58-1d039f9790ac1243-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f572d37d-c824-7338-53c8-fbeeca3a5d43",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "441d5f53-01d6-3f46-72d2-dd04a2463279",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -173,20 +173,20 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f572d37d-c824-7338-53c8-fbeeca3a5d43",
-        "x-ms-request-id": "f348ed8b-a01a-0010-48e6-35a4fd000000",
+        "x-ms-client-request-id": "441d5f53-01d6-3f46-72d2-dd04a2463279",
+        "x-ms-request-id": "9ca3cc9d-c01a-0083-0de4-3532b6000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "RandomSeed": "1358807126",
+    "RandomSeed": "506064524",
     "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiName.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4d68f2705b22b445aff1da0db99eaddd-b4f71f6a190c7548-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f3a6e2c3-21a6-d31b-28b4-2d3e1b31ed76",
+        "x-ms-date": "Fri, 29 May 2020 00:05:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F4F9A5EA\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3a6e2c3-21a6-d31b-28b4-2d3e1b31ed76",
+        "x-ms-request-id": "83c44fac-501e-00c0-544c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb/test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5f4af5842b893347946b46f3b6f05990-f8824e5a45f5dc4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "61524f1e-09e6-c5ef-ed13-e6f3054b9161",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F5054D02\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "61524f1e-09e6-c5ef-ed13-e6f3054b9161",
+        "x-ms-request-id": "7539ed4e-e01f-000e-5f4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb/test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de/test-file-e34bbaec-5287-dc25-0d95-484e3a0e9b9b?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "eb2f0c74-3abc-3fb5-5524-89122bf870fc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F51136C5\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "eb2f0c74-3abc-3fb5-5524-89122bf870fc",
+        "x-ms-request-id": "7539ed4f-e01f-000e-604c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f87e815d-a61c-05a5-a9eb-17de94a5afd6",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "f87e815d-a61c-05a5-a9eb-17de94a5afd6",
+        "x-ms-request-id": "7539ed50-e01f-000e-614c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5054D02",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F51136C5",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-f3f01318-4d89-cc99-70dc-fb72b1ec95de/test-file-e34bbaec-5287-dc25-0d95-484e3a0e9b9b"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-c894be35-6ca8-20ef-f4f1-2f0ec62d45cb?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a7436f73ed73624889a30b989d4c0cdc-5c0b8dc1be0be449-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a9b4f72e-7779-a1e0-7b83-1d939d5b6cf2",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a9b4f72e-7779-a1e0-7b83-1d939d5b6cf2",
+        "x-ms-request-id": "83c44fde-501e-00c0-7d4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "110400654",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryAsciiNameAsync.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-68e993210047484db4b041dfe74ac2a6-996cbc1b690e4e4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "50db8106-99e2-faf5-9d47-03f95ff5b36a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5D743AD\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "50db8106-99e2-faf5-9d47-03f95ff5b36a",
+        "x-ms-request-id": "83c450e5-501e-00c0-574c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9/test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d81c55790b8a444a9599a742ec3c3a7c-555385b6ae654043-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9b8d3d76-a3fc-5b00-97dd-4dd04267869b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5E2EA92\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9b8d3d76-a3fc-5b00-97dd-4dd04267869b",
+        "x-ms-request-id": "7539ed5c-e01f-000e-6a4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9/test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6/test-file-10f8c46b-0769-a7c7-62e1-ba50e9317eb7?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "acda9a26-e3a4-8abb-a9ee-ed828330c762",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F5EE861E\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "acda9a26-e3a4-8abb-a9ee-ed828330c762",
+        "x-ms-request-id": "7539ed5d-e01f-000e-6b4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a7aafd56-da8c-c6f6-052b-eb465fe21793",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "a7aafd56-da8c-c6f6-052b-eb465fe21793",
+        "x-ms-request-id": "7539ed5e-e01f-000e-6c4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5E2EA92",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5EE861E",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-af855e62-fcb2-70b8-cd27-78e33e7dd1c6/test-file-10f8c46b-0769-a7c7-62e1-ba50e9317eb7"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-2506f85d-52c4-b529-acec-78ff914558a9?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ac51a1704e475c448f700760e516af1f-165390dd1940ee4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "852c6117-1f85-09d5-f14a-5a313ba5c9f4",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "852c6117-1f85-09d5-f14a-5a313ba5c9f4",
+        "x-ms-request-id": "83c45120-501e-00c0-064c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "494872270",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiName.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1885764c21865d4da731848b8b1b60c6-6c0919c24ee38549-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cdac5acd-a2e0-4c3d-5d3f-c09de22826f4",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F5375A3C\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cdac5acd-a2e0-4c3d-5d3f-c09de22826f4",
+        "x-ms-request-id": "83c44ff1-501e-00c0-0b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a/test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-32163589c02e9e4082b00da0d43ab653-e2bfb84ae4aa8b47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5cdb0062-b163-e3ae-4c38-1bf570f9716d",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "ETag": "\u00220x8D80363F5430135\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5cdb0062-b163-e3ae-4c38-1bf570f9716d",
+        "x-ms-request-id": "7539ed52-e01f-000e-624c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a/test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-74c486c1-3f46-f359-aa47-c034d3b9fba1?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d2d12ed1-9fde-923d-b30f-03df515a2c32",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F54E4E96\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d2d12ed1-9fde-923d-b30f-03df515a2c32",
+        "x-ms-request-id": "7539ed53-e01f-000e-634c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4224b5ad-9e27-3f8f-5b23-c0c888c702dc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "4224b5ad-9e27-3f8f-5b23-c0c888c702dc",
+        "x-ms-request-id": "7539ed54-e01f-000e-644c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5430135",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F54E4E96",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-directory-c62ca622-303d-452d-27da-39f9d6cbdcbf/test-\u0192\u00A1\u00A3\u20AC\u203D%3A-74c486c1-3f46-f359-aa47-c034d3b9fba1"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-02b97ed9-2d64-d2e1-03f4-1391cef20c3a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-54150c71cd34e64681c66325e687fd84-711395957acde14e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9c320ac6-ea35-560b-a7e7-756a41f04d92",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c320ac6-ea35-560b-a7e7-756a41f04d92",
+        "x-ms-request-id": "83c45052-501e-00c0-5f4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "670912280",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromDirectoryNonAsciiNameAsync.json
@@ -1,0 +1,180 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-54aaea5603531240964589f58143e826-aa82dcb94c65344b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "16efcc3d-f4fe-8787-5d76-dce50223be7a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F612AD72\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16efcc3d-f4fe-8787-5d76-dce50223be7a",
+        "x-ms-request-id": "83c4512c-501e-00c0-114c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3/test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-49ad54e694b3b34abd2d206e966bef9b-988f9c169710784d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "06e5ea9f-4bf2-7b9e-ed18-d03245b6640a",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F61E2D3D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "06e5ea9f-4bf2-7b9e-ed18-d03245b6640a",
+        "x-ms-request-id": "7539ed5f-e01f-000e-6d4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3/test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-7330fb00-52dc-a9a4-9226-17a3c8ffbca0?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dd03b81c-b61a-91ae-0b87-6e101c719bbc",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F6297A9A\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dd03b81c-b61a-91ae-0b87-6e101c719bbc",
+        "x-ms-request-id": "7539ed60-e01f-000e-6e4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8d16fd58-87b2-cff0-bc59-c8730cb7f6e5",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "8d16fd58-87b2-cff0-bc59-c8730cb7f6e5",
+        "x-ms-request-id": "7539ed61-e01f-000e-6f4c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F61E2D3D",
+            "isDirectory": "true",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1"
+          },
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F6297A9A",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-directory-62c192cd-5c59-2d59-0a43-0bc77dfed7f1/test-\u0192\u00A1\u00A3\u20AC\u203D%3A-7330fb00-52dc-a9a4-9226-17a3c8ffbca0"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-cf02eed2-a163-c6cf-dc4f-f86e40cb68a3?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7a6937c038a3b945826c2b2adf51731f-61d28393de2d5b4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1fb76952-0d5b-d609-1065-c27b6ff0176b",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1fb76952-0d5b-d609-1065-c27b6ff0176b",
+        "x-ms-request-id": "83c4517a-501e-00c0-4c4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "300069817",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiName.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0c123c582866ca4b8b8b70bb1acf63bd-1cbe72977ea1434b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "19e886a9-d716-0773-40fb-ba72d161bfb9",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5770AD2\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "19e886a9-d716-0773-40fb-ba72d161bfb9",
+        "x-ms-request-id": "83c45062-501e-00c0-6f4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b/test-file-640f6b0c-8e6e-59f7-dab8-e7a8c6ed4cd3?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "95c95ecc-925b-1a3c-8e8f-3f5eefcb4152",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5828A95\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "95c95ecc-925b-1a3c-8e8f-3f5eefcb4152",
+        "x-ms-request-id": "7539ed57-e01f-000e-664c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "67dbe677-b723-7c77-e5ec-8c8851c64674",
+        "x-ms-date": "Fri, 29 May 2020 00:05:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "67dbe677-b723-7c77-e5ec-8c8851c64674",
+        "x-ms-request-id": "7539ed58-e01f-000e-674c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5828A95",
+            "lastModified": "Fri, 29 May 2020 00:05:12 GMT",
+            "name": "test-file-640f6b0c-8e6e-59f7-dab8-e7a8c6ed4cd3"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-4acb8a0d-dd34-4dc3-3e07-cdb0a0ffaa3b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-88a74dd2dbbc3045975507c4261672c3-237807f1ccdfcb4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "09e6a22f-daef-f72f-6ee5-c96e18182980",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "09e6a22f-daef-f72f-6ee5-c96e18182980",
+        "x-ms-request-id": "83c4509b-501e-00c0-1b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "633551975",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemAsciiNameAsync.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f6f5e5fb9d6aa14ab9f94c1cb4fe1a18-a4cc318b7c764b44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5c700f78-7814-ad15-413d-3a2236cf273c",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F64EDAA8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5c700f78-7814-ad15-413d-3a2236cf273c",
+        "x-ms-request-id": "83c4518a-501e-00c0-5a4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67/test-file-9d411be1-01df-f22c-a11a-a59b9f7facd2?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "154f95cd-4092-7695-e27d-bafad2790ec2",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F65A3358\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "154f95cd-4092-7695-e27d-bafad2790ec2",
+        "x-ms-request-id": "7539ed62-e01f-000e-704c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "09ce95fd-962f-0940-2425-2ae83358d57f",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "09ce95fd-962f-0940-2425-2ae83358d57f",
+        "x-ms-request-id": "7539ed63-e01f-000e-714c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F65A3358",
+            "lastModified": "Fri, 29 May 2020 00:05:14 GMT",
+            "name": "test-file-9d411be1-01df-f22c-a11a-a59b9f7facd2"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-846d0413-7090-ddb1-a528-2e141bd64a67?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0b0b872cfa13e5488748d7cd305aec7e-11aa6dbc268f3a42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3cfd5871-05ab-fa92-27ce-580df0edbf70",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3cfd5871-05ab-fa92-27ce-580df0edbf70",
+        "x-ms-request-id": "83c451b0-501e-00c0-774c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "949313137",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiName.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-910926da80f76e4681e250b0b2a794db-9b210104cb5e8646-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "00790507-ed04-9b8a-cdbe-a11173312cb7",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5A70026\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "00790507-ed04-9b8a-cdbe-a11173312cb7",
+        "x-ms-request-id": "83c450ae-501e-00c0-2b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-91c34577-ef16-0d15-6bd4-660711495b35?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f3b7ca47-c318-17b3-ef6b-943087828a83",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "ETag": "\u00220x8D80363F5B27FEB\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:13 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3b7ca47-c318-17b3-ef6b-943087828a83",
+        "x-ms-request-id": "7539ed59-e01f-000e-684c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "46c07acf-6891-c21c-1e50-c04abee9fef9",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "46c07acf-6891-c21c-1e50-c04abee9fef9",
+        "x-ms-request-id": "7539ed5a-e01f-000e-694c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F5B27FEB",
+            "lastModified": "Fri, 29 May 2020 00:05:13 GMT",
+            "name": "test-\u0192\u00A1\u00A3\u20AC\u203D%3A-91c34577-ef16-0d15-6bd4-660711495b35"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-834c11c3-947b-9479-11da-9b6fb52f521d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5b338584b1014447b197397ca2043907-ea11be9e7cddfa4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0c60bc72-43c2-faf1-50c9-8378bcb66742",
+        "x-ms-date": "Fri, 29 May 2020 00:05:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0c60bc72-43c2-faf1-50c9-8378bcb66742",
+        "x-ms-request-id": "83c450d5-501e-00c0-4b4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1268590554",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_FromFileSystemNonAsciiNameAsync.json
@@ -1,0 +1,141 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-549e46a0b9a82f46a35f9fc04c1b08d2-2b844a461d766f47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "bd343d99-798e-c956-82de-bb0a08dd4cca",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:13 GMT",
+        "ETag": "\u00220x8D80363F67E5A9B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd343d99-798e-c956-82de-bb0a08dd4cca",
+        "x-ms-request-id": "83c451ba-501e-00c0-014c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-1576c511-1dac-62d7-1df0-562cee90651e?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1184fc62-3f68-7b8e-66d1-a09e2329dbf2",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:14 GMT",
+        "ETag": "\u00220x8D80363F689B349\u0022",
+        "Last-Modified": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1184fc62-3f68-7b8e-66d1-a09e2329dbf2",
+        "x-ms-request-id": "7539ed64-e01f-000e-724c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984?resource=filesystem\u0026recursive=true\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f1ca1218-540b-68b5-d121-687cab57af72",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "f1ca1218-540b-68b5-d121-687cab57af72",
+        "x-ms-request-id": "7539ed65-e01f-000e-734c-35df91000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": {
+        "paths": [
+          {
+            "contentLength": "0",
+            "etag": "0x8D80363F689B349",
+            "lastModified": "Fri, 29 May 2020 00:05:14 GMT",
+            "name": "test-\u0192\u00A1\u00A3\u20AC\u203D%3A-1576c511-1dac-62d7-1df0-562cee90651e"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-77cf429c-b5db-3d26-fcfc-9a360b820984?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-36ec6ee55330974cbed1cd93d1956320-089f3aa42f347e44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200528.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "11859ced-ea5f-24e6-e7fa-d61e15ff1978",
+        "x-ms-date": "Fri, 29 May 2020 00:05:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 00:05:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "11859ced-ea5f-24e6-e7fa-d61e15ff1978",
+        "x-ms-request-id": "83c451e0-501e-00c0-1e4c-350e1f000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "337560350",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_NonAsciiName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_NonAsciiName.json
@@ -1,0 +1,192 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e9b6482d0d1bd14e9dadfaba532ed353-5a77649199ea794e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "279b96a5-a863-73a2-7929-ffc122556ecf",
+        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "ETag": "\u00220x8D803F0727EEDF8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:52 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "279b96a5-a863-73a2-7929-ffc122556ecf",
+        "x-ms-request-id": "7a949bb6-001a-00bc-52d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-9b4fec4c8a002c4c83266320ee3df6d2-84a2780ddc82c14b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a1822b17-c79a-6e3f-fbd0-be267451dd27",
+        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "ETag": "\u00220x8D803F0728798B7\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:52 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a1822b17-c79a-6e3f-fbd0-be267451dd27",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-29T16:50:52.1448631Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:52.1448631Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:52.1448631Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "7a949bb8-001a-00bc-53d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-1e4a873f-06e6-cd67-f422-d5983c0ae0d8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-23fdba677a6ef44f8383c11e1c87c994-66db12392d2bf547-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6351d316-9f45-1060-c3b4-ad77f2a631f1",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "ETag": "\u00220x8D803F0728F8967\u0022",
+        "Last-Modified": "Fri, 29 May 2020 16:50:52 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6351d316-9f45-1060-c3b4-ad77f2a631f1",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-05-29T16:50:52.1968999Z",
+        "x-ms-file-creation-time": "2020-05-29T16:50:52.1968999Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-29T16:50:52.1968999Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "7a949bb9-001a-00bc-54d9-35856a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978?restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6881fc05-7db9-df92-8c28-a71c9a66bd1e",
+        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "application/xml",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "6881fc05-7db9-df92-8c28-a71c9a66bd1e",
+        "x-ms-request-id": "7a949bba-001a-00bc-55d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4\u0022 DirectoryPath=\u0022test-directory-ffb33523-378b-ca9b-683c-34519652e978\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-\u0192\u00A1\u00A3\u20AC\u203D%3A-1e4a873f-06e6-cd67-f422-d5983c0ae0d8\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d98f1d1289b3e946a7bcc00071911a4f-8fb625aa9e303541-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f572d37d-c824-7338-53c8-fbeeca3a5d43",
+        "x-ms-date": "Fri, 29 May 2020 16:50:52 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 29 May 2020 16:50:51 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f572d37d-c824-7338-53c8-fbeeca3a5d43",
+        "x-ms-request-id": "7a949bbb-001a-00bc-56d9-35856a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1358807126",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_NonAsciiNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/GetFileClient_NonAsciiNameAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-71377377-6074-5941-e34b-b96f043e6ec0?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c29b78dcb08e1549be8d91f60898d4ee-18945e7ec4b8fe46-00",
+        "traceparent": "00-b0ce3f588640a9449319ccf7eebeb452-45b55dbfcb383c48-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "279b96a5-a863-73a2-7929-ffc122556ecf",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "a91c1566-4793-a0af-1766-4bbe8d41650e",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
-        "ETag": "\u00220x8D803FE11885693\u0022",
-        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
+        "ETag": "\u00220x8D803FC226ADCE3\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "279b96a5-a863-73a2-7929-ffc122556ecf",
-        "x-ms-request-id": "f348ed86-a01a-0010-44e6-35a4fd000000",
+        "x-ms-client-request-id": "a91c1566-4793-a0af-1766-4bbe8d41650e",
+        "x-ms-request-id": "9ca3cc9e-c01a-0083-0ee4-3532b6000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978?restype=directory",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-71377377-6074-5941-e34b-b96f043e6ec0/test-directory-ae2a1ef3-51fd-fe02-6db4-a200d62c2739?restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-31a2724eece48c429c33e5e074dbbc61-e0646bea14278049-00",
+        "traceparent": "00-a9c48f6587ecd442930454557e0857ad-35491031a46def40-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a1822b17-c79a-6e3f-fbd0-be267451dd27",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "12207c0d-9680-153b-131e-3cdfa4aecaea",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,40 +55,40 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
-        "ETag": "\u00220x8D803FE11909B2E\u0022",
-        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
+        "ETag": "\u00220x8D803FC2273695F\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a1822b17-c79a-6e3f-fbd0-be267451dd27",
+        "x-ms-client-request-id": "12207c0d-9680-153b-131e-3cdfa4aecaea",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-29T18:28:22.4191278Z",
-        "x-ms-file-creation-time": "2020-05-29T18:28:22.4191278Z",
+        "x-ms-file-change-time": "2020-05-29T18:14:31.7556063Z",
+        "x-ms-file-creation-time": "2020-05-29T18:14:31.7556063Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-29T18:28:22.4191278Z",
+        "x-ms-file-last-write-time": "2020-05-29T18:14:31.7556063Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "f348ed88-a01a-0010-45e6-35a4fd000000",
+        "x-ms-request-id": "9ca3cca0-c01a-0083-0fe4-3532b6000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-1e4a873f-06e6-cd67-f422-d5983c0ae0d8",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-71377377-6074-5941-e34b-b96f043e6ec0/test-directory-ae2a1ef3-51fd-fe02-6db4-a200d62c2739/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-0db7123e-7638-2eeb-f15e-0dea7a34d024",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-66439a83eaf77744ae68716a332cf632-5eb6f2de5da50e4b-00",
+        "traceparent": "00-d440369eb3c7ef439a86d8c5f1912eb6-ac768155e536954c-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6351d316-9f45-1060-c3b4-ad77f2a631f1",
+        "x-ms-client-request-id": "1b8feb48-e790-9754-90f2-202189519ade",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -101,29 +101,29 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
-        "ETag": "\u00220x8D803FE11988BE1\u0022",
-        "Last-Modified": "Fri, 29 May 2020 18:28:22 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
+        "ETag": "\u00220x8D803FC227BA838\u0022",
+        "Last-Modified": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6351d316-9f45-1060-c3b4-ad77f2a631f1",
+        "x-ms-client-request-id": "1b8feb48-e790-9754-90f2-202189519ade",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-29T18:28:22.4711649Z",
-        "x-ms-file-creation-time": "2020-05-29T18:28:22.4711649Z",
+        "x-ms-file-change-time": "2020-05-29T18:14:31.8096440Z",
+        "x-ms-file-creation-time": "2020-05-29T18:14:31.8096440Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-29T18:28:22.4711649Z",
+        "x-ms-file-last-write-time": "2020-05-29T18:14:31.8096440Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "f348ed89-a01a-0010-46e6-35a4fd000000",
+        "x-ms-request-id": "9ca3cca1-c01a-0083-10e5-3532b6000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4/test-directory-ffb33523-378b-ca9b-683c-34519652e978?restype=directory\u0026comp=list",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-71377377-6074-5941-e34b-b96f043e6ec0/test-directory-ae2a1ef3-51fd-fe02-6db4-a200d62c2739?restype=directory\u0026comp=list",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
@@ -131,8 +131,8 @@
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6881fc05-7db9-df92-8c28-a71c9a66bd1e",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "8fa11b38-b4a5-d794-c05c-c819f497e7f3",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -141,30 +141,30 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Content-Type": "application/xml",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "6881fc05-7db9-df92-8c28-a71c9a66bd1e",
-        "x-ms-request-id": "f348ed8a-a01a-0010-47e6-35a4fd000000",
+        "x-ms-client-request-id": "8fa11b38-b4a5-d794-c05c-c819f497e7f3",
+        "x-ms-request-id": "9ca3cca2-c01a-0083-11e5-3532b6000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4\u0022 DirectoryPath=\u0022test-directory-ffb33523-378b-ca9b-683c-34519652e978\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-\u0192\u00A1\u00A3\u20AC\u203D%3A-1e4a873f-06e6-cd67-f422-d5983c0ae0d8\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.file.core.windows.net/\u0022 ShareName=\u0022test-share-71377377-6074-5941-e34b-b96f043e6ec0\u0022 DirectoryPath=\u0022test-directory-ae2a1ef3-51fd-fe02-6db4-a200d62c2739\u0022\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-\u0192\u00A1\u00A3\u20AC\u203D%3A-0db7123e-7638-2eeb-f15e-0dea7a34d024\u003C/Name\u003E\u003CProperties\u003E\u003CContent-Length\u003E1048576\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d01dbbb4-90d7-bff8-c63e-ce14ff027da4?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-71377377-6074-5941-e34b-b96f043e6ec0?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b44857abfc09d246943eae359fc73ac0-d1daf045d5a42a46-00",
+        "traceparent": "00-0284a39dfc229444b8bbdacabd36085c-3877389238e4234e-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f572d37d-c824-7338-53c8-fbeeca3a5d43",
-        "x-ms-date": "Fri, 29 May 2020 18:28:22 GMT",
+        "x-ms-client-request-id": "6de87d4d-0aaf-9a39-8249-ce5fa8c534c1",
+        "x-ms-date": "Fri, 29 May 2020 18:14:31 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -173,20 +173,20 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 29 May 2020 18:28:21 GMT",
+        "Date": "Fri, 29 May 2020 18:14:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f572d37d-c824-7338-53c8-fbeeca3a5d43",
-        "x-ms-request-id": "f348ed8b-a01a-0010-48e6-35a4fd000000",
+        "x-ms-client-request-id": "6de87d4d-0aaf-9a39-8249-ce5fa8c534c1",
+        "x-ms-request-id": "9ca3cca3-c01a-0083-12e5-3532b6000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "RandomSeed": "1358807126",
+    "RandomSeed": "1308916652",
     "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUri.json
@@ -5,13 +5,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-75d4f35c9ab9484fbcc83dffc2b1587a-7f192ef4f47b1544-00",
+        "traceparent": "00-df7ae3cdcfe9de42835346a90b4289b5-68bd4e07dc25344a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0454ab5d-c7b5-d2de-6f07-30f74d1ae70a",
-        "x-ms-date": "Sat, 16 May 2020 00:26:17 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:39 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,15 +19,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:17 GMT",
-        "ETag": "\u00220x8D7F92FC03566AA\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:17 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95C97AD45\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:40 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0454ab5d-c7b5-d2de-6f07-30f74d1ae70a",
-        "x-ms-request-id": "dc179438-d01a-0036-4318-2b3f49000000",
+        "x-ms-request-id": "f41215d9-b01a-0100-0ce2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -37,13 +37,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-31aed8ae06c8a041adef7a69f9ad8e6e-6d4046ae7dcd5b4d-00",
+        "traceparent": "00-3f1e778c334d904386a2c4a4be819189-dee44275598b1d45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "36debedc-7980-0f2c-eebe-70e4e42364ec",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,40 +55,40 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0473A7D\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95CD58DE0\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "36debedc-7980-0f2c-eebe-70e4e42364ec",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-16T00:26:18.0887165Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:18.0887165Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:41.2164576Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:41.2164576Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:18.0887165Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:41.2164576Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "dc17943a-d01a-0036-4418-2b3f49000000",
+        "x-ms-request-id": "f41215dc-b01a-0100-0de2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D-a9c81b08-3cd6-51e0-f41c-395eb4514ac3",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-a9c81b08-3cd6-51e0-f41c-395eb4514ac3",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3c8e3aa9b722844598d745aab4f4ded6-b775186645175949-00",
+        "traceparent": "00-dd200dd1924f7b4c9e72b8a785408698-039bee74ce1db94e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "afde192b-4aa4-16cc-af59-d1d75d9405db",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -101,22 +101,22 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0571BD7\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95CE659C9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "afde192b-4aa4-16cc-af59-d1d75d9405db",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-16T00:26:18.1927895Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:18.1927895Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:41.3265353Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:41.3265353Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:18.1927895Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:41.3265353Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "dc17943b-d01a-0036-4518-2b3f49000000",
+        "x-ms-request-id": "f41215dd-b01a-0100-0ee2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -127,13 +127,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ebd8773157a73447a9431b64da2c54a0-ac4f6da7e1bc1d4c-00",
+        "traceparent": "00-236b8ae3f7ad16448d4edce1a47654b1-ba5ee75833c1c243-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1e15fcbc-a848-f741-0029-6541a60e75ce",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -141,15 +141,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0629955\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95CEF05A9\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1e15fcbc-a848-f741-0029-6541a60e75ce",
-        "x-ms-request-id": "dc17943c-d01a-0036-4618-2b3f49000000",
+        "x-ms-request-id": "f41215de-b01a-0100-0fe2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -159,13 +159,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a8c9e4c5b4d6f04caf5d18acdf482b07-1ffa68b9785ddf4e-00",
+        "traceparent": "00-88a8fb3ff4792d40a396f09f4e4812ee-ecaeab8257470448-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b44ff2dc-fad5-8023-6794-c50ebc9e843f",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -177,22 +177,22 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC06AA75F\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95CF79AF8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b44ff2dc-fad5-8023-6794-c50ebc9e843f",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-16T00:26:18.3208799Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:18.3208799Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:41.4396152Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:41.4396152Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:18.3208799Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:41.4396152Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "dc17943e-d01a-0036-4718-2b3f49000000",
+        "x-ms-request-id": "f41215e0-b01a-0100-10e2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,14 +203,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b4a25ae49301e142bccb61d15d603f27-4a9b5943fea85947-00",
+        "traceparent": "00-be2857426ed96944a94cd73f77a43bf6-3fb2d04bd9bd2e4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "964f8a3d-9708-0bfb-f178-f876cd0a10ed",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -223,40 +223,40 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0735B86\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95CFFB2BE\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "964f8a3d-9708-0bfb-f178-f876cd0a10ed",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-16T00:26:18.3779206Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:18.3779206Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:41.4926526Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:41.4926526Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:18.3779206Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:41.4926526Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "dc17943f-d01a-0036-4818-2b3f49000000",
+        "x-ms-request-id": "f41215e1-b01a-0100-11e2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D-a9c81b08-3cd6-51e0-f41c-395eb4514ac3?comp=range",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-a9c81b08-3cd6-51e0-f41c-395eb4514ac3?comp=range",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-2094ca6aea24b94d9e3a5273ee3b97c6-e3aa86cd3195f148-00",
+        "traceparent": "00-32b6a141f1a7db4383a01ae9abcd73fd-e675f44b73579348-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c0ade32c-bafd-e683-1c84-17d16cf6694c",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-range": "bytes=0-1023",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07",
@@ -267,15 +267,15 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "HQleALV7oUJA7Om88jQ6yQ==",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC07E0BD4\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:40 GMT",
+        "ETag": "\u00220x8D803F95D0A630D\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c0ade32c-bafd-e683-1c84-17d16cf6694c",
-        "x-ms-request-id": "dc179440-d01a-0036-4918-2b3f49000000",
+        "x-ms-request-id": "f41215e2-b01a-0100-12e2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -286,14 +286,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7490fea43c967b4885abc6b15d63403f-09a877d57b4d0d48-00",
+        "traceparent": "00-3114a7ca2c6b154f96b85423e390600f-64d4635efa6a874e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9aafb32b-cdb0-7610-8468-49dade10d617",
-        "x-ms-copy-source": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D-a9c81b08-3cd6-51e0-f41c-395eb4514ac3",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-copy-source": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-a9c81b08-3cd6-51e0-f41c-395eb4514ac3",
+        "x-ms-date": "Fri, 29 May 2020 17:54:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -301,17 +301,17 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC08BA2DD\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:41 GMT",
+        "ETag": "\u00220x8D803F95D5B77E8\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9aafb32b-cdb0-7610-8468-49dade10d617",
-        "x-ms-copy-id": "ad2a61ac-1aba-40eb-a684-4936631adb07",
+        "x-ms-copy-id": "c7b35c0e-1528-44d3-8454-aeb285daf601",
         "x-ms-copy-status": "success",
-        "x-ms-request-id": "dc179441-d01a-0036-4a18-2b3f49000000",
+        "x-ms-request-id": "f41215e3-b01a-0100-13e2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -321,13 +321,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7a35bd50c3849f40b12ad6bdc38181fc-2c343419d6aac74c-00",
+        "traceparent": "00-2ae957335b78864c964da98fe9c6267a-0c22b58532f2af4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b9a5fe8a-cf47-ad9c-1173-06484a4f54c9",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -336,13 +336,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b9a5fe8a-cf47-ad9c-1173-06484a4f54c9",
-        "x-ms-request-id": "dc179442-d01a-0036-4b18-2b3f49000000",
+        "x-ms-request-id": "f41215e4-b01a-0100-14e2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -352,13 +352,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d5b3fdcc2c1d6b4c90f3fca150be9fb4-d37ad42b70658b49-00",
+        "traceparent": "00-7d9f0d1c90816c47a800bd64c1e39115-55c2ed1bcd3fdd48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "df4fa6a8-1d6b-b5d0-3b76-faec41884e6a",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -367,13 +367,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:41 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "df4fa6a8-1d6b-b5d0-3b76-faec41884e6a",
-        "x-ms-request-id": "dc179443-d01a-0036-4c18-2b3f49000000",
+        "x-ms-request-id": "f41215e6-b01a-0100-15e2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUriAsync.json
@@ -5,13 +5,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-48029d53fa2e8e43a7af40c0215f5ae2-bf4f5a80a4ce9f4f-00",
+        "traceparent": "00-0015dbdb26cf5642a8883ef6b4e893c8-3aa09eb4c9f87e47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fcc1238e-1939-f2ac-3e7c-b5d56d08bdfa",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,15 +19,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0B29C8F\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:41 GMT",
+        "ETag": "\u00220x8D803F95D9C2F79\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fcc1238e-1939-f2ac-3e7c-b5d56d08bdfa",
-        "x-ms-request-id": "dc179445-d01a-0036-4d18-2b3f49000000",
+        "x-ms-request-id": "f41215e7-b01a-0100-16e2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -37,13 +37,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7a73b36c8f0db24eb1c6ba517ec02217-d5ea4add63112645-00",
+        "traceparent": "00-9bae4a2da0da2342888607659acbde95-4fd7a9b92531c341-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0a37fd5c-4620-bb59-87e8-fced89870536",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,40 +55,40 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0BE068E\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:41 GMT",
+        "ETag": "\u00220x8D803F95DA75BB0\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0a37fd5c-4620-bb59-87e8-fced89870536",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-16T00:26:18.8672654Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:18.8672654Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:42.5914288Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:42.5914288Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:18.8672654Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:42.5914288Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "dc179447-d01a-0036-4e18-2b3f49000000",
+        "x-ms-request-id": "f41215e9-b01a-0100-17e2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D-154241d7-6004-450b-632d-f294d9c262b1",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-154241d7-6004-450b-632d-f294d9c262b1",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0febb49fed6408409e4ddc09917c3bf0-4c2a540ac8da8c42-00",
+        "traceparent": "00-a86bb037477e254283f074ae1be0da62-b3acf466a47cdd44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "efc85361-e7d0-17f6-42b9-dcbf7103ca1c",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -101,22 +101,22 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0C6BAB0\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
+        "ETag": "\u00220x8D803F95DB05DFC\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "efc85361-e7d0-17f6-42b9-dcbf7103ca1c",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-16T00:26:18.9243056Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:18.9243056Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:42.6504700Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:42.6504700Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:18.9243056Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:42.6504700Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "dc179448-d01a-0036-4f18-2b3f49000000",
+        "x-ms-request-id": "f41215ea-b01a-0100-18e2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -127,13 +127,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-af0baec3d7a2814489c064ad855b2fe9-bd46ee01a342454f-00",
+        "traceparent": "00-758a69ce06230648b89397eb7712b66e-dcf70c13d2ffef43-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "665eca09-aff6-48b5-aac5-43edb3a9b714",
-        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -141,15 +141,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0CF5184\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
+        "ETag": "\u00220x8D803F95DB9A830\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "665eca09-aff6-48b5-aac5-43edb3a9b714",
-        "x-ms-request-id": "dc179449-d01a-0036-5018-2b3f49000000",
+        "x-ms-request-id": "f41215eb-b01a-0100-19e2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -159,13 +159,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e04546975323f64a9a610bacfb203eb2-519d7345357c1a45-00",
+        "traceparent": "00-3970aee7a626cb40ba86e6202aee28c9-d25e123e13a6c143-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "245a79a8-cec6-745a-6ca7-b189102bbcdb",
-        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -177,22 +177,22 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:18 GMT",
-        "ETag": "\u00220x8D7F92FC0D75F86\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
+        "ETag": "\u00220x8D803F95DC23B8B\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "245a79a8-cec6-745a-6ca7-b189102bbcdb",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-05-16T00:26:19.0333830Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:19.0333830Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:42.7675531Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:42.7675531Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:19.0333830Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:42.7675531Z",
         "x-ms-file-parent-id": "0",
         "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
-        "x-ms-request-id": "dc17944b-d01a-0036-5118-2b3f49000000",
+        "x-ms-request-id": "f41215ed-b01a-0100-1ae2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -203,14 +203,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-20aa479ebd495d4baf355403671cd593-b01bf79c1a8d9441-00",
+        "traceparent": "00-41aca88dc0a44342a1b28c4d76350d79-19448c68ed19a04b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a6b8af86-9c8a-8797-33b0-583e61256b08",
         "x-ms-content-length": "1048576",
-        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -223,40 +223,40 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:19 GMT",
-        "ETag": "\u00220x8D7F92FC0DF7748\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
+        "ETag": "\u00220x8D803F95DCA2C32\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a6b8af86-9c8a-8797-33b0-583e61256b08",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2020-05-16T00:26:19.0864200Z",
-        "x-ms-file-creation-time": "2020-05-16T00:26:19.0864200Z",
+        "x-ms-file-change-time": "2020-05-29T17:54:42.8195890Z",
+        "x-ms-file-creation-time": "2020-05-29T17:54:42.8195890Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2020-05-16T00:26:19.0864200Z",
+        "x-ms-file-last-write-time": "2020-05-29T17:54:42.8195890Z",
         "x-ms-file-parent-id": "13835128424026341376",
         "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
-        "x-ms-request-id": "dc17944c-d01a-0036-5218-2b3f49000000",
+        "x-ms-request-id": "f41215ee-b01a-0100-1be2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D-154241d7-6004-450b-632d-f294d9c262b1?comp=range",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-154241d7-6004-450b-632d-f294d9c262b1?comp=range",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "1024",
-        "traceparent": "00-ee73358fe2295442b8235a54431cc84d-a17edf6fcb4f8648-00",
+        "traceparent": "00-b9fa572d7c983e4f927dc0dc8a732f39-4a3b4a24bf0f034f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5907d07b-a8a5-13f8-c938-fe7e08572dc5",
-        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-range": "bytes=0-1023",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07",
@@ -267,15 +267,15 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "zjv7FdxXuQ/lL\u002BFOqCHbXA==",
-        "Date": "Sat, 16 May 2020 00:26:19 GMT",
-        "ETag": "\u00220x8D7F92FC0E7B62A\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
+        "ETag": "\u00220x8D803F95DD243FD\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5907d07b-a8a5-13f8-c938-fe7e08572dc5",
-        "x-ms-request-id": "dc17944d-d01a-0036-5318-2b3f49000000",
+        "x-ms-request-id": "f41215ef-b01a-0100-1ce2-35d44e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -286,14 +286,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2a8c6a52f47ff748aaf053af9e75658b-77e536386865ab47-00",
+        "traceparent": "00-2c9e3ccf789d914b84d900dabf02ade2-ec58df6910711241-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6ecf2ecd-c341-8270-1fe5-a722a5d5b5fa",
-        "x-ms-copy-source": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D-154241d7-6004-450b-632d-f294d9c262b1",
-        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-copy-source": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D%253A-154241d7-6004-450b-632d-f294d9c262b1",
+        "x-ms-date": "Fri, 29 May 2020 17:54:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -301,17 +301,17 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:19 GMT",
-        "ETag": "\u00220x8D7F92FC0F3ED5F\u0022",
-        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
+        "ETag": "\u00220x8D803F95DDEC964\u0022",
+        "Last-Modified": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6ecf2ecd-c341-8270-1fe5-a722a5d5b5fa",
-        "x-ms-copy-id": "412c6de7-3f2c-4b49-ac9f-d995b8b94f1c",
+        "x-ms-copy-id": "97541238-c0f9-43b0-b973-07b8526f5654",
         "x-ms-copy-status": "success",
-        "x-ms-request-id": "dc17944e-d01a-0036-5418-2b3f49000000",
+        "x-ms-request-id": "f41215f0-b01a-0100-1de2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -321,13 +321,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-336596c3ce42d64a88edf4dd10f2ae71-2f9e0656bca0a149-00",
+        "traceparent": "00-fe55c64f64941d4a954b7d8fd61942ee-89dd01b2a0d88648-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d9b1dd64-be88-0984-71a9-a0179069e9b2",
-        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:43 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -336,13 +336,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d9b1dd64-be88-0984-71a9-a0179069e9b2",
-        "x-ms-request-id": "dc17944f-d01a-0036-5518-2b3f49000000",
+        "x-ms-request-id": "f41215f1-b01a-0100-1ee2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -352,13 +352,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2fe7c770fc3f2d41a03d6248bbd69ab7-9fbc1004c5e0af4a-00",
+        "traceparent": "00-fa8454560a74cb47871d291996cdeae0-bbd96858fbb4ba47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200529.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c8beedc9-dc24-c972-1ea8-41bc4e53b3db",
-        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-date": "Fri, 29 May 2020 17:54:43 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -367,13 +367,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "Date": "Fri, 29 May 2020 17:54:42 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c8beedc9-dc24-c972-1ea8-41bc4e53b3db",
-        "x-ms-request-id": "dc179450-d01a-0036-5618-2b3f49000000",
+        "x-ms-request-id": "f41215f2-b01a-0100-1fe2-35d44e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []


### PR DESCRIPTION
There's a bug where if a percent sign is in the segment of a uri, and a valid value behind it, the UriBuilder will see the value as already escaped and will not escape that value of the segment. However if the segment was meant to be named with a percent sign, then we don't encode the percent sign, naming the segment in the Uri incorrectly.

Example:
"file-name-%3A" will be sent as "file-name-%3A", which the service will interpret as "file-name-:".
this PR will ensure that the file name will encode the %, so "file-name-%3A" will be sent as "file-name-%253A" and the service will interpret as "file-name-%3A"