### PR TITLE
Consistency operation failed status management in LRO 

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -32,7 +32,7 @@
 - `ReceiptLocale` removed from `RecognizedReceipt`.
 - An `InvalidOperationException` is now raised if trying to access the `Value` property of a `TrainingOperation` when a trained model is invalid.
 - A `RequestFailedException` is now raised if a model with `status=="invalid"` is returned from the `StartTraining` and `StartTrainingAsync` methods.
-- A `RequestFailedException` is now raised if an operation like `StartRecognizeReceipts`, `StartRecognizeContent`, or `StartRecognizeCustomForms` fails.
+- A `RequestFailedException` is now raised if an operation like `StartRecognizeReceipts` or `StartRecognizeContent` fails.
 - An `InvalidOperationException` is now raised if trying to access the `Value` property of a `xxOperation` object when a the executed operation failed.
 
 ### New Features

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Protected constructors have been removed from `Operation` types, such as `TrainingOperation` or `RecognizeContentOperation`.
 - `USReceipt`, `USReceiptItem`, `USReceiptType` and `FormField{T}` types removed. Information about a `RecognizedReceipt` must now be extracted from its `RecognizedForm`.
 - `ReceiptLocale` removed from `RecognizedReceipt`.
+- An `InvalidOperationException` is now raised if trying to access the `Value` property of a `TrainingOperation` when a trained model is invalid.
+- A `RequestFailedException` is now raised if a model with `status=="invalid"` is returned from the `StartTraining` and `StartTrainingAsync` methods.
+- A `RequestFailedException` is now raised if an operation like `StartRecognizeReceipts`, `StartRecognizeContent`, or `StartRecognizeCustomForms` fails.
+- An `InvalidOperationException` is now raised if trying to access the `Value` property of a `xxOperation` object when a the executed operation failed.
 
 ### New Features
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -33,7 +33,7 @@
 - An `InvalidOperationException` is now raised if trying to access the `Value` property of a `TrainingOperation` when a trained model is invalid.
 - A `RequestFailedException` is now raised if a model with `status=="invalid"` is returned from the `StartTraining` and `StartTrainingAsync` methods.
 - A `RequestFailedException` is now raised if an operation like `StartRecognizeReceipts` or `StartRecognizeContent` fails.
-- An `InvalidOperationException` is now raised if trying to access the `Value` property of a `xxOperation` object when a the executed operation failed.
+- An `InvalidOperationException` is now raised if trying to access the `Value` property of a `xxOperation` object when the executed operation failed.
 
 ### New Features
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.AI.FormRecognizer.Models;
+using Azure.Core.Pipeline;
 
 namespace Azure.AI.FormRecognizer
 {
@@ -29,6 +33,39 @@ namespace Azure.AI.FormRecognizer
             }
 
             return guid;
