### PR TITLE
[Event Hubs Client] Fix Test Environment Typo

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
@@ -58,7 +58,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         ///   Initializes a new instance of the <see cref="StorageTestEnvironment"/> class.
         /// </summary>
         ///
-        public StorageTestEnvironment() : base("eventhubs")
+        public StorageTestEnvironment() : base("eventhub")
         {
             ActiveStorageAccount = new Lazy<StorageProperties>(EnsureStorageAccount, LazyThreadSafetyMode.ExecutionAndPublication);
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo on the constructor of the StorageTestEnvironment, which initializes the base class with an incorrect service directory name.

# Last Upstream Rebase

Monday, June 8, 8:58am (EDT)