### PR TITLE
[FormRecognizer] Remove Operation type constructors

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -27,6 +27,7 @@
 - In preparation for service-side changes, `FieldValue.AsInt32` has been replaced by `FieldValue.AsInt64`, which returns a `long`.
 - The order of the values for `USReceiptType` have changed so that `Other` has now a value of `1`.
 - Parameter `useTrainingLabels` is now required for `FormTrainingClient.StartTraining`.
+- Protected constructors have been removed from `Operation` types, such as `TrainingOperation` or `RecognizeContentOperation`.
 
 ### New Features
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -116,14 +116,6 @@ namespace Azure.AI.FormRecognizer.Training
             Id = string.Join("/", substrs, substrs.Length - 3, 3);
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CopyModelOperation"/> class.
-        /// </summary>
-        protected CopyModelOperation()
-        {
-        }
-
-
         /// <inheritdoc/>
         public override Response GetRawResponse() => _response;
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
@@ -68,13 +68,6 @@ namespace Azure.AI.FormRecognizer.Models
             Id = operationLocation.Split('/').Last();
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RecognizeContentOperation"/> class.
-        /// </summary>
-        protected RecognizeContentOperation()
-        {
-        }
-
         /// <inheritdoc/>
         public override Response GetRawResponse() => _response;
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -114,13 +114,6 @@ namespace Azure.AI.FormRecognizer.Models
             Id = operationId;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RecognizeCustomFormsOperation"/> class.
-        /// </summary>
-        protected RecognizeCustomFormsOperation()
-        {
-        }
-
         /// <inheritdoc/>
         public override Response UpdateStatus(CancellationToken cancellationToken = default) =>
             UpdateStatusAsync(false, cancellationToken).EnsureCompleted();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
@@ -70,13 +70,6 @@ namespace Azure.AI.FormRecognizer.Models
             Id = operationLocation.Split('/').Last();
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RecognizeReceiptsOperation"/> class.
-        /// </summary>
-        protected RecognizeReceiptsOperation()
-        {
-        }
-
         /// <inheritdoc/>
         public override ValueTask<Response<RecognizedReceiptCollection>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(cancellationToken);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOperation.cs
@@ -53,13 +53,6 @@ namespace Azure.AI.FormRecognizer.Training
         public override ValueTask<Response<CustomFormModel>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(pollingInterval, cancellationToken);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TrainingOperation"/> class for mocking.
-        /// </summary>
-        protected TrainingOperation()
-        {
-        }
-
         internal TrainingOperation(string location, ServiceRestClient allOperations)
         {
             _serviceClient = allOperations;


### PR DESCRIPTION
Fixes #11528.

We decided on removing the protected constructors for Preview 3. Opened #12401 to keep track of the discussion.