### PR TITLE
Binary data API changes

### DIFF
--- a/sdk/core/Azure.Core.Experimental/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Experimental/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.1.0-preview.2 (Unreleased)
 
+### Breaking Changes
+- `BinaryData`: Renamed `AsString` to `ToString`.
+- `BinaryData`: Replaced `Create(string)` with constructor taking string.
+- `BinaryData`: Renamed `Create(Stream)`/`CreateAsync(Stream)` to `FromStream`/`FromStreamAsync`.
+- `BinaryData`: Renamed `Create<T>`/`CreateAsync<T>` to `FromSerializable<T>`/`FromSerializableAsync<T>`.
+- `BinaryData`: Renamed `As<T>`/`AsAsync<T>` to `Deserialize<T>`/`DeserializeAsync<T>`.
 
 ## 0.1.0-preview.1 (2020-06-04)
 

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -6,23 +6,23 @@ namespace Azure.Core
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public BinaryData(System.ReadOnlyMemory<byte> data) { throw null; }
-        public System.Threading.Tasks.ValueTask<T> AsAsync<T>(Azure.Core.ObjectSerializer serializer) { throw null; }
+        public BinaryData(string data) { throw null; }
+        public BinaryData(string data, System.Text.Encoding encoding) { throw null; }
         public System.ReadOnlyMemory<byte> AsBytes() { throw null; }
