### PR TITLE
JsonConverter tests and minor fixes

### DIFF
--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/DateTimeRfc1123JsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/DateTimeRfc1123JsonConverter.cs
@@ -35,14 +35,12 @@ namespace Microsoft.Rest.Serialization
                 //of the resulting DateTime to be DateTimeKind.Utc since that is what the RFC1123 specification implies.
                 //See: http://stackoverflow.com/questions/1201378/how-does-datetime-touniversaltime-work
                 //See: http://stackoverflow.com/questions/16442484/datetime-unspecified-kind
-                DateTime? time = o as DateTime?;
-
-                if (time.HasValue && time.Value.Kind == DateTimeKind.Unspecified)
+                if (o is DateTime time && time.Kind == DateTimeKind.Unspecified)
                 {
-                    time = DateTime.SpecifyKind(time.Value, DateTimeKind.Utc);
+                    return DateTime.SpecifyKind(time, DateTimeKind.Utc);
                 }
 
-                return time;
+                return o;
             }
             catch (FormatException ex)
             {

--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Rest.Serialization
 {
     public class UnixTimeJsonConverter : JsonConverter
     {
+        private const long UnixEpochSeconds = 62135596800;
+
         public static readonly DateTime EpochDate = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         /// <summary>
@@ -18,7 +20,11 @@ namespace Microsoft.Rest.Serialization
         /// <returns>Number of seconds since the Unix epoch.</returns>
         private static long ToUnixTime(DateTime dateTime)
         {
-            return (long)dateTime.Subtract(EpochDate).TotalSeconds;
+            // Note: Divide first to round toward 0001-01-01, rather than
+            // toward the Unix epoch, to match DateTimeOffset.ToUnixTimeSeconds
+            // https://github.com/dotnet/runtime/blob/v5.0.0-preview.5.20278.1/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs#L583-L603
+            long seconds = dateTime.Ticks / TimeSpan.TicksPerSecond;
+            return seconds - UnixEpochSeconds;
         }
 
         /// <summary>

--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Rest.Serialization
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            if (objectType != typeof(DateTime?))
+            if (objectType != typeof(DateTime?) && objectType != typeof(DateTime))
             {
                 return serializer.Deserialize(reader, objectType);
             }

--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
@@ -12,20 +12,21 @@ namespace Microsoft.Rest.Serialization
         public static readonly DateTime EpochDate = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         /// <summary>
-        /// Converts a byte array to a Base64Url encoded string
+        /// Converts a <see cref="DateTime"/> to Unix time in seconds.
         /// </summary>
-        /// <param name="input">The byte array to convert</param>
-        /// <returns>The Base64Url encoded form of the input</returns>
+        /// <param name="dateTime">Date to convert.</param>
+        /// <returns>Number of seconds since the Unix epoch.</returns>
         private static long ToUnixTime(DateTime dateTime)
         {
             return (long)dateTime.Subtract(EpochDate).TotalSeconds;
         }
 
         /// <summary>
-        /// Converts a Base64Url encoded string to a byte array
+        /// Converts a Unix time in seconds to a <see cref="DateTime"/>.
         /// </summary>
-        /// <param name="input">The Base64Url encoded string</param>
-        /// <returns>The byte array represented by the enconded string</returns>
+        /// <param name="seconds">Number of seconds since the Unix epoch.</param>
+        /// <returns>UTC <see cref="DateTime"/> <paramref name="seconds"/> since
+        /// the Unix epoch.</returns>
         private static DateTime FromUnixTime(long seconds)
         {
             return EpochDate.AddSeconds(seconds);

--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/UnixTimeJsonConverter.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Rest.Serialization
         /// </summary>
         /// <param name="input">The byte array to convert</param>
         /// <returns>The Base64Url encoded form of the input</returns>
-        private static long? ToUnixTime(DateTime dateTime)
+        private static long ToUnixTime(DateTime dateTime)
         {
-            return (long?)dateTime.Subtract(EpochDate).TotalSeconds;
+            return (long)dateTime.Subtract(EpochDate).TotalSeconds;
         }
 
         /// <summary>
@@ -26,13 +26,9 @@ namespace Microsoft.Rest.Serialization
         /// </summary>
         /// <param name="input">The Base64Url encoded string</param>
         /// <returns>The byte array represented by the enconded string</returns>
-        private static DateTime? FromUnixTime(long? seconds)
+        private static DateTime FromUnixTime(long seconds)
         {
-            if (seconds.HasValue)
-            {
-                return EpochDate.AddSeconds(seconds.Value);
-            }
-            return null;
+            return EpochDate.AddSeconds(seconds);
         }
 
         public override bool CanConvert(Type objectType)
@@ -55,7 +51,7 @@ namespace Microsoft.Rest.Serialization
 
                 if (value.HasValue)
                 {
-                    return FromUnixTime(value);
+                    return FromUnixTime(value.Value);
                 }
             }
 

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/Base64UrlJsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/Base64UrlJsonConverterTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    public class Base64UrlJsonConverterTests
+    {
+        // Test vector which incorporates both URL-safe characters and padding
+        private const string TestBase64NoPad = "MTA-MTE_Cg";
+        private const string TestBase64Pad = "MTA-MTE_Cg==";
+        private readonly byte[] TestBytes =
+            new byte[] { 0x31, 0x30, 0x3e, 0x31, 0x31, 0x3f, 0x0a };
+
+        [Fact]
+        public void CanSerialize()
+        {
+            var holder = new Base64UrlData
+            {
+                Data = TestBytes,
+            };
+            var serializedJson = JsonConvert.SerializeObject(holder);
+            var expectedJson = "{\"Data\":\"" + TestBase64NoPad + "\"}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: Currently handled internally by JSON.NET:
+        // https://github.com/JamesNK/Newtonsoft.Json/issues/1639
+        [Fact]
+        public void CanSerializeNull()
+        {
+            var holder = new Base64UrlData();
+            var serializeSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Include,
+            };
+            var serializedJson = JsonConvert.SerializeObject(holder, serializeSettings);
+            var expectedJson = "{\"Data\":null}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanDeserialize()
+        {
+            var json = "{\"Data\":\"" + TestBase64NoPad + "\"}";
+            var holder = JsonConvert.DeserializeObject<Base64UrlData>(json);
+            Assert.Equal(TestBytes, holder.Data);
+        }
+
+        [Fact]
+        public void CanDeserializeNull()
+        {
+            var json = "{\"Data\":null}";
+            var holder = JsonConvert.DeserializeObject<Base64UrlData>(json);
+            Assert.Null(holder.Data);
+        }
+
+        [Fact]
+        public void CanDeserializePadded()
+        {
+            var json = "{\"Data\":\"" + TestBase64Pad + "\"}";
+            var holder = JsonConvert.DeserializeObject<Base64UrlData>(json);
+            Assert.Equal(TestBytes, holder.Data);
+        }
+
+        [Fact]
+        public void CanDeserializeNonUrlSafe()
+        {
+            var base64 = TestBase64NoPad.Replace('-', '+').Replace('_', '/');
+            var json = "{\"Data\":\"" + base64 + "\"}";
+            var holder = JsonConvert.DeserializeObject<Base64UrlData>(json);
+            Assert.Equal(TestBytes, holder.Data);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeEmptyAsNull()
+        {
+            var json = "{\"Data\":\"\"}";
+            var holder = JsonConvert.DeserializeObject<Base64UrlData>(json);
+            Assert.Null(holder.Data);
+        }
+
+        [Fact]
+        public void DeserializeThrowsForExtraPadding()
+        {
+            var json = "{\"Data\":\"" + TestBase64NoPad + "===\"}";
+            Assert.Throws<FormatException>(() => JsonConvert.DeserializeObject<Base64UrlData>(json));
+        }
+
+        [Fact]
+        public void DeserializeThrowsForInvalidChar()
+        {
+            var json = "{\"Data\":\"NotBase#64\"}";
+            Assert.Throws<FormatException>(() => JsonConvert.DeserializeObject<Base64UrlData>(json));
+        }
+
+        private class Base64UrlData
+        {
+            [JsonConverter(typeof(Base64UrlJsonConverter))]
+            public byte[] Data { get; set; }
+        }
+    }
+}

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/DateJsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/DateJsonConverterTests.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    public class DateJsonConverterTests
+    {
+        [Fact]
+        public void CanSerializeLocal()
+        {
+            var date = new DateTime(2020, 2, 29, 0, 0, 0, DateTimeKind.Local);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            var expectedJson = @"{
+  ""dt"": ""2020-02-29"",
+  ""dtn"": ""2020-02-29"",
+  ""dto"": ""2020-02-29"",
+  ""dton"": ""2020-02-29""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanSerializeUnspecified()
+        {
+            var date = new DateTime(2020, 2, 29);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            var expectedJson = @"{
+  ""dt"": ""2020-02-29"",
+  ""dtn"": ""2020-02-29"",
+  ""dto"": ""2020-02-29"",
+  ""dton"": ""2020-02-29""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanSerializeUtc()
+        {
+            var date = new DateTime(2020, 2, 29, 0, 0, 0, DateTimeKind.Utc);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            var expectedJson = @"{
+  ""dt"": ""2020-02-29"",
+  ""dtn"": ""2020-02-29"",
+  ""dto"": ""2020-02-29"",
+  ""dton"": ""2020-02-29""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: Currently handled internally by JSON.NET:
+        // https://github.com/JamesNK/Newtonsoft.Json/issues/1639
+        [Fact]
+        public void CanSerializeNull()
+        {
+            var dates = new DateData();
+            var serializeSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Include,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented, serializeSettings);
+            var expectedJson = @"{
+  ""dt"": ""0001-01-01"",
+  ""dtn"": null,
+  ""dto"": ""0001-01-01"",
+  ""dton"": null
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void SerializeRemovesTime()
+        {
+            var date = new DateTime(2020, 2, 29, 12, 30, 30, 500);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            var expectedJson = @"{
+  ""dt"": ""2020-02-29"",
+  ""dtn"": ""2020-02-29"",
+  ""dto"": ""2020-02-29"",
+  ""dton"": ""2020-02-29""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanDeserialize()
+        {
+            var json = @"{
+  ""dt"": ""2020-02-29"",
+  ""dtn"": ""2020-02-29"",
+  ""dto"": ""2020-02-29"",
+  ""dton"": ""2020-02-29""
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime(2020, 2, 29);
+            var dateOffset = new DateTimeOffset(date);
+            Assert.Equal(date, dates.DateTime);
+            Assert.Equal(date, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
+        }
+
+        [Fact]
+        public void CanDeserializeNull()
+        {
+            var json = @"{
+  ""dtn"": null,
+  ""dton"": null
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime();
+            var dateOffset = new DateTimeOffset();
+            Assert.Equal(date, dates.DateTime);
+            Assert.Null(dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializePreservesTime()
+        {
+            var json = @"{
+  ""dt"": ""2020-02-29T12:30:30.5"",
+  ""dtn"": ""2020-02-29T12:30:30.5"",
+  ""dto"": ""2020-02-29T12:30:30.5"",
+  ""dton"": ""2020-02-29T12:30:30.5""
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime(2020, 2, 29, 12, 30, 30, 500);
+            var dateOffset = new DateTimeOffset(date);
+            Assert.Equal(date, dates.DateTime);
+            Assert.Equal(date, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializePreservesTimeUtc()
+        {
+            var json = @"{
+  ""dt"": ""2020-02-29T12:30:30.5Z"",
+  ""dtn"": ""2020-02-29T12:30:30.5Z"",
+  ""dto"": ""2020-02-29T12:30:30.5Z"",
+  ""dton"": ""2020-02-29T12:30:30.5Z""
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime(2020, 2, 29, 12, 30, 30, 500, DateTimeKind.Utc);
+            var dateOffset = new DateTimeOffset(date);
+            Assert.Equal(date, dates.DateTime);
+            Assert.Equal(date, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
+        }
+
+        [Fact]
+        public void DeserializeThrowsForEmptyNonNullable()
+        {
+            var json = "{\"dt\":\"\"}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        [Fact]
+        public void CanDeserializeEmptyAsNull()
+        {
+            var json = @"{
+  ""dtn"": """",
+  ""dton"": """"
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime();
+            var dateOffset = new DateTimeOffset();
+            Assert.Equal(date, dates.DateTime);
+            Assert.Null(dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
+        }
+
+        [Fact]
+        public void DeserializeThrowsForInvalidDate()
+        {
+            var json = "{\"dt\":\"invalid\"}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        private class DateData
+        {
+            [JsonConverter(typeof(DateJsonConverter))]
+            [JsonProperty("dt")]
+            public DateTime DateTime { get; set; }
+
+            [JsonConverter(typeof(DateJsonConverter))]
+            [JsonProperty("dtn")]
+            public DateTime? DateTimeNullable { get; set; }
+
+            [JsonProperty("dto")]
+            [JsonConverter(typeof(DateJsonConverter))]
+            public DateTimeOffset DateTimeOffset { get; set; }
+
+            [JsonProperty("dton")]
+            [JsonConverter(typeof(DateJsonConverter))]
+            public DateTimeOffset? DateTimeOffsetNullable { get; set; }
+        }
+    }
+}

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/DateTimeRfc1123JsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/DateTimeRfc1123JsonConverterTests.cs
@@ -1,0 +1,262 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    public class DateTimeRfc1123JsonConverterTests
+    {
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void CanSerializeLocal()
+        {
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, 500, DateTimeKind.Local);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            // Note: Time of DateTimeOffset is converted to UTC, DateTime is not.
+            var dateStrGmt = date.ToUniversalTime().ToString("R");
+            var expectedJson = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dto"": """ + dateStrGmt + @""",
+  ""dton"": """ + dateStrGmt + @"""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanSerializeUnspecified()
+        {
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, 500);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            // Note: Time of DateTimeOffset is converted to UTC, DateTime is not.
+            var dateStrGmt = date.ToUniversalTime().ToString("R");
+            var expectedJson = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dto"": """ + dateStrGmt + @""",
+  ""dton"": """ + dateStrGmt + @"""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanSerializeUtc()
+        {
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, 500, DateTimeKind.Utc);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            var expectedJson = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dto"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dton"": ""Sat, 29 Feb 2020 08:05:04 GMT""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: Currently handled internally by JSON.NET:
+        // https://github.com/JamesNK/Newtonsoft.Json/issues/1639
+        [Fact]
+        public void CanSerializeNull()
+        {
+            var dates = new DateData();
+            var serializeSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Include,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented, serializeSettings);
+            var expectedJson = @"{
+  ""dt"": ""Mon, 01 Jan 0001 00:00:00 GMT"",
+  ""dtn"": null,
+  ""dto"": ""Mon, 01 Jan 0001 00:00:00 GMT"",
+  ""dton"": null
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void CanDeserialize()
+        {
+            var json = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dto"": ""Sat, 29 Feb 2020 08:05:04 GMT"",
+  ""dton"": ""Sat, 29 Feb 2020 08:05:04 GMT""
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, DateTimeKind.Utc);
+            var dateOffset = new DateTimeOffset();
+            Assert.Equal(date, dates.DateTime);
+            Assert.Equal(date, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
+        }
+
+        [Fact]
+        public void CanDeserializeNull()
+        {
+            var json = @"{
+  ""dtn"": null,
+  ""dton"": null
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime();
+            var dateOffset = new DateTimeOffset();
+            Assert.Equal(date, dates.DateTime);
+            Assert.Null(dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeThrowsIfNoDow()
+        {
+            var json = @"{
+  ""dt"": ""29 Feb 2020 08:05:04 GMT"",
+  ""dtn"": ""29 Feb 2020 08:05:04 GMT"",
+  ""dto"": ""29 Feb 2020 08:05:04 GMT"",
+  ""dton"": ""29 Feb 2020 08:05:04 GMT""
+}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeThrowsIfNoSeconds()
+        {
+            var json = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05 GMT"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05 GMT"",
+  ""dto"": ""Sat, 29 Feb 2020 08:05 GMT"",
+  ""dton"": ""Sat, 29 Feb 2020 08:05 GMT""
+}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeThrowsIfUt()
+        {
+            var json = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 UT"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 UT"",
+  ""dto"": ""Sat, 29 Feb 2020 08:05:04 UT"",
+  ""dton"": ""Sat, 29 Feb 2020 08:05:04 UT""
+}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeThrowsIfPst()
+        {
+            var json = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 PST"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 PST"",
+  ""dto"": ""Sat, 29 Feb 2020 08:05:04 PST"",
+  ""dton"": ""Sat, 29 Feb 2020 08:05:04 PST""
+}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeThrowsIfTzOffset()
+        {
+            var json = @"{
+  ""dt"": ""Sat, 29 Feb 2020 08:05:04 +0700"",
+  ""dtn"": ""Sat, 29 Feb 2020 08:05:04 +0700"",
+  ""dto"": ""Sat, 29 Feb 2020 08:05:04 +0700"",
+  ""dton"": ""Sat, 29 Feb 2020 08:05:04 +0700""
+}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        [Fact]
+        public void DeserializeThrowsForEmptyNonNullable()
+        {
+            var json = "{\"dt\":\"\"}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        [Fact]
+        public void CanDeserializeEmptyAsNull()
+        {
+            var json = @"{
+  ""dtn"": """",
+  ""dton"": """"
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = new DateTime();
+            var dateOffset = new DateTimeOffset();
+            Assert.Equal(date, dates.DateTime);
+            Assert.Null(dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
+        }
+
+        [Fact]
+        public void DeserializeThrowsForInvalidDate()
+        {
+            var json = "{\"dt\":\"invalid\"}";
+            Assert.Throws<JsonException>(() => JsonConvert.DeserializeObject<DateData>(json));
+        }
+
+        private class DateData
+        {
+            [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+            [JsonProperty("dt")]
+            public DateTime DateTime { get; set; }
+
+            [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+            [JsonProperty("dtn")]
+            public DateTime? DateTimeNullable { get; set; }
+
+            [JsonProperty("dto")]
+            [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+            public DateTimeOffset DateTimeOffset { get; set; }
+
+            [JsonProperty("dton")]
+            [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+            public DateTimeOffset? DateTimeOffsetNullable { get; set; }
+        }
+    }
+}

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/DateTimeRfc1123JsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/DateTimeRfc1123JsonConverterTests.cs
@@ -104,8 +104,6 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
             Assert.Equal(expectedJson, serializedJson);
         }
 
-        // Note: The test author makes no statement about whether this behavior
-        // is correct/desirable.  This test demonstrates current behavior.
         [Fact]
         public void CanDeserialize()
         {
@@ -117,11 +115,11 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
 }";
             var dates = JsonConvert.DeserializeObject<DateData>(json);
             var date = new DateTime(2020, 2, 29, 8, 5, 4, DateTimeKind.Utc);
-            var dateOffset = new DateTimeOffset();
+            var dateOffset = new DateTimeOffset(date);
             Assert.Equal(date, dates.DateTime);
             Assert.Equal(date, dates.DateTimeNullable);
             Assert.Equal(dateOffset, dates.DateTimeOffset);
-            Assert.Null(dates.DateTimeOffsetNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
         }
 
         [Fact]

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/Iso8601TimeSpanConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/Iso8601TimeSpanConverterTests.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    public class Iso8601TimeSpanConverterTests
+    {
+        [Fact]
+        public void CanSerialize()
+        {
+            var time = new TimeSpan(1, 1, 1, 1, 1);
+            var times = new TimeData
+            {
+                TimeSpan = time,
+                TimeSpanNullable = time,
+            };
+            var serializedJson = JsonConvert.SerializeObject(times, Formatting.Indented);
+            var expectedJson = @"{
+  ""ts"": ""P1DT1H1M1.001S"",
+  ""tsn"": ""P1DT1H1M1.001S""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanSerializeManyDays()
+        {
+            var time = TimeSpan.FromDays(396);
+            var times = new TimeData
+            {
+                TimeSpan = time,
+                TimeSpanNullable = time,
+            };
+            var serializedJson = JsonConvert.SerializeObject(times, Formatting.Indented);
+            // Note: Does not use Year, Month, or Week periods
+            var expectedJson = @"{
+  ""ts"": ""P396D"",
+  ""tsn"": ""P396D""
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: Currently handled internally by JSON.NET:
+        // https://github.com/JamesNK/Newtonsoft.Json/issues/1639
+        [Fact]
+        public void CanSerializeNull()
+        {
+            var times = new TimeData();
+            var serializeSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Include,
+            };
+            var serializedJson = JsonConvert.SerializeObject(times, Formatting.Indented, serializeSettings);
+            var expectedJson = @"{
+  ""ts"": ""PT0S"",
+  ""tsn"": null
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanDeserialize()
+        {
+            var json = @"{
+  ""ts"": ""P1DT1H1M1.001S"",
+  ""tsn"": ""P1DT1H1M1.001S""
+}";
+            var times = JsonConvert.DeserializeObject<TimeData>(json);
+            var time = new TimeSpan(1, 1, 1, 1, 1);
+            Assert.Equal(time, times.TimeSpan);
+            Assert.Equal(time, times.TimeSpanNullable);
+        }
+
+        [Fact]
+        public void CanDeserializeManyHours()
+        {
+            var json = @"{
+  ""ts"": ""PT36H"",
+  ""tsn"": ""PT36H""
+}";
+            var times = JsonConvert.DeserializeObject<TimeData>(json);
+            var time = TimeSpan.FromHours(36);
+            Assert.Equal(time, times.TimeSpan);
+            Assert.Equal(time, times.TimeSpanNullable);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeThrowsForWeek()
+        {
+            var json = @"{
+  ""ts"": ""P1W""
+}";
+            Assert.Throws<FormatException>(() => JsonConvert.DeserializeObject<TimeData>(json));
+        }
+
+        [Fact]
+        public void CanDeserializeYearMonth()
+        {
+            var json = @"{
+  ""ts"": ""P1Y1M"",
+  ""tsn"": ""P1Y1M""
+}";
+            var times = JsonConvert.DeserializeObject<TimeData>(json);
+            var now = DateTime.Now;
+            var time = now.AddYears(1).AddMonths(1) - now;
+            Assert.Equal(time, times.TimeSpan);
+            Assert.Equal(time, times.TimeSpanNullable);
+        }
+
+        [Fact]
+        public void CanDeserializeNull()
+        {
+            var json = @"{
+  ""tsn"": null
+}";
+            var times = JsonConvert.DeserializeObject<TimeData>(json);
+            var time = new TimeSpan();
+            Assert.Equal(time, times.TimeSpan);
+            Assert.Null(times.TimeSpanNullable);
+        }
+
+        [Fact]
+        public void DeserializeThrowsForEmptyNonNullable()
+        {
+            var json = @"{
+  ""ts"": """"
+}";
+            Assert.Throws<FormatException>(() => JsonConvert.DeserializeObject<TimeData>(json));
+        }
+
+        [Fact]
+        public void DeserializeThrowsForEmptyNullable()
+        {
+            var json = @"{
+  ""tsn"": """"
+}";
+            Assert.Throws<FormatException>(() => JsonConvert.DeserializeObject<TimeData>(json));
+        }
+
+        [Fact]
+        public void DeserializeThrowsForInvalid()
+        {
+            var json = "{\"ts\":\"invalid\"}";
+            Assert.Throws<FormatException>(() => JsonConvert.DeserializeObject<TimeData>(json));
+        }
+
+        private class TimeData
+        {
+            [JsonConverter(typeof(Iso8601TimeSpanConverter))]
+            [JsonProperty("ts")]
+            public TimeSpan TimeSpan { get; set; }
+
+            [JsonConverter(typeof(Iso8601TimeSpanConverter))]
+            [JsonProperty("tsn")]
+            public TimeSpan? TimeSpanNullable { get; set; }
+        }
+    }
+}

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/UnixTimeJsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/UnixTimeJsonConverterTests.cs
@@ -27,16 +27,23 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         public void CanSerializeLocal()
         {
             var date = new DateTime(2020, 2, 29, 8, 5, 4, 600, DateTimeKind.Local);
+            var dateOffset = new DateTimeOffset(date);
             var dates = new DateData
             {
                 DateTime = date,
                 DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
             };
             var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
             // DateTime is seconds since midnight 1970-01-01 local time, rounded down
+            // DateTimeOffset is seconds since midnight 1970-01-01 UTC, rounded down
+            var dateOffsetUnix = ToUnixTime(dateOffset.UtcDateTime);
             var expectedJson = @"{
   ""dt"": 1582963504,
-  ""dtn"": 1582963504
+  ""dtn"": 1582963504,
+  ""dto"": " + dateOffsetUnix + @",
+  ""dton"": " + dateOffsetUnix + @"
 }";
             Assert.Equal(expectedJson, serializedJson);
         }
@@ -47,16 +54,23 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         public void CanSerializeUnspecified()
         {
             var date = new DateTime(2020, 2, 29, 8, 5, 4, 600);
+            var dateOffset = new DateTimeOffset(date);
             var dates = new DateData
             {
                 DateTime = date,
                 DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
             };
             var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
             // DateTime is seconds since midnight 1970-01-01 ignoring tz, rounded down
+            // DateTimeOffset is seconds since midnight 1970-01-01 UTC, rounded down
+            var dateOffsetUnix = ToUnixTime(dateOffset.UtcDateTime);
             var expectedJson = @"{
   ""dt"": 1582963504,
-  ""dtn"": 1582963504
+  ""dtn"": 1582963504,
+  ""dto"": " + dateOffsetUnix + @",
+  ""dton"": " + dateOffsetUnix + @"
 }";
             Assert.Equal(expectedJson, serializedJson);
         }
@@ -65,16 +79,21 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         public void CanSerializeUtc()
         {
             var date = new DateTime(2020, 2, 29, 8, 5, 4, 600, DateTimeKind.Utc);
+            var dateOffset = new DateTimeOffset(date);
             var dates = new DateData
             {
                 DateTime = date,
                 DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
             };
             var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
             // Seconds since midnight 1970-01-01 UTC, rounded down
             var expectedJson = @"{
   ""dt"": 1582963504,
-  ""dtn"": 1582963504
+  ""dtn"": 1582963504,
+  ""dto"": 1582963504,
+  ""dton"": 1582963504
 }";
             Assert.Equal(expectedJson, serializedJson);
         }
@@ -92,7 +111,9 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
             var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented, serializeSettings);
             var expectedJson = @"{
   ""dt"": -62135596800,
-  ""dtn"": null
+  ""dtn"": null,
+  ""dto"": -62135596800,
+  ""dton"": null
 }";
             Assert.Equal(expectedJson, serializedJson);
         }
@@ -102,24 +123,32 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         {
             var json = @"{
   ""dt"": 0,
-  ""dtn"": 0
+  ""dtn"": 0,
+  ""dto"": 0,
+  ""dton"": 0
 }";
             var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var dateOffset = new DateTimeOffset(UnixTimeJsonConverter.EpochDate);
             Assert.Equal(UnixTimeJsonConverter.EpochDate, dates.DateTime);
             Assert.Equal(UnixTimeJsonConverter.EpochDate, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
         }
 
         [Fact]
         public void CanDeserializeNull()
         {
             var json = @"{
-  ""dtn"": null
+  ""dtn"": null,
+  ""dton"": null
 }";
             var dates = JsonConvert.DeserializeObject<DateData>(json);
             var date = new DateTime();
             var dateOffset = new DateTimeOffset();
             Assert.Equal(date, dates.DateTime);
             Assert.Null(dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
         }
 
         [Fact]
@@ -127,11 +156,16 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         {
             var json = @"{
   ""dt"": ""0"",
-  ""dtn"": ""0""
+  ""dtn"": ""0"",
+  ""dto"": ""0"",
+  ""dton"": ""0""
 }";
             var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var dateOffset = new DateTimeOffset(UnixTimeJsonConverter.EpochDate);
             Assert.Equal(UnixTimeJsonConverter.EpochDate, dates.DateTime);
             Assert.Equal(UnixTimeJsonConverter.EpochDate, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
         }
 
         // Note: The test author makes no statement about whether this behavior
@@ -141,11 +175,15 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         {
             var json = @"{
   ""dt"": """",
-  ""dtn"": """"
+  ""dtn"": """",
+  ""dto"": """",
+  ""dton"": """"
 }";
             var dates = JsonConvert.DeserializeObject<DateData>(json);
             Assert.Equal(new DateTime(), dates.DateTime);
             Assert.Null(dates.DateTimeNullable);
+            Assert.Equal(new DateTimeOffset(), dates.DateTimeOffset);
+            Assert.Null(dates.DateTimeOffsetNullable);
         }
 
         // Note: The test author makes no statement about whether this behavior
@@ -155,13 +193,17 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
         {
             var json = @"{
   ""dt"": 86400.9,
-  ""dtn"": 86400.9
+  ""dtn"": 86400.9,
+  ""dto"": 86400.9,
+  ""dton"": 86400.9
 }";
             var dates = JsonConvert.DeserializeObject<DateData>(json);
             var date = UnixTimeJsonConverter.EpochDate.AddDays(1).AddSeconds(1);
             var dateOffset = new DateTimeOffset(date);
             Assert.Equal(date, dates.DateTime);
             Assert.Equal(date, dates.DateTimeNullable);
+            Assert.Equal(dateOffset, dates.DateTimeOffset);
+            Assert.Equal(dateOffset, dates.DateTimeOffsetNullable);
         }
 
         [Fact]
@@ -180,6 +222,14 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
             [JsonConverter(typeof(UnixTimeJsonConverter))]
             [JsonProperty("dtn")]
             public DateTime? DateTimeNullable { get; set; }
+
+            [JsonProperty("dto")]
+            [JsonConverter(typeof(UnixTimeJsonConverter))]
+            public DateTimeOffset DateTimeOffset { get; set; }
+
+            [JsonProperty("dton")]
+            [JsonConverter(typeof(UnixTimeJsonConverter))]
+            public DateTimeOffset? DateTimeOffsetNullable { get; set; }
         }
     }
 }

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/UnixTimeJsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/UnixTimeJsonConverterTests.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
+{
+    public class UnixTimeJsonConverterTests
+    {
+        private static long ToUnixTime(DateTime dateTime)
+        {
+            // Copied from DateTimeOffset.ToUnixTimeSeconds for .NET < 4.6
+            // https://github.com/dotnet/runtime/blob/v5.0.0-preview.5.20278.1/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs#L583-L603
+            const long UnixEpochSeconds = 62135596800;
+            long seconds = dateTime.Ticks / TimeSpan.TicksPerSecond;
+            return seconds - UnixEpochSeconds;
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void CanSerializeLocal()
+        {
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, 600, DateTimeKind.Local);
+            var dates = new DateData
+            {
+                DateTimeNullable = date,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            // DateTime is seconds since midnight 1970-01-01 local time, rounded down
+            var expectedJson = @"{
+  ""dtn"": 1582963504
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void CanSerializeUnspecified()
+        {
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, 600);
+            var dates = new DateData
+            {
+                DateTimeNullable = date,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            // DateTime is seconds since midnight 1970-01-01 ignoring tz, rounded down
+            var expectedJson = @"{
+  ""dtn"": 1582963504
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanSerializeUtc()
+        {
+            var date = new DateTime(2020, 2, 29, 8, 5, 4, 600, DateTimeKind.Utc);
+            var dates = new DateData
+            {
+                DateTimeNullable = date,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            // Seconds since midnight 1970-01-01 UTC, rounded down
+            var expectedJson = @"{
+  ""dtn"": 1582963504
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        // Note: Currently handled internally by JSON.NET:
+        // https://github.com/JamesNK/Newtonsoft.Json/issues/1639
+        [Fact]
+        public void CanSerializeNull()
+        {
+            var dates = new DateData();
+            var serializeSettings = new JsonSerializerSettings()
+            {
+                NullValueHandling = NullValueHandling.Include,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented, serializeSettings);
+            var expectedJson = @"{
+  ""dtn"": null
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
+        [Fact]
+        public void CanDeserialize()
+        {
+            var json = @"{
+  ""dtn"": 0
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            Assert.Equal(UnixTimeJsonConverter.EpochDate, dates.DateTimeNullable);
+        }
+
+        [Fact]
+        public void CanDeserializeNull()
+        {
+            var json = @"{
+  ""dtn"": null
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            Assert.Null(dates.DateTimeNullable);
+        }
+
+        [Fact]
+        public void CanDeserializeString()
+        {
+            var json = @"{
+  ""dtn"": ""0""
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            Assert.Equal(UnixTimeJsonConverter.EpochDate, dates.DateTimeNullable);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void CanDeserializeEmptyString()
+        {
+            var json = @"{
+  ""dtn"": """"
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            Assert.Null(dates.DateTimeNullable);
+        }
+
+        // Note: The test author makes no statement about whether this behavior
+        // is correct/desirable.  This test demonstrates current behavior.
+        [Fact]
+        public void DeserializeRoundsToSecond()
+        {
+            var json = @"{
+  ""dtn"": 86400.9
+}";
+            var dates = JsonConvert.DeserializeObject<DateData>(json);
+            var date = UnixTimeJsonConverter.EpochDate.AddDays(1).AddSeconds(1);
+            Assert.Equal(date, dates.DateTimeNullable);
+        }
+
+        private class DateData
+        {
+            [JsonConverter(typeof(UnixTimeJsonConverter))]
+            [JsonProperty("dtn")]
+            public DateTime? DateTimeNullable { get; set; }
+        }
+    }
+}

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/UnixTimeJsonConverterTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Serialization/UnixTimeJsonConverterTests.cs
@@ -98,6 +98,29 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Serialization
             Assert.Equal(expectedJson, serializedJson);
         }
 
+        [Fact]
+        public void CanSerializeNegative()
+        {
+            var date = new DateTime(1950, 3, 1, 8, 5, 4, 400, DateTimeKind.Utc);
+            var dateOffset = new DateTimeOffset(date);
+            var dates = new DateData
+            {
+                DateTime = date,
+                DateTimeNullable = date,
+                DateTimeOffset = dateOffset,
+                DateTimeOffsetNullable = dateOffset,
+            };
+            var serializedJson = JsonConvert.SerializeObject(dates, Formatting.Indented);
+            // Seconds since midnight 1970-01-01 ignoring zone, rounded down (away from 0)
+            var expectedJson = @"{
+  ""dt"": -626025296,
+  ""dtn"": -626025296,
+  ""dto"": -626025296,
+  ""dton"": -626025296
+}";
+            Assert.Equal(expectedJson, serializedJson);
+        }
+
         // Note: Currently handled internally by JSON.NET:
         // https://github.com/JamesNK/Newtonsoft.Json/issues/1639
         [Fact]


### PR DESCRIPTION
While working on #12493, I noticed some brokenness in `UnixTimeJsonConverter` and realized that several of the converters lacked tests.  This PR adds some.  The tests are intended to document current behavior, rather than specify intended behavior (since I'm not sure which behavior is intended).  Comments note cases that seemed likely to be unintentional.

This PR also includes commits which fix a few issues I thought would be uncontroversial:

- [x] `DateTimeRfc1123JsonConverter` support deserializing `DateTimeOffset` and `DateTimeOffset?`
- [x] `UnixTimeJsonConverter` support serializing and deserializing `DateTime`, `DateTimeOffset`, and `DateTimeOffset?`.
- [x] `UnixTimeJsonConverter` round negative values away from 0 (toward 0001-01-01) as done by `DateTimeOffset.ToUnixTimeSeconds`.

If any of the above are controversial, I can easily move the commits to separate PRs.

Some potential issues which I noticed and did not address, but would be willing to do so:

- [ ] `Base64UrlJsonConverter` deserializes the empty string as `null` rather than an empty array.
- [ ] `DateTimeRfc1123JsonConverter` serializes `DateTimeKind.Local` as GMT without conversion (e.g. 8:00 AM local time is serialized as "08:00:00 GMT").
- [ ] `DateTimeRfc1123JsonConverter` can not deserialize time zones other than "GMT".
- [ ] `DateTimeRfc1123JsonConverter` can not deserialize dates with missing day of week or missing seconds (both optional in RFC 1123).
- [ ] `Iso8601TimeSpanConverter` does not support weeks.
- [ ] `UnixTimeJsonConverter` rounds non-integer values to whole seconds during deserialization.
- [ ] Inconsistent deserialization exceptions:
  `Base64UrlJsonConverter` throws `FormatException`
  `DateJsonConverter` throws `JsonException`
  `DateTimeRfc1123JsonConverter` throws `JsonException`
  `Iso8601TimeSpanConverter` throws `FormatException`
  `UnixTimeJsonConverter` throws `JsonSerializationException`
  For reference, JSON.NET typically throws `JsonSerializationException` for type mismatches and `FormatException` for string value parsing errors.
- [ ] Inconsistent treatment of the empty string:
  `DateJsonConverter` deserializes as `null`, throws for non-nullable types
  `DateTimeRfc1123JsonConverter` deserializes as `null`, throws for non-nullable types
  `Iso8601TimeSpanConverter` throws for nullable and non-nullable types
  `UnixTimeJsonConverter` deserializes as 1970-01-01 for nullable and non-nullable types

Thanks for considering,
Kevin

P.S. `UnixTimeJsonConverter.EpochDate` is no longer used, but is left as-is to preserve the current API.  Should it be marked as deprecated?