### PR TITLE
Added PlaybackOnlyAttribute

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/PlaybackOnlyAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/PlaybackOnlyAttribute.cs
@@ -14,6 +14,16 @@ namespace Azure.Core.TestFramework
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited = true)]
     public class PlaybackOnlyAttribute : NUnitAttribute, IApplyToTest
     {
+        private readonly string _reason;
+
+        /// <summary>
+        /// Constructs the attribute giving a reason the associated tests is playback only.
+        /// </summary>
+        public PlaybackOnlyAttribute(string reason)
+        {
+            _reason = reason;
+        }
+
         /// <summary>
         /// Modifies the <paramref name="test"/> by adding categories to it and changing the run state as needed.
         /// </summary>
@@ -28,7 +38,7 @@ namespace Azure.Core.TestFramework
                 if (mode != RecordedTestMode.Playback)
                 {
                     test.RunState = RunState.Ignored;
-                    test.Properties.Set("_SKIPREASON", $"Live tests will not run when AZURE_TEST_MODE is {mode}");
+                    test.Properties.Set("_SKIPREASON", $"Playback tests will not run when AZURE_TEST_MODE is {mode}.  This test was skipped for the following reason: {_reason}");
                 }
             }
         }

--- a/sdk/core/Azure.Core.TestFramework/src/PlaybackOnlyAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/PlaybackOnlyAttribute.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Azure.Core.TestFramework
+{
+    /// <summary>
+    /// Attribute on test assemblies, classes, or methods that run only against playback resources.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited = true)]
+    public class PlaybackOnlyAttribute : NUnitAttribute, IApplyToTest
+    {
+        /// <summary>
+        /// Modifies the <paramref name="test"/> by adding categories to it and changing the run state as needed.
+        /// </summary>
+        /// <param name="test">The <see cref="Test"/> to modify.</param>
+        public void ApplyToTest(Test test)
+        {
+            test.Properties.Add("Category", "Playback");
+
+            if (test.RunState != RunState.NotRunnable)
+            {
+                RecordedTestMode mode = RecordedTestUtilities.GetModeFromEnvironment();
+                if (mode != RecordedTestMode.Playback)
+                {
+                    test.RunState = RunState.Ignored;
+                    test.Properties.Set("_SKIPREASON", $"Live tests will not run when AZURE_TEST_MODE is {mode}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We would like the ability to mark some tests as playback-only.

For example: https://github.com/Azure/azure-sdk-for-net/pull/12609/files#diff-e152777102db76590298fbda43777754R1769

Related https://github.com/Azure/azure-sdk-for-net/pull/12609