### PR TITLE
[TA] Drop preview and change readme links to absolute

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0 (Unreleased)
+## 1.0.0 (2020-06-09)
 - First stable release of Azure.AI.TextAnalytics package.
 
 ## 1.0.0-preview.5 (2020-05-27)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 1.0.0-preview.6 (Unreleased)
-
+## 1.0.0 (Unreleased)
+- First stable release of Azure.AI.TextAnalytics package.
 
 ## 1.0.0-preview.5 (2020-05-27)
 ### Breaking changes

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -34,13 +34,13 @@ You can create either resource using:
 Below is an example of how you can create a Text Analytics resource using the CLI:
 
 ```PowerShell
-# Create a new resource group to hold the text analytics resource -
+# Create a new resource group to hold the Text Analytics resource -
 # if using an existing resource group, skip this step
 az group create --name <your-resource-name> --location <location>
 ```
 
 ```PowerShell
-# Create text analytics
+# Create Text Analytics
 az cognitiveservices account create \
     --name <your-resource-name> \
     --resource-group <your-resource-group-name> \
@@ -325,7 +325,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [textanalytics_refdocs]: https://aka.ms/azsdk-net-textanalytics-ref-docs
 [textanalytics_nuget_package]: https://www.nuget.org/packages/Azure.AI.TextAnalytics
 [textanalytics_samples]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/README.md
-[textanalytics_rest_api]: https://westus.dev.cognitive.microsoft.com/docs/services/TextAnalytics-v3-0-Preview-1/operations/Languages
+[textanalytics_rest_api]: https://westus.dev.cognitive.microsoft.com/docs/services/TextAnalytics-v3-0/operations/Languages
 [cognitive_resource_portal]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
 [cognitive_resource_cli]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account-cli
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -14,7 +14,7 @@ Azure Cognitive Services Text Analytics is a cloud service that provides advance
 Install the Azure Text Analytics client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet add package Azure.AI.TextAnalytics --version 1.0.0-preview.5
+dotnet add package Azure.AI.TextAnalytics
 ```
 **Note:** This package version targets Azure Text Analytics service API version v3.0.
 
@@ -320,11 +320,11 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 
 
 <!-- LINKS -->
-[textanalytics_client_src]: src
+[textanalytics_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/src
 [textanalytics_docs]: https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/
 [textanalytics_refdocs]: https://aka.ms/azsdk-net-textanalytics-ref-docs
 [textanalytics_nuget_package]: https://www.nuget.org/packages/Azure.AI.TextAnalytics
-[textanalytics_samples]: /samples/README.md
+[textanalytics_samples]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/README.md
 [textanalytics_rest_api]: https://westus.dev.cognitive.microsoft.com/docs/services/TextAnalytics-v3-0-Preview-1/operations/Languages
 [cognitive_resource_portal]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account
 [cognitive_resource_cli]: https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account-cli
@@ -335,23 +335,23 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [named_entity_recognition]: https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/how-tos/text-analytics-how-to-entity-linking
 [named_entities_categories]: https://docs.microsoft.com/azure/cognitive-services/Text-Analytics/named-entity-types
 
-[textanalytics_client_class]: src/TextAnalyticsClient.cs
-[azure_identity]: ../../identity/Azure.Identity
+[textanalytics_client_class]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+[azure_identity]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity
 [cognitive_auth]: https://docs.microsoft.com/azure/cognitive-services/authentication
 [register_aad_app]: https://docs.microsoft.com/azure/cognitive-services/authentication#assign-a-role-to-a-service-principal
 [aad_grant_access]: https://docs.microsoft.com/azure/cognitive-services/authentication#assign-a-role-to-a-service-principal
 [custom_subdomain]: https://docs.microsoft.com/azure/cognitive-services/authentication#create-a-resource-with-a-custom-subdomain
-[DefaultAzureCredential]: ../../identity/Azure.Identity/README.md
-[logging]: ../../core/Azure.Core/samples/Diagnostics.md
+[DefaultAzureCredential]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity/README.md
+[logging]: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/samples/Diagnostics.md
 [data_limits]: https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits
-[contributing]: ../../../CONTRIBUTING.md
+[contributing]: https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md
 
-[detect_language_sample]: samples/Sample1_DetectLanguage.md
-[analyze_sentiment_sample]: samples/Sample2_AnalyzeSentiment.md
-[extract_key_phrases_sample]: samples/Sample3_ExtractKeyPhrases.md
-[recognize_entities_sample]: samples/Sample4_RecognizeEntities.md
-[recognize_linked_entities_sample]: samples/Sample6_RecognizeLinkedEntities.md
-[mock_client_sample]: samples/Sample_MockClient.md
+[detect_language_sample]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+[analyze_sentiment_sample]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+[extract_key_phrases_sample]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+[recognize_entities_sample]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+[recognize_linked_entities_sample]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+[mock_client_sample]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
 
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_sub]: https://azure.microsoft.com/free/

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/README.md
@@ -4,6 +4,7 @@ languages:
 - csharp
 products:
 - azure
