### PR TITLE
IoT hub service client authentication via connection string

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/CodeMaid.config
+++ b/sdk/iot/Azure.Iot.Hub.Service/CodeMaid.config
@@ -36,6 +36,10 @@
       <setting name="Progressing_ShowBuildProgressOnBuildStart" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="Cleaning_SkipRemoveAndSortUsingStatementsDuringAutoCleanupOnSave"
+        serializeAs="String">
+        <value>False</value>
+      </setting>
     </SteveCadwallader.CodeMaid.Properties.Settings>
   </userSettings>
 </configuration>

--- a/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
@@ -50,8 +50,10 @@ namespace Azure.Iot.Hub.Service
     public partial class IoTHubServiceClient
     {
         protected IoTHubServiceClient() { }
-        public IoTHubServiceClient(System.Uri endpoint) { }
-        public IoTHubServiceClient(System.Uri endpoint, Azure.Iot.Hub.Service.IoTHubServiceClientOptions options) { }
+        public IoTHubServiceClient(string connectionString) { }
+        public IoTHubServiceClient(string connectionString, Azure.Iot.Hub.Service.IoTHubServiceClientOptions options) { }
+        public IoTHubServiceClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
+        public IoTHubServiceClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.Iot.Hub.Service.IoTHubServiceClientOptions options) { }
         public Azure.Iot.Hub.Service.DevicesClient Devices { get { throw null; } }
         public Azure.Iot.Hub.Service.FilesClient Files { get { throw null; } }
         public Azure.Iot.Hub.Service.JobsClient Jobs { get { throw null; } }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/FixedSasTokenProvider.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/FixedSasTokenProvider.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// Implementation of a shared access signature provider with a fixed token.
