### PR TITLE
Use JsonConverterAttribute in SerializeProperties

### DIFF
--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/JsonConverterHelper.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/JsonConverterHelper.cs
@@ -77,7 +77,16 @@ namespace Microsoft.Rest.Serialization
                         propertyName = property.PropertyName.Substring("properties.".Length);
                     }
                     writer.WritePropertyName(propertyName);
-                    serializer.Serialize(writer, memberValue);
+
+                    if (memberValue != null
+                        && property.Converter?.CanWrite == true)
+                    {
+                        property.Converter.WriteJson(writer, memberValue, serializer);
+                    }
+                    else
+                    {
+                        serializer.Serialize(writer, memberValue);
+                    }
                 }
 
                 // serialize additional properties

--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/PolymorphicDeserializeJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/PolymorphicDeserializeJsonConverter.cs
@@ -103,7 +103,20 @@ namespace Microsoft.Rest.Serialization
                     var property = SelectTokenCaseInsensitive(item, expectedProperty.PropertyName);
                     if (property != null)
                     {
-                        var propertyValue = property.ToObject(expectedProperty.PropertyType, serializer);
+                        object propertyValue;
+                        if (expectedProperty.Converter?.CanRead == true)
+                        {
+                            propertyValue = expectedProperty.Converter.ReadJson(
+                                new JTokenReader(property),
+                                expectedProperty.PropertyType,
+                                expectedProperty.ValueProvider.GetValue(result),
+                                serializer);
+                        }
+                        else
+                        {
+                            propertyValue = property.ToObject(expectedProperty.PropertyType, serializer);
+                        }
+
                         expectedProperty.ValueProvider.SetValue(result, propertyValue);
                     }
                 }

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/JsonSerializationTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/JsonSerializationTests.cs
@@ -65,6 +65,64 @@ namespace Microsoft.Rest.ClientRuntime.Tests
         }
 
         [Fact]
+        public void PolymorphicSerializeWithPropertyConverter()
+        {
+            var dog = new Dog
+            {
+                Name = "Doug",
+                Birthday = new DateTime(2020, 2, 29),
+                LikesDogfood = true,
+            };
+
+            var serializeSettings = new JsonSerializerSettings();
+            serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            serializeSettings.Converters.Add(new PolymorphicSerializeJsonConverter<Animal>("dType"));
+
+            var serializedJson = JsonConvert.SerializeObject(dog, Formatting.Indented, serializeSettings);
+
+            string dougJson = @"{
+  ""dType"": ""dog"",
+  ""likesDogfood"": true,
+  ""bestFriend"": null,
+  ""name"": ""Doug"",
+  ""birthday"": 1582934400
+}";
+            Assert.Equal(dougJson, serializedJson);
+
+            var deserializeSettings = new JsonSerializerSettings();
+            deserializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            deserializeSettings.Converters.Add(new PolymorphicDeserializeJsonConverter<Animal>("dType"));
+
+            var deserializedDog = (Dog)JsonConvert.DeserializeObject<Animal>(serializedJson, deserializeSettings);
+            Assert.Equal(dog.Birthday, deserializedDog.Birthday);
+        }
+
+        [Fact]
+        public void PolymorphicSerializeNullWithPropertyConverter()
+        {
+            var dog = new Dog
+            {
+                Name = "Doug",
+                LikesDogfood = true,
+            };
+
+            var serializeSettings = new JsonSerializerSettings();
+            serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            serializeSettings.Converters.Add(new PolymorphicSerializeJsonConverter<Animal>("dType"));
+
+            var serializedJson = JsonConvert.SerializeObject(dog, Formatting.Indented, serializeSettings);
+
+            string dougJson = @"{
+  ""dType"": ""dog"",
+  ""likesDogfood"": true,
+  ""bestFriend"": null,
+  ""name"": ""Doug"",
+  ""birthday"": null
+}";
+            Assert.Equal(dougJson, serializedJson);
+        }
+
+        [Fact]
         public void PolymorphismWorksWithReadOnlyProperties()
         {
             var deserializeSettings = new JsonSerializerSettings();

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/JsonSerializationTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/JsonSerializationTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Globalization;
 using System.Net.Http;
 using Microsoft.Rest.ClientRuntime.Tests.Resources;
+using Microsoft.Rest.ClientRuntime.Tests.Serialization;
 using Microsoft.Rest.Serialization;
 using Microsoft.Rest.TransientFaultHandling;
 using Newtonsoft.Json;
@@ -95,6 +96,44 @@ namespace Microsoft.Rest.ClientRuntime.Tests
 
             var deserializedDog = (Dog)JsonConvert.DeserializeObject<Animal>(serializedJson, deserializeSettings);
             Assert.Equal(dog.Birthday, deserializedDog.Birthday);
+        }
+
+        [Fact]
+        public void PolymorphicSerializeCanReadWrite()
+        {
+            var data = new OneWayConvertibleData
+            {
+                ReadConverted = "InitialRead",
+                WriteConverted = "InitialWrite",
+            };
+            var serializeSettings = new JsonSerializerSettings();
+            serializeSettings.Converters.Add(
+                new PolymorphicSerializeJsonConverter<OneWayConvertibleData>("dType"));
+            var serializedJson = JsonConvert.SerializeObject(data, Formatting.Indented, serializeSettings);
+
+            string dataJson = @"{
+  ""dType"": ""owcd"",
+  ""readConverted"": ""InitialRead"",
+  ""writeConverted"": ""StaticWriteOnlyJsonConverter""
+}";
+            Assert.Equal(dataJson, serializedJson);
+        }
+
+        [Fact]
+        public void PolymorphicDeserializeCanReadWrite()
+        {
+            string dataJson = @"{
+  ""dType"": ""owcd"",
+  ""readConverted"": ""InitialRead"",
+  ""writeConverted"": ""InitialWrite""
+}";
+
+            var deserializeSettings = new JsonSerializerSettings();
+            deserializeSettings.Converters.Add(new PolymorphicDeserializeJsonConverter<OneWayConvertibleData>("dType"));
+            var deserializedData = JsonConvert.DeserializeObject<OneWayConvertibleData>(dataJson, deserializeSettings);
+
+            Assert.Equal("StaticReadOnlyJsonConverter", deserializedData.ReadConverted);
+            Assert.Equal("InitialWrite", deserializedData.WriteConverted);
         }
 
         [Fact]