+        }
+
+        public static async ValueTask<RequestFailedException> CreateExceptionForFailedOperationAsync(bool async, ClientDiagnostics diagnostics, Response response, IReadOnlyList<FormRecognizerError> errors, string errorMessage = default)
+        {
+            string errorCode = default;
+
+            if (string.IsNullOrEmpty(errorMessage))
+            {
+                if (errors.Count > 0)
+                {
+                    var firstError = errors[0];
+
+                    errorMessage = firstError.Message;
+                    errorCode = firstError.ErrorCode;
+                }
+                else
+                {
+                    errorMessage = "Operation failed.";
+                }
+            }
+
+            var errorInfo = new Dictionary<string, string>();
+            int index = 0;
+
+            foreach (var error in errors)
+            {
+                errorInfo.Add($"error-{index}", $"{error.ErrorCode}: {error.Message}");
+                index++;
+            }
+
+            return async
+                ? await diagnostics.CreateRequestFailedExceptionAsync(response, errorMessage, errorCode, errorInfo).ConfigureAwait(false)
+                : diagnostics.CreateRequestFailedException(response, errorMessage, errorCode, errorInfo);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -45,7 +45,18 @@ namespace Azure.AI.FormRecognizer.Training
         public override string Id { get; }
 
         /// <inheritdoc/>
-        public override CustomFormModelInfo Value => OperationHelpers.GetValue(ref _value);
+        public override CustomFormModelInfo Value
+        {
+            get
+            {
+                if (HasCompleted && !HasValue)
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException("Copy model operation failed");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                else
+                    return OperationHelpers.GetValue(ref _value);
+            }
+        }
 
         /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
@@ -88,7 +99,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// Initializes a new instance of the <see cref="CopyModelOperation"/> class.
         /// </summary>
         /// <param name="serviceClient">The client for communicating with the Form Recognizer Azure Cognitive Service through its REST API.</param>
-        /// <param name="diagnostics">Provides tools for exception creation in case of failure.</param>
+        /// <param name="diagnostics">The client diagnostics for exception creation in case of failure.</param>
         /// <param name="operationLocation">The address of the long-running operation. It can be obtained from the response headers upon starting the operation.</param>
         /// <param name="targetModelId">Model id in the target Form Recognizer Resource.</param>
         internal CopyModelOperation(ServiceRestClient serviceClient, ClientDiagnostics diagnostics, string operationLocation, string targetModelId)
@@ -159,7 +170,7 @@ namespace Azure.AI.FormRecognizer.Training
                 else if (update.Value.Status == OperationStatus.Failed)
                 {
                     _hasCompleted = true;
-                    _value = ConvertValue(update.Value, _targetModelId, CustomFormModelStatus.Invalid);
+
                     throw await CreateExceptionForFailedOperationAsync(async, update.Value.CopyResult.Errors).ConfigureAwait(false);
                 }
             }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -166,7 +166,7 @@ namespace Azure.AI.FormRecognizer.Training
 
                 if (update.Value.Status == OperationStatus.Succeeded)
                 {
-                    // we need to first assign a vaue and then mark the operation as completed to avoid race conditions
+                    // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
                     _value = ConvertValue(update.Value, _targetModelId, CustomFormModelStatus.Ready);
                     _hasCompleted = true;
                 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -41,6 +41,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <summary>An ID representing the operation that can be used along with <see cref="_modelId"/> to poll for the status of the long-running operation.</summary>
         private readonly string _resultId;
 
+        private RequestFailedException _requestFailedException;
+
         /// <inheritdoc/>
         public override string Id { get; }
 
@@ -51,7 +53,7 @@ namespace Azure.AI.FormRecognizer.Training
             {
                 if (HasCompleted && !HasValue)
 #pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
-                    throw new InvalidOperationException("Copy model operation failed");
+                    throw _requestFailedException;
 #pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
                 else
                     return OperationHelpers.GetValue(ref _value);
@@ -164,14 +166,17 @@ namespace Azure.AI.FormRecognizer.Training
 
                 if (update.Value.Status == OperationStatus.Succeeded)
                 {
-                    _hasCompleted = true;
+                    // we need to first assign a vaue and then mark the operation as completed to avoid race conditions
                     _value = ConvertValue(update.Value, _targetModelId, CustomFormModelStatus.Ready);
+                    _hasCompleted = true;
                 }
                 else if (update.Value.Status == OperationStatus.Failed)
                 {
+                    _requestFailedException = await ClientCommon
+                        .CreateExceptionForFailedOperationAsync(async, _diagnostics, _response, update.Value.CopyResult.Errors)
+                        .ConfigureAwait(false);
                     _hasCompleted = true;
-
-                    throw await CreateExceptionForFailedOperationAsync(async, update.Value.CopyResult.Errors).ConfigureAwait(false);
+                    throw _requestFailedException;
                 }
             }
 
@@ -185,37 +190,6 @@ namespace Azure.AI.FormRecognizer.Training
                 result.CreatedDateTime,
                 result.LastUpdatedDateTime,
                 status);
