### PR TITLE
Update generate.ps1 for AutoRest version

### DIFF
--- a/sdk/resources/Microsoft.Azure.Management.Resource/src/generate.ps1
+++ b/sdk/resources/Microsoft.Azure.Management.Resource/src/generate.ps1
@@ -3,13 +3,13 @@
 # and copy these new set of files to the main Generated folder. This way exisiting files will not be deleted.
 
 # Generate package with resources tag
-# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-resources-2019-10" -SdkGenerationDirectory "$PSScriptRoot\Generated\Resources"
+# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-resources-2019-10" -SdkGenerationDirectory "$PSScriptRoot\Generated\Resources"
 
 # Generate package with subscriptions tag
-Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-subscriptions-2020-01" -SdkGenerationDirectory "$PSScriptRoot\Generated\Subscriptions"
+Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-subscriptions-2020-01" -SdkGenerationDirectory "$PSScriptRoot\Generated\Subscriptions"
 
 # Generate package with policy tag
-# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-policy-2019-09" -SdkGenerationDirectory "$PSScriptRoot\Generated"
+# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-policy-2019-09" -SdkGenerationDirectory "$PSScriptRoot\Generated"
 
 # Generate package with deployment scripts
-# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-deploymentscripts-2019-10-preview" -SdkGenerationDirectory "$PSScriptRoot\Generated\DeploymentScripts"
+# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-deploymentscripts-2019-10-preview" -SdkGenerationDirectory "$PSScriptRoot\Generated\DeploymentScripts"


### PR DESCRIPTION
It seems that AutoRest version restriction for generating the Resources SDK changed. Using the latest master branch of SDK repo, the AutoRest "V2" produced schema errors. We were able to generate the SDK without errors by using the latest version of AutoRest. 

Also found the linked commit which seems to be related to AutoRest version requirement change: https://github.com/Azure/azure-sdk-for-net/commit/82b3e736e66151a529260cf3b996e92dee3cd698#diff-d9cb33753189ab29d54760a2ac998bc6

Based on that updating the generate.ps1 AutoRest version parameter.
