### PR TITLE
Fix to BlobContainerClient CreateIfNotExists NullReferenceException

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -426,9 +426,10 @@ namespace Azure.Storage.Blobs.Specialized
                     $"{nameof(Uri)}: {Uri}\n" +
                     $"{nameof(httpHeaders)}: {httpHeaders}");
                 var conditions = new AppendBlobRequestConditions { IfNoneMatch = new ETag(Constants.Wildcard) };
+                Response<BlobContentInfo> response;
                 try
                 {
-                    Response<BlobContentInfo> response = await CreateInternal(
+                    response = await CreateInternal(
                         httpHeaders,
                         metadata,
                         conditions,
@@ -436,13 +437,11 @@ namespace Azure.Storage.Blobs.Specialized
                         cancellationToken,
                         $"{nameof(AppendBlobClient)}.{nameof(CreateIfNotExists)}")
                         .ConfigureAwait(false);
-
-                    return response;
                 }
                 catch (RequestFailedException storageRequestFailedException)
                 when (storageRequestFailedException.ErrorCode == BlobErrorCode.BlobAlreadyExists)
                 {
-                    return default;
+                    response = Response.FromValue(new BlobContentInfo(), default);
                 }
                 catch (Exception ex)
                 {
@@ -453,6 +452,7 @@ namespace Azure.Storage.Blobs.Specialized
                 {
                     Pipeline.LogMethodExit(nameof(AppendBlobClient));
                 }
+                return response;
             }
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -854,7 +854,7 @@ namespace Azure.Storage.Blobs
                 catch (RequestFailedException storageRequestFailedException)
                 when (storageRequestFailedException.ErrorCode == BlobErrorCode.ContainerAlreadyExists)
                 {
-                    response = default;
+                    response = Response.FromValue(new BlobContainerInfo(), default);
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -516,9 +516,10 @@ namespace Azure.Storage.Blobs.Specialized
                     $"{nameof(sequenceNumber)}: {sequenceNumber}\n" +
                     $"{nameof(httpHeaders)}: {httpHeaders}");
                 var conditions = new PageBlobRequestConditions { IfNoneMatch = new ETag(Constants.Wildcard) };
+                Response<BlobContentInfo> response;
                 try
                 {
-                    return await CreateInternal(
+                    response = await CreateInternal(
                         size,
                         sequenceNumber,
                         httpHeaders,
@@ -532,7 +533,7 @@ namespace Azure.Storage.Blobs.Specialized
                 catch (RequestFailedException storageRequestFailedException)
                 when (storageRequestFailedException.ErrorCode == BlobErrorCode.BlobAlreadyExists)
                 {
-                    return default;
+                    response = Response.FromValue(new BlobContentInfo(), default);
                 }
                 catch (Exception ex)
                 {
@@ -543,6 +544,7 @@ namespace Azure.Storage.Blobs.Specialized
                 {
                     Pipeline.LogMethodExit(nameof(PageBlobClient));
                 }
+                return response;
             }
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -509,11 +509,12 @@ namespace Azure.Storage.Blobs.Test
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
 
             // Act
-            await container.CreateIfNotExistsAsync();
+            Response<BlobContainerInfo> createResponse = await container.CreateIfNotExistsAsync();
 
             // Assert
-            Response<BlobContainerProperties> response = await container.GetPropertiesAsync();
-            Assert.IsNotNull(response.Value.ETag);
+            Response<BlobContainerProperties> propertiesResponse = await container.GetPropertiesAsync();
+            Assert.IsNotNull(createResponse.Value.ETag);
+            Assert.IsNotNull(propertiesResponse.Value.ETag);
 
             // Cleanup
             await container.DeleteAsync();
@@ -527,12 +528,12 @@ namespace Azure.Storage.Blobs.Test
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             await container.CreateAsync();
 
-            // Act
-            await container.CreateIfNotExistsAsync();
+            BlobContainerInfo containerInfo = await container.CreateIfNotExistsAsync();
 
             // Assert
             Response<BlobContainerProperties> response = await container.GetPropertiesAsync();
             Assert.IsNotNull(response.Value.ETag);
+            Assert.AreEqual(containerInfo.ETag.ToString(), "<null>");
 
             // Cleanup
             await container.DeleteAsync();

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/CreateIfNotExistsAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/CreateIfNotExistsAsync_Exists.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9ffb0b8274f41f4abced19868010d455-48f48368b3f95545-00",
+        "traceparent": "00-6582a536fd19eb4f872fa7d8364348c6-b9422ac4b3c00a4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "3d95e4e7-cf02-3431-842e-802c2e4d7585",
-        "x-ms-date": "Wed, 11 Dec 2019 03:34:28 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 03:34:28 GMT",
-        "ETag": "\u00220x8D77DEB075304BB\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 03:34:28 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:12 GMT",
+        "ETag": "\u00220x8D8071E85284E0D\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "3d95e4e7-cf02-3431-842e-802c2e4d7585",
-        "x-ms-request-id": "85a1e70e-d01e-0048-5ad3-af8f0c000000",
+        "x-ms-request-id": "1ee5cfcd-501e-00c9-5a07-3902d1000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59/test-blob-41e306e1-592e-80e6-a083-6f536af6a305",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59/test-blob-41e306e1-592e-80e6-a083-6f536af6a305",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-6339b9eb23694b4783506b4833fb7701-8123c7aebd62df4d-00",
+        "traceparent": "00-8d9e1b671ffcc543b51562d402a0bcea-b5a99a66d6c86f44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "21faa706-b00c-8d79-fe15-9c7e60deca8e",
-        "x-ms-date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -54,35 +54,35 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 03:34:28 GMT",
-        "ETag": "\u00220x8D77DEB075F7665\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:12 GMT",
+        "ETag": "\u00220x8D8071E85306998\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "21faa706-b00c-8d79-fe15-9c7e60deca8e",
-        "x-ms-request-id": "85a1e710-d01e-0048-5bd3-af8f0c000000",
+        "x-ms-request-id": "1ee5cfd7-501e-00c9-6207-3902d1000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59/test-blob-41e306e1-592e-80e6-a083-6f536af6a305",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59/test-blob-41e306e1-592e-80e6-a083-6f536af6a305",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
         "If-None-Match": "*",
-        "traceparent": "00-aa53a90a002f7b498d17460ae2be5537-046fe7ae39fad546-00",
+        "traceparent": "00-25aea4603530484a878662419f7a587f-ed8f3be2ea321b45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "c24ca1fe-81fb-d9f9-029f-560d14d92e73",
-        "x-ms-date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -91,33 +91,33 @@
       "ResponseHeaders": {
         "Content-Length": "220",
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:12 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c24ca1fe-81fb-d9f9-029f-560d14d92e73",
         "x-ms-error-code": "BlobAlreadyExists",
-        "x-ms-request-id": "85a1e711-d01e-0048-5cd3-af8f0c000000",
+        "x-ms-request-id": "1ee5cfe1-501e-00c9-6c07-3902d1000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified blob already exists.\n",
-        "RequestId:85a1e711-d01e-0048-5cd3-af8f0c000000\n",
-        "Time:2019-12-11T03:34:29.1542255Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:1ee5cfe1-501e-00c9-6c07-3902d1000000\n",
+        "Time:2020-06-02T17:58:13.8380413Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59?restype=container\u0026comp=list",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59?restype=container\u0026comp=list",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "be7fc623-0892-0a92-81c8-af7fca541cd5",
-        "x-ms-date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -125,31 +125,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "be7fc623-0892-0a92-81c8-af7fca541cd5",
-        "x-ms-request-id": "85a1e714-d01e-0048-5fd3-af8f0c000000",
+        "x-ms-request-id": "1ee5cfed-501e-00c9-7707-3902d1000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-41e306e1-592e-80e6-a083-6f536af6a305\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 03:34:29 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 03:34:29 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEB075F7665\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-41e306e1-592e-80e6-a083-6f536af6a305\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003ETue, 02 Jun 2020 17:58:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003ETue, 02 Jun 2020 17:58:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D8071E85306998\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-8a37978e-97cf-cbd2-f57d-231439b8ee59?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d060fd4a0f5d204b8b573820f48b1626-09fb39d99adcbb45-00",
+        "traceparent": "00-e2ac41f016089e449754915acf528400-51700d47c0012e45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4eea78d7-6f5a-4ae0-7330-915f222e1bf0",
-        "x-ms-date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -157,13 +156,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 03:34:29 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4eea78d7-6f5a-4ae0-7330-915f222e1bf0",
-        "x-ms-request-id": "85a1e715-d01e-0048-60d3-af8f0c000000",
+        "x-ms-request-id": "1ee5cff4-501e-00c9-7e07-3902d1000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -171,6 +170,6 @@
   ],
   "Variables": {
     "RandomSeed": "586279383",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/CreateIfNotExistsAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/CreateIfNotExistsAsync_ExistsAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2c626f669f860c4f847e288ccb6d1696-a9a8e918ca1cc242-00",
+        "traceparent": "00-a45e22b65ba528448e629df956bda120-d9925bc798d2204f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e587df74-0519-ced5-c65b-81aa3b2a5144",
-        "x-ms-date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:14 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,33 +20,33 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 03:35:00 GMT",
-        "ETag": "\u00220x8D77DEB1A34BC4E\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
+        "ETag": "\u00220x8D8071E859EFFB9\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e587df74-0519-ced5-c65b-81aa3b2a5144",
-        "x-ms-request-id": "85a1e9a7-d01e-0048-67d3-af8f0c000000",
+        "x-ms-request-id": "c8324eda-101e-0009-7307-398895000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43/test-blob-b918a137-a471-c6b6-7990-9ce7ccef3e3e",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43/test-blob-b918a137-a471-c6b6-7990-9ce7ccef3e3e",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-b273e777d72e0e469834098bda534eec-05525fe8b233274e-00",
+        "traceparent": "00-fee463447cd88b488f26759208c49d09-5d2fec8dfd57cf45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "321b5e6c-4063-cf82-29c0-6b8868ee02d6",
-        "x-ms-date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:14 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -54,35 +54,35 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 03:35:00 GMT",
-        "ETag": "\u00220x8D77DEB1A4126BB\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
+        "ETag": "\u00220x8D8071E85A75CFA\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "321b5e6c-4063-cf82-29c0-6b8868ee02d6",
-        "x-ms-request-id": "85a1e9aa-d01e-0048-69d3-af8f0c000000",
+        "x-ms-request-id": "c8324efa-101e-0009-0e07-398895000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43/test-blob-b918a137-a471-c6b6-7990-9ce7ccef3e3e",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43/test-blob-b918a137-a471-c6b6-7990-9ce7ccef3e3e",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
         "If-None-Match": "*",
-        "traceparent": "00-fcf9fa9b965f084da8af3e96737376e0-89bb67328cbe9c42-00",
+        "traceparent": "00-bcb42b8cecadbf4e8de05db7e9e15f96-eba4550718518741-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "AppendBlob",
         "x-ms-client-request-id": "6d7a9f32-0cd4-87da-398b-9e5ecda1f231",
-        "x-ms-date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:14 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -91,33 +91,33 @@
       "ResponseHeaders": {
         "Content-Length": "220",
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6d7a9f32-0cd4-87da-398b-9e5ecda1f231",
         "x-ms-error-code": "BlobAlreadyExists",
-        "x-ms-request-id": "85a1e9ab-d01e-0048-6ad3-af8f0c000000",
+        "x-ms-request-id": "c8324f12-101e-0009-2307-398895000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified blob already exists.\n",
-        "RequestId:85a1e9ab-d01e-0048-6ad3-af8f0c000000\n",
-        "Time:2019-12-11T03:35:00.8304956Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:c8324f12-101e-0009-2307-398895000000\n",
+        "Time:2020-06-02T17:58:14.6189128Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43?restype=container\u0026comp=list",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43?restype=container\u0026comp=list",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c956e3cf-9473-1001-685b-4545ebc530d5",
-        "x-ms-date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:14 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -125,31 +125,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
         "x-ms-client-request-id": "c956e3cf-9473-1001-685b-4545ebc530d5",
-        "x-ms-request-id": "85a1e9ac-d01e-0048-6bd3-af8f0c000000",
+        "x-ms-request-id": "c8324f21-101e-0009-3107-398895000000",
         "x-ms-version": "2019-07-07"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanstagetest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-b918a137-a471-c6b6-7990-9ce7ccef3e3e\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EWed, 11 Dec 2019 03:35:00 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EWed, 11 Dec 2019 03:35:00 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D77DEB1A4126BB\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://amandadev2.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Etest-blob-b918a137-a471-c6b6-7990-9ce7ccef3e3e\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003ETue, 02 Jun 2020 17:58:14 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003ETue, 02 Jun 2020 17:58:14 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8D8071E85A75CFA\u003C/Etag\u003E\u003CContent-Length\u003E0\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5 /\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EAppendBlob\u003C/BlobType\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-c52a161e-6ea6-1142-bac1-afcea7a61e43?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-adf7c9d06993e14fa3addbfaa3813698-fc4efee0d3c7e740-00",
+        "traceparent": "00-2c174d71eb1eb940bbe9e99a84ac62c2-5958f71b406b9d4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e98e2c99-284b-fbbe-eed2-29b499e7f674",
-        "x-ms-date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:14 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -157,13 +156,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 03:35:00 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e98e2c99-284b-fbbe-eed2-29b499e7f674",
-        "x-ms-request-id": "85a1e9af-d01e-0048-6dd3-af8f0c000000",
+        "x-ms-request-id": "c8324f34-101e-0009-4307-398895000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -171,6 +170,6 @@
   ],
   "Variables": {
     "RandomSeed": "1354371058",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsyncAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsyncAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-87c4794b-cc46-5e30-c0c6-6fa86e58e09b?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-87c4794b-cc46-5e30-c0c6-6fa86e58e09b?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9103818f5987a0468a17526ad99d084b-2eb5ea806d70d949-00",
+        "traceparent": "00-f00c12b5de500948babee87ca8efd55d-b428976286df054e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c3cfc6c7-619e-ddcc-5f09-5ae70ec7bf55",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
-        "ETag": "\u00220x8D77DEF01BE0AF4\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
+        "ETag": "\u00220x8D8067F07F750F9\u0022",
+        "Last-Modified": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c3cfc6c7-619e-ddcc-5f09-5ae70ec7bf55",
-        "x-ms-request-id": "db366ebf-d01e-0015-7bd7-af8588000000",
+        "x-ms-request-id": "f6fec31b-601e-00a7-0d67-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-87c4794b-cc46-5e30-c0c6-6fa86e58e09b?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-87c4794b-cc46-5e30-c0c6-6fa86e58e09b?restype=container",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2934ee87770411409d6b2c8bbc905a4e-05d3f5a96bfb8644-00",
+        "traceparent": "00-fdcc40a44a00a34986b01673f44cd54e-e01c8213f050204e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a7e00649-1d88-10fc-2ee8-ebd8eba55525",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -51,14 +51,13 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
-        "ETag": "\u00220x8D77DEF01BE0AF4\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
+        "ETag": "\u00220x8D8067F07F750F9\u0022",
+        "Last-Modified": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Vary": "Origin",
         "x-ms-client-request-id": "a7e00649-1d88-10fc-2ee8-ebd8eba55525",
         "x-ms-default-encryption-scope": "$account-encryption-key",
         "x-ms-deny-encryption-scope-override": "false",
@@ -66,23 +65,23 @@
         "x-ms-has-legal-hold": "false",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "db366ec1-d01e-0015-7cd7-af8588000000",
+        "x-ms-request-id": "f6fec34e-601e-00a7-3b67-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-87c4794b-cc46-5e30-c0c6-6fa86e58e09b?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-87c4794b-cc46-5e30-c0c6-6fa86e58e09b?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3eb6f4cd60be7a4cbc8ac3472ee61dac-2a18a03254179d41-00",
+        "traceparent": "00-ab64245b2f83e543b5ba1b9835d81443-335b767f14e92847-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "079e85d2-17e6-c3cc-0808-52907c3e1a46",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -90,13 +89,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "079e85d2-17e6-c3cc-0808-52907c3e1a46",
-        "x-ms-request-id": "db366ec2-d01e-0015-7dd7-af8588000000",
+        "x-ms-request-id": "f6fec372-601e-00a7-5d67-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -104,6 +103,6 @@
   ],
   "Variables": {
     "RandomSeed": "1407020672",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_Error.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_Error.json
@@ -1,13 +1,13 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-f6f04e82-4ed3-bc74-d762-bcdc62de15d7?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-f6f04e82-4ed3-bc74-d762-bcdc62de15d7?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-812f71975571074989d0ed813e521b73-e819f809ccdf9148-00",
+        "traceparent": "00-714edfc2d8fa484fb2e56691a83e2a24-bdea48643f6a2348-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.4.0-dev.20200219.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "118583b9-b8c2-b697-d77a-08a1aa921b7c",
         "x-ms-return-client-request-id": "true",
@@ -18,25 +18,25 @@
       "ResponseHeaders": {
         "Content-Length": "223",
         "Content-Type": "application/xml",
-        "Date": "Wed, 19 Feb 2020 23:31:52 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:32 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "118583b9-b8c2-b697-d77a-08a1aa921b7c",
         "x-ms-error-code": "ResourceNotFound",
-        "x-ms-request-id": "4bd7437d-d01e-006f-2c7c-e7a2de000000",
+        "x-ms-request-id": "f6fec1dd-601e-00a7-6267-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EResourceNotFound\u003C/Code\u003E\u003CMessage\u003EThe specified resource does not exist.\n",
-        "RequestId:4bd7437d-d01e-006f-2c7c-e7a2de000000\n",
-        "Time:2020-02-19T23:31:53.0307293Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:f6fec1dd-601e-00a7-6267-38abf8000000\n",
+        "Time:2020-06-01T22:56:33.4004780Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],
   "Variables": {
     "RandomSeed": "1778751716",
-    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttp://seandevtest.file.core.windows.net\nhttp://seandevtest.queue.core.windows.net\nhttp://seandevtest.table.core.windows.net\n\n\n\n\nhttp://seandevtest-secondary.blob.core.windows.net\nhttp://seandevtest-secondary.file.core.windows.net\nhttp://seandevtest-secondary.queue.core.windows.net\nhttp://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=http://seandevtest.queue.core.windows.net/;FileEndpoint=http://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=http://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_ErrorAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_ErrorAsync.json
@@ -1,13 +1,13 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-dd96b21b-6714-be13-436d-0c8f2b494656?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-dd96b21b-6714-be13-436d-0c8f2b494656?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-c892959bc751674d80719ae5df0cd70f-3d993408e4be2b4d-00",
+        "traceparent": "00-6df788d5b5da6345a971a0b9bbb51a6e-d43a62712222cb44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.4.0-dev.20200219.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "37b7d1ca-ad4d-a6ad-3f16-6ff0e7314c65",
         "x-ms-return-client-request-id": "true",
@@ -18,25 +18,25 @@
       "ResponseHeaders": {
         "Content-Length": "223",
         "Content-Type": "application/xml",
-        "Date": "Wed, 19 Feb 2020 23:32:01 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "37b7d1ca-ad4d-a6ad-3f16-6ff0e7314c65",
         "x-ms-error-code": "ResourceNotFound",
-        "x-ms-request-id": "e598b510-101e-003d-197c-e7bf2c000000",
+        "x-ms-request-id": "f6fec3ac-601e-00a7-1367-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EResourceNotFound\u003C/Code\u003E\u003CMessage\u003EThe specified resource does not exist.\n",
-        "RequestId:e598b510-101e-003d-197c-e7bf2c000000\n",
-        "Time:2020-02-19T23:32:02.0740421Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:f6fec3ac-601e-00a7-1367-38abf8000000\n",
+        "Time:2020-06-01T22:56:33.8998365Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],
   "Variables": {
     "RandomSeed": "268175402",
-    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttp://seandevtest.file.core.windows.net\nhttp://seandevtest.queue.core.windows.net\nhttp://seandevtest.table.core.windows.net\n\n\n\n\nhttp://seandevtest-secondary.blob.core.windows.net\nhttp://seandevtest-secondary.file.core.windows.net\nhttp://seandevtest-secondary.queue.core.windows.net\nhttp://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=http://seandevtest.queue.core.windows.net/;FileEndpoint=http://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=http://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_Exists.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-485ba092c89b6246b14854c9c7794625-0146ff7c6cab3542-00",
+        "traceparent": "00-2afdbd0e4fc986408f0fa30ba0a60b11-f0be90f71766204d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "070643df-f82a-a24d-e29b-7ba9ea67eb23",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:21 GMT",
-        "ETag": "\u00220x8D77DEEECAA8039\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:32 GMT",
+        "ETag": "\u00220x8D8067F07D6073F\u0022",
+        "Last-Modified": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "070643df-f82a-a24d-e29b-7ba9ea67eb23",
-        "x-ms-request-id": "db366c2b-d01e-0015-0ad7-af8588000000",
+        "x-ms-request-id": "f6fec23a-601e-00a7-3a67-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8892650a5ab7204da9c5cbd0b632665c-ea30d7ba9ebbe44a-00",
+        "traceparent": "00-c6dc564504a177488dbd9f8fea0521eb-2ce1142058039a4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e4a7b378-25bc-758c-4a42-aa677400d6e3",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,34 +52,34 @@
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:32 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e4a7b378-25bc-758c-4a42-aa677400d6e3",
         "x-ms-error-code": "ContainerAlreadyExists",
-        "x-ms-request-id": "db366c2e-d01e-0015-0cd7-af8588000000",
+        "x-ms-request-id": "f6fec281-601e-00a7-7b67-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
-        "RequestId:db366c2e-d01e-0015-0cd7-af8588000000\n",
-        "Time:2019-12-11T04:02:22.3340119Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:f6fec281-601e-00a7-7b67-38abf8000000\n",
+        "Time:2020-06-01T22:56:33.5505858Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-eebbdf3178d95b4dbd2639961e271c5c-618c37e126b8b04c-00",
+        "traceparent": "00-13395ecf634a7d4fbf4c142b44b5c4fb-814ede8c5c18334a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3630dc31-07bf-9567-1924-e4e223b1e18e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -87,14 +87,13 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:22 GMT",
-        "ETag": "\u00220x8D77DEEECAA8039\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:32 GMT",
+        "ETag": "\u00220x8D8067F07D6073F\u0022",
+        "Last-Modified": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Vary": "Origin",
         "x-ms-client-request-id": "3630dc31-07bf-9567-1924-e4e223b1e18e",
         "x-ms-default-encryption-scope": "$account-encryption-key",
         "x-ms-deny-encryption-scope-override": "false",
@@ -102,23 +101,23 @@
         "x-ms-has-legal-hold": "false",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "db366c2f-d01e-0015-0dd7-af8588000000",
+        "x-ms-request-id": "f6fec2be-601e-00a7-3067-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-05f23944-b0b9-4109-41ec-048627c22cb7?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b4f72324f76c1a4ab4bbc2bbb213b6e7-77fceed87c090c42-00",
+        "traceparent": "00-1077ae048cadba4d9aafc366d72a417d-e32918ed1ea73e4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9736ad1c-9fd0-e024-a9d2-16e46049ee78",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -126,13 +125,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:22 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:32 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9736ad1c-9fd0-e024-a9d2-16e46049ee78",
-        "x-ms-request-id": "db366c30-d01e-0015-0ed7-af8588000000",
+        "x-ms-request-id": "f6fec2e6-601e-00a7-5867-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -140,6 +139,6 @@
   ],
   "Variables": {
     "RandomSeed": "1054396929",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CreateIfNotExistsAsync_ExistsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9217cdc45478e048a8bd223d6b37954b-bb0d577bdfc64643-00",
+        "traceparent": "00-1e67e2220b9ac6438c240be069cf8d56-76bd02e7c623a94d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "802b81cb-8b84-299c-7281-ef5fd42e7f71",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
-        "ETag": "\u00220x8D77DEF01E2AEDA\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
+        "ETag": "\u00220x8D8067F081DA4B8\u0022",
+        "Last-Modified": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "802b81cb-8b84-299c-7281-ef5fd42e7f71",
-        "x-ms-request-id": "db366ec3-d01e-0015-7ed7-af8588000000",
+        "x-ms-request-id": "f6fec3dc-601e-00a7-4067-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1d966f4e75a4724486d414e93ea485c2-9be61c5f107be54d-00",
+        "traceparent": "00-e78adbecdb3d734c899b61b5ad387b71-d830eaf2a98c7643-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "70d9b4d0-b334-ef2e-40e8-caeba4b2f03f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:34 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,34 +52,34 @@
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "70d9b4d0-b334-ef2e-40e8-caeba4b2f03f",
         "x-ms-error-code": "ContainerAlreadyExists",
-        "x-ms-request-id": "db366ec6-d01e-0015-7fd7-af8588000000",
+        "x-ms-request-id": "f6fec3fb-601e-00a7-5a67-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
-        "RequestId:db366ec6-d01e-0015-7fd7-af8588000000\n",
-        "Time:2019-12-11T04:02:57.9323600Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:f6fec3fb-601e-00a7-5a67-38abf8000000\n",
+        "Time:2020-06-01T22:56:34.0199232Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ebeca52ad8691244bc2d231a2e42b5f1-f8c9150fd45adb4c-00",
+        "traceparent": "00-cc23e3aecf429f4a8fcce9e9e8d89286-7879d78d9d4fca4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1f8eea04-0f54-dd3c-784d-5480c71648e2",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:34 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -87,14 +87,13 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
-        "ETag": "\u00220x8D77DEF01E2AEDA\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
+        "ETag": "\u00220x8D8067F081DA4B8\u0022",
+        "Last-Modified": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "Vary": "Origin",
         "x-ms-client-request-id": "1f8eea04-0f54-dd3c-784d-5480c71648e2",
         "x-ms-default-encryption-scope": "$account-encryption-key",
         "x-ms-deny-encryption-scope-override": "false",
@@ -102,23 +101,23 @@
         "x-ms-has-legal-hold": "false",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "db366ec7-d01e-0015-80d7-af8588000000",
+        "x-ms-request-id": "f6fec415-601e-00a7-7167-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fba9a782-01ee-0bab-3574-39a5f26033b3?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-bd0a2e6ce9011a42a0deb4de66b0d0a8-e77616a6eea48140-00",
+        "traceparent": "00-a737e15ab3d90e49b4cc3fe155a43279-7d7ec14c9bd09243-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200601.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bae6103b-d024-7aeb-d585-6ea6ba9c7269",
-        "x-ms-date": "Wed, 11 Dec 2019 04:02:58 GMT",
+        "x-ms-date": "Mon, 01 Jun 2020 22:56:34 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -126,13 +125,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:02:57 GMT",
+        "Date": "Mon, 01 Jun 2020 22:56:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bae6103b-d024-7aeb-d585-6ea6ba9c7269",
-        "x-ms-request-id": "db366ec8-d01e-0015-01d7-af8588000000",
+        "x-ms-request-id": "f6fec44b-601e-00a7-2067-38abf8000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -140,6 +139,6 @@
   ],
   "Variables": {
     "RandomSeed": "61532685",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/CreateIfNotExistsAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/CreateIfNotExistsAsync_Exists.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-aa04e466aef4894790b04cc512657f83-6d36b874812c514a-00",
+        "traceparent": "00-9360dab8b4d18f4a9bb8ef596f3cbad4-28d4a1944bd2fd49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e2ffbdc6-d6e4-e7e5-ca82-04f4283f79a4",
-        "x-ms-date": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,34 +20,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:36:32 GMT",
-        "ETag": "\u00220x8D77DF3B2E2DB83\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:15 GMT",
+        "ETag": "\u00220x8D8071E86C59C0B\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:16 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e2ffbdc6-d6e4-e7e5-ca82-04f4283f79a4",
-        "x-ms-request-id": "00dc5c2b-701e-0023-2fdc-af08f8000000",
+        "x-ms-request-id": "9b9b1694-e01e-00f9-7807-3958fb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a/test-blob-14000e24-3d12-3099-87b6-9de5b389493f",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a/test-blob-14000e24-3d12-3099-87b6-9de5b389493f",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-1578b42289bf244390e16fe7744dccb2-219b0d121725f743-00",
+        "traceparent": "00-00db093babfba64bb88cd3403a6b000e-17a378b6c0229d42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "240c2561-49c4-89bb-23ce-5b2d39003440",
-        "x-ms-date": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,36 +55,36 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:36:32 GMT",
-        "ETag": "\u00220x8D77DF3B2EFC6D7\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:15 GMT",
+        "ETag": "\u00220x8D8071E86CD74F0\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:16 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "240c2561-49c4-89bb-23ce-5b2d39003440",
-        "x-ms-request-id": "00dc5c2d-701e-0023-30dc-af08f8000000",
+        "x-ms-request-id": "9b9b16e0-e01e-00f9-3b07-3958fb000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a/test-blob-14000e24-3d12-3099-87b6-9de5b389493f",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a/test-blob-14000e24-3d12-3099-87b6-9de5b389493f",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
         "If-None-Match": "*",
-        "traceparent": "00-e817db5dae583749b2c1245cd434eb21-4412d1d7c0ffdd4e-00",
+        "traceparent": "00-64123a293c8e894db64843c3b2d21086-c82d4ee24af28544-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "8d8320cf-257c-a97a-e3c9-8e05b3873c1e",
-        "x-ms-date": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -93,34 +93,34 @@
       "ResponseHeaders": {
         "Content-Length": "220",
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8d8320cf-257c-a97a-e3c9-8e05b3873c1e",
         "x-ms-error-code": "BlobAlreadyExists",
-        "x-ms-request-id": "00dc5c2e-701e-0023-31dc-af08f8000000",
+        "x-ms-request-id": "9b9b1725-e01e-00f9-7a07-3958fb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified blob already exists.\n",
-        "RequestId:00dc5c2e-701e-0023-31dc-af08f8000000\n",
-        "Time:2019-12-11T04:36:32.9632762Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:9b9b1725-e01e-00f9-7a07-3958fb000000\n",
+        "Time:2020-06-02T17:58:16.5426703Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-59c60408-7dbf-7bbb-0451-6c186fd4f19a?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d4d9c3d11d273041a1a8c813a0033ed1-7d0c0c01ea23354e-00",
+        "traceparent": "00-7d2995ea188abe4e9f7499f1437b1af6-dcf317d237a6834f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "185e5c72-a77c-13c3-4a57-a62338c962d1",
-        "x-ms-date": "Wed, 11 Dec 2019 04:36:33 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -128,13 +128,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:36:32 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "185e5c72-a77c-13c3-4a57-a62338c962d1",
-        "x-ms-request-id": "00dc5c2f-701e-0023-32dc-af08f8000000",
+        "x-ms-request-id": "9b9b1748-e01e-00f9-1907-3958fb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -142,6 +142,6 @@
   ],
   "Variables": {
     "RandomSeed": "983910991",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/CreateIfNotExistsAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/CreateIfNotExistsAsync_ExistsAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c12add66d3b62a438f23a8c6d816d337-7d67409300fbcf45-00",
+        "traceparent": "00-17b5b1001fbe6449a3ef0e7a984b0cf0-c51a2a96b9143944-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "ffe05389-e3b0-4cd7-88cb-f740768814a1",
-        "x-ms-date": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,34 +20,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:37:46 GMT",
-        "ETag": "\u00220x8D77DF3DF00B174\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:17 GMT",
+        "ETag": "\u00220x8D8071E8729FC93\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:17 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ffe05389-e3b0-4cd7-88cb-f740768814a1",
-        "x-ms-request-id": "00dc623d-701e-0023-62dc-af08f8000000",
+        "x-ms-request-id": "e5bcfaa2-001e-0095-0c07-39f328000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61/test-blob-ffc56b80-7f93-bcbe-6679-4f3c7e2452eb",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61/test-blob-ffc56b80-7f93-bcbe-6679-4f3c7e2452eb",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-1b04785b424fd14e81aa39deffed62ba-e8d46e046223f74a-00",
+        "traceparent": "00-1c08249bcf006841991e2e15e1226f95-35012dd0ed6b4a44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "b36808a4-de53-0a86-9423-9837949bcd63",
-        "x-ms-date": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -55,36 +55,36 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:37:46 GMT",
-        "ETag": "\u00220x8D77DF3DF0D326A\u0022",
-        "Last-Modified": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:17 GMT",
+        "ETag": "\u00220x8D8071E8733EA8D\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:17 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b36808a4-de53-0a86-9423-9837949bcd63",
-        "x-ms-request-id": "00dc623f-701e-0023-63dc-af08f8000000",
+        "x-ms-request-id": "e5bcfabe-001e-0095-2107-39f328000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61/test-blob-ffc56b80-7f93-bcbe-6679-4f3c7e2452eb",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61/test-blob-ffc56b80-7f93-bcbe-6679-4f3c7e2452eb",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "0",
         "If-None-Match": "*",
-        "traceparent": "00-a10414f21dfced44991f266ada779df0-d6d1b4973c909c42-00",
+        "traceparent": "00-5cf0eeb833e8bd49a31b982782f6816e-7b02505716668d46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-content-length": "1024",
         "x-ms-blob-type": "PageBlob",
         "x-ms-client-request-id": "7597b704-9ebb-3998-d9a9-d72c137ade56",
-        "x-ms-date": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -93,34 +93,34 @@
       "ResponseHeaders": {
         "Content-Length": "220",
         "Content-Type": "application/xml",
-        "Date": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:17 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7597b704-9ebb-3998-d9a9-d72c137ade56",
         "x-ms-error-code": "BlobAlreadyExists",
-        "x-ms-request-id": "00dc6244-701e-0023-67dc-af08f8000000",
+        "x-ms-request-id": "e5bcfaee-001e-0095-4907-39f328000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified blob already exists.\n",
-        "RequestId:00dc6244-701e-0023-67dc-af08f8000000\n",
-        "Time:2019-12-11T04:37:46.9725535Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:e5bcfaee-001e-0095-4907-39f328000000\n",
+        "Time:2020-06-02T17:58:17.2175120Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seanstagetest.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61?restype=container",
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-7064f998-28f6-720e-04f4-793dbf30aa61?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f56ac84309a338478994e3c7c2ec98f9-206f33d854279946-00",
+        "traceparent": "00-7e78abbac6be274797e4652f86dd6dfb-dbe7dd9c784bac4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191210.1\u002B4108f7dcb3b573f551e264a3052039412b91b2f8",
-          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "dc32834b-5803-daa7-73ee-3d2bd124c13f",
-        "x-ms-date": "Wed, 11 Dec 2019 04:37:47 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -128,13 +128,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 11 Dec 2019 04:37:46 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:17 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "dc32834b-5803-daa7-73ee-3d2bd124c13f",
-        "x-ms-request-id": "00dc6245-701e-0023-68dc-af08f8000000",
+        "x-ms-request-id": "e5bcfb03-001e-0095-5c07-39f328000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -142,6 +142,6 @@
   ],
   "Variables": {
     "RandomSeed": "1200575414",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanstagetest\nU2FuaXRpemVk\nhttp://seanstagetest.blob.core.windows.net\nhttp://seanstagetest.file.core.windows.net\nhttp://seanstagetest.queue.core.windows.net\nhttp://seanstagetest.table.core.windows.net\n\n\n\n\nhttp://seanstagetest-secondary.blob.core.windows.net\nhttp://seanstagetest-secondary.file.core.windows.net\nhttp://seanstagetest-secondary.queue.core.windows.net\nhttp://seanstagetest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanstagetest.blob.core.windows.net/;QueueEndpoint=http://seanstagetest.queue.core.windows.net/;FileEndpoint=http://seanstagetest.file.core.windows.net/;BlobSecondaryEndpoint=http://seanstagetest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanstagetest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanstagetest-secondary.file.core.windows.net/;AccountName=seanstagetest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -927,7 +927,7 @@ namespace Azure.Storage.Files.DataLake
             catch (RequestFailedException storageRequestFailedException)
             when (storageRequestFailedException.ErrorCode == "PathAlreadyExists")
             {
-                response = default;
+                response = Response.FromValue(new PathInfo(), default);
             }
             catch (Exception ex)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -299,7 +299,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Response<PathInfo> response = await directory.CreateIfNotExistsAsync();
 
             // Assert
-            Assert.IsNull(response);
+            Assert.AreEqual(response.Value.ETag.ToString(), "<null>");
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -306,7 +306,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Response<PathInfo> response = await file.CreateIfNotExistsAsync();
 
             // Assert
-            Assert.IsNull(response);
+            Assert.AreEqual(response.Value.ETag.ToString(), "<null>");
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -344,7 +344,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Response<FileSystemInfo> response = await fileSystemClient.CreateIfNotExistsAsync();
 
                 // Assert
-                Assert.IsNull(response);
+                Assert.AreEqual(response.Value.ETag.ToString(), "<null>");
             }
             finally
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CreateIfNotExistsAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CreateIfNotExistsAsync_Exists.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-14378f8386e41e45bba224443ea2def0-844eb8dd9dce8e48-00",
+        "traceparent": "00-b7ae1cb8703db5408b8b0809258b34b1-fd2ff858d4529746-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "8edf4b05-97e6-2716-444a-8dd1792e4512",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:42 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:19 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,31 +20,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:20:41 GMT",
-        "ETag": "\u00220x8D7B1B5462E6FDA\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:20:42 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:19 GMT",
+        "ETag": "\u00220x8D8071E88B8A3E7\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:19 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8edf4b05-97e6-2716-444a-8dd1792e4512",
-        "x-ms-request-id": "b7426799-f01e-0098-379e-e35f3e000000",
+        "x-ms-request-id": "ef509c3e-001e-00cd-7707-39c6cb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398/test-directory-49081b26-482e-7c21-8485-90a06a6840a3?resource=directory",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398/test-directory-49081b26-482e-7c21-8485-90a06a6840a3?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-590043709baa4a47ae1bc5c8f241b8f2-782a7d210c1ab24e-00",
+        "traceparent": "00-77cd7bb06e06fd4a985a1efd2fdddf43-6f2114bd3f344544-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7f83ef86-9323-bc0d-2a62-0a600776bcdb",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:42 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:19 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,32 +52,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:20:41 GMT",
-        "ETag": "\u00220x8D7B1B546369923\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:20:42 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:19 GMT",
+        "ETag": "\u00220x8D8071E88D01D23\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:19 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7f83ef86-9323-bc0d-2a62-0a600776bcdb",
-        "x-ms-request-id": "63b51d84-401f-000b-139e-e38434000000",
+        "x-ms-request-id": "7cf85319-001f-004b-1507-390a72000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398/test-directory-49081b26-482e-7c21-8485-90a06a6840a3?resource=directory",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398/test-directory-49081b26-482e-7c21-8485-90a06a6840a3?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "If-None-Match": "*",
-        "traceparent": "00-b0988bd5101cfa42bb9f05880d8fe319-42dc8612c6709944-00",
+        "traceparent": "00-0ff1105e317c3242a0c4e1da6c461867-2352a5fff4bf4540-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7b1a498a-c1e5-0c80-a6b9-ddf8e9518306",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:42 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:19 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -86,35 +86,35 @@
       "ResponseHeaders": {
         "Content-Length": "168",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Feb 2020 01:20:41 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:19 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7b1a498a-c1e5-0c80-a6b9-ddf8e9518306",
         "x-ms-error-code": "PathAlreadyExists",
-        "x-ms-request-id": "63b51d85-401f-000b-149e-e38434000000",
+        "x-ms-request-id": "7cf8531a-001f-004b-1607-390a72000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": {
         "error": {
           "code": "PathAlreadyExists",
-          "message": "The specified path already exists.\nRequestId:63b51d85-401f-000b-149e-e38434000000\nTime:2020-02-15T01:20:42.1590954Z"
+          "message": "The specified path already exists.\nRequestId:7cf8531a-001f-004b-1607-390a72000000\nTime:2020-06-02T17:58:19.9477288Z"
         }
       }
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-04f922ce-6c6b-da11-cf7c-ee7b533a8398?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c35e831da9b7b94486e0222333f53a0f-ca52401ec6ca0a45-00",
+        "traceparent": "00-6dd9a6af6b9c7e43ab32e6d871091cf2-1da7839115b97144-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bdd553aa-415c-48f6-6925-1fff5fbf4717",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:42 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:20 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -122,13 +122,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:20:41 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:19 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "bdd553aa-415c-48f6-6925-1fff5fbf4717",
-        "x-ms-request-id": "b7426813-f01e-0098-2b9e-e35f3e000000",
+        "x-ms-request-id": "ef509c47-001e-00cd-7c07-39c6cb000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -136,6 +136,6 @@
   ],
   "Variables": {
     "RandomSeed": "1902561018",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttp://seannse.blob.core.windows.net\nhttp://seannse.file.core.windows.net\nhttp://seannse.queue.core.windows.net\nhttp://seannse.table.core.windows.net\n\n\n\n\nhttp://seannse-secondary.blob.core.windows.net\nhttp://seannse-secondary.file.core.windows.net\nhttp://seannse-secondary.queue.core.windows.net\nhttp://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://seannse.blob.core.windows.net/;QueueEndpoint=http://seannse.queue.core.windows.net/;FileEndpoint=http://seannse.file.core.windows.net/;BlobSecondaryEndpoint=http://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CreateIfNotExistsAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CreateIfNotExistsAsync_ExistsAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cba1b6cc2f21f74980cde30b3a1e7935-43f22f683b965b48-00",
+        "traceparent": "00-c2bf4775c23fa040b6b7075d8a027503-a716f2aac8c9244c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "6792972b-c302-a025-fa60-cc5f14c5cd9f",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,31 +20,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:20:59 GMT",
-        "ETag": "\u00220x8D7B1B5508D35F6\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:20 GMT",
+        "ETag": "\u00220x8D8071E89A0B474\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:21 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6792972b-c302-a025-fa60-cc5f14c5cd9f",
-        "x-ms-request-id": "2db1e857-b01e-006d-7e9e-e3cb14000000",
+        "x-ms-request-id": "3d3ebcd9-201e-0011-4707-396c95000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0/test-directory-81044582-71ba-da0f-5e00-626968a95817?resource=directory",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0/test-directory-81044582-71ba-da0f-5e00-626968a95817?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9c9888ef021f7c4cbe724c0cba144ce5-8600160550a36d4e-00",
+        "traceparent": "00-118b62e0b01abe4c8d096ec46c35b391-6e5920ac4a2c884f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ea7b175b-77de-baf8-88b8-080260bc3850",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,32 +52,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:20:58 GMT",
-        "ETag": "\u00220x8D7B1B550944C70\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:21 GMT",
+        "ETag": "\u00220x8D8071E89B9CB43\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:21 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ea7b175b-77de-baf8-88b8-080260bc3850",
-        "x-ms-request-id": "63b5209c-401f-000b-209e-e38434000000",
+        "x-ms-request-id": "8a260916-d01f-0093-6907-392d2b000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0/test-directory-81044582-71ba-da0f-5e00-626968a95817?resource=directory",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0/test-directory-81044582-71ba-da0f-5e00-626968a95817?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "If-None-Match": "*",
-        "traceparent": "00-09476e159ff87848ac98610d8abc76ec-e96f9fb8d965e54b-00",
+        "traceparent": "00-8dfc6913bff1da4ca8f289b03a05cd05-6620d8661924c342-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "500daaa0-6e2d-c338-f195-358e1dec96d4",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -86,35 +86,35 @@
       "ResponseHeaders": {
         "Content-Length": "168",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Feb 2020 01:20:58 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:21 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "500daaa0-6e2d-c338-f195-358e1dec96d4",
         "x-ms-error-code": "PathAlreadyExists",
-        "x-ms-request-id": "63b5209d-401f-000b-219e-e38434000000",
+        "x-ms-request-id": "8a260917-d01f-0093-6a07-392d2b000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": {
         "error": {
           "code": "PathAlreadyExists",
-          "message": "The specified path already exists.\nRequestId:63b5209d-401f-000b-219e-e38434000000\nTime:2020-02-15T01:20:59.5483388Z"
+          "message": "The specified path already exists.\nRequestId:8a260917-d01f-0093-6a07-392d2b000000\nTime:2020-06-02T17:58:21.4769981Z"
         }
       }
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-e07483e4-1f92-89a8-fa34-9d7b54d98df0?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-141205b67b58b443af2d76161dec45a6-877e7b29e4da7740-00",
+        "traceparent": "00-f8dd2d7069002143b275d183635ea40c-3ab4dc39a1568347-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b6616e1b-e7ae-9922-7c60-39e0dbc93e6b",
-        "x-ms-date": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -122,13 +122,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:20:59 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:20 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b6616e1b-e7ae-9922-7c60-39e0dbc93e6b",
-        "x-ms-request-id": "2db1e86c-b01e-006d-0c9e-e3cb14000000",
+        "x-ms-request-id": "3d3ebd6a-201e-0011-3007-396c95000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -136,6 +136,6 @@
   ],
   "Variables": {
     "RandomSeed": "1477481490",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttp://seannse.blob.core.windows.net\nhttp://seannse.file.core.windows.net\nhttp://seannse.queue.core.windows.net\nhttp://seannse.table.core.windows.net\n\n\n\n\nhttp://seannse-secondary.blob.core.windows.net\nhttp://seannse-secondary.file.core.windows.net\nhttp://seannse-secondary.queue.core.windows.net\nhttp://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://seannse.blob.core.windows.net/;QueueEndpoint=http://seannse.queue.core.windows.net/;FileEndpoint=http://seannse.file.core.windows.net/;BlobSecondaryEndpoint=http://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/CreateIfNotExistsAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/CreateIfNotExistsAsync_Exists.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7833c7312973a6478e4d50d95d6baf2e-334f6e784a90f240-00",
+        "traceparent": "00-27baacce070127499d37e19ddf81bbc0-796c75babbbd4840-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "f383241d-59dc-035c-0dcd-56282465821f",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,31 +20,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:38 GMT",
-        "ETag": "\u00220x8D7B1B568633E96\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:22 GMT",
+        "ETag": "\u00220x8D8071E8A9513AC\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f383241d-59dc-035c-0dcd-56282465821f",
-        "x-ms-request-id": "1775fb8e-c01e-0015-519e-e368ec000000",
+        "x-ms-request-id": "c4e774e6-201e-00b8-7107-39ade7000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615/test-directory-3507a10f-3d4f-5c49-bf35-baa58d50208c?resource=directory",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615/test-directory-3507a10f-3d4f-5c49-bf35-baa58d50208c?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-aba16a86b873744ba1e645453184be5a-05fa5679d3fc2243-00",
+        "traceparent": "00-301aa221fb7a24478d4323e61ee6f48f-f2fa8c585b63d943-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d95a7496-76e6-e083-da27-33a79eb776bc",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,31 +52,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:38 GMT",
-        "ETag": "\u00220x8D7B1B5686D1688\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:22 GMT",
+        "ETag": "\u00220x8D8071E8AAFFF93\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:23 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d95a7496-76e6-e083-da27-33a79eb776bc",
-        "x-ms-request-id": "02313c6d-301f-0073-679e-e327cc000000",
+        "x-ms-request-id": "236cf03e-f01f-002d-6907-394552000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615/test-directory-3507a10f-3d4f-5c49-bf35-baa58d50208c/test-file-2c25c9ac-7e1c-ec66-6850-dd8dcb5ecd10?resource=file",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615/test-directory-3507a10f-3d4f-5c49-bf35-baa58d50208c/test-file-2c25c9ac-7e1c-ec66-6850-dd8dcb5ecd10?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3cd59f97ff99d045ae446f1b242a679f-7d68698a8422f146-00",
+        "traceparent": "00-a4e6d2fc297f864daa85c1baa662ca9f-63522778a131f64f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c53eb44b-728a-173f-0d6e-719598f6157b",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -84,32 +84,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:38 GMT",
-        "ETag": "\u00220x8D7B1B56871E63B\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:22 GMT",
+        "ETag": "\u00220x8D8071E8ABCD3E9\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:23 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c53eb44b-728a-173f-0d6e-719598f6157b",
-        "x-ms-request-id": "02313c70-301f-0073-6a9e-e327cc000000",
+        "x-ms-request-id": "236cf03f-f01f-002d-6a07-394552000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615/test-directory-3507a10f-3d4f-5c49-bf35-baa58d50208c/test-file-2c25c9ac-7e1c-ec66-6850-dd8dcb5ecd10?resource=file",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615/test-directory-3507a10f-3d4f-5c49-bf35-baa58d50208c/test-file-2c25c9ac-7e1c-ec66-6850-dd8dcb5ecd10?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "If-None-Match": "*",
-        "traceparent": "00-fff2e15db6e5c24bbdc6ae5202656f96-4d1bca6de2924048-00",
+        "traceparent": "00-52a5d5a9d747bb419b418395efb27433-555a8dbd23876543-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "16413d38-0720-2385-1ff7-0b87d510f47f",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -118,35 +118,35 @@
       "ResponseHeaders": {
         "Content-Length": "168",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Feb 2020 01:21:38 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:22 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "16413d38-0720-2385-1ff7-0b87d510f47f",
         "x-ms-error-code": "PathAlreadyExists",
-        "x-ms-request-id": "02313c76-301f-0073-709e-e327cc000000",
+        "x-ms-request-id": "236cf040-f01f-002d-6b07-394552000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": {
         "error": {
           "code": "PathAlreadyExists",
-          "message": "The specified path already exists.\nRequestId:02313c76-301f-0073-709e-e327cc000000\nTime:2020-02-15T01:21:39.5944057Z"
+          "message": "The specified path already exists.\nRequestId:236cf040-f01f-002d-6b07-394552000000\nTime:2020-06-02T17:58:23.1775366Z"
         }
       }
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-7cf89841-21bd-9bba-79af-cb66283c1615?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c8ad6ca6bb09334288dea25be017a0da-436411cd247b1847-00",
+        "traceparent": "00-38b74b8eb391f44ab34e9cecc6bf416c-046ba96ccd95564e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5b5c9a70-feb4-525b-9ded-20b0523e9112",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -154,13 +154,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:38 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:22 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5b5c9a70-feb4-525b-9ded-20b0523e9112",
-        "x-ms-request-id": "1775fba8-c01e-0015-669e-e368ec000000",
+        "x-ms-request-id": "c4e775b0-201e-00b8-0c07-39ade7000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -168,6 +168,6 @@
   ],
   "Variables": {
     "RandomSeed": "1425937147",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttp://seannse.blob.core.windows.net\nhttp://seannse.file.core.windows.net\nhttp://seannse.queue.core.windows.net\nhttp://seannse.table.core.windows.net\n\n\n\n\nhttp://seannse-secondary.blob.core.windows.net\nhttp://seannse-secondary.file.core.windows.net\nhttp://seannse-secondary.queue.core.windows.net\nhttp://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://seannse.blob.core.windows.net/;QueueEndpoint=http://seannse.queue.core.windows.net/;FileEndpoint=http://seannse.file.core.windows.net/;BlobSecondaryEndpoint=http://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/CreateIfNotExistsAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileClientTests/CreateIfNotExistsAsync_ExistsAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-75963b09f52977458a1953ae9602e5c7-9c9f1ba3222a6243-00",
+        "traceparent": "00-3fde0c8063f2e44d9cace7403d461296-9cc9852abaa1bb4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "acc658c1-5204-7220-bfc9-b734e2368d67",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -20,31 +20,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:53 GMT",
-        "ETag": "\u00220x8D7B1B5712A6CE6\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:24 GMT",
+        "ETag": "\u00220x8D8071E8B9C5EA2\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:24 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "acc658c1-5204-7220-bfc9-b734e2368d67",
-        "x-ms-request-id": "574a857a-e01e-004f-459e-e30e0b000000",
+        "x-ms-request-id": "a9383774-d01e-0093-5007-392d2b000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f/test-directory-c61da910-021d-b977-b71e-0df05932d74f?resource=directory",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f/test-directory-c61da910-021d-b977-b71e-0df05932d74f?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1a9de8317791c94da8a0e3e1c972a8f9-a5b395116d307f4b-00",
+        "traceparent": "00-4d0f4aa16ac7154bb7190c387071fff9-7d84ce6da7702643-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ea8f4286-a5a2-bf5b-e10c-f4e64430198d",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,31 +52,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:54 GMT",
-        "ETag": "\u00220x8D7B1B5713887F5\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:24 GMT",
+        "ETag": "\u00220x8D8071E8BB52B9E\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:24 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ea8f4286-a5a2-bf5b-e10c-f4e64430198d",
-        "x-ms-request-id": "6bf336f6-501f-0065-389e-e3d11b000000",
+        "x-ms-request-id": "085099d7-701f-001c-6e07-39a441000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f/test-directory-c61da910-021d-b977-b71e-0df05932d74f/test-file-d83e68f2-00d8-459f-0e01-bf133805e901?resource=file",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f/test-directory-c61da910-021d-b977-b71e-0df05932d74f/test-file-d83e68f2-00d8-459f-0e01-bf133805e901?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6c264a248146fe4fac2fa33c0801a89d-37c978161fd37848-00",
+        "traceparent": "00-cd40fb3753349642932898fecdbeb07c-3e6faa36fc8da544-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "677f3cf1-2978-8573-a249-dba0e54786dc",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -84,32 +84,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:54 GMT",
-        "ETag": "\u00220x8D7B1B5713D3C9B\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:24 GMT",
+        "ETag": "\u00220x8D8071E8BC18AAC\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:24 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "677f3cf1-2978-8573-a249-dba0e54786dc",
-        "x-ms-request-id": "6bf336f8-501f-0065-3a9e-e3d11b000000",
+        "x-ms-request-id": "085099d8-701f-001c-6f07-39a441000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.dfs.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f/test-directory-c61da910-021d-b977-b71e-0df05932d74f/test-file-d83e68f2-00d8-459f-0e01-bf133805e901?resource=file",
+      "RequestUri": "http://amandacanaryoauth.dfs.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f/test-directory-c61da910-021d-b977-b71e-0df05932d74f/test-file-d83e68f2-00d8-459f-0e01-bf133805e901?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "If-None-Match": "*",
-        "traceparent": "00-f8898fd5160aad43bd2121bf99073206-8e624e083a29c144-00",
+        "traceparent": "00-b45097774388a442b0dab83e91108bd2-ebc86fd38de1ca48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fb22e92a-8285-f289-4de4-7459110b6967",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -118,35 +118,35 @@
       "ResponseHeaders": {
         "Content-Length": "168",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fb22e92a-8285-f289-4de4-7459110b6967",
         "x-ms-error-code": "PathAlreadyExists",
-        "x-ms-request-id": "6bf336fa-501f-0065-3c9e-e3d11b000000",
+        "x-ms-request-id": "085099d9-701f-001c-7007-39a441000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": {
         "error": {
           "code": "PathAlreadyExists",
-          "message": "The specified path already exists.\nRequestId:6bf336fa-501f-0065-3c9e-e3d11b000000\nTime:2020-02-15T01:21:54.3490209Z"
+          "message": "The specified path already exists.\nRequestId:085099d9-701f-001c-7007-39a441000000\nTime:2020-06-02T17:58:24.8843964Z"
         }
       }
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-9002a241-0203-6bd1-0f61-821fe48e779f?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-34b59ffd2bfad04f906c162904a9978e-95a3c55c49ea9f4a-00",
+        "traceparent": "00-cf56cab07a0fb349b562e0fee8c600cc-bc46385e29ee8942-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fc7681da-8a24-9f56-69d7-36e18e91f2b0",
-        "x-ms-date": "Sat, 15 Feb 2020 01:21:54 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -154,13 +154,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:21:53 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:24 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fc7681da-8a24-9f56-69d7-36e18e91f2b0",
-        "x-ms-request-id": "574a864f-e01e-004f-099e-e30e0b000000",
+        "x-ms-request-id": "a9383832-d01e-0093-6407-392d2b000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -168,6 +168,6 @@
   ],
   "Variables": {
     "RandomSeed": "1380889928",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttp://seannse.blob.core.windows.net\nhttp://seannse.file.core.windows.net\nhttp://seannse.queue.core.windows.net\nhttp://seannse.table.core.windows.net\n\n\n\n\nhttp://seannse-secondary.blob.core.windows.net\nhttp://seannse-secondary.file.core.windows.net\nhttp://seannse-secondary.queue.core.windows.net\nhttp://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://seannse.blob.core.windows.net/;QueueEndpoint=http://seannse.queue.core.windows.net/;FileEndpoint=http://seannse.file.core.windows.net/;BlobSecondaryEndpoint=http://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CreateIfNotExistAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CreateIfNotExistAsync_Exists.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-8028c520-1316-f8d0-6235-bc92e5a0d4af?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8028c520-1316-f8d0-6235-bc92e5a0d4af?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-858b2128a60a0c4db1b62c48ee39b4bf-c242f0735259a640-00",
+        "traceparent": "00-a7a68f90b562584ca395381afbab832f-9b976864d4f02448-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "533b1afc-37be-c80e-1f84-280eaf571a7d",
-        "x-ms-date": "Sat, 15 Feb 2020 01:22:49 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:22:49 GMT",
-        "ETag": "\u00220x8D7B1B592793960\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:22:50 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:25 GMT",
+        "ETag": "\u00220x8D8071E8C3DC066\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:25 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "533b1afc-37be-c80e-1f84-280eaf571a7d",
-        "x-ms-request-id": "d4346cf0-601e-00a5-0c9e-e32925000000",
+        "x-ms-request-id": "7efe1ff5-a01e-00a6-2e07-39413f000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-8028c520-1316-f8d0-6235-bc92e5a0d4af?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8028c520-1316-f8d0-6235-bc92e5a0d4af?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fe78de4f7db0604f9ca02fcdcfa5c773-fb622ad663bf574c-00",
+        "traceparent": "00-7b23f0c27291d044bd9adcbb1f53c6e4-e40e0f29a9883c4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ca952092-8064-d4f1-8484-7beba5f10432",
-        "x-ms-date": "Sat, 15 Feb 2020 01:22:50 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,34 +52,34 @@
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/xml",
-        "Date": "Sat, 15 Feb 2020 01:22:49 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:25 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ca952092-8064-d4f1-8484-7beba5f10432",
         "x-ms-error-code": "ContainerAlreadyExists",
-        "x-ms-request-id": "d4346d77-601e-00a5-059e-e32925000000",
+        "x-ms-request-id": "7efe2043-a01e-00a6-6b07-39413f000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
-        "RequestId:d4346d77-601e-00a5-059e-e32925000000\n",
-        "Time:2020-02-15T01:22:50.1919550Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:7efe2043-a01e-00a6-6b07-39413f000000\n",
+        "Time:2020-06-02T17:58:25.7086524Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-8028c520-1316-f8d0-6235-bc92e5a0d4af?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8028c520-1316-f8d0-6235-bc92e5a0d4af?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-eb9b36f999f2da4abe6f98a82a4e0fd9-0c7c1ec29bcd4941-00",
+        "traceparent": "00-72940ab5c34dce458790ff5fbb9055af-cc68ad7fbc9c754a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8e7c40aa-4fc1-0519-0585-09f45266acd3",
-        "x-ms-date": "Sat, 15 Feb 2020 01:22:50 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -87,13 +87,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:22:49 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:25 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8e7c40aa-4fc1-0519-0585-09f45266acd3",
-        "x-ms-request-id": "d4346d90-601e-00a5-1b9e-e32925000000",
+        "x-ms-request-id": "7efe208b-a01e-00a6-2407-39413f000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -101,6 +101,6 @@
   ],
   "Variables": {
     "RandomSeed": "1180487666",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttp://seannse.blob.core.windows.net\nhttp://seannse.file.core.windows.net\nhttp://seannse.queue.core.windows.net\nhttp://seannse.table.core.windows.net\n\n\n\n\nhttp://seannse-secondary.blob.core.windows.net\nhttp://seannse-secondary.file.core.windows.net\nhttp://seannse-secondary.queue.core.windows.net\nhttp://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://seannse.blob.core.windows.net/;QueueEndpoint=http://seannse.queue.core.windows.net/;FileEndpoint=http://seannse.file.core.windows.net/;BlobSecondaryEndpoint=http://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CreateIfNotExistAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CreateIfNotExistAsync_ExistsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-8a71df22-e451-e186-9ea2-27b5c94d1ebf?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8a71df22-e451-e186-9ea2-27b5c94d1ebf?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-5dc97712f24080408c56f99438d3edac-6a1e5f8adaa8804a-00",
+        "traceparent": "00-8adaa20b02a3b8458910cd3701697410-4ea06d33d733b745-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fd954378-7636-65ab-0d49-9501a6d11673",
-        "x-ms-date": "Sat, 15 Feb 2020 01:23:51 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:23:51 GMT",
-        "ETag": "\u00220x8D7B1B5B76660F6\u0022",
-        "Last-Modified": "Sat, 15 Feb 2020 01:23:52 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:26 GMT",
+        "ETag": "\u00220x8D8071E8CBA9DB3\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 17:58:26 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fd954378-7636-65ab-0d49-9501a6d11673",
-        "x-ms-request-id": "9f1fd397-a01e-00aa-579e-e35f49000000",
+        "x-ms-request-id": "7c0e0828-901e-0059-3707-3971a2000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-8a71df22-e451-e186-9ea2-27b5c94d1ebf?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8a71df22-e451-e186-9ea2-27b5c94d1ebf?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0991661aa41d8040b7a50b449289dd6a-928843d762216240-00",
+        "traceparent": "00-4efc8b479d6ae64aa3035eda3cf622ac-5d7c95a6f8f5b34e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "863c0b50-20b7-b189-54b1-6dba5726c388",
-        "x-ms-date": "Sat, 15 Feb 2020 01:23:52 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,34 +52,34 @@
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/xml",
-        "Date": "Sat, 15 Feb 2020 01:23:51 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:26 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "863c0b50-20b7-b189-54b1-6dba5726c388",
         "x-ms-error-code": "ContainerAlreadyExists",
-        "x-ms-request-id": "9f1fd41c-a01e-00aa-439e-e35f49000000",
+        "x-ms-request-id": "7c0e0839-901e-0059-4407-3971a2000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
-        "RequestId:9f1fd41c-a01e-00aa-439e-e35f49000000\n",
-        "Time:2020-02-15T01:23:52.1091520Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:7c0e0839-901e-0059-4407-3971a2000000\n",
+        "Time:2020-06-02T17:58:26.5219608Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seannse.blob.core.windows.net/test-filesystem-8a71df22-e451-e186-9ea2-27b5c94d1ebf?restype=container",
+      "RequestUri": "http://amandacanaryoauth.blob.core.windows.net/test-filesystem-8a71df22-e451-e186-9ea2-27b5c94d1ebf?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7ad8c5fb066dad4898b1b9455a8af1f0-ecf0ac46f1b62a4c-00",
+        "traceparent": "00-66b0041c763a594d96c5371d504876c2-46f9e030d53d6a40-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.0.0-dev.20200214.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9bb0f61c-8f95-6fbb-b1d6-74ea8372dd91",
-        "x-ms-date": "Sat, 15 Feb 2020 01:23:52 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 17:58:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -87,13 +87,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Sat, 15 Feb 2020 01:23:51 GMT",
+        "Date": "Tue, 02 Jun 2020 17:58:26 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9bb0f61c-8f95-6fbb-b1d6-74ea8372dd91",
-        "x-ms-request-id": "9f1fd43c-a01e-00aa-5d9e-e35f49000000",
+        "x-ms-request-id": "7c0e085f-901e-0059-6307-3971a2000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -101,6 +101,6 @@
   ],
   "Variables": {
     "RandomSeed": "1863469022",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseannse\nU2FuaXRpemVk\nhttp://seannse.blob.core.windows.net\nhttp://seannse.file.core.windows.net\nhttp://seannse.queue.core.windows.net\nhttp://seannse.table.core.windows.net\n\n\n\n\nhttp://seannse-secondary.blob.core.windows.net\nhttp://seannse-secondary.file.core.windows.net\nhttp://seannse-secondary.queue.core.windows.net\nhttp://seannse-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://seannse.blob.core.windows.net/;QueueEndpoint=http://seannse.queue.core.windows.net/;FileEndpoint=http://seannse.file.core.windows.net/;BlobSecondaryEndpoint=http://seannse-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seannse-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seannse-secondary.file.core.windows.net/;AccountName=seannse;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandacanaryoauth\nU2FuaXRpemVk\nhttp://amandacanaryoauth.blob.core.windows.net\nhttp://amandacanaryoauth.file.core.windows.net\nhttp://amandacanaryoauth.queue.core.windows.net\nhttp://amandacanaryoauth.table.core.windows.net\n\n\n\n\nhttp://amandacanaryoauth-secondary.blob.core.windows.net\nhttp://amandacanaryoauth-secondary.file.core.windows.net\nhttp://amandacanaryoauth-secondary.queue.core.windows.net\nhttp://amandacanaryoauth-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandacanaryoauth.blob.core.windows.net/;QueueEndpoint=http://amandacanaryoauth.queue.core.windows.net/;FileEndpoint=http://amandacanaryoauth.file.core.windows.net/;BlobSecondaryEndpoint=http://amandacanaryoauth-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandacanaryoauth-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandacanaryoauth-secondary.file.core.windows.net/;AccountName=amandacanaryoauth;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -574,7 +574,7 @@ namespace Azure.Storage.Files.Shares
                 catch (RequestFailedException storageRequestFailedException)
                 when (storageRequestFailedException.ErrorCode == ShareErrorCode.ShareAlreadyExists)
                 {
-                    response = default;
+                    response = Response.FromValue(new ShareInfo(), default);
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -647,9 +647,10 @@ namespace Azure.Storage.Files.Shares
                 Pipeline.LogMethodEnter(
                     nameof(ShareDirectoryClient),
                     message: $"{nameof(Uri)}: {Uri}");
+                Response<ShareDirectoryInfo> response;
                 try
                 {
-                    Response<ShareDirectoryInfo> response = await CreateInternal(
+                    response = await CreateInternal(
                         metadata,
                         smbProperties,
                         filePermission,
@@ -657,13 +658,11 @@ namespace Azure.Storage.Files.Shares
                         cancellationToken,
                         operationName: operationName ?? $"{nameof(ShareDirectoryClient)}.{nameof(CreateIfNotExists)}")
                         .ConfigureAwait(false);
-
-                    return response;
                 }
                 catch (RequestFailedException storageRequestFailedException)
                 when (storageRequestFailedException.ErrorCode == ShareErrorCode.ResourceAlreadyExists)
                 {
-                    return default;
+                    response = Response.FromValue(new ShareDirectoryInfo(new RawStorageDirectoryInfo()), default);
                 }
                 catch (Exception ex)
                 {
@@ -674,6 +673,7 @@ namespace Azure.Storage.Files.Shares
                 {
                     Pipeline.LogMethodExit(nameof(ShareDirectoryClient));
                 }
+                return response;
             }
         }
         #endregion CreateIfNotExists

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -278,7 +278,7 @@ namespace Azure.Storage.Files.Shares.Test
             Response<ShareDirectoryInfo> response = await directory.CreateIfNotExistsAsync();
 
             // Assert
-            Assert.IsNull(response);
+            Assert.AreEqual(response.Value.ETag.ToString(), "<null>");
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CreateIfNotExists_Exists.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CreateIfNotExists_Exists.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e4efc838392a934087c29860e12c09d0-72d8869d01622345-00",
+        "traceparent": "00-2e2ac2b8bc53414197b557e21e5feca7-419c39f4d7829343-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "eaadba9a-1523-1fae-0484-0b3933ec7170",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 22:58:24 GMT",
-        "ETag": "\u00220x8D7B65863E9E41D\u0022",
-        "Last-Modified": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:45 GMT",
+        "ETag": "\u00220x8D8072C492370B4\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 19:36:45 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "eaadba9a-1523-1fae-0484-0b3933ec7170",
-        "x-ms-request-id": "89672630-e01a-004e-4141-e8cfef000000",
+        "x-ms-request-id": "9a128355-d01a-0132-5d15-398c9e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b/test-directory-3b236ae3-f9f5-8014-eef0-8c6ea686e211?restype=directory",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b/test-directory-3b236ae3-f9f5-8014-eef0-8c6ea686e211?restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9cacc1c17d25294eb8b9378f94bc72eb-4b412ee49e6c9a44-00",
+        "traceparent": "00-60306f824475e240b10cd902866fce9d-8b13d1527cff8c41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9235d0f0-182c-a0c7-a52c-fc33883f797d",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,39 +55,39 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 22:58:24 GMT",
-        "ETag": "\u00220x8D7B65863EEC0E7\u0022",
-        "Last-Modified": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:45 GMT",
+        "ETag": "\u00220x8D8072C4933717B\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9235d0f0-182c-a0c7-a52c-fc33883f797d",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-02-20T22:58:24.6183143Z",
-        "x-ms-file-creation-time": "2020-02-20T22:58:24.6183143Z",
+        "x-ms-file-change-time": "2020-06-02T19:36:46.0988795Z",
+        "x-ms-file-creation-time": "2020-06-02T19:36:46.0988795Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-02-20T22:58:24.6183143Z",
+        "x-ms-file-last-write-time": "2020-06-02T19:36:46.0988795Z",
         "x-ms-file-parent-id": "0",
-        "x-ms-file-permission-key": "5337567907660077720*2506815767522118929",
-        "x-ms-request-id": "89672633-e01a-004e-4241-e8cfef000000",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "9a128358-d01a-0132-5e15-398c9e000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b/test-directory-3b236ae3-f9f5-8014-eef0-8c6ea686e211?restype=directory",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b/test-directory-3b236ae3-f9f5-8014-eef0-8c6ea686e211?restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-aefdb7374ba95a41b99448241ff049b3-40d6027b7feb6144-00",
+        "traceparent": "00-10017a90d2b1ba46a419d9bfad991a7f-be496ccbfc5fde4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d57ed80b-4f50-03e5-eaca-883acce522f5",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -100,34 +100,34 @@
       "ResponseHeaders": {
         "Content-Length": "228",
         "Content-Type": "application/xml",
-        "Date": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:45 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d57ed80b-4f50-03e5-eaca-883acce522f5",
         "x-ms-error-code": "ResourceAlreadyExists",
-        "x-ms-request-id": "89672634-e01a-004e-4341-e8cfef000000",
+        "x-ms-request-id": "9a128359-d01a-0132-5f15-398c9e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EResourceAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified resource already exists.\n",
-        "RequestId:89672634-e01a-004e-4341-e8cfef000000\n",
-        "Time:2020-02-20T22:58:24.6524950Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:9a128359-d01a-0132-5f15-398c9e000000\n",
+        "Time:2020-06-02T19:36:46.1841426Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-2e083557-e7d0-dfa0-626f-6d05e714b23b?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c4a7a2d717a1db4f8e6779b5103f2c86-8e6c77cc7c6bce41-00",
+        "traceparent": "00-afe6bf75928cde4d92109eab9603ea22-91f3793cfac5594d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b0271b77-a3c0-532c-141a-97b7bbce4e6d",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -136,13 +136,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 22:58:24 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:45 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b0271b77-a3c0-532c-141a-97b7bbce4e6d",
-        "x-ms-request-id": "89672635-e01a-004e-4441-e8cfef000000",
+        "x-ms-request-id": "9a12835a-d01a-0132-6015-398c9e000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -150,6 +150,6 @@
   ],
   "Variables": {
     "RandomSeed": "1786636505",
-    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttp://seandevtest.file.core.windows.net\nhttp://seandevtest.queue.core.windows.net\nhttp://seandevtest.table.core.windows.net\n\n\n\n\nhttp://seandevtest-secondary.blob.core.windows.net\nhttp://seandevtest-secondary.file.core.windows.net\nhttp://seandevtest-secondary.queue.core.windows.net\nhttp://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=http://seandevtest.queue.core.windows.net/;FileEndpoint=http://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=http://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CreateIfNotExists_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CreateIfNotExists_ExistsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fa372cd8972e0441b8d10fccaff10bcc-a0eb7d754d7fa349-00",
+        "traceparent": "00-7b7a3eb4f3ee544f823f50e08087c967-cc32ad679261e649-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d0922e63-8581-c650-b190-faa1cdee6cc9",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:38 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 22:58:38 GMT",
-        "ETag": "\u00220x8D7B6586C76FE25\u0022",
-        "Last-Modified": "Thu, 20 Feb 2020 22:58:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:45 GMT",
+        "ETag": "\u00220x8D8072C496BE384\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d0922e63-8581-c650-b190-faa1cdee6cc9",
-        "x-ms-request-id": "93edb25d-001a-0029-1241-e87c48000000",
+        "x-ms-request-id": "0dd5dcda-001a-009e-2b15-39eb5c000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7/test-directory-9ae5f426-56e8-99c2-abd0-cba74ec14328?restype=directory",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7/test-directory-9ae5f426-56e8-99c2-abd0-cba74ec14328?restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4d955b92c56ada469c7d5c2c72d95d7e-86093f0899777a4e-00",
+        "traceparent": "00-aebc68253bc73e49abdf0ddd6c05aac9-e6ea6c4dd644e842-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6e02c3af-7948-0c3b-6bf9-25b0baa877ef",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -55,39 +55,39 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 22:58:38 GMT",
-        "ETag": "\u00220x8D7B6586C7C7EB4\u0022",
-        "Last-Modified": "Thu, 20 Feb 2020 22:58:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:46 GMT",
+        "ETag": "\u00220x8D8072C497D31FF\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6e02c3af-7948-0c3b-6bf9-25b0baa877ef",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2020-02-20T22:58:38.9690036Z",
-        "x-ms-file-creation-time": "2020-02-20T22:58:38.9690036Z",
+        "x-ms-file-change-time": "2020-06-02T19:36:46.5822207Z",
+        "x-ms-file-creation-time": "2020-06-02T19:36:46.5822207Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2020-02-20T22:58:38.9690036Z",
+        "x-ms-file-last-write-time": "2020-06-02T19:36:46.5822207Z",
         "x-ms-file-parent-id": "0",
-        "x-ms-file-permission-key": "5337567907660077720*2506815767522118929",
-        "x-ms-request-id": "93edb263-001a-0029-1341-e87c48000000",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "0dd5dcdd-001a-009e-2c15-39eb5c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7/test-directory-9ae5f426-56e8-99c2-abd0-cba74ec14328?restype=directory",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7/test-directory-9ae5f426-56e8-99c2-abd0-cba74ec14328?restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c5eb8c6098fd404e9aa2de879d443665-a548758526545a4b-00",
+        "traceparent": "00-e4172890b95c044a97b3fc6d91b5bdc8-19140b1a5ef8ce4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8bf8deb0-d5bf-18e0-21be-00a800752b2d",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-file-attributes": "None",
         "x-ms-file-creation-time": "Now",
         "x-ms-file-last-write-time": "Now",
@@ -100,34 +100,34 @@
       "ResponseHeaders": {
         "Content-Length": "228",
         "Content-Type": "application/xml",
-        "Date": "Thu, 20 Feb 2020 22:58:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8bf8deb0-d5bf-18e0-21be-00a800752b2d",
         "x-ms-error-code": "ResourceAlreadyExists",
-        "x-ms-request-id": "93edb264-001a-0029-1441-e87c48000000",
+        "x-ms-request-id": "0dd5dcde-001a-009e-2d15-39eb5c000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EResourceAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified resource already exists.\n",
-        "RequestId:93edb264-001a-0029-1441-e87c48000000\n",
-        "Time:2020-02-20T22:58:39.0039947Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:0dd5dcde-001a-009e-2d15-39eb5c000000\n",
+        "Time:2020-06-02T19:36:46.6539331Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-a7bfd308-dcc3-a7ea-56a5-822d9a33f6a7?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-605168fa577f054e840ddc70916f4fde-5756983168663245-00",
+        "traceparent": "00-6a7c3d3b5c3b6d4ca7a5bcb10bd233d1-7360cd7373f78340-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "db0001d5-ecb0-7730-f1f7-4d66007fff58",
-        "x-ms-date": "Thu, 20 Feb 2020 22:58:39 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -136,13 +136,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 22:58:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "db0001d5-ecb0-7730-f1f7-4d66007fff58",
-        "x-ms-request-id": "93edb265-001a-0029-1541-e87c48000000",
+        "x-ms-request-id": "0dd5dcdf-001a-009e-2e15-39eb5c000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -150,6 +150,6 @@
   ],
   "Variables": {
     "RandomSeed": "1102798942",
-    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttp://seandevtest.file.core.windows.net\nhttp://seandevtest.queue.core.windows.net\nhttp://seandevtest.table.core.windows.net\n\n\n\n\nhttp://seandevtest-secondary.blob.core.windows.net\nhttp://seandevtest-secondary.file.core.windows.net\nhttp://seandevtest-secondary.queue.core.windows.net\nhttp://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=http://seandevtest.queue.core.windows.net/;FileEndpoint=http://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=http://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CreateIfNotExistsAsync_Exists.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CreateIfNotExistsAsync_Exists.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-6b697143-8e95-6547-0c07-c898c835ccac?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-6b697143-8e95-6547-0c07-c898c835ccac?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8b090effb1ac5742b63d4447b3ac485e-0c17b74f42604e4f-00",
+        "traceparent": "00-30c338ea3017864386a2afa5de25382b-f0a7b0546b369a49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fc99c4fd-4b09-e1d7-884a-dcf782691731",
-        "x-ms-date": "Thu, 20 Feb 2020 23:01:25 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 23:01:25 GMT",
-        "ETag": "\u00220x8D7B658D0046AB8\u0022",
-        "Last-Modified": "Thu, 20 Feb 2020 23:01:25 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:46 GMT",
+        "ETag": "\u00220x8D8072C49B2A3E7\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fc99c4fd-4b09-e1d7-884a-dcf782691731",
-        "x-ms-request-id": "abf74a9f-201a-0071-5941-e87833000000",
+        "x-ms-request-id": "937961b1-601a-0109-0b15-39cec0000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-6b697143-8e95-6547-0c07-c898c835ccac?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-6b697143-8e95-6547-0c07-c898c835ccac?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9e84996ffff48a44a4d156e260b36973-c441a8f3278a1147-00",
+        "traceparent": "00-5f8083bdb8e02b41b74a8c789bd410f1-e87aef8a7fb15344-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "049abc80-d09c-1ca2-dd67-3455a3006a92",
-        "x-ms-date": "Thu, 20 Feb 2020 23:01:26 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,34 +52,34 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/xml",
-        "Date": "Thu, 20 Feb 2020 23:01:25 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "049abc80-d09c-1ca2-dd67-3455a3006a92",
         "x-ms-error-code": "ShareAlreadyExists",
-        "x-ms-request-id": "abf74aa2-201a-0071-5a41-e87833000000",
+        "x-ms-request-id": "937961b6-601a-0109-0e15-39cec0000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EShareAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified share already exists.\n",
-        "RequestId:abf74aa2-201a-0071-5a41-e87833000000\n",
-        "Time:2020-02-20T23:01:25.9842402Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:937961b6-601a-0109-0e15-39cec0000000\n",
+        "Time:2020-06-02T19:36:47.1006039Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-6b697143-8e95-6547-0c07-c898c835ccac?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-6b697143-8e95-6547-0c07-c898c835ccac?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ad6bd26de2161b47852592c3cad0c7bc-8ba9629b91a1084d-00",
+        "traceparent": "00-e5e18d78bfb9c04f84ac95348fcd608d-547549d02938ad48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c6770084-13ce-4c95-b893-069efd411f78",
-        "x-ms-date": "Thu, 20 Feb 2020 23:01:26 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -88,13 +88,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 23:01:25 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:46 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c6770084-13ce-4c95-b893-069efd411f78",
-        "x-ms-request-id": "abf74aa3-201a-0071-5b41-e87833000000",
+        "x-ms-request-id": "937961b7-601a-0109-0f15-39cec0000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -102,6 +102,6 @@
   ],
   "Variables": {
     "RandomSeed": "1448772398",
-    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttp://seandevtest.file.core.windows.net\nhttp://seandevtest.queue.core.windows.net\nhttp://seandevtest.table.core.windows.net\n\n\n\n\nhttp://seandevtest-secondary.blob.core.windows.net\nhttp://seandevtest-secondary.file.core.windows.net\nhttp://seandevtest-secondary.queue.core.windows.net\nhttp://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=http://seandevtest.queue.core.windows.net/;FileEndpoint=http://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=http://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CreateIfNotExistsAsync_ExistsAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CreateIfNotExistsAsync_ExistsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-ef0b5308-4cde-1dd1-0823-6a958530078c?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ef0b5308-4cde-1dd1-0823-6a958530078c?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e419f032b3b1f348977efef1139048b1-0de2a3dbac787049-00",
+        "traceparent": "00-1619f7a06fec15408adb614dc0603e3a-1752638792507642-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9d8ef369-ea4b-bf0f-f549-a9034f18090c",
-        "x-ms-date": "Thu, 20 Feb 2020 23:01:38 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -19,31 +19,31 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 23:01:38 GMT",
-        "ETag": "\u00220x8D7B658D7A8F58E\u0022",
-        "Last-Modified": "Thu, 20 Feb 2020 23:01:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:47 GMT",
+        "ETag": "\u00220x8D8072C49F0DF97\u0022",
+        "Last-Modified": "Tue, 02 Jun 2020 19:36:47 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9d8ef369-ea4b-bf0f-f549-a9034f18090c",
-        "x-ms-request-id": "4ffbafde-101a-0072-2241-e87b34000000",
+        "x-ms-request-id": "cb58905d-301a-0138-8015-399517000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-ef0b5308-4cde-1dd1-0823-6a958530078c?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ef0b5308-4cde-1dd1-0823-6a958530078c?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-be8b1ce1825e6648a29cadaf96390e04-72bdb2022ab40e4b-00",
+        "traceparent": "00-72d269462402ad41bd5bb21f2251a71b-974caae2fb5b3f41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "922bf762-6aa1-b240-eda4-d847526f4322",
-        "x-ms-date": "Thu, 20 Feb 2020 23:01:38 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
       },
@@ -52,34 +52,34 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/xml",
-        "Date": "Thu, 20 Feb 2020 23:01:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "922bf762-6aa1-b240-eda4-d847526f4322",
         "x-ms-error-code": "ShareAlreadyExists",
-        "x-ms-request-id": "4ffbafe1-101a-0072-2341-e87b34000000",
+        "x-ms-request-id": "cb589060-301a-0138-0115-399517000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EShareAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified share already exists.\n",
-        "RequestId:4ffbafe1-101a-0072-2341-e87b34000000\n",
-        "Time:2020-02-20T23:01:38.8096375Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:cb589060-301a-0138-0115-399517000000\n",
+        "Time:2020-06-02T19:36:47.3933674Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "http://seandevtest.file.core.windows.net/test-share-ef0b5308-4cde-1dd1-0823-6a958530078c?restype=share",
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-ef0b5308-4cde-1dd1-0823-6a958530078c?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f0cf90e3c4be0243844960492ee2fff5-04b6efbac66e6a45-00",
+        "traceparent": "00-60789d298599eb41bdd6339b2996531f-6362444056145a46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.2.0-dev.20200220.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200602.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "57a098a3-77ec-006b-5238-b2840260b971",
-        "x-ms-date": "Thu, 20 Feb 2020 23:01:38 GMT",
+        "x-ms-date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-07-07"
@@ -88,13 +88,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 20 Feb 2020 23:01:38 GMT",
+        "Date": "Tue, 02 Jun 2020 19:36:47 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "57a098a3-77ec-006b-5238-b2840260b971",
-        "x-ms-request-id": "4ffbafe2-101a-0072-2441-e87b34000000",
+        "x-ms-request-id": "cb589061-301a-0138-0215-399517000000",
         "x-ms-version": "2019-07-07"
       },
       "ResponseBody": []
@@ -102,6 +102,6 @@
   ],
   "Variables": {
     "RandomSeed": "730782574",
-    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttp://seandevtest.file.core.windows.net\nhttp://seandevtest.queue.core.windows.net\nhttp://seandevtest.table.core.windows.net\n\n\n\n\nhttp://seandevtest-secondary.blob.core.windows.net\nhttp://seandevtest-secondary.file.core.windows.net\nhttp://seandevtest-secondary.queue.core.windows.net\nhttp://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=http://seandevtest.queue.core.windows.net/;FileEndpoint=http://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=http://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -331,7 +331,7 @@ namespace Azure.Storage.Files.Shares.Test
             Response<ShareInfo> response = await share.CreateIfNotExistsAsync();
 
             // Assert
-            Assert.IsNull(response);
+            Assert.AreEqual(response.Value.ETag.ToString(), "<null>");
 
             // Cleanup
             await share.DeleteAsync();


### PR DESCRIPTION
When calling BlobContainerClient.CreateIfNotExists, a NullReferenceException occurs when Response<BlobContainerInfo>'s implicit cast to BlobContainerInfo fails to unwrap a null response.

Instead of returning default, we can return a default BlobContainerInfo object and wrap a Response around it.

Resolves #9758 