-        }
-
-        private async ValueTask<RequestFailedException> CreateExceptionForFailedOperationAsync(bool async, IReadOnlyList<FormRecognizerError> errors)
-        {
-            string errorMessage = default;
-            string errorCode = default;
-
-            if (errors.Count > 0)
-            {
-                var firstError = errors[0];
-
-                errorMessage = firstError.Message;
-                errorCode = firstError.ErrorCode;
-            }
-            else
-            {
-                errorMessage = "Copy model operation failed.";
-            }
-
-            var errorInfo = new Dictionary<string, string>();
-            int index = 0;
-
-            foreach (var error in errors)
-            {
-                errorInfo.Add($"error-{index}", $"{error.ErrorCode}: {error.Message}");
-                index++;
-            }
-
-            return async
-                ? await _diagnostics.CreateRequestFailedExceptionAsync(_response, errorMessage, errorCode, errorInfo).ConfigureAwait(false)
-                : _diagnostics.CreateRequestFailedException(_response, errorMessage, errorCode, errorInfo);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -133,7 +133,7 @@ namespace Azure.AI.FormRecognizer
             FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
 
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response =  ServiceClient.AnalyzeLayoutAsync(contentType, form, cancellationToken);
-            return new RecognizeContentOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeContentOperation(ServiceClient, Diagnostics,response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Azure.AI.FormRecognizer
             FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
 
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response = await ServiceClient.AnalyzeLayoutAsyncAsync(contentType, form, cancellationToken).ConfigureAwait(false);
-            return new RecognizeContentOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeContentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Azure.AI.FormRecognizer
 
             SourcePath_internal sourcePath = new SourcePath_internal(formUrl.AbsoluteUri);
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response = ServiceClient.AnalyzeLayoutAsync(sourcePath, cancellationToken);
-            return new RecognizeContentOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeContentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace Azure.AI.FormRecognizer
 
             SourcePath_internal sourcePath = new SourcePath_internal(formUrl.AbsoluteUri);
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response = await ServiceClient.AnalyzeLayoutAsyncAsync(sourcePath, cancellationToken).ConfigureAwait(false);
-            return new RecognizeContentOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeContentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         #endregion
@@ -213,7 +213,7 @@ namespace Azure.AI.FormRecognizer
             FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(receipt, nameof(receipt));
 
             ResponseWithHeaders<ServiceAnalyzeReceiptAsyncHeaders> response = await ServiceClient.AnalyzeReceiptAsyncAsync(contentType, receipt, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken).ConfigureAwait(false);
-            return new RecognizeReceiptsOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Azure.AI.FormRecognizer
             FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(receipt, nameof(receipt));
 
             ResponseWithHeaders<ServiceAnalyzeReceiptAsyncHeaders> response = ServiceClient.AnalyzeReceiptAsync(contentType, receipt, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken);
-            return new RecognizeReceiptsOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Azure.AI.FormRecognizer
 
             SourcePath_internal sourcePath = new SourcePath_internal(receiptUrl.AbsoluteUri);
             ResponseWithHeaders<ServiceAnalyzeReceiptAsyncHeaders> response = await ServiceClient.AnalyzeReceiptAsyncAsync(includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken).ConfigureAwait(false);
-            return new RecognizeReceiptsOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Azure.AI.FormRecognizer
 
             SourcePath_internal sourcePath = new SourcePath_internal(receiptUrl.AbsoluteUri);
             ResponseWithHeaders<ServiceAnalyzeReceiptAsyncHeaders> response = ServiceClient.AnalyzeReceiptAsync(includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken);
-            return new RecognizeReceiptsOperation(ServiceClient, response.Headers.OperationLocation);
+            return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         #endregion

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -133,7 +133,7 @@ namespace Azure.AI.FormRecognizer
             FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
 
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response =  ServiceClient.AnalyzeLayoutAsync(contentType, form, cancellationToken);
-            return new RecognizeContentOperation(ServiceClient, Diagnostics,response.Headers.OperationLocation);
+            return new RecognizeContentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -114,7 +114,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <returns>
         /// <para>A <see cref="TrainingOperation"/> to wait on this long-running operation. Its <see cref="TrainingOperation"/>.Value upon successful
         /// completion will contain meta-data about the trained model.</para>
-        /// <para>If the training fails, an exception is raised, and a model with an "invalid" status is still created in the Form Recognizer resource.</para>
+        /// <para>Even if training fails, a model is created in the Form Recognizer account with an "invalid" status.
+        /// A <see cref="RequestFailedException"/> will be raised containing the modelId to access this invalid model.</para>
         /// </returns>
         [ForwardsClientCalls]
         public virtual TrainingOperation StartTraining(Uri trainingFilesUri, bool useTrainingLabels, TrainingFileFilter trainingFileFilter = default, CancellationToken cancellationToken = default)
@@ -137,7 +138,8 @@ namespace Azure.AI.FormRecognizer.Training
         /// <returns>
         /// <para>A <see cref="TrainingOperation"/> to wait on this long-running operation. Its <see cref="TrainingOperation"/>.Value upon successful
         /// completion will contain meta-data about the trained model.</para>
-        /// <para>If the training fails, an exception is raised, and a model with an "invalid" status is still created in the Form Recognizer resource.</para>
+        /// <para>Even if training fails, a model is created in the Form Recognizer account with an "invalid" status.
+        /// A <see cref="RequestFailedException"/> will be raised containing the modelId to access this invalid model.</para>
         /// </returns>
         [ForwardsClientCalls]
         public virtual async Task<TrainingOperation> StartTrainingAsync(Uri trainingFilesUri, bool useTrainingLabels, TrainingFileFilter trainingFileFilter = default, CancellationToken cancellationToken = default)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -111,8 +111,11 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="useTrainingLabels">If <c>true</c>, use a label file created in the &lt;link-to-label-tool-doc&gt; to provide training-time labels for training a model. If <c>false</c>, the model will be trained from forms only.</param>
         /// <param name="trainingFileFilter">Filter to apply to the documents in the source path for training.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A <see cref="TrainingOperation"/> to wait on this long-running operation.  Its <see cref="TrainingOperation"/>.Value upon successful
-        /// completion will contain meta-data about the trained model.</returns>
+        /// <returns>
+        /// <para>A <see cref="TrainingOperation"/> to wait on this long-running operation. Its <see cref="TrainingOperation"/>.Value upon successful
+        /// completion will contain meta-data about the trained model.</para>
+        /// <para>If the training fails, an exception is raised, and a model with an "invalid" status is still created in the Form Recognizer resource.</para>
+        /// </returns>
         [ForwardsClientCalls]
         public virtual TrainingOperation StartTraining(Uri trainingFilesUri, bool useTrainingLabels, TrainingFileFilter trainingFileFilter = default, CancellationToken cancellationToken = default)
         {
@@ -121,7 +124,7 @@ namespace Azure.AI.FormRecognizer.Training
             var trainRequest = new TrainRequest_internal(trainingFilesUri.AbsoluteUri, trainingFileFilter, useTrainingLabels);
 
             ResponseWithHeaders<ServiceTrainCustomModelAsyncHeaders> response = ServiceClient.TrainCustomModelAsync(trainRequest);
-            return new TrainingOperation(response.Headers.Location, ServiceClient);
+            return new TrainingOperation(response.Headers.Location, ServiceClient, Diagnostics);
         }
 
         /// <summary>
@@ -131,8 +134,11 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="useTrainingLabels">If <c>true</c>, use a label file created in the &lt;link-to-label-tool-doc&gt; to provide training-time labels for training a model. If <c>false</c>, the model will be trained from forms only.</param>
         /// <param name="trainingFileFilter">Filter to apply to the documents in the source path for training.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>A <see cref="TrainingOperation"/> to wait on this long-running operation.  Its <see cref="TrainingOperation"/>.Value upon successful
-        /// completion will contain meta-data about the trained model.</returns>
+        /// <returns>
+        /// <para>A <see cref="TrainingOperation"/> to wait on this long-running operation. Its <see cref="TrainingOperation"/>.Value upon successful
+        /// completion will contain meta-data about the trained model.</para>
+        /// <para>If the training fails, an exception is raised, and a model with an "invalid" status is still created in the Form Recognizer resource.</para>
+        /// </returns>
         [ForwardsClientCalls]
         public virtual async Task<TrainingOperation> StartTrainingAsync(Uri trainingFilesUri, bool useTrainingLabels, TrainingFileFilter trainingFileFilter = default, CancellationToken cancellationToken = default)
         {
@@ -141,7 +147,7 @@ namespace Azure.AI.FormRecognizer.Training
             var trainRequest = new TrainRequest_internal(trainingFilesUri.AbsoluteUri, trainingFileFilter, useTrainingLabels);
 
             ResponseWithHeaders<ServiceTrainCustomModelAsyncHeaders> response = await ServiceClient.TrainCustomModelAsyncAsync(trainRequest).ConfigureAwait(false);
-            return new TrainingOperation(response.Headers.Location, ServiceClient);
+            return new TrainingOperation(response.Headers.Location, ServiceClient, Diagnostics);
         }
 
         #endregion

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -42,7 +42,18 @@ namespace Azure.AI.FormRecognizer.Models
         public override string Id { get; }
 
         /// <inheritdoc/>
-        public override RecognizedFormCollection Value => OperationHelpers.GetValue(ref _value);
+        public override RecognizedFormCollection Value
+        {
+            get
+            {
+                if (HasCompleted && !HasValue)
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException("RecognizeCustomForms operation failed.");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                else
+                    return OperationHelpers.GetValue(ref _value);
+            }
+        }
 
         /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
@@ -148,7 +159,6 @@ namespace Azure.AI.FormRecognizer.Models
                 else if (update.Value.Status == OperationStatus.Failed)
                 {
                     _hasCompleted = true;
-                    _value = new RecognizedFormCollection(new List<RecognizedForm>());
 
                     throw await CreateExceptionForFailedOperationAsync(async, update.Value.AnalyzeResult.Errors).ConfigureAwait(false);
                 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -38,6 +38,8 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>An ID representing the operation that can be used along with <see cref="_modelId"/> to poll for the status of the long-running operation.</summary>
         private readonly string _resultId;
 
+        private RequestFailedException _requestFailedException;
+
         /// <inheritdoc/>
         public override string Id { get; }
 
@@ -48,7 +50,7 @@ namespace Azure.AI.FormRecognizer.Models
             {
                 if (HasCompleted && !HasValue)
 #pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
-                    throw new InvalidOperationException("RecognizeCustomForms operation failed.");
+                    throw _requestFailedException;
 #pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
                 else
                     return OperationHelpers.GetValue(ref _value);
@@ -153,14 +155,17 @@ namespace Azure.AI.FormRecognizer.Models
 
                 if (update.Value.Status == OperationStatus.Succeeded)
                 {
-                    _hasCompleted = true;
+                    // we need to first assign a vaue and then mark the operation as completed to avoid race conditions
                     _value = ConvertToRecognizedForms(update.Value.AnalyzeResult);
+                    _hasCompleted = true;
                 }
                 else if (update.Value.Status == OperationStatus.Failed)
                 {
+                    _requestFailedException = await ClientCommon
+                        .CreateExceptionForFailedOperationAsync(async, _diagnostics, _response, update.Value.AnalyzeResult.Errors)
+                        .ConfigureAwait(false);
                     _hasCompleted = true;
-
-                    throw await CreateExceptionForFailedOperationAsync(async, update.Value.AnalyzeResult.Errors).ConfigureAwait(false);
+                    throw _requestFailedException;
                 }
             }
 
@@ -192,37 +197,6 @@ namespace Azure.AI.FormRecognizer.Models
                 forms.Add(new RecognizedForm(documentResult, analyzeResult.PageResults, analyzeResult.ReadResults));
             }
             return new RecognizedFormCollection(forms);
-        }
-
-        private async ValueTask<RequestFailedException> CreateExceptionForFailedOperationAsync(bool async, IReadOnlyList<FormRecognizerError> errors)
-        {
-            string errorMessage = default;
-            string errorCode = default;
-
-            if (errors.Count > 0)
-            {
-                var firstError = errors[0];
-
-                errorMessage = firstError.Message;
-                errorCode = firstError.ErrorCode;
-            }
-            else
-            {
-                errorMessage = "RecognizeCustomForms operation failed.";
-            }
-
-            var errorInfo = new Dictionary<string, string>();
-            int index = 0;
-
-            foreach (var error in errors)
-            {
-                errorInfo.Add($"error-{index}", $"{error.ErrorCode}: {error.Message}");
-                index++;
-            }
-
-            return async
-                ? await _diagnostics.CreateRequestFailedExceptionAsync(_response, errorMessage, errorCode, errorInfo).ConfigureAwait(false)
-                : _diagnostics.CreateRequestFailedException(_response, errorMessage, errorCode, errorInfo);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -155,7 +155,7 @@ namespace Azure.AI.FormRecognizer.Models
 
                 if (update.Value.Status == OperationStatus.Succeeded)
                 {
-                    // we need to first assign a vaue and then mark the operation as completed to avoid race conditions
+                    // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
                     _value = ConvertToRecognizedForms(update.Value.AnalyzeResult);
                     _hasCompleted = true;
                 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
@@ -123,7 +123,7 @@ namespace Azure.AI.FormRecognizer.Models
 
                 if (update.Value.Status == OperationStatus.Succeeded)
                 {
-                    // we need to first assign a vaue and then mark the operation as completed to avoid race conditions
+                    // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
                     _value = ConvertToRecognizedReceipts(update.Value.AnalyzeResult);
                     _hasCompleted = true;
                 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOperation.cs
@@ -117,7 +117,7 @@ namespace Azure.AI.FormRecognizer.Training
 
                 if (update.Value.ModelInfo.Status == CustomFormModelStatus.Ready)
                 {
-                    // we need to first assign a vaue and then mark the operation as completed to avoid race conditions
+                    // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
                     _value = new CustomFormModel(update.Value);
                     _hasCompleted = true;
                 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -866,7 +866,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             Assert.True(operation.HasCompleted);
             Assert.False(operation.HasValue);
-            Assert.Throws<InvalidOperationException>(() => operation.Value.GetType());
+            Assert.Throws<RequestFailedException>(() => operation.Value.GetType());
         }
 
         private void ValidateFormPage(FormPage formPage, bool includeTextContent, int expectedPageNumber)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -102,7 +102,6 @@ namespace Azure.AI.FormRecognizer.Tests
             }
 
             await operation.WaitForCompletionAsync();
-
             Assert.IsTrue(operation.HasValue);
 
             var formPage = operation.Value.Single();
@@ -866,8 +865,8 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.AreEqual(expectedErrorCode, capturedException.ErrorCode);
 
             Assert.True(operation.HasCompleted);
-            Assert.True(operation.HasValue);
-            Assert.AreEqual(0, operation.Value.Count);
+            Assert.False(operation.HasValue);
+            Assert.Throws<InvalidOperationException>(() => operation.Value.GetType());
         }
 
         private void ValidateFormPage(FormPage formPage, bool includeTextContent, int expectedPageNumber)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -109,22 +109,10 @@ namespace Azure.AI.FormRecognizer.Tests
             var containerUrl = new Uri("https://someUrl");
 
             TrainingOperation operation = await client.StartTrainingAsync(containerUrl, useTrainingLabels: false);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
 
-            await operation.WaitForCompletionAsync();
-
-            Assert.IsTrue(operation.HasValue);
-
-            CustomFormModel model = operation.Value;
-
-            Assert.IsNotNull(model.ModelId);
-            Assert.IsNotNull(model.RequestedOn);
-            Assert.IsNotNull(model.CompletedOn);
-            Assert.IsNotNull(model.Status);
-            Assert.AreEqual(CustomFormModelStatus.Invalid, model.Status);
-            Assert.IsNotNull(model.Errors);
-            Assert.AreEqual(1, model.Errors.Count);
-            Assert.IsNotNull(model.Errors.FirstOrDefault().ErrorCode);
-            Assert.IsNotNull(model.Errors.FirstOrDefault().Message);
+            Assert.False(operation.HasValue);
+            Assert.Throws<InvalidOperationException>(() => operation.Value.GetType());
         }
 
         [Test]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -112,7 +112,7 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
 
             Assert.False(operation.HasValue);
-            Assert.Throws<InvalidOperationException>(() => operation.Value.GetType());
+            Assert.Throws<RequestFailedException>(() => operation.Value.GetType());
         }
 
         [Test]


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/11473

Follows the guidance:
- Throw exception if training method returns model with "invalid" status
- Exception message should include model_id, along with message from service that explains why it failed
- Include in documentation that a model is still created even if the training operation fails

For other operations, when `OperationStatus.Failed` we throw exception and if the user tries to access the `.Value` of the LRO, we throw an `InvalidOperationException` (similar to how it is handled in [KV ](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateOperation.cs#L66)). 