@@ -602,6 +641,18 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             {
                 JsonConvert.DefaultSettings = oldDefault;
             }
+        }
+
+        [JsonObject("owcd")]
+        private class OneWayConvertibleData
+        {
+            [JsonConverter(typeof(StaticReadOnlyJsonConverter))]
+            [JsonProperty("readConverted")]
+            public string ReadConverted { get; set; }
+
+            [JsonConverter(typeof(StaticWriteOnlyJsonConverter))]
+            [JsonProperty("writeConverted")]
+            public string WriteConverted { get; set; }
         }
 
         private class Model

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Resources/Animal.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Resources/Animal.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+
+using Microsoft.Rest.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Microsoft.Rest.ClientRuntime.Tests.Resources
@@ -14,6 +18,10 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
 
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonConverter(typeof(UnixTimeJsonConverter))]
+        [JsonProperty("birthday")]
+        public DateTime? Birthday { get; set; }
 
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalProperties { get; set; }

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/StaticReadOnlyJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/StaticReadOnlyJsonConverter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+using System;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    /// <summary>
+    /// <see cref="JsonConverter"/> which reads its class name and can't write.
+    /// </summary>
+    public class StaticReadOnlyJsonConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return nameof(StaticReadOnlyJsonConverter);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/StaticWriteOnlyJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/StaticWriteOnlyJsonConverter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+using System;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    /// <summary>
+    /// <see cref="JsonConverter"/> which writes its class name and can't read.
+    /// </summary>
+    public class StaticWriteOnlyJsonConverter : JsonConverter
+    {
+        public override bool CanRead => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(nameof(StaticWriteOnlyJsonConverter));
+        }
+    }
+}


### PR DESCRIPTION
If a property is declared with [`JsonConverterAttribute`](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonConverterAttribute.htm) and has a non-`null`
value, use the converter to write the value in
[`JsonConverterHelper.SerializeProperties`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.rest.serialization.jsonconverterhelper.serializeproperties), to match Json.NET behavior.

Fixes: #12490