### PR TITLE
Fix deadlock when using AzureKeyVaultXmlEncryptor.Encrypt (sync) from .NET Framework

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/AzureKeyVaultXmlDecryptor.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/AzureKeyVaultXmlDecryptor.cs
@@ -24,7 +24,7 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Keys
 
         public XElement Decrypt(XElement encryptedElement)
         {
-            return DecryptAsync(encryptedElement).GetAwaiter().GetResult();
+            return Task.Run(() => DecryptAsync(encryptedElement)).GetAwaiter().GetResult();
         }
 
         private async Task<XElement> DecryptAsync(XElement encryptedElement)

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/AzureKeyVaultXmlEncryptor.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/AzureKeyVaultXmlEncryptor.cs
@@ -36,7 +36,7 @@ namespace Azure.Extensions.AspNetCore.DataProtection.Keys
 
         public EncryptedXmlInfo Encrypt(XElement plaintextElement)
         {
-            return EncryptAsync(plaintextElement).GetAwaiter().GetResult();
+            return Task.Run(() => EncryptAsync(plaintextElement)).GetAwaiter().GetResult();
         }
 
         private async Task<EncryptedXmlInfo> EncryptAsync(XElement plaintextElement)


### PR DESCRIPTION
Fixes dotnet/aspnetcore#18387.

**Context**

I'm [replacing the default data protection mechanism](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/compatibility/replacing-machinekey?view=aspnetcore-3.1) in a .NET Framework project. When invoking `ProtectKeysWithAzureKeyVault()` my app experienced the symptoms laid out in dotnet/aspnetcore#18387.  The updates in this PR resolve the deadlock.