+- azure-cognitive-services
 - azure-text-analytics
 name: Azure Text Analytics samples for .NET
 description: Samples for the Azure.AI.TextAnalytics client library

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentResultCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentResultCollection.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics
         public TextDocumentBatchStatistics Statistics { get; }
 
         /// <summary>
-        /// Gets the version of the text analytics model used by this operation
+        /// Gets the version of the Text Analytics model used by this operation
         /// on this batch of documents.
         /// </summary>
         public string ModelVersion { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Cognitive Services Text Analytics Service client library</Description>
     <AssemblyTitle>Microsoft Azure.AI.TextAnalytics client library</AssemblyTitle>
-    <Version>1.0.0-preview.6</Version>
+    <Version>1.0.0</Version>
     <PackageTags>Microsoft Azure Text Analytics</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntity.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// A word or phrase identified as an entity that can be categorized
     /// as known type in a given taxonomy.  The set of categories recognized by the
-    /// text analytics service is described at
+    /// Text Analytics service is described at
     /// <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/Text-Analytics/named-entity-types"/>.
     /// </summary>
     public readonly struct CategorizedEntity
@@ -25,7 +25,7 @@ namespace Azure.AI.TextAnalytics
         public string Text { get; }
 
         /// <summary>
-        /// Gets the entity category inferred by the text analytics service's
+        /// Gets the entity category inferred by the Text Analytics service's
         /// named entity recognition model.  The list of available categories is
         /// described at
         /// <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/Text-Analytics/named-entity-types"/>.
@@ -33,7 +33,7 @@ namespace Azure.AI.TextAnalytics
         public EntityCategory Category { get; }
 
         /// <summary>
-        /// Gets the sub category of the entity inferred by the text analytics service's
+        /// Gets the sub category of the entity inferred by the Text Analytics service's
         /// named entity recognition model.  This property may not have a value if
         /// a sub category doesn't exist for this entity.  The list of available categories and
         /// subcategories is described at

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectLanguageInput.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectLanguageInput.cs
@@ -7,7 +7,7 @@ namespace Azure.AI.TextAnalytics
     /// An input to the detect language operation.  This object allows the
     /// caller to specify a unique document id, as well as the full text of a
     /// document and a hint indicating the document's country of origin to assist
-    /// the text analytics predictive model in detecting the document's language.
+    /// the Text Analytics predictive model in detecting the document's language.
     /// </summary>
     public class DetectLanguageInput : TextAnalyticsInput
     {
@@ -28,7 +28,7 @@ namespace Azure.AI.TextAnalytics
         public DetectLanguageInput(string id, string text) : base(id, text) { }
 
         /// <summary>
-        /// Gets or sets a hint to assist the text analytics model in predicting
+        /// Gets or sets a hint to assist the Text Analytics model in predicting
         /// the language the document is written in.  If unspecified, this value
         /// will be set to the default country hint in <see cref="TextAnalyticsClientOptions"/>
         /// in the request sent to the service.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectLanguageResultCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectLanguageResultCollection.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.TextAnalytics
         public TextDocumentBatchStatistics Statistics { get; }
 
         /// <summary>
-        /// Gets the version of the text analytics model used by this operation
+        /// Gets the version of the Text Analytics model used by this operation
         /// on this batch of documents.
         /// </summary>
         public string ModelVersion { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesResultCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesResultCollection.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics
         public TextDocumentBatchStatistics Statistics { get; }
 
         /// <summary>
-        /// Gets the version of the text analytics model used by this operation
+        /// Gets the version of the Text Analytics model used by this operation
         /// on this batch of documents.
         /// </summary>
         public string ModelVersion { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityMatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityMatch.cs
@@ -5,7 +5,7 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// Details regarding the specific substring in the document matching
-    /// the linked entity, or well-known item, that the text analytics model
+    /// the linked entity, or well-known item, that the Text Analytics model
     /// identified.
     /// </summary>
     public readonly struct LinkedEntityMatch

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesResultCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesResultCollection.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics
         public TextDocumentBatchStatistics Statistics { get; }
 
         /// <summary>
-        /// Gets the version of the text analytics model used by this operation
+        /// Gets the version of the Text Analytics model used by this operation
         /// on this batch of documents.
         /// </summary>
         public string ModelVersion { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesResultCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesResultCollection.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics
         public TextDocumentBatchStatistics Statistics { get; }
 
         /// <summary>
-        /// Gets the version of the text analytics model used by this operation
+        /// Gets the version of the Text Analytics model used by this operation
         /// on this batch of documents.
         /// </summary>
         public string ModelVersion { get; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -117,7 +117,7 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="document">The document to analyze.</param>
         /// <param name="countryHint">Indicates the country of origin of the
-        /// document to assist the text analytics model in predicting the language
+        /// document to assist the Text Analytics model in predicting the language
         /// it is written in.  If unspecified, this value will be set to the
         /// default country hint in <see cref="TextAnalyticsClientOptions"/>
         /// in the request sent to the service.
@@ -176,7 +176,7 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="document">The document to analyze.</param>
         /// <param name="countryHint">Indicates the country of origin of the
-        /// document to assist the text analytics model in predicting the language
+        /// document to assist the Text Analytics model in predicting the language
         /// it is written in.  If unspecified, this value will be set to the
         /// default country hint in <see cref="TextAnalyticsClientOptions"/>
         /// in the request sent to the service.
@@ -235,7 +235,7 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="documents">A collection of documents to analyze.</param>
         /// <param name="countryHint">Indicates the country of origin of all of
-        /// the documents to assist the text analytics model in predicting
+        /// the documents to assist the Text Analytics model in predicting
         /// the language they are written in.  If unspecified, this value will be
         /// set to the default country hint in <see cref="TextAnalyticsClientOptions"/>
         /// in the request sent to the service.
@@ -269,7 +269,7 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="documents">A collection of documents to analyze.</param>
         /// <param name="countryHint">Indicates the country of origin of all of
-        /// the documents to assist the text analytics model in predicting
+        /// the documents to assist the Text Analytics model in predicting
         /// the language they are written in.  If unspecified, this value will be
         /// set to the default country hint in <see cref="TextAnalyticsClientOptions"/>
         /// in the request sent to the service.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsInput.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsInput.cs
@@ -5,7 +5,7 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// An input representing an individual text document to
-    /// be analyzed by the text analytics predictive model for a given operation.
+    /// be analyzed by the Text Analytics predictive model for a given operation.
     /// </summary>
     public class TextAnalyticsInput
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsResult.cs
@@ -4,7 +4,7 @@
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
-    /// Base type for results of text analytics operations corresponding to a
+    /// Base type for results of Text Analytics operations corresponding to a
     /// document.  If the operation is unsuccessful, the Id and
     /// Error properties will be populated, but not others.
     /// </summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextDocumentInput.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextDocumentInput.cs
@@ -5,7 +5,7 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// An input representing an individual text document to
-    /// be analyzed by the text analytics predictive model for a given operation.
+    /// be analyzed by the Text Analytics predictive model for a given operation.
     /// The document contains the document's id, the full text of the document,
     /// and the language that the document is written in.
     /// </summary>


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/12472
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/12513

It also includes:
- Rename `text analytics` to `Text Analytics`
- Update service REST API link to point to v3.0