+    /// </summary>
+    internal class FixedSasTokenProvider : ISasTokenProvider
+    {
+        private readonly string _sharedAccessSignature;
+
+        // Protected constructor, to allow mocking
+        protected FixedSasTokenProvider()
+        {
+        }
+
+        internal FixedSasTokenProvider(string sharedAccessSignature)
+        {
+            _sharedAccessSignature = sharedAccessSignature;
+        }
+
+        public string GetSasToken()
+        {
+            return _sharedAccessSignature;
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/ISasTokenProvider.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/ISasTokenProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// The token provider interface for shared access signature based authentication.
+    /// </summary>
+    internal interface ISasTokenProvider
+    {
+        /// <summary>
+        /// Retrieve the shared access signature to be used.
+        /// </summary>
+        /// <returns>The shared access signature to be used for authenticating HTTP requests to the service. It is called once per HTTP request.</returns>
+        public string GetSasToken();
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/IotHubConnectionString.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/IotHubConnectionString.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// Implementation for creating the shared access signature token provider.
+    /// </summary>
+    internal class IotHubConnectionString
+    {
+        private const string HostNameIdentifier = "HostName";
+        private const string SharedAccessKeyIdentifier = "SharedAccessKey";
+        private const string SharedAccessKeyNameIdentifier = "SharedAccessKeyName";
+        private const string SharedAccessSignatureIdentifier = "SharedAccessSignature";
+
+        private readonly ConnectionString _connectionString;
+        private readonly string _sharedAccessPolicy;
+        private readonly string _sharedAccessKey;
+        private readonly string _sharedAccessSignature;
+
+        internal IotHubConnectionString(string connectionString)
+        {
+            _connectionString = ConnectionString.Parse(connectionString);
+            _sharedAccessKey = _connectionString.GetNonRequired(SharedAccessKeyIdentifier);
+            _sharedAccessPolicy = _connectionString.GetNonRequired(SharedAccessKeyNameIdentifier);
+            _sharedAccessSignature = _connectionString.GetNonRequired(SharedAccessSignatureIdentifier);
+
+            if (!ValidateInput(_sharedAccessPolicy, _sharedAccessKey, _sharedAccessSignature))
+            {
+                throw new ArgumentException("Specify either both the sharedAccessKey and sharedAccessKeyName, or only sharedAccessSignature");
+            }
+
+            HostName = _connectionString.GetRequired(HostNameIdentifier);
+        }
+
+        internal string HostName { get; }
+
+        internal ISasTokenProvider GetSasTokenProvider()
+        {
+            if (_sharedAccessSignature == null)
+            {
+                return new SasTokenProviderWithSharedAccessKey(HostName, _sharedAccessPolicy, _sharedAccessKey);
+            }
+            return new FixedSasTokenProvider(_sharedAccessSignature);
+        }
+
+        private static bool ValidateInput(string sharedAccessPolicy, string sharedAccessKey, string sharedAccessSignature)
+        {
+            if (sharedAccessSignature == null)
+            {
+                return sharedAccessKey != null && sharedAccessPolicy != null;
+            }
+            else
+            {
+                return sharedAccessKey == null && sharedAccessPolicy == null;
+            }
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SasTokenAuthenticationPolicy.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SasTokenAuthenticationPolicy.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// The shared access signature based HTTP pipeline policy.
+    /// This authentication policy injects the sas token into the HTTP authentication header for each HTTP request made.
+    /// </summary>
+    internal class SasTokenAuthenticationPolicy : HttpPipelinePolicy
+    {
+        private readonly ISasTokenProvider _sasTokenProvider;
+
+        internal SasTokenAuthenticationPolicy(ISasTokenProvider sasTokenProvider)
+        {
+            _sasTokenProvider = sasTokenProvider;
+        }
+
+        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            AddHeaders(message);
+            ProcessNext(message, pipeline);
+        }
+
+        public override async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            AddHeaders(message);
+            await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+        }
+
+        private void AddHeaders(HttpMessage message)
+        {
+            message.Request.Headers.Add(HttpHeader.Names.Authorization, _sasTokenProvider.GetSasToken());
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SasTokenProviderWithSharedAccessKey.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SasTokenProviderWithSharedAccessKey.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// Implementation of a shared access signature provider with token caching and refresh.
+    /// </summary>
+    internal class SasTokenProviderWithSharedAccessKey : ISasTokenProvider
+    {
+        // The default time to live for a sas token is set to 30 minutes.
+        private static readonly TimeSpan s_defaultTimeToLive = TimeSpan.FromMinutes(30);
+
+        // Time buffer before expiry when the token should be renewed, expressed as a percentage of the time to live.
+        // The token will be renewed when it has 15% or less of the sas token's lifespan left.
+        private const int s_renewalTimeBufferPercentage = 15;
+
+        private readonly object _lock = new object();
+
+        private readonly string _hostName;
+        private readonly string _sharedAccessPolicy;
+        private readonly string _sharedAccessKey;
+        private readonly TimeSpan _timeToLive;
+
+        private string _cachedSasToken;
+        private DateTimeOffset _tokenExpiryTime;
+
+        // Protected constructor, to allow mocking
+        protected SasTokenProviderWithSharedAccessKey()
+        {
+        }
+
+        internal SasTokenProviderWithSharedAccessKey(string hostName, string sharedAccessPolicy, string sharedAccessKey, TimeSpan? timeToLive = null)
+        {
+            _hostName = hostName;
+            _sharedAccessPolicy = sharedAccessPolicy;
+            _sharedAccessKey = sharedAccessKey;
+            _timeToLive = timeToLive ?? s_defaultTimeToLive;
+
+            _cachedSasToken = null;
+        }
+
+        string ISasTokenProvider.GetSasToken()
+        {
+            lock (_lock)
+            {
+                if (IsTokenExpired())
+                {
+                    var builder = new SharedAccessSignatureBuilder
+                    {
+                        HostName = _hostName,
+                        SharedAccessPolicy = _sharedAccessPolicy,
+                        SharedAccessKey = _sharedAccessKey,
+                        TimeToLive = _timeToLive,
+                    };
+
+                    _tokenExpiryTime = DateTimeOffset.UtcNow.Add(_timeToLive);
+                    _cachedSasToken = builder.ToSignature();
+                }
+
+                return _cachedSasToken;
+            }
+        }
+
+        private bool IsTokenExpired()
+        {
+            // The token is considered expired if this is the first time it is being accessed (not cached yet)
+            // or the current time is greater than or equal to the token expiry time, less 15% buffer.
+            if (_cachedSasToken == null)
+            {
+                return true;
+            }
+
+            var bufferTimeInMilliseconds = (double)s_renewalTimeBufferPercentage / 100 * _timeToLive.TotalMilliseconds;
+            DateTimeOffset tokenExpiryTimeWithBuffer = _tokenExpiryTime.AddMilliseconds(-bufferTimeInMilliseconds);
+            return DateTimeOffset.UtcNow.CompareTo(tokenExpiryTimeWithBuffer) >= 0;
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureBuilder.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureBuilder.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// Builds the shared access signature based on the access policy passed.
+    /// </summary>
+    internal class SharedAccessSignatureBuilder
+    {
+        internal string SharedAccessPolicy { get; set; }
+
+        internal string SharedAccessKey { get; set; }
+
+        internal string HostName { get; set; }
+
+        internal TimeSpan TimeToLive { get; set; }
+
+        internal string ToSignature()
+        {
+            return BuildSignature(SharedAccessPolicy, SharedAccessKey, HostName, TimeToLive);
+        }
+
+        private static string BuildSignature(string sharedAccessPolicy, string sharedAccessKey, string hostName, TimeSpan timeToLive)
+        {
+            string expiresOn = BuildExpiresOn(timeToLive);
+            string audience = WebUtility.UrlEncode(hostName);
+            var fields = new List<string>
+            {
+                audience,
+                expiresOn
+            };
+
+            // Example string to be signed:
+            // dh://myiothub.azure-devices.net/a/b/c?myvalue1=a
+            // <Value for ExpiresOn>
+
+            string signature = Sign(string.Join("\n", fields), sharedAccessKey);
+
+            // Example returned string:
+            // SharedAccessSignature sr=ENCODED(dh://myiothub.azure-devices.net/a/b/c?myvalue1=a)&sig=<Signature>&se=<ExpiresOnValue>[&skn=<KeyName>]
+
+            var buffer = new StringBuilder();
+            buffer.Append($"{SharedAccessSignatureConstants.SharedAccessSignature} " +
+                $"{SharedAccessSignatureConstants.AudienceFieldName}={audience}" +
+                $"&{SharedAccessSignatureConstants.SignatureFieldName}={WebUtility.UrlEncode(signature)}" +
+                $"&{SharedAccessSignatureConstants.ExpiryFieldName}={WebUtility.UrlEncode(expiresOn)}");
+
+            if (!string.IsNullOrWhiteSpace(sharedAccessPolicy))
+            {
+                buffer.Append($"&{SharedAccessSignatureConstants.KeyNameFieldName}={WebUtility.UrlEncode(sharedAccessPolicy)}");
+            }
+
+            return buffer.ToString();
+        }
+
+        private static string BuildExpiresOn(TimeSpan timeToLive)
+        {
+            DateTimeOffset expiresOn = DateTimeOffset.UtcNow.Add(timeToLive);
+            TimeSpan secondsFromBaseTime = expiresOn.Subtract(SharedAccessSignatureConstants.EpochTime);
+            long seconds = Convert.ToInt64(secondsFromBaseTime.TotalSeconds, CultureInfo.InvariantCulture);
+            return Convert.ToString(seconds, CultureInfo.InvariantCulture);
+        }
+
+        private static string Sign(string requestString, string key)
+        {
+            using (var hmac = new HMACSHA256(Convert.FromBase64String(key)))
+            {
+                return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(requestString)));
+            }
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureConstants.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureConstants.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// The constants used for building the IoT hub service shared access signature token.
+    /// </summary>
+    internal static class SharedAccessSignatureConstants
+    {
+        internal const int MaxKeyNameLength = 256;
+        internal const int MaxKeyLength = 256;
+        internal const string SharedAccessSignature = "SharedAccessSignature";
+        internal const string AudienceFieldName = "sr";
+        internal const string SignatureFieldName = "sig";
+        internal const string KeyNameFieldName = "skn";
+        internal const string ExpiryFieldName = "se";
+        internal const string SignedResourceFullFieldName = SharedAccessSignature + " " + AudienceFieldName;
+        internal const string KeyValueSeparator = "=";
+        internal const string PairSeparator = "&";
+        internal static readonly DateTime EpochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        internal static readonly TimeSpan MaxClockSkew = TimeSpan.FromMinutes(5);
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Azure.Iot.Hub.Service.csproj
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Azure.Iot.Hub.Service.csproj
@@ -47,6 +47,9 @@
     <Compile Include="$(AzureCoreSharedSources)Argument.cs">
       <LinkBase>Shared\Azure.Core</LinkBase>
     </Compile>
+    <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs">
+      <LinkBase>Shared\Azure.Core</LinkBase>
+    </Compile>
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />

--- a/sdk/iot/Azure.Iot.Hub.Service/src/IoTHubServiceClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/IoTHubServiceClient.cs
@@ -4,16 +4,18 @@
 using System;
 using Azure.Core;
 using Azure.Core.Pipeline;
+using Azure.Iot.Hub.Service.Authentication;
 
 namespace Azure.Iot.Hub.Service
 {
     /// <summary>
-    /// The IoT Hub Service Client
+    /// The IoT Hub Service Client.
     /// </summary>
     public class IoTHubServiceClient
     {
         private readonly HttpPipeline _httpPipeline;
         private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly Uri _endpoint;
         private readonly RegistryManagerRestClient _registryManagerRestClient;
         private readonly TwinRestClient _twinRestClient;
         private readonly DeviceMethodRestClient _deviceMethodRestClient;
@@ -22,22 +24,27 @@ namespace Azure.Iot.Hub.Service
         /// place holder for Devices
         /// </summary>
         public DevicesClient Devices { get; private set; }
+
         /// <summary>
         /// place holder for Modules
         /// </summary>
         public ModulesClient Modules { get; private set; }
+
         /// <summary>
         /// place holder for Statistics
         /// </summary>
         public StatisticsClient Statistics { get; private set; }
+
         /// <summary>
         /// place holder for Messages
         /// </summary>
         public CloudToDeviceMessagesClient Messages { get; private set; }
+
         /// <summary>
         /// place holder for Files
         /// </summary>
         public FilesClient Files { get; private set; }
+
         /// <summary>
         /// place holder for Jobs
         /// </summary>
@@ -54,24 +61,42 @@ namespace Azure.Iot.Hub.Service
         /// <summary>
         /// Initializes a new instance of the <see cref="IoTHubServiceClient"/> class.
         /// </summary>
-        public IoTHubServiceClient(Uri endpoint)
-            : this(endpoint, new IoTHubServiceClientOptions())
+        /// <param name="connectionString">
+        /// The IoT Hub connection string, with either "iothubowner", "service", "registryRead" or "registryReadWrite" policy, as applicable.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#access-control-and-permissions"/>.
+        /// </param>
+        public IoTHubServiceClient(string connectionString)
+            : this(connectionString, new IoTHubServiceClientOptions())
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IoTHubServiceClient"/> class.
         /// </summary>
-        public IoTHubServiceClient(Uri endpoint, IoTHubServiceClientOptions options)
+        /// <param name="connectionString">
+        /// The IoT Hub connection string, with either "iothubowner", "service", "registryRead" or "registryReadWrite" policy, as applicable.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#access-control-and-permissions"/>.
+        /// </param>
+        /// <param name="options">
+        /// Options that allow configuration of requests sent to the IoT Hub service.
+        /// </param>
+        public IoTHubServiceClient(string connectionString, IoTHubServiceClientOptions options)
         {
             Argument.AssertNotNull(options, nameof(options));
 
+            var iotHubConnectionString = new IotHubConnectionString(connectionString);
+            ISasTokenProvider sasProvider = iotHubConnectionString.GetSasTokenProvider();
+
+            _endpoint = BuildEndpointUriFromHostName(iotHubConnectionString.HostName);
+
             _clientDiagnostics = new ClientDiagnostics(options);
+
+            options.AddPolicy(new SasTokenAuthenticationPolicy(sasProvider), HttpPipelinePosition.PerCall);
             _httpPipeline = HttpPipelineBuilder.Build(options);
 
-            _registryManagerRestClient  = new RegistryManagerRestClient(_clientDiagnostics, _httpPipeline, endpoint, options.GetVersionString());
+            _registryManagerRestClient = new RegistryManagerRestClient(_clientDiagnostics, _httpPipeline, _endpoint, options.GetVersionString());
             _twinRestClient = new TwinRestClient(_clientDiagnostics, _httpPipeline, null, options.GetVersionString());
-            _deviceMethodRestClient = new DeviceMethodRestClient(_clientDiagnostics, _httpPipeline, endpoint, options.GetVersionString());
+            _deviceMethodRestClient = new DeviceMethodRestClient(_clientDiagnostics, _httpPipeline, _endpoint, options.GetVersionString());
 
             Devices = new DevicesClient(_registryManagerRestClient, _twinRestClient, _deviceMethodRestClient);
             Modules = new ModulesClient(_registryManagerRestClient, _twinRestClient, _deviceMethodRestClient);
@@ -80,6 +105,74 @@ namespace Azure.Iot.Hub.Service
             Messages = new CloudToDeviceMessagesClient();
             Files = new FilesClient();
             Jobs = new JobsClient();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IoTHubServiceClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">
+        /// The IoT Hub service instance URI to connect to.
+        /// </param>
+        /// <param name="credential">
+        /// The <see cref="TokenCredential"/> implementation which will be used to request for the authentication token.
+        /// </param>
+        public IoTHubServiceClient(Uri endpoint, TokenCredential credential)
+            : this(endpoint, credential, new IoTHubServiceClientOptions())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IoTHubServiceClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">
+        /// The IoT Hub service instance URI to connect to.
+        /// </param>
+        /// <param name="credential">
+        /// The <see cref="TokenCredential"/> implementation which will be used to request for the authentication token.
+        /// </param>
+        /// <param name="options">
+        /// Options that allow configuration of requests sent to the IoT Hub service.
+        /// </param>
+        public IoTHubServiceClient(Uri endpoint, TokenCredential credential, IoTHubServiceClientOptions options)
+        {
+            Argument.AssertNotNull(options, nameof(options));
+
+            _endpoint = endpoint;
+            _clientDiagnostics = new ClientDiagnostics(options);
+
+            options.AddPolicy(new BearerTokenAuthenticationPolicy(credential, GetAuthorizationScopes(_endpoint)), HttpPipelinePosition.PerCall);
+            _httpPipeline = HttpPipelineBuilder.Build(options);
+
+            _registryManagerRestClient = new RegistryManagerRestClient(_clientDiagnostics, _httpPipeline, _endpoint, options.GetVersionString());
+            _twinRestClient = new TwinRestClient(_clientDiagnostics, _httpPipeline, null, options.GetVersionString());
+            _deviceMethodRestClient = new DeviceMethodRestClient(_clientDiagnostics, _httpPipeline, _endpoint, options.GetVersionString());
+
+            Devices = new DevicesClient(_registryManagerRestClient, _twinRestClient, _deviceMethodRestClient);
+            Modules = new ModulesClient(_registryManagerRestClient, _twinRestClient, _deviceMethodRestClient);
+
+            Statistics = new StatisticsClient();
+            Messages = new CloudToDeviceMessagesClient();
+            Files = new FilesClient();
+            Jobs = new JobsClient();
+        }
+
+        /// <summary>
+        /// Gets the scope for authentication/authorization policy.
+        /// </summary>
+        /// <param name="endpoint">The IoT Hub service instance Uri.</param>
+        /// <returns>List of scopes for the specified endpoint.</returns>
+        internal static string[] GetAuthorizationScopes(Uri endpoint)
+        {
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
+            Argument.AssertNotNullOrEmpty(endpoint.AbsoluteUri, nameof(endpoint.AbsoluteUri));
+
+            // TODO: GetAuthorizationScopes for IoT Hub
+            return null;
+        }
+
+        private static Uri BuildEndpointUriFromHostName(string hostName)
+        {
+            return new UriBuilder { Scheme = "https", Host = hostName }.Uri;
         }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/Azure.Iot.Hub.Service.Tests.csproj
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/Azure.Iot.Hub.Service.Tests.csproj
@@ -6,14 +6,22 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="nunit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
     <ProjectReference Include="..\src\Azure.Iot.Hub.Service.csproj" />
   </ItemGroup>
+
+  <!-- required by TestFramework.props -->
+  <ItemGroup>
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Castle.Core" />
+  </ItemGroup>
+  
 </Project>

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/Azure.Iot.Hub.Service.Tests.csproj
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/Azure.Iot.Hub.Service.Tests.csproj
@@ -18,6 +18,12 @@
     <ProjectReference Include="..\src\Azure.Iot.Hub.Service.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="config\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <!-- required by TestFramework.props -->
   <ItemGroup>
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/E2eTestBase.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/E2eTestBase.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Iot.Hub.Service.Tests
+{
+    /// <summary>
+    /// This class will initialize all the settings and create and instance of the IoT Hub service client.
+    /// </summary>
+    [Parallelizable(ParallelScope.Self)]
+    public abstract class E2eTestBase : RecordedTestBase<IotHubServiceTestEnvironment>
+    {
+        public E2eTestBase(bool isAsync)
+         : base(isAsync, TestSettings.Instance.TestMode)
+        {
+        }
+
+        public E2eTestBase(bool isAsync, RecordedTestMode testMode)
+           : base(isAsync, testMode)
+        {
+        }
+
+        [SetUp]
+        public virtual void SetupE2eTestBase()
+        {
+            TestDiagnostics = false;
+
+            // TODO: set via client options and pipeline instead
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+        }
+
+        protected IoTHubServiceClient GetClient()
+        {
+            return InstrumentClient(
+                new IoTHubServiceClient(
+                    new Uri(TestEnvironment.IotHubHostname)));
+        }
+
+        protected string GetRandom()
+        {
+            return Recording.GenerateId();
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/E2eTestBase.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/E2eTestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Net;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -36,8 +35,7 @@ namespace Azure.Iot.Hub.Service.Tests
         protected IoTHubServiceClient GetClient()
         {
             return InstrumentClient(
-                new IoTHubServiceClient(
-                    new Uri(TestEnvironment.IotHubHostname)));
+                new IoTHubServiceClient(TestSettings.Instance.IotHubConnectionString));
         }
 
         protected string GetRandom()

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/IotHubServiceTestEnvironment.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/IotHubServiceTestEnvironment.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+
+namespace Azure.Iot.Hub.Service.Tests
+{
+    // This class contains the configurations required to be set to run tests against the CI pipeline.
+    public class IotHubServiceTestEnvironment : TestEnvironment
+    {
+        public IotHubServiceTestEnvironment()
+            : base("iothub")
+        {
+        }
+
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/IotHubServiceTestEnvironment.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/IotHubServiceTestEnvironment.cs
@@ -9,9 +9,8 @@ namespace Azure.Iot.Hub.Service.Tests
     public class IotHubServiceTestEnvironment : TestEnvironment
     {
         public IotHubServiceTestEnvironment()
-            : base("iothub")
+            : base("iot")
         {
         }
-
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/TestSettings.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/TestSettings.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Reflection;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Iot.Hub.Service.Tests
+{
+    /// <summary>
+    /// These are the settings that will be used by the end-to-end tests tests.
+    /// The json files configured in the config will load the settings specific to a user.
+    /// </summary>
+    public class TestSettings
+    {
+        public const string IotHubServiceEnvironmentVariablesPrefix = "IOTHUB";
+
+        // These environment variables are required to be set to run tests against the CI pipeline.
+        // If these environment variables exist in the environment, their values will replace (supersede) config.json values.
+        private static readonly string s_iotHubConnectionString = $"{IotHubServiceEnvironmentVariablesPrefix}_CONNECTION_STRING";
+        private static readonly string s_iotHubServiceTestMode = $"AZURE_IOT_TEST_MODE";
+
+        public static TestSettings Instance { get; private set; }
+
+        public RecordedTestMode TestMode { get; set; }
+
+        /// <summary>
+        /// The working directory of the tests.
+        /// </summary>
+        public string WorkingDirectory { get; private set; }
+
+        /// <summary>
+        /// The IoT Hub instance connection string.
+        /// </summary>
+        public string IotHubConnectionString { get; set; }
+
+        /// <summary>
+        /// The IoT Hub instance hostname.
+        /// </summary>
+        public string IotHubHostName { get; set; }
+
+        static TestSettings()
+        {
+            if (Instance != null)
+            {
+                return;
+            }
+
+            string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            var uri = new UriBuilder(codeBase);
+            string path = Uri.UnescapeDataString(uri.Path);
+            string workingDirectory = Path.GetDirectoryName(path);
+
+            string userName = Environment.UserName;
+
+            // Initialize the settings related to IoT Hub instance and auth
+            var testSettingsConfigBuilder = new ConfigurationBuilder();
+
+            string testSettingsCommonPath = Path.Combine(workingDirectory, "config", "common.config.json");
+            testSettingsConfigBuilder.AddJsonFile(testSettingsCommonPath);
+
+            string testSettingsUserPath = Path.Combine(workingDirectory, "config", $"{userName}.config.json");
+            if (File.Exists(testSettingsUserPath))
+            {
+                testSettingsConfigBuilder.AddJsonFile(testSettingsUserPath);
+            }
+
+            IConfiguration config = testSettingsConfigBuilder.Build();
+
+            // This will set the values from the above config files into the TestSettings Instance.
+            Instance = config.Get<TestSettings>();
+            Instance.WorkingDirectory = workingDirectory;
+
+            // We will override settings if they can be found in the environment variables.
+            OverrideFromEnvVariables();
+        }
+
+        // These environment variables are required to be set to run tests against the CI pipeline.
+        private static void OverrideFromEnvVariables()
+        {
+
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/TestSettings.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/TestSettings.cs
@@ -15,11 +15,12 @@ namespace Azure.Iot.Hub.Service.Tests
     /// </summary>
     public class TestSettings
     {
-        public const string IotHubServiceEnvironmentVariablesPrefix = "IOTHUB";
+        public const string IotHubServiceEnvironmentVariablesPrefix = "IOT";
 
         // These environment variables are required to be set to run tests against the CI pipeline.
         // If these environment variables exist in the environment, their values will replace (supersede) config.json values.
         private static readonly string s_iotHubConnectionString = $"{IotHubServiceEnvironmentVariablesPrefix}_CONNECTION_STRING";
+
         private static readonly string s_iotHubServiceTestMode = $"AZURE_IOT_TEST_MODE";
 
         public static TestSettings Instance { get; private set; }
@@ -37,7 +38,7 @@ namespace Azure.Iot.Hub.Service.Tests
         public string IotHubConnectionString { get; set; }
 
         /// <summary>
-        /// The IoT Hub instance hostname.
+        /// The IoT Hub instance hostName.
         /// </summary>
         public string IotHubHostName { get; set; }
 
@@ -80,7 +81,6 @@ namespace Azure.Iot.Hub.Service.Tests
         // These environment variables are required to be set to run tests against the CI pipeline.
         private static void OverrideFromEnvVariables()
         {
-
         }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/prerequisites/setup.ps1
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/prerequisites/setup.ps1
@@ -115,8 +115,13 @@ Write-Host("Writing user config file - $fileName`n")
 $appSecretJsonEscaped = ConvertTo-Json $appSecret
 $config = @"
 {
+<<<<<<< HEAD
     "IotHubConnectionString": "$iotHubConnectionString",
     "IotHubHostName": "$iotHubHostName",
+=======
+    "IotHubHostName": "$iotHubHostName",
+    "IotHubConnectionString": "$iotHubConnectionString",
+>>>>>>> 0223e524ec... feat(e2e-tests): Add initial setup for E2E tests
     "ApplicationId": "$appId",
     "ClientSecret": $appSecretJsonEscaped,
     "TestMode":  "Live"


### PR DESCRIPTION
- Add implementation for IoT Hub service client authentication via connection string
- Add initial setup required for E2E tests

Used the SDK board recommended [Azure Application Configuration Service SDK](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs) for reference.