### PR TITLE
Changing ORDestinationPolicy to ORDestinationPolicyId

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -380,7 +380,7 @@ namespace Azure.Storage.Blobs.Models
         public Azure.Storage.Blobs.Models.LeaseState LeaseState { get { throw null; } }
         public Azure.Storage.Blobs.Models.LeaseStatus LeaseStatus { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } }
-        public string ObjectReplicationDestinationPolicy { get { throw null; } }
+        public string ObjectReplicationDestinationPolicyId { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Storage.Blobs.Models.ObjectReplicationPolicy> ObjectReplicationSourceProperties { get { throw null; } }
         public long TagCount { get { throw null; } }
         public string VersionId { get { throw null; } }
@@ -683,7 +683,7 @@ namespace Azure.Storage.Blobs.Models
         public Azure.Storage.Blobs.Models.LeaseState LeaseState { get { throw null; } }
         public Azure.Storage.Blobs.Models.LeaseStatus LeaseStatus { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> Metadata { get { throw null; } }
-        public string ObjectReplicationDestinationPolicy { get { throw null; } }
+        public string ObjectReplicationDestinationPolicyId { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Storage.Blobs.Models.ObjectReplicationPolicy> ObjectReplicationSourceProperties { get { throw null; } }
         public long TagCount { get { throw null; } }
         public string VersionId { get { throw null; } }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobExtensions.cs
@@ -106,7 +106,7 @@ namespace Azure.Storage.Blobs
                 LastModified = properties.LastModified,
                 CreatedOn = properties.CreatedOn,
                 Metadata = properties.Metadata,
-                ObjectReplicationDestinationPolicy = properties.ObjectReplicationPolicyId,
+                ObjectReplicationDestinationPolicyId = properties.ObjectReplicationPolicyId,
                 ObjectReplicationSourceProperties =
                     properties.ObjectReplicationRules?.Count > 0
                     ? BlobExtensions.ParseObjectReplicationIds(properties.ObjectReplicationRules)
@@ -163,13 +163,13 @@ namespace Azure.Storage.Blobs
         /// List of <see cref="ObjectReplicationPolicy"/>, which contains the Policy ID and the respective
         /// rule(s) and replication status(s) for each policy.
         /// If the blob has object replication policy applied and is the destination blob,
-        /// this method will return default as the policy id should be set in ObjectReplicationDestinationPolicy
-        /// (e.g. <see cref="BlobProperties.ObjectReplicationDestinationPolicy"/>,<see cref="BlobDownloadDetails.ObjectReplicationDestinationPolicy"/>).
+        /// this method will return default as the policy id should be set in ObjectReplicationDestinationPolicyId
+        /// (e.g. <see cref="BlobProperties.ObjectReplicationDestinationPolicyId"/>,<see cref="BlobDownloadDetails.ObjectReplicationDestinationPolicyId"/>).
         /// </returns>
         internal static IList<ObjectReplicationPolicy> ParseObjectReplicationIds(this IDictionary<string, string> OrIds)
         {
             // If the dictionary contains a key with policy id, we are not required to do any parsing since
-            // the policy id should already be stored in the ObjectReplicationDestinationPolicy.
+            // the policy id should already be stored in the ObjectReplicationDestinationPolicyId.
             if (OrIds.First().Key == "policy-id")
             {
                 return default;

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
@@ -110,7 +110,7 @@ namespace Azure.Storage.Blobs.Models
                     flattened.ObjectReplicationRules?.Count > 0
                     ? BlobExtensions.ParseObjectReplicationIds(flattened.ObjectReplicationRules)
                     : null,
-                ObjectReplicationDestinationPolicy = flattened.ObjectReplicationPolicyId
+                ObjectReplicationDestinationPolicyId = flattened.ObjectReplicationPolicyId
             };
         }
 
@@ -274,7 +274,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Object Replication Policy Id. This value is only set when the policy id
         /// </summary>
-        public string ObjectReplicationDestinationPolicy { get; internal set; }
+        public string ObjectReplicationDestinationPolicyId { get; internal set; }
     }
 
     /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobProperties.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Object Replication Policy Id of the destination blob.
         /// </summary>
-        public string ObjectReplicationDestinationPolicy { get; internal set; }
+        public string ObjectReplicationDestinationPolicyId { get; internal set; }
 
         /// <summary>
         /// Parsed Object Replication Policy Id, Rule Id(s) and status of the source blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobsModelFactory.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobsModelFactory.cs
@@ -208,7 +208,7 @@ namespace Azure.Storage.Blobs.Models
                 VersionId = versionId,
                 ObjectReplicationSourceProperties = objectReplicationSourceProperties,
                 IsCurrentVersion = isCurrentVersion,
-                ObjectReplicationDestinationPolicy = objectReplicationDestinationPolicy,
+                ObjectReplicationDestinationPolicyId = objectReplicationDestinationPolicy,
                 TagCount = tagCount,
                 Metadata = metadata,
                 ExpiresOn = expiresOn,
@@ -596,7 +596,7 @@ namespace Azure.Storage.Blobs.Models
                 VersionId = versionId,
                 IsSealed = isSealed,
                 ObjectReplicationSourceProperties = objectReplicationSourceProperties,
-                ObjectReplicationDestinationPolicy = objectReplicationDestinationPolicy
+                ObjectReplicationDestinationPolicyId = objectReplicationDestinationPolicy
             };
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/ObjectReplicationPolicy.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/ObjectReplicationPolicy.cs
@@ -10,9 +10,9 @@ namespace Azure.Storage.Blobs.Models
     /// Contains Object Replication Policy ID and the respective list of
     /// <see cref="ObjectReplicationRule"/>(s). This is used when retrieving the
     /// Object Replication Properties on the source blob. The policy id for the
-    /// destination blob is set in ObjectReplicationDestinationPolicy of the respective
-    /// method responses. (e.g. <see cref="BlobProperties.ObjectReplicationDestinationPolicy"/>,
-    /// <see cref="BlobDownloadDetails.ObjectReplicationDestinationPolicy"/>).
+    /// destination blob is set in ObjectReplicationDestinationPolicyId of the respective
+    /// method responses. (e.g. <see cref="BlobProperties.ObjectReplicationDestinationPolicyId"/>,
+    /// <see cref="BlobDownloadDetails.ObjectReplicationDestinationPolicyId"/>).
     /// </summary>
     public class ObjectReplicationPolicy
     {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -585,8 +585,8 @@ namespace Azure.Storage.Blobs.Test
 
             //Assert
             Assert.AreEqual(1, sourceResponse.Value.Details.ObjectReplicationSourceProperties.Count);
-            Assert.IsNull(sourceResponse.Value.Details.ObjectReplicationDestinationPolicy);
-            Assert.IsNotEmpty(destResponse.Value.Details.ObjectReplicationDestinationPolicy);
+            Assert.IsNull(sourceResponse.Value.Details.ObjectReplicationDestinationPolicyId);
+            Assert.IsNotEmpty(destResponse.Value.Details.ObjectReplicationDestinationPolicyId);
             Assert.IsNull(destResponse.Value.Details.ObjectReplicationSourceProperties);
         }
         #endregion Sequential Download
@@ -2896,8 +2896,8 @@ namespace Azure.Storage.Blobs.Test
 
             // Assert
             Assert.AreEqual(1, source_response.Value.ObjectReplicationSourceProperties.Count);
-            Assert.IsNull(source_response.Value.ObjectReplicationDestinationPolicy);
-            Assert.IsNotEmpty(dest_response.Value.ObjectReplicationDestinationPolicy);
+            Assert.IsNull(source_response.Value.ObjectReplicationDestinationPolicyId);
+            Assert.IsNotEmpty(dest_response.Value.ObjectReplicationDestinationPolicyId);
             Assert.IsNull(dest_response.Value.ObjectReplicationSourceProperties);
         }
 


### PR DESCRIPTION
As per APIView comment, changing `ObjectReplicationDestinationPolicy` to `ObjectReplicationDestinationPolicyId`.

Related to PR #12740 (aka I forgot to add it to this PR)