### PR TITLE
Move Link Replacement Above Package Creation

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -24,7 +24,7 @@ jobs:
         displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
         inputs:
           version: "$(DotNetCoreSDKVersion)"
-      - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
+      - template: /eng/common/pipelines/templates/steps/replace-relative-links.yml
         parameters:
           TargetFolder: '.'
           RootFolder: '.'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -24,6 +24,12 @@ jobs:
         displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
         inputs:
           version: "$(DotNetCoreSDKVersion)"
+      - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
+        parameters:
+          TargetFolder: '.'
+          RootFolder: '.'
+          BuildSHA: $(Build.SourceVersion)
+          RepoId: 'Azure/azure-sdk-for-net'
       - script: >-
           dotnet pack eng/service.proj -o $(Build.ArtifactStagingDirectory) -warnaserror /p:ServiceDirectory=${{parameters.ServiceToBuild}}
           /p:PublicSign=false $(VersioningProperties) /p:Configuration=$(BuildConfiguration) /p:CommitSHA=$(Build.SourceVersion)

--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -7,12 +7,6 @@ steps:
     displayName: 'Use Python 3.6'
     inputs:
       versionSpec: '3.6'
-  - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
-    parameters:
-      TargetFolder: '.'
-      RootFolder: '.'
-      BuildSHA: $(Build.SourceVersion)
-      RepoId: 'Azure/azure-sdk-for-net'
   - pwsh: |
       # Download and Extract or restore Packages required for Doc Generation
       Write-Host "Download and Extract mdoc to Build.BinariesDirectory/mdoc"


### PR DESCRIPTION
As it currently is set up, only docs.MS get's the readme link updates. This means that all the readmes submitted by the release step to Docs.MS side don't have relative link replacement.

@Azure/azure-sdk-eng 
