### PR TITLE
Speed up mgmt tests in playback mode

### DIFF
--- a/sdk/blueprint/Microsoft.Azure.Management.Blueprint/tests/ScenarioTests/BlueprintTests.cs
+++ b/sdk/blueprint/Microsoft.Azure.Management.Blueprint/tests/ScenarioTests/BlueprintTests.cs
@@ -478,7 +478,10 @@ namespace Management.Blueprint.Tests.ScenarioTests
                     return result;
                 }
 
-                await Task.Delay(pullingInterval);
+                if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+                {
+                    await Task.Delay(pullingInterval);
+                }
             }
 
             throw new TimeoutException();

--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/Helpers/ResourceUtils.cs
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/Helpers/ResourceUtils.cs
@@ -1,5 +1,6 @@
 using Microsoft.Azure.Management.NetApp;
 using Microsoft.Azure.Management.NetApp.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Xunit;
@@ -91,7 +92,10 @@ namespace NetApp.Tests.Helpers
             var resource = netAppMgmtClient.Accounts.CreateOrUpdate(netAppAccount, resourceGroup, accountName);
             Assert.Equal(resource.Name, accountName);
 
-            Thread.Sleep(delay); // some robustness against ARM caching
+            if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+            {
+                Thread.Sleep(delay); // some robustness against ARM caching
+            }
 
             return resource;
         }
@@ -123,7 +127,10 @@ namespace NetApp.Tests.Helpers
             }
             Assert.Equal(resource.Name, accountName + '/' + poolName);
 
-            Thread.Sleep(delay); // some robustness against ARM caching
+            if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+            {
+                Thread.Sleep(delay); // some robustness against ARM caching
+            }
 
             return resource;
         }
@@ -151,7 +158,10 @@ namespace NetApp.Tests.Helpers
             var resource = netAppMgmtClient.Volumes.CreateOrUpdate(volume, resourceGroup, accountName, poolName, volumeName);
             Assert.Equal(resource.Name, accountName + '/' + poolName + '/' + volumeName);
 
-            Thread.Sleep(delay); // some robustness against ARM caching
+            if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+            {
+                Thread.Sleep(delay); // some robustness against ARM caching
+            }
 
             return resource;
         }
@@ -193,7 +203,10 @@ namespace NetApp.Tests.Helpers
             var resource = netAppMgmtClient.Volumes.CreateOrUpdate(volume, resourceGroup, accountName, poolName, volumeName);
             Assert.Equal(resource.Name, accountName + '/' + poolName + '/' + volumeName);
 
-            Thread.Sleep(delay); // some robustness against ARM caching
+            if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+            {
+                Thread.Sleep(delay); // some robustness against ARM caching
+            }
 
             return resource;
         }
@@ -255,7 +268,10 @@ namespace NetApp.Tests.Helpers
             // e.g. snapshot deletion might not be complete and therefore pool has child resource
             while (retry == true)
             {
-                Thread.Sleep(delay);
+                if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+                {
+                    Thread.Sleep(delay);
+                }
 
                 try
                 {
@@ -290,7 +306,10 @@ namespace NetApp.Tests.Helpers
             // e.g. snapshot deletion might not be complete and therefore volume has child resource
             while (retry == true)
             {
-                Thread.Sleep(delay);
+                if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+                {
+                    Thread.Sleep(delay);
+                }
 
                 try
                 {
@@ -326,7 +345,10 @@ namespace NetApp.Tests.Helpers
             // all levels
             while (retry == true)
             {
-                Thread.Sleep(delay);
+                if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+                {
+                    Thread.Sleep(delay);
+                }
 
                 try
                 {

--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/ResourceTests/VolumeTests.cs
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/ResourceTests/VolumeTests.cs
@@ -397,7 +397,10 @@ namespace NetApp.Tests.ResourceTests
                 {
                     replicationStatus = netAppMgmtClient.Volumes.ReplicationStatusMethod(ResourceUtils.remoteResourceGroup, ResourceUtils.remoteAccountName1, ResourceUtils.remotePoolName1, ResourceUtils.remoteVolumeName1);
                     attempts++;
-                    Thread.Sleep(100);
+                    if (Environment.GetEnvironmentVariable("AZURE_TEST_MODE") == "Record")
+                    {
+                        Thread.Sleep(100);
+                    }
                 } while (replicationStatus.Healthy.Value || attempts == 5);
             }
             Assert.True(replicationStatus.Healthy);


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Speed up some tests in:
- `Microsoft.Azure.Management.NetApp.Tests`
- `Microsoft.Azure.Management.Blueprint.Tests`

They take too long to run (~10min), and it's caused by unnecessary `Thread.Sleep()` or `Task.Delay()`, so I added an `if` clause to disable sleeping in playback mode.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