-        public System.IO.Stream AsStream() { throw null; }
-        public string AsString() { throw null; }
-        public string AsString(System.Text.Encoding encoding) { throw null; }
-        public T As<T>(Azure.Core.ObjectSerializer serializer) { throw null; }
-        public static Azure.Core.BinaryData Create(System.IO.Stream stream) { throw null; }
-        public static Azure.Core.BinaryData Create(string data) { throw null; }
-        public static Azure.Core.BinaryData Create(string data, System.Text.Encoding encoding) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> CreateAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> CreateAsync<T>(T data, Azure.Core.ObjectSerializer serializer) { throw null; }
-        public static Azure.Core.BinaryData Create<T>(T data, Azure.Core.ObjectSerializer serializer) { throw null; }
+        public System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(Azure.Core.ObjectSerializer serializer) { throw null; }
+        public T Deserialize<T>(Azure.Core.ObjectSerializer serializer) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> FromSerializableAsync<T>(T data, Azure.Core.ObjectSerializer serializer) { throw null; }
+        public static Azure.Core.BinaryData FromSerializable<T>(T data, Azure.Core.ObjectSerializer serializer) { throw null; }
+        public static Azure.Core.BinaryData FromStream(System.IO.Stream stream) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> FromStreamAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static implicit operator System.ReadOnlyMemory<byte> (Azure.Core.BinaryData data) { throw null; }
+        public System.IO.Stream ToStream() { throw null; }
+        public override string ToString() { throw null; }
+        public string ToString(System.Text.Encoding encoding) { throw null; }
     }
     public partial class JsonObjectSerializer : Azure.Core.ObjectSerializer
     {

--- a/sdk/core/Azure.Core.Experimental/tests/BinaryDataTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/BinaryDataTests.cs
@@ -30,17 +30,17 @@ namespace Azure.Core.Tests
         public void CanCreateBinaryDataFromString()
         {
             var payload = "some data";
-            var data = BinaryData.Create(payload);
-            Assert.AreEqual(payload, data.AsString());
+            var data = new BinaryData(payload);
+            Assert.AreEqual(payload, data.ToString());
         }
 
         [Test]
         public void AsStringThrowsOnNullEncoding()
         {
             var payload = "some data";
-            var data = BinaryData.Create(payload);
+            var data = new BinaryData(payload);
             Assert.That(
-                () => data.AsString(null),
+                () => data.ToString(null),
                 Throws.InstanceOf<ArgumentException>());
         }
 
@@ -49,14 +49,14 @@ namespace Azure.Core.Tests
         {
             var buffer = Encoding.UTF8.GetBytes("some data");
             var payload = new MemoryStream(buffer);
-            var data = BinaryData.Create(payload);
+            var data = BinaryData.FromStream(payload);
             Assert.AreEqual(buffer, data.AsBytes().ToArray());
-            Assert.AreEqual(payload, data.AsStream());
+            Assert.AreEqual(payload, data.ToStream());
 
             payload.Position = 0;
-            data = await BinaryData.CreateAsync(payload);
+            data = await BinaryData.FromStreamAsync(payload);
             Assert.AreEqual(buffer, data.AsBytes().ToArray());
-            Assert.AreEqual(payload, data.AsStream());
+            Assert.AreEqual(payload, data.ToStream());
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace Azure.Core.Tests
             mockStream.Setup(s => s.CanSeek).Returns(true);
             mockStream.Setup(s => s.Length).Returns((long)int.MaxValue + 1);
             Assert.That(
-                () => BinaryData.Create(mockStream.Object),
+                () => BinaryData.FromStream(mockStream.Object),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
@@ -75,17 +75,17 @@ namespace Azure.Core.Tests
         {
             var payload = new TestModel { A = "value", B = 5, C = true};
             var serializer = new JsonObjectSerializer();
-            await AssertData(BinaryData.Create(payload, serializer));
-            await AssertData(await BinaryData.CreateAsync(payload, serializer));
+            await AssertData(BinaryData.FromSerializable(payload, serializer));
+            await AssertData(await BinaryData.FromSerializableAsync(payload, serializer));
 
             async Task AssertData(BinaryData data)
             {
-                Assert.AreEqual(payload.A, data.As<TestModel>(serializer).A);
-                Assert.AreEqual(payload.B, data.As<TestModel>(serializer).B);
-                Assert.AreEqual(payload.C, data.As<TestModel>(serializer).C);
-                Assert.AreEqual(payload.A, (await data.AsAsync<TestModel>(serializer)).A);
-                Assert.AreEqual(payload.B, (await data.AsAsync<TestModel>(serializer)).B);
-                Assert.AreEqual(payload.C, (await data.AsAsync<TestModel>(serializer)).C);
+                Assert.AreEqual(payload.A, data.Deserialize<TestModel>(serializer).A);
+                Assert.AreEqual(payload.B, data.Deserialize<TestModel>(serializer).B);
+                Assert.AreEqual(payload.C, data.Deserialize<TestModel>(serializer).C);
+                Assert.AreEqual(payload.A, (await data.DeserializeAsync<TestModel>(serializer)).A);
+                Assert.AreEqual(payload.B, (await data.DeserializeAsync<TestModel>(serializer)).B);
+                Assert.AreEqual(payload.C, (await data.DeserializeAsync<TestModel>(serializer)).C);
             }
         }
 
@@ -94,10 +94,10 @@ namespace Azure.Core.Tests
         {
             var payload = new TestModel { A = "value", B = 5, C = true };
             Assert.That(
-                () => BinaryData.Create(payload, null),
+                () => BinaryData.FromSerializable(payload, null),
                 Throws.InstanceOf<ArgumentNullException>());
             Assert.That(
-                async () => await BinaryData.CreateAsync(payload, null),
+                async () => await BinaryData.FromSerializableAsync(payload, null),
                 Throws.InstanceOf<ArgumentNullException>());
         }
 
@@ -105,11 +105,11 @@ namespace Azure.Core.Tests
         public void CreateThrowsOnNullStream()
         {
             Assert.That(
-                () => BinaryData.Create(stream: null),
+                () => BinaryData.FromStream(null),
                 Throws.InstanceOf<ArgumentNullException>());
 
             Assert.That(
-                async () => await BinaryData.CreateAsync(stream: null),
+                async () => await BinaryData.FromStreamAsync(null),
                 Throws.InstanceOf<ArgumentNullException>());
         }
 
@@ -118,16 +118,16 @@ namespace Azure.Core.Tests
         {
             var payload = new TestModel { A = "value", B = 5, C = true };
             var serializer = new JsonObjectSerializer();
-            AssertData(BinaryData.Create(payload, serializer));
-            AssertData(await BinaryData.CreateAsync(payload, serializer));
+            AssertData(BinaryData.FromSerializable(payload, serializer));
+            AssertData(await BinaryData.FromSerializableAsync(payload, serializer));
 
             void AssertData(BinaryData data)
             {
                 Assert.That(
-                    () => data.As<string>(serializer),
+                    () => data.Deserialize<string>(serializer),
                     Throws.InstanceOf<Exception>());
                 Assert.That(
-                    async () => await data.AsAsync<string>(serializer),
+                    async () => await data.DeserializeAsync<string>(serializer),
                     Throws.InstanceOf<Exception>());
             }
         }
@@ -137,12 +137,12 @@ namespace Azure.Core.Tests
         {
             var payload = new TestModel { A = "value", B = 5, C = true };
             var serializer = new JsonObjectSerializer();
-            var data = BinaryData.Create(payload, serializer);
+            var data = BinaryData.FromSerializable(payload, serializer);
             Assert.That(
-                () => data.As<TestModel>(null),
+                () => data.Deserialize<TestModel>(null),
                 Throws.InstanceOf<ArgumentNullException>());
             Assert.That(
-                async () => await data.AsAsync<TestModel>(null),
+                async () => await data.DeserializeAsync<TestModel>(null),
                 Throws.InstanceOf<ArgumentNullException>());
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -149,7 +149,7 @@ ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
 
 // get the message body as a string
-string body = receivedMessage.Body.AsString();
+string body = receivedMessage.Body.ToString();
 Console.WriteLine(body);
 ```
 
@@ -248,7 +248,7 @@ IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveBatchA
 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
 {
     // get the message body as a string
-    string body = receivedMessage.Body.AsString();
+    string body = receivedMessage.Body.ToString();
     Console.WriteLine(body);
 }
 ```

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -125,7 +125,7 @@ ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
 
 // get the message body as a string
-string body = receivedMessage.Body.AsString();
+string body = receivedMessage.Body.ToString();
 Console.WriteLine(body);
 ```
 
@@ -279,7 +279,7 @@ processor.ProcessErrorAsync += ErrorHandler;
 
 async Task MessageHandler(ProcessMessageEventArgs args)
 {
-    string body = args.Message.Body.AsString();
+    string body = args.Message.Body.ToString();
     Console.WriteLine(body);
 
     // we can evaluate application logic and use that to determine how to settle the message.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
@@ -29,7 +29,7 @@ ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
 
 // get the message body as a string
-string body = receivedMessage.Body.AsString();
+string body = receivedMessage.Body.ToString();
 Console.WriteLine(body);
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
@@ -44,7 +44,7 @@ processor.ProcessErrorAsync += ErrorHandler;
 
 async Task MessageHandler(ProcessMessageEventArgs args)
 {
-    string body = args.Message.Body.AsString();
+    string body = args.Message.Body.ToString();
     Console.WriteLine(body);
 
     // we can evaluate application logic and use that to determine how to settle the message.
@@ -125,7 +125,7 @@ processor.ProcessErrorAsync += ErrorHandler;
 
 async Task MessageHandler(ProcessSessionMessageEventArgs args)
 {
-    var body = args.Message.Body.AsString();
+    var body = args.Message.Body.ToString();
 
     // we can evaluate application logic and use that to determine how to settle the message.
     await args.CompleteAsync(args.Message);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
@@ -55,7 +55,7 @@ processor.ProcessErrorAsync += ErrorHandler;
 
 async Task MessageHandler(ProcessSessionMessageEventArgs args)
 {
-    var body = args.Message.Body.AsString();
+    var body = args.Message.Body.ToString();
 
     // we can evaluate application logic and use that to determine how to settle the message.
     await args.CompleteAsync(args.Message);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -48,6 +48,9 @@
 
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusMessage(string body, Encoding encoding)
         {
             Argument.AssertNotNull(encoding, nameof(encoding));
-            Body = BinaryData.Create(body, encoding);
+            Body = new BinaryData(body, encoding);
             Properties = new Dictionary<string, object>();
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                     receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
                 }
                 var receivedMessage = await receiver.ReceiveAsync().ConfigureAwait(false);
-                Assert.AreEqual(message.Body.AsString(), receivedMessage.Body.AsString());
+                Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
 
                 await client.DisposeAsync();
                 Assert.IsTrue(client.IsDisposed);
@@ -79,7 +79,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                     receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
                 }
                 var receivedMessage = await receiver.ReceiveAsync().ConfigureAwait(false);
-                Assert.AreEqual(message.Body.AsString(), receivedMessage.Body.AsString());
+                Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
 
                 if (!useSessions)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -158,14 +158,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                     B = 5,
                     C = false
                 };
-                var body = BinaryData.Create(testBody, serializer);
+                var body = BinaryData.FromSerializable(testBody, serializer);
                 var msg = new ServiceBusMessage(body);
 
                 await sender.SendAsync(msg);
 
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var received = await receiver.ReceiveAsync();
-                var receivedBody = received.Body.As<TestBody>(serializer);
+                var receivedBody = received.Body.Deserialize<TestBody>(serializer);
                 Assert.AreEqual(testBody.A, receivedBody.A);
                 Assert.AreEqual(testBody.B, receivedBody.B);
                 Assert.AreEqual(testBody.C, receivedBody.C);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
@@ -41,16 +41,16 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
         }
 
         [Test]
-        public void SetMessageBodyAsString()
+        public void SetMessageBodyToString()
         {
             var messageBody = "some message";
             var message = new ServiceBusMessage(messageBody);
-            Assert.AreEqual(message.Body.AsString(), messageBody);
-            Assert.AreEqual(message.Body.AsString(), messageBody);
+            Assert.AreEqual(message.Body.ToString(), messageBody);
+            Assert.AreEqual(message.Body.ToString(), messageBody);
 
             message = new ServiceBusMessage(messageBody, Encoding.UTF32);
-            Assert.AreEqual(message.Body.AsString(Encoding.UTF32), messageBody);
-            Assert.AreNotEqual(message.Body.AsString(), messageBody);
+            Assert.AreEqual(message.Body.ToString(Encoding.UTF32), messageBody);
+            Assert.AreNotEqual(message.Body.ToString(), messageBody);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -55,11 +55,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     sequenceNumber: (long)sequenceNumber,
                     maxMessages: messageCt))
                 {
-                    var peekedText = peekedMessage.Body.AsString();
+                    var peekedText = peekedMessage.Body.ToString();
                     var sentMsg = sentMessageIdToMsg[peekedMessage.MessageId];
 
                     sentMessageIdToMsg.Remove(peekedMessage.MessageId);
-                    Assert.AreEqual(sentMsg.Body.AsString(), peekedText);
+                    Assert.AreEqual(sentMsg.Body.ToString(), peekedText);
                     Assert.AreEqual(sentMsg.PartitionKey, peekedMessage.PartitionKey);
                     Assert.IsTrue(peekedMessage.SequenceNumber >= sequenceNumber);
                     ct++;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
@@ -42,10 +42,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
 
                 // get the message body as a string
-                string body = receivedMessage.Body.AsString();
+                string body = receivedMessage.Body.ToString();
                 Console.WriteLine(body);
                 #endregion
-                Assert.AreEqual("Hello world!", receivedMessage.Body.AsString());
+                Assert.AreEqual("Hello world!", receivedMessage.Body.ToString());
             }
         }
 
@@ -75,8 +75,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 #endregion
 
                 // get the message body as a string
-                string body = peekedMessage.Body.AsString();
-                Assert.AreEqual("Hello world!", peekedMessage.Body.AsString());
+                string body = peekedMessage.Body.ToString();
+                Assert.AreEqual("Hello world!", peekedMessage.Body.ToString());
             }
         }
 
@@ -114,7 +114,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
                 {
                     // get the message body as a string
-                    string body = receivedMessage.Body.AsString();
+                    string body = receivedMessage.Body.ToString();
                     Console.WriteLine(body);
                 }
                 #endregion
@@ -123,7 +123,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
                 {
                     sentMessagesEnum.MoveNext();
-                    Assert.AreEqual(sentMessagesEnum.Current.Body.AsString(), receivedMessage.Body.AsString());
+                    Assert.AreEqual(sentMessagesEnum.Current.Body.ToString(), receivedMessage.Body.ToString());
                 }
             }
         }
@@ -163,13 +163,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
                 {
                     // get the message body as a string using an implicit cast
-                    string body = receivedMessage.Body.AsString();
+                    string body = receivedMessage.Body.ToString();
                 }
                 var sentMessagesEnum = messageBatch.AsEnumerable<ServiceBusMessage>().GetEnumerator();
                 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
                 {
                     sentMessagesEnum.MoveNext();
-                    Assert.AreEqual(sentMessagesEnum.Current.Body.AsString(), receivedMessage.Body.AsString());
+                    Assert.AreEqual(sentMessagesEnum.Current.Body.ToString(), receivedMessage.Body.ToString());
                 }
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
@@ -61,7 +61,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 async Task MessageHandler(ProcessMessageEventArgs args)
                 {
-                    string body = args.Message.Body.AsString();
+                    string body = args.Message.Body.ToString();
                     Console.WriteLine(body);
 
                     // we can evaluate application logic and use that to determine how to settle the message.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
@@ -68,7 +68,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 async Task MessageHandler(ProcessSessionMessageEventArgs args)
                 {
-                    var body = args.Message.Body.AsString();
+                    var body = args.Message.Body.ToString();
 
                     // we can evaluate application logic and use that to determine how to settle the message.
                     await args.CompleteAsync(args.Message);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
 
                 Assert.NotNull(receivedMessage);
-                Assert.AreEqual(message.Body.AsString(), receivedMessage.Body.AsString());
+                Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
                 await receiver.CompleteAsync(receivedMessage);
             };
         }
@@ -66,14 +66,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
 
                 Assert.NotNull(receivedMessage);
-                Assert.AreEqual(message1.Body.AsString(), receivedMessage.Body.AsString());
+                Assert.AreEqual(message1.Body.ToString(), receivedMessage.Body.ToString());
                 await receiver.CompleteAsync(receivedMessage);
 
                 receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
                 receivedMessage = await receiver.ReceiveAsync();
 
                 Assert.NotNull(receivedMessage);
-                Assert.AreEqual(message2.Body.AsString(), receivedMessage.Body.AsString());
+                Assert.AreEqual(message2.Body.ToString(), receivedMessage.Body.ToString());
                 await receiver.CompleteAsync(receivedMessage);
             };
         }


### PR DESCRIPTION
Note: Renamed AsString/AsStream -> ToString/ToStream since these are allocating (and also to avoid confusion between ToString/AsString), but left AsBytes since this does not allocate.

Didn't add the `public BinaryData(object serializable, Type type, ObjectSerializer serializer = default)` as I'm not sure if we want this considering it would be sync only.