### PR TITLE
Ignore Azure.Management.KeyVault.Tests

### DIFF
--- a/sdk/core/service.projects
+++ b/sdk/core/service.projects
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- Remove mgmt plane tests from nightly live runs: https://github.com/Azure/azure-sdk-for-net/issues/12211 -->
+    <ProjectReference Remove="$(MSBuildThisFileDirectory)..\keyvault\Azure.Management.KeyVault\tests\Azure.Management.KeyVault.Tests.csproj" Condition="'$(AZURE_KEYVAULT_TEST_MODE)' == 'Live'" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Works around #12211 by ignoring tests that fail sporadically for both
live and playback tests.