### PR TITLE
API changes and batch schedule

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -63,19 +63,19 @@ In the interest of simplifying the API surface we've made a single top level cli
 
 ### Sending messages
 
-The v4 client allowed for sending a single message or a list of messages, which had the potential to fail unexpectedly if the maximum allowable size was exceeded. v7 aims to prevent this by allowing you to first create a batch of messages using `CreateBatchAsync` and then attempt to add messages to that using `TryAdd()`. If the batch accepts a message, you can be confident that it will not violate size constraints when calling Send to send the batch. v7 still allows sending a single message and sending an `IEnumerable` of messages, though using the `IEnumerable` overload has the same risks as V4.
+The v4 client allowed for sending a single message or a list of messages, which had the potential to fail unexpectedly if the maximum allowable size was exceeded. v7 aims to prevent this by allowing you to first create a batch of messages using `CreateMessageBatchAsync` and then attempt to add messages to that using `TryAddMessage()`. If the batch accepts a message, you can be confident that it will not violate size constraints when calling Send to send the batch. v7 still allows sending a single message and sending an `IEnumerable` of messages, though using the `IEnumerable` overload has the same risks as V4.
 
 | In v4                                          | Equivalent in v7                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
 | `QueueClient.SendAsync(Message)` or `MessageSender.SendAsync(Message)`                          | `ServiceBusSender.SendMessageAsync(ServiceBusMessage)`                               | [Send a message](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-message) |
-| `QueueClient.SendAsync(IList<Message>)` or `MessageSender.SendAsync(IList<Message>)`                          | `messageBatch = ServiceBusSender.CreateBatchAsync()` `messageBatch.TryAdd(ServiceBusMessage)` `ServiceBusSender.SendMessagesAsync(messageBatch)` or `ServiceBusSender.SendMessagesAsync(IEnumerable<ServiceBusMessage>)`                              | [Send a batch of messages](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-batch-of-messages) |
+| `QueueClient.SendAsync(IList<Message>)` or `MessageSender.SendAsync(IList<Message>)`                          | `messageBatch = ServiceBusSender.CreateMessageBatchAsync()` `messageBatch.TryAddMessage(ServiceBusMessage)` `ServiceBusSender.SendMessagesAsync(messageBatch)` or `ServiceBusSender.SendMessagesAsync(IEnumerable<ServiceBusMessage>)`                              | [Send a batch of messages](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-batch-of-messages) |
 
 ### Receiving messages 
 
 | In v4                                          | Equivalent in v7                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
-| `MessageReceiver.ReceiveAsync()`                      | `ServiceBusReceiver.ReceiveAsync()`                               | [Receive a message](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-message) |
-| `MessageReceiver.ReceiveAsync()`                      | `ServiceBusReceiver.ReceiveBatchAsync()`                               | [Receive a batch of messages](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-batch-of-messages) |
+| `MessageReceiver.ReceiveAsync()`                      | `ServiceBusReceiver.ReceiveMessageAsync()`                               | [Receive a message](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-message) |
+| `MessageReceiver.ReceiveAsync()`                      | `ServiceBusReceiver.ReceiveMessagesAsync()`                               | [Receive a batch of messages](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-batch-of-messages) |
 | `QueueClient.RegisterMessageHandler()` or   `MessageReceiver.RegisterMessageHandler()`                    | `ServiceBusProcessor.ProcessMessageAsync += MessageHandler` `ServiceBusProcessor.ProcessErrorAsync += ErrorHandler` `ServiceBusProcessor.StartProcessingAsync()`                               | [Receive messages using processor](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md) |
 
 ### Working with sessions 
@@ -83,7 +83,7 @@ The v4 client allowed for sending a single message or a list of messages, which 
 | In v4                                          | Equivalent in v7                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
 | `MessageSender.SendAsync(new Message{SessionId = "sessionId"})`                      | `ServiceBusSender.SendMessageAsync(new ServiceBusMessage{SessionId = "sessionId"})`                               | [Send a message to session](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md) |
-| `IMessageSession.ReceiveAsync()`                      | `ServiceBusSessionReceiver.ReceiveAsync()`                               | [Receive a message from session](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md) |
+| `IMessageSession.ReceiveAsync()`                      | `ServiceBusSessionReceiver.ReceiveMessageAsync()`                               | [Receive a message from session](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md) |
 | `IMessageSession.RegisterMessageHandler()`                    | `ServiceBusSessionProcessor.ProcessMessageAsync += MessageHandler` `ServiceBusSessionProcessor.ProcessErrorAsync += ErrorHandler` `ServiceBusSessionProcessor.StartProcessingAsync()`                               | [Receive messages from session processor](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md) |
 
 ## Migration samples
@@ -165,8 +165,8 @@ attempt to fit all of the supplied messages in a single message batch that we wi
 too large to fit in a single batch, the operation will throw an exception. 
 
 The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object, 
-which will allow you to attempt to add messages one at a time to the batch using the `TryAdd` method. If the message cannot 
-fit in the batch, `TryAdd` will return false. If the `ServiceBusMessageBatch` accepts a message, user can be confident that 
+which will allow you to attempt to add messages one at a time to the batch using the `TryAddMessage` method. If the message cannot 
+fit in the batch, `TryAddMessage` will return false. If the `ServiceBusMessageBatch` accepts a message, user can be confident that 
 it will not violate size constraints when calling `SendMessagesAsync()` via `ServiceBusSender`. To receive a set of messages, a
 user would call `ReceiveMessagesAsync()` method via `ServiceBusReceiver`. 
 
@@ -230,8 +230,8 @@ Or using the safe-batching feature:
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
 await sender.SendMessagesAsync(messageBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -140,13 +140,13 @@ ServiceBusSender sender = client.CreateSender(queueName);
 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
 // send the message
-await sender.SendAsync(message);
+await sender.SendMessageAsync(message);
 
 // create a receiver that we can use to receive the message
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // get the message body as a string
 string body = receivedMessage.Body.ToString();
@@ -223,18 +223,18 @@ IList<ServiceBusMessage> messages = new List<ServiceBusMessage>();
 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 // send the messages
-await sender.SendAsync(messages);
+await sender.SendMessagesAsync(messages);
 ```
 
 Or using the safe-batching feature:
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 ```
 
 And to receive a batch:
@@ -243,7 +243,7 @@ And to receive a batch:
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // the received message is a different type as it contains some service set properties
-IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveBatchAsync(maxMessages: 2);
+IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveMessagesAsync(maxMessages: 2);
 
 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -116,13 +116,13 @@ ServiceBusSender sender = client.CreateSender(queueName);
 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
 // send the message
-await sender.SendAsync(message);
+await sender.SendMessageAsync(message);
 
 // create a receiver that we can use to receive the message
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // get the message body as a string
 string body = receivedMessage.Body.ToString();
@@ -141,19 +141,19 @@ IList<ServiceBusMessage> messages = new List<ServiceBusMessage>();
 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 // send the messages
-await sender.SendAsync(messages);
+await sender.SendMessagesAsync(messages);
 ```
 The second way of doing this is using safe-batching. With safe-batching, you can create a 
 `ServiceBusMessageBatch` object, which will allow you to attempt to add messages one at a time to the 
 batch using the `TryAdd` method. If the message cannot fit in the batch, `TryAdd` will return false.
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 ```
 
 ### Complete a message
@@ -173,16 +173,16 @@ ServiceBusSender sender = client.CreateSender(queueName);
 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
 // send the message
-await sender.SendAsync(message);
+await sender.SendMessageAsync(message);
 
 // create a receiver that we can use to receive and settle the message
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // complete the message, thereby deleting it from the service
-await receiver.CompleteAsync(receivedMessage);
+await receiver.CompleteMessageAsync(receivedMessage);
 ```
 
 ### Abandon a message
@@ -190,10 +190,10 @@ await receiver.CompleteAsync(receivedMessage);
 Abandoning a message releases our receiver's lock, which allows the message to be received by this or other receivers.
 
 ```C# Snippet:ServiceBusAbandonMessage
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // abandon the message, thereby releasing the lock and allowing it to be received again by this or other receivers
-await receiver.AbandonAsync(receivedMessage);
+await receiver.AbandonMessageAsync(receivedMessage);
 ```
 
 ### Defer a message
@@ -203,11 +203,11 @@ Instead, there are separate methods, `ReceiveDeferredMessageAsync` and `ReceiveD
 for receiving deferred messages.
 
 ```C# Snippet:ServiceBusDeferMessage
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // defer the message, thereby preventing the message from being received again without using
 // the received deferred message API.
-await receiver.DeferAsync(receivedMessage);
+await receiver.DeferMessageAsync(receivedMessage);
 
 // receive the deferred message by specifying the service set sequence number of the original
 // received message
@@ -221,14 +221,14 @@ by the service after they have been received a certain number of times. Applicat
 their requirements. When a message is dead lettered it is actually moved to a subqueue of the original queue.
 
 ```C# Snippet:ServiceBusDeadLetterMessage
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // deadletter the message, thereby preventing the message from being received again without receiving from the dead letter queue.
-await receiver.DeadLetterAsync(receivedMessage);
+await receiver.DeadLetterMessageAsync(receivedMessage);
 
 // receive the dead lettered message with receiver scoped to the dead letter queue.
 ServiceBusReceiver dlqReceiver = client.CreateDeadLetterReceiver(queueName);
-ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveAsync();
+ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveMessageAsync();
 ```
 
 ### Using the Processor
@@ -249,12 +249,12 @@ await using var client = new ServiceBusClient(connectionString);
 ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 
 // get the options to use for configuring the processor
 var options = new ServiceBusProcessorOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -149,8 +149,8 @@ batch using the `TryAdd` method. If the message cannot fit in the batch, `TryAdd
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
 await sender.SendMessagesAsync(messageBatch);
@@ -250,8 +250,8 @@ ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
 await sender.SendMessagesAsync(messageBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -131,7 +131,7 @@ Console.WriteLine(body);
 
 ### Send and receive a batch of messages
 
-There are two ways of sending several messages at once. The first way uses the `SendAsync`
+There are two ways of sending several messages at once. The first way uses the `SendMessagesAsync`
 overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of
 the supplied messages in a single message batch that we will send to the service. If the messages are too large
 to fit in a single batch, the operation will throw an exception.
@@ -198,8 +198,8 @@ await receiver.AbandonMessageAsync(receivedMessage);
 
 ### Defer a message
 
-Deferring a message will prevent it from being received again using the `ReceiveAsync` or `ReceiveBatchAsync` methods.
-Instead, there are separate methods, `ReceiveDeferredMessageAsync` and `ReceiveDeferredMessageBatchAsync` 
+Deferring a message will prevent it from being received again using the `ReceiveMessageAsync` or `ReceiveMessagesAsync` methods.
+Instead, there are separate methods, `ReceiveDeferredMessageAsync` and `ReceiveDeferredMessagesAsync` 
 for receiving deferred messages.
 
 ```C# Snippet:ServiceBusDeferMessage

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -1,8 +1,8 @@
 namespace Azure.Messaging.ServiceBus
 {
-    public partial class CreateBatchOptions
+    public partial class CreateMessageBatchOptions
     {
-        public CreateBatchOptions() { }
+        public CreateMessageBatchOptions() { }
         public long? MaxSizeInBytes { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
@@ -255,29 +255,27 @@ namespace Azure.Messaging.ServiceBus
         public bool IsDisposed { get { throw null; } }
         public int PrefetchCount { get { throw null; } }
         public Azure.Messaging.ServiceBus.ReceiveMode ReceiveMode { get { throw null; } }
-        public virtual System.Threading.Tasks.Task AbandonAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task AbandonAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task CompleteAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task CompleteAsync(string lockToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task DeadLetterAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task DeadLetterAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, string deadLetterReason, string deadLetterErrorDescription = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task DeadLetterAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task DeferAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task DeferAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task AbandonMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task AbandonMessageAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task CompleteMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task CompleteMessageAsync(string lockToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task DeadLetterMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task DeadLetterMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, string deadLetterReason, string deadLetterErrorDescription = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task DeadLetterMessageAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task DeadLetterMessageAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task DeferMessageAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task DeferMessageAsync(string lockToken, System.Collections.Generic.IDictionary<string, object> propertiesToModify = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage> PeekAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage> PeekAtAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> PeekBatchAsync(int maxMessages, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> PeekBatchAtAsync(long sequenceNumber, int maxMessages, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage> ReceiveAsync(System.TimeSpan? maxWaitTime = default(System.TimeSpan?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> ReceiveBatchAsync(int maxMessages, System.TimeSpan? maxWaitTime = default(System.TimeSpan?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage> PeekMessageAsync(long? fromSequenceNumber = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> PeekMessagesAsync(int maxMessages, long? fromSequenceNumber = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage> ReceiveDeferredMessageAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> ReceiveDeferredMessageBatchAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage> ReceiveMessageAsync(System.TimeSpan? maxWaitTime = default(System.TimeSpan?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IList<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage>> ReceiveMessagesAsync(int maxMessages, System.TimeSpan? maxWaitTime = default(System.TimeSpan?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task RenewMessageLockAsync(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<System.DateTimeOffset> RenewMessageLockAsync(string lockToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -330,17 +328,19 @@ namespace Azure.Messaging.ServiceBus
         public bool IsDisposed { get { throw null; } }
         public string ViaEntityPath { get { throw null; } }
         public virtual System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateBatchAsync(Azure.Messaging.ServiceBus.CreateBatchOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateBatchAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task CancelScheduledMessagesAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateBatchAsync(Azure.Messaging.ServiceBus.CreateMessageBatchOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateMessageBatchAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public virtual System.Threading.Tasks.Task<long> ScheduleMessageAsync(Azure.Messaging.ServiceBus.ServiceBusMessage message, System.DateTimeOffset scheduledEnqueueTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task SendAsync(Azure.Messaging.ServiceBus.ServiceBusMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task SendAsync(Azure.Messaging.ServiceBus.ServiceBusMessageBatch messageBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<long[]> ScheduleMessagesAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.DateTimeOffset scheduledEnqueueTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendMessageAsync(Azure.Messaging.ServiceBus.ServiceBusMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendMessagesAsync(Azure.Messaging.ServiceBus.ServiceBusMessageBatch messageBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendMessagesAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -329,7 +329,7 @@ namespace Azure.Messaging.ServiceBus
         public string ViaEntityPath { get { throw null; } }
         public virtual System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CancelScheduledMessagesAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateBatchAsync(Azure.Messaging.ServiceBus.CreateMessageBatchOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateMessageBatchAsync(Azure.Messaging.ServiceBus.CreateMessageBatchOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask<Azure.Messaging.ServiceBus.ServiceBusMessageBatch> CreateMessageBatchAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -177,7 +177,7 @@ namespace Azure.Messaging.ServiceBus
         public long MaxSizeInBytes { get { throw null; } }
         public long SizeInBytes { get { throw null; } }
         public void Dispose() { }
-        public bool TryAdd(Azure.Messaging.ServiceBus.ServiceBusMessage message) { throw null; }
+        public bool TryAddMessage(Azure.Messaging.ServiceBus.ServiceBusMessage message) { throw null; }
     }
     public partial class ServiceBusProcessor
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
@@ -35,7 +35,7 @@ Console.WriteLine(body);
 
 ### Send and receive a batch of messages
 
-There are two ways of sending several messages at once. The first way uses the `SendAsync`
+There are two ways of sending several messages at once. The first way uses the `SendMessagesAsync`
 overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of
 the supplied messages in a single message batch that we will send to the service. If the messages are too large
 to fit in a single batch, the operation will throw an exception.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
@@ -53,8 +53,8 @@ TryAdd will return false.
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
 await sender.SendMessagesAsync(messageBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
@@ -20,13 +20,13 @@ ServiceBusSender sender = client.CreateSender(queueName);
 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
 // send the message
-await sender.SendAsync(message);
+await sender.SendMessageAsync(message);
 
 // create a receiver that we can use to receive the message
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // get the message body as a string
 string body = receivedMessage.Body.ToString();
@@ -45,19 +45,19 @@ IList<ServiceBusMessage> messages = new List<ServiceBusMessage>();
 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 // send the messages
-await sender.SendAsync(messages);
+await sender.SendMessagesAsync(messages);
 ```
 The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object,
 which will allow you to attempt to messages one at a time to the batch using TryAdd. If the message cannot fit in the batch,
 TryAdd will return false.
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 ```
 
 ## Peeking a message
@@ -65,7 +65,7 @@ await sender.SendAsync(messageBatch);
 It's also possible to simply peek a message. Peeking a message does not require the message to be locked.
 
 ```C# Snippet:ServiceBusPeek
-ServiceBusReceivedMessage peekedMessage = await receiver.PeekAsync();
+ServiceBusReceivedMessage peekedMessage = await receiver.PeekMessageAsync();
 ```
 
 ### Schedule a message

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample02_MessageSettlement.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample02_MessageSettlement.md
@@ -18,35 +18,35 @@ ServiceBusSender sender = client.CreateSender(queueName);
 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
 // send the message
-await sender.SendAsync(message);
+await sender.SendMessageAsync(message);
 
 // create a receiver that we can use to receive and settle the message
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // complete the message, thereby deleting it from the service
-await receiver.CompleteAsync(receivedMessage);
+await receiver.CompleteMessageAsync(receivedMessage);
 ```
 
 ### Abandon a message
 
 ```C# Snippet:ServiceBusAbandonMessage
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // abandon the message, thereby releasing the lock and allowing it to be received again by this or other receivers
-await receiver.AbandonAsync(receivedMessage);
+await receiver.AbandonMessageAsync(receivedMessage);
 ```
 
 ### Defer a message
 
 ```C# Snippet:ServiceBusDeferMessage
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // defer the message, thereby preventing the message from being received again without using
 // the received deferred message API.
-await receiver.DeferAsync(receivedMessage);
+await receiver.DeferMessageAsync(receivedMessage);
 
 // receive the deferred message by specifying the service set sequence number of the original
 // received message
@@ -56,14 +56,14 @@ ServiceBusReceivedMessage deferredMessage = await receiver.ReceiveDeferredMessag
 ### Dead letter a message
 
 ```C# Snippet:ServiceBusDeadLetterMessage
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 // deadletter the message, thereby preventing the message from being received again without receiving from the dead letter queue.
-await receiver.DeadLetterAsync(receivedMessage);
+await receiver.DeadLetterMessageAsync(receivedMessage);
 
 // receive the dead lettered message with receiver scoped to the dead letter queue.
 ServiceBusReceiver dlqReceiver = client.CreateDeadLetterReceiver(queueName);
-ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveAsync();
+ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveMessageAsync();
 ```
 
 ## Source

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
@@ -23,14 +23,14 @@ ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello 
 };
 
 // send the message
-await sender.SendAsync(message);
+await sender.SendMessageAsync(message);
 
 // create a session receiver that we can use to receive the message. Since we don't specify a
 // particular session, we will get the next available session from the service.
 ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 Console.WriteLine(receivedMessage.SessionId);
 
 // we can also set arbitrary session state using this receiver
@@ -53,7 +53,7 @@ ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
     });
 
 // the received message is a different type as it contains some service set properties
-ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 Console.WriteLine(receivedMessage.SessionId);
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
@@ -15,8 +15,8 @@ ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
 await sender.SendMessagesAsync(messageBatch);
@@ -88,12 +88,12 @@ ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(
+messageBatch.TryAddMessage(
     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
     {
         SessionId = "Session1"
     });
-messageBatch.TryAdd(
+messageBatch.TryAddMessage(
     new ServiceBusMessage(Encoding.UTF8.GetBytes("Second"))
     {
         SessionId = "Session2"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md
@@ -14,12 +14,12 @@ await using var client = new ServiceBusClient(connectionString);
 ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 
 // get the options to use for configuring the processor
 var options = new ServiceBusProcessorOptions
@@ -87,7 +87,7 @@ await using var client = new ServiceBusClient(connectionString);
 ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(
     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
     {
@@ -100,7 +100,7 @@ messageBatch.TryAdd(
     });
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 
 // get the options to use for configuring the processor
 var options = new ServiceBusSessionProcessorOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
@@ -18,12 +18,12 @@ ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-messageBatch.TryAdd(
+messageBatch.TryAddMessage(
     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
     {
         SessionId = "Session1"
     });
-messageBatch.TryAdd(
+messageBatch.TryAddMessage(
     new ServiceBusMessage(Encoding.UTF8.GetBytes("Second"))
     {
         SessionId = "Session2"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
@@ -17,7 +17,7 @@ await using var client = new ServiceBusClient(connectionString);
 ServiceBusSender sender = client.CreateSender(queueName);
 
 // create a message batch that we can send
-ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 messageBatch.TryAdd(
     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
     {
@@ -30,7 +30,7 @@ messageBatch.TryAdd(
     });
 
 // send the message batch
-await sender.SendAsync(messageBatch);
+await sender.SendMessagesAsync(messageBatch);
 
 // get the options to use for configuring the processor
 var options = new ServiceBusSessionProcessorOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
@@ -11,13 +11,13 @@ string queueName = "<queue_name>";
 await using var client = new ServiceBusClient(connectionString);
 ServiceBusSender sender = client.CreateSender(queueName);
 
-await sender.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+await sender.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
-ServiceBusReceivedMessage firstMessage = await receiver.ReceiveAsync();
+ServiceBusReceivedMessage firstMessage = await receiver.ReceiveMessageAsync();
 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
 {
-    await sender.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
-    await receiver.CompleteAsync(firstMessage);
+    await sender.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+    await receiver.CompleteMessageAsync(firstMessage);
     ts.Complete();
 }
 ```
@@ -33,7 +33,7 @@ string queueB = "<other_queue_name>";
 await using var client = new ServiceBusClient(connectionString);
 
 ServiceBusSender senderA = client.CreateSender(queueA);
-await senderA.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+await senderA.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 
 ServiceBusSender senderBViaA = client.CreateSender(queueB, new ServiceBusSenderOptions
 {
@@ -41,11 +41,11 @@ ServiceBusSender senderBViaA = client.CreateSender(queueB, new ServiceBusSenderO
 });
 
 ServiceBusReceiver receiverA = client.CreateReceiver(queueA);
-ServiceBusReceivedMessage firstMessage = await receiverA.ReceiveAsync();
+ServiceBusReceivedMessage firstMessage = await receiverA.ReceiveMessageAsync();
 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
 {
-    await receiverA.CompleteAsync(firstMessage);
-    await senderBViaA.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+    await receiverA.CompleteMessageAsync(firstMessage);
+    await senderBViaA.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
     ts.Complete();
 }
 ```

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
@@ -60,7 +60,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   The set of options to apply to the batch.
         /// </summary>
         ///
-        private CreateBatchOptions Options { get; }
+        private CreateMessageBatchOptions Options { get; }
 
         /// <summary>
         ///   The set of messages that have been added to the batch.
@@ -74,7 +74,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <param name="options">The set of options to apply to the batch.</param>
         ///
-        public AmqpMessageBatch(CreateBatchOptions options)
+        public AmqpMessageBatch(CreateMessageBatchOptions options)
         {
             Argument.AssertNotNull(options, nameof(options));
             Argument.AssertNotNull(options.MaxSizeInBytes, nameof(options.MaxSizeInBytes));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageBatch.cs
@@ -98,7 +98,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <returns><c>true</c> if the message was added; otherwise, <c>false</c>.</returns>
         ///
-        public override bool TryAdd(ServiceBusMessage message)
+        public override bool TryAddMessage(ServiceBusMessage message)
         {
             Argument.AssertNotNull(message, nameof(message));
             Argument.AssertNotDisposed(_disposed, nameof(ServiceBusMessageBatch));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -158,14 +158,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        public override async ValueTask<TransportMessageBatch> CreateBatchAsync(
+        public override async ValueTask<TransportMessageBatch> CreateMessageBatchAsync(
             CreateMessageBatchOptions options,
             CancellationToken cancellationToken)
         {
             TransportMessageBatch messageBatch = null;
             Task createBatchTask = _retryPolicy.RunOperation(async (timeout) =>
             {
-                messageBatch = await CreateBatchInternalAsync(
+                messageBatch = await CreateMessageBatchInternalAsync(
                     options,
                     timeout).ConfigureAwait(false);
             },
@@ -175,7 +175,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             return messageBatch;
         }
 
-        internal async ValueTask<TransportMessageBatch> CreateBatchInternalAsync(
+        internal async ValueTask<TransportMessageBatch> CreateMessageBatchInternalAsync(
             CreateMessageBatchOptions options,
             TimeSpan timeout)
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -159,7 +159,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
         public override async ValueTask<TransportMessageBatch> CreateBatchAsync(
-            CreateBatchOptions options,
+            CreateMessageBatchOptions options,
             CancellationToken cancellationToken)
         {
             TransportMessageBatch messageBatch = null;
@@ -176,7 +176,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         }
 
         internal async ValueTask<TransportMessageBatch> CreateBatchInternalAsync(
-            CreateBatchOptions options,
+            CreateMessageBatchOptions options,
             TimeSpan timeout)
         {
             Argument.AssertNotNull(options, nameof(options));
@@ -361,106 +361,105 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         ///
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="messages"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public override async Task<long> ScheduleMessageAsync(
-            ServiceBusMessage message,
+        public override async Task<long[]> ScheduleMessagesAsync(
+            IList<ServiceBusMessage> messages,
             CancellationToken cancellationToken = default)
         {
-            long sequenceNumber = 0;
-            Task scheduleTask = _retryPolicy.RunOperation(async (timeout) =>
+            long[] seqNumbers = null;
+            await _retryPolicy.RunOperation(async (timeout) =>
             {
-                sequenceNumber = await ScheduleMessageInternalAsync(
-                    message,
+                seqNumbers = await ScheduleMessageInternalAsync(
+                    messages,
                     timeout,
                     cancellationToken).ConfigureAwait(false);
             },
             _connectionScope,
-            cancellationToken);
-            await scheduleTask.ConfigureAwait(false);
-            return sequenceNumber;
+            cancellationToken).ConfigureAwait(false);
+            return seqNumbers ?? Array.Empty<long>();
         }
 
         /// <summary>
         ///
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="messages"></param>
         /// <param name="timeout"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        internal async Task<long> ScheduleMessageInternalAsync(
-            ServiceBusMessage message,
+        internal async Task<long[]> ScheduleMessageInternalAsync(
+            IList<ServiceBusMessage> messages,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
             var sendLink = default(SendingAmqpLink);
             try
             {
-                using (AmqpMessage amqpMessage = AmqpMessageConverter.SBMessageToAmqpMessage(message))
+
+                var request = AmqpRequestMessage.CreateRequest(
+                        ManagementConstants.Operations.ScheduleMessageOperation,
+                        timeout,
+                        null);
+
+                if (_sendLink.TryGetOpenedObject(out sendLink))
                 {
+                    request.AmqpMessage.ApplicationProperties.Map[ManagementConstants.Request.AssociatedLinkName] = sendLink.Name;
+                }
 
-                    var request = AmqpRequestMessage.CreateRequest(
-                            ManagementConstants.Operations.ScheduleMessageOperation,
-                            timeout,
-                            null);
-
-                    if (_sendLink.TryGetOpenedObject(out sendLink))
-                    {
-                        request.AmqpMessage.ApplicationProperties.Map[ManagementConstants.Request.AssociatedLinkName] = sendLink.Name;
-                    }
-
+                List<AmqpMap> entries = new List<AmqpMap>();
+                foreach (ServiceBusMessage message in messages)
+                {
+                    using AmqpMessage amqpMessage = AmqpMessageConverter.SBMessageToAmqpMessage(message);
+                    var entry = new AmqpMap();
                     ArraySegment<byte>[] payload = amqpMessage.GetPayload();
                     var buffer = new BufferListStream(payload);
                     ArraySegment<byte> value = buffer.ReadBytes((int)buffer.Length);
+                    entry[ManagementConstants.Properties.Message] = value;
+                    entry[ManagementConstants.Properties.MessageId] = message.MessageId;
 
-                    var entry = new AmqpMap();
+                    if (!string.IsNullOrWhiteSpace(message.SessionId))
                     {
-                        entry[ManagementConstants.Properties.Message] = value;
-                        entry[ManagementConstants.Properties.MessageId] = message.MessageId;
-
-                        if (!string.IsNullOrWhiteSpace(message.SessionId))
-                        {
-                            entry[ManagementConstants.Properties.SessionId] = message.SessionId;
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(message.PartitionKey))
-                        {
-                            entry[ManagementConstants.Properties.PartitionKey] = message.PartitionKey;
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(message.ViaPartitionKey))
-                        {
-                            entry[ManagementConstants.Properties.ViaPartitionKey] = message.ViaPartitionKey;
-                        }
+                        entry[ManagementConstants.Properties.SessionId] = message.SessionId;
                     }
 
-                    request.Map[ManagementConstants.Properties.Messages] = new List<AmqpMap> { entry };
-
-
-                    AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
-                        _connectionScope,
-                        _managementLink,
-                        request,
-                        timeout).ConfigureAwait(false);
-
-                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-
-                    if (amqpResponseMessage.StatusCode == AmqpResponseStatusCode.OK)
+                    if (!string.IsNullOrWhiteSpace(message.PartitionKey))
                     {
-                        var sequenceNumbers = amqpResponseMessage.GetValue<long[]>(ManagementConstants.Properties.SequenceNumbers);
-                        if (sequenceNumbers == null || sequenceNumbers.Length < 1)
-                        {
-                            throw new ServiceBusException(true, "Could not schedule message successfully.");
-                        }
-
-                        return sequenceNumbers[0];
-
+                        entry[ManagementConstants.Properties.PartitionKey] = message.PartitionKey;
                     }
-                    else
+
+                    if (!string.IsNullOrWhiteSpace(message.ViaPartitionKey))
                     {
-                        throw amqpResponseMessage.ToMessagingContractException();
+                        entry[ManagementConstants.Properties.ViaPartitionKey] = message.ViaPartitionKey;
                     }
+
+                    entries.Add(entry);
+                }
+
+                request.Map[ManagementConstants.Properties.Messages] = entries;
+
+                AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
+                    _connectionScope,
+                    _managementLink,
+                    request,
+                    timeout).ConfigureAwait(false);
+
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                if (amqpResponseMessage.StatusCode == AmqpResponseStatusCode.OK)
+                {
+                    var sequenceNumbers = amqpResponseMessage.GetValue<long[]>(ManagementConstants.Properties.SequenceNumbers);
+                    if (sequenceNumbers == null || sequenceNumbers.Length < 1)
+                    {
+                        throw new ServiceBusException(true, "Could not schedule message successfully.");
+                    }
+
+                    return sequenceNumbers;
+
+                }
+                else
+                {
+                    throw amqpResponseMessage.ToMessagingContractException();
                 }
             }
             catch (Exception exception)
@@ -479,17 +478,17 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         ///
         /// </summary>
-        /// <param name="sequenceNumber"></param>
+        /// <param name="sequenceNumbers"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public override async Task CancelScheduledMessageAsync(
-            long sequenceNumber,
+        public override async Task CancelScheduledMessagesAsync(
+            long[] sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
             Task cancelMessageTask = _retryPolicy.RunOperation(async (timeout) =>
             {
                 await CancelScheduledMessageInternalAsync(
-                    sequenceNumber,
+                    sequenceNumbers,
                     timeout,
                     cancellationToken).ConfigureAwait(false);
             },
@@ -501,12 +500,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         ///
         /// </summary>
-        /// <param name="sequenceNumber"></param>
+        /// <param name="sequenceNumbers"></param>
         /// <param name="timeout"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         internal async Task CancelScheduledMessageInternalAsync(
-            long sequenceNumber,
+            long[] sequenceNumbers,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
@@ -523,7 +522,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     request.AmqpMessage.ApplicationProperties.Map[ManagementConstants.Request.AssociatedLinkName] = sendLink.Name;
                 }
 
-                request.Map[ManagementConstants.Properties.SequenceNumbers] = new[] { sequenceNumber };
+                request.Map[ManagementConstants.Properties.SequenceNumbers] = sequenceNumbers;
 
                 AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
                         _connectionScope,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportMessageBatch.cs
@@ -43,7 +43,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns><c>true</c> if the message was added; otherwise, <c>false</c>.</returns>
         ///
-        public abstract bool TryAdd(ServiceBusMessage message);
+        public abstract bool TryAddMessage(ServiceBusMessage message);
 
         /// <summary>
         ///   Clears the batch, removing all messages and resetting the

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>List of messages received. Returns an empty list if no message is found.</returns>
-        public abstract Task<IList<ServiceBusReceivedMessage>> ReceiveBatchAsync(
+        public abstract Task<IList<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
             int maximumMessageCount,
             TimeSpan? maxWaitTime,
             CancellationToken cancellationToken);
@@ -117,10 +117,10 @@ namespace Azure.Messaging.ServiceBus.Core
         /// The first call to PeekBatchBySequenceAsync(long, int, CancellationToken) fetches the first active message for this receiver. Each subsequent call
         /// fetches the subsequent message in the entity.
         /// Unlike a received message, peeked message will not have lock token associated with it, and hence it cannot be Completed/Abandoned/Deferred/Deadlettered/Renewed.
-        /// Also, unlike <see cref="ReceiveBatchAsync(int, TimeSpan?, CancellationToken)"/>, this method will fetch even Deferred messages (but not Deadlettered messages).
+        /// Also, unlike <see cref="ReceiveMessagesAsync(int, TimeSpan?, CancellationToken)"/>, this method will fetch even Deferred messages (but not Deadlettered messages).
         /// </remarks>
         /// <returns></returns>
-        public abstract Task<IList<ServiceBusReceivedMessage>> PeekBatchAtAsync(
+        public abstract Task<IList<ServiceBusReceivedMessage>> PeekMessagesAsync(
             long? sequenceNumber,
             int messageCount = 1,
             CancellationToken cancellationToken = default);
@@ -179,7 +179,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <returns>Messages identified by sequence number are returned. Returns null if no messages are found.
         /// Throws if the messages have not been deferred.</returns>
         /// <seealso cref="DeferAsync"/>
-        public abstract Task<IList<ServiceBusReceivedMessage>> ReceiveDeferredMessageBatchAsync(
+        public abstract Task<IList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
             IList<long> sequenceNumbers,
             CancellationToken cancellationToken = default);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
@@ -41,10 +41,10 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
         ///
         public abstract ValueTask<TransportMessageBatch> CreateBatchAsync(
-            CreateBatchOptions options,
+            CreateMessageBatchOptions options,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -76,21 +76,21 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <summary>
         ///
         /// </summary>
-        /// <param name="message"></param>
+        /// <param name="messages"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public abstract Task<long> ScheduleMessageAsync(
-            ServiceBusMessage message,
+        public abstract Task<long[]> ScheduleMessagesAsync(
+            IList<ServiceBusMessage> messages,
             CancellationToken cancellationToken = default);
 
         /// <summary>
         ///
         /// </summary>
-        /// <param name="sequenceNumber"></param>
+        /// <param name="sequenceNumbers"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public abstract Task CancelScheduledMessageAsync(
-            long sequenceNumber,
+        public abstract Task CancelScheduledMessagesAsync(
+            long[] sequenceNumbers,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
@@ -41,9 +41,9 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateMessageBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
         ///
-        public abstract ValueTask<TransportMessageBatch> CreateBatchAsync(
+        public abstract ValueTask<TransportMessageBatch> CreateMessageBatchAsync(
             CreateMessageBatchOptions options,
             CancellationToken cancellationToken);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -264,19 +264,19 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(ReceiveDeferredMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: ReceiveDeferredMessageAsync start. MessageCount = {1}, LockTokens = {2}")]
+        [Event(ReceiveDeferredMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: ReceiveDeferredMessageAsync start. MessageCount = {1}, SequenceNumbers = {2}")]
         public void ReceiveDeferredMessageStartCore(string identifier, int messageCount, string sequenceNumbers)
         {
             WriteEvent(ReceiveDeferredMessageStartEvent, identifier, messageCount, sequenceNumbers);
         }
 
         [NonEvent]
-        public virtual void ReceiveDeferredMessageStart(string identifier, int messageCount, IEnumerable<long> sequenceNumbers)
+        public virtual void ReceiveDeferredMessageStart(string identifier, IList<long> sequenceNumbers)
         {
             if (IsEnabled())
             {
                 var formattedSequenceNumbers = StringUtility.GetFormattedSequenceNumbers(sequenceNumbers);
-                ReceiveDeferredMessageStartCore(identifier, messageCount, formattedSequenceNumbers);
+                ReceiveDeferredMessageStartCore(identifier, sequenceNumbers.Count, formattedSequenceNumbers);
             }
         }
 
@@ -329,17 +329,17 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         #endregion
 
         #region Scheduling
-        [Event(ScheduleMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: ScheduleMessageAsync start. ScheduleTimeUtc = {1}")]
-        public virtual void ScheduleMessageStart(string identifier, string scheduledEnqueueTime)
+        [Event(ScheduleMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: ScheduleMessageAsync start. MessageCount = {1}, ScheduleTimeUtc = {2}")]
+        public virtual void ScheduleMessagesStart(string identifier, int messageCount, string scheduledEnqueueTime)
         {
             if (IsEnabled())
             {
-                WriteEvent(ScheduleMessageStartEvent, identifier, scheduledEnqueueTime);
+                WriteEvent(ScheduleMessageStartEvent, identifier, messageCount, scheduledEnqueueTime);
             }
         }
 
         [Event(ScheduleMessageCompleteEvent, Level = EventLevel.Informational, Message = "{0}: ScheduleMessageAsync done.")]
-        public virtual void ScheduleMessageComplete(string identifier)
+        public virtual void ScheduleMessagesComplete(string identifier)
         {
             if (IsEnabled())
             {
@@ -348,7 +348,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [Event(ScheduleMessageExceptionEvent, Level = EventLevel.Error, Message = "{0}: ScheduleMessageAsync Exception: {1}.")]
-        public virtual void ScheduleMessageException(string identifier, string exception)
+        public virtual void ScheduleMessagesException(string identifier, string exception)
         {
             if (IsEnabled())
             {
@@ -356,17 +356,27 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(CancelScheduledMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: CancelScheduledMessageAsync start. SequenceNumber = {1}")]
-        public virtual void CancelScheduledMessageStart(string identifier, long sequenceNumber)
+        [NonEvent]
+        public virtual void CancelScheduledMessagesStart(string identifier, long[] sequenceNumbers)
         {
             if (IsEnabled())
             {
-                WriteEvent(CancelScheduledMessageStartEvent, identifier, sequenceNumber);
+                var formattedSequenceNumbers = StringUtility.GetFormattedSequenceNumbers(sequenceNumbers);
+                CancelScheduledMessagesStartCore(identifier, sequenceNumbers.Length, formattedSequenceNumbers);
+            }
+        }
+
+        [Event(CancelScheduledMessageStartEvent, Level = EventLevel.Informational, Message = "{0}: CancelScheduledMessageAsync start. MessageCount = {1}, SequenceNumbers = {2}")]
+        public virtual void CancelScheduledMessagesStartCore(string identifier, int messageCount, string sequenceNumbers)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(CancelScheduledMessageStartEvent, identifier, messageCount, sequenceNumbers);
             }
         }
 
         [Event(CancelScheduledMessageCompleteEvent, Level = EventLevel.Informational, Message = "{0}: CancelScheduledMessageAsync done.")]
-        public virtual void CancelScheduledMessageComplete(string identifier)
+        public virtual void CancelScheduledMessagesComplete(string identifier)
         {
             if (IsEnabled())
             {
@@ -375,7 +385,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [Event(CancelScheduledMessageExceptionEvent, Level = EventLevel.Error, Message = "{0}: CancelScheduledMessageAsync Exception: {1}.")]
-        public virtual void CancelScheduledMessageException(string identifier, string exception)
+        public virtual void CancelScheduledMessagesException(string identifier, string exception)
         {
             if (IsEnabled())
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
@@ -53,7 +53,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            await _receiver.AbandonAsync(message, propertiesToModify, cancellationToken)
+            await _receiver.AbandonMessageAsync(message, propertiesToModify, cancellationToken)
             .ConfigureAwait(false);
             message.IsSettled = true;
         }
@@ -68,7 +68,7 @@ namespace Azure.Messaging.ServiceBus
             ServiceBusReceivedMessage message,
             CancellationToken cancellationToken = default)
         {
-            await _receiver.CompleteAsync(
+            await _receiver.CompleteMessageAsync(
                 message,
                 cancellationToken)
             .ConfigureAwait(false);
@@ -89,7 +89,7 @@ namespace Azure.Messaging.ServiceBus
             string deadLetterErrorDescription = default,
             CancellationToken cancellationToken = default)
         {
-            await _receiver.DeadLetterAsync(
+            await _receiver.DeadLetterMessageAsync(
                 message,
                 deadLetterReason,
                 deadLetterErrorDescription,
@@ -110,7 +110,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            await _receiver.DeadLetterAsync(
+            await _receiver.DeadLetterMessageAsync(
                 message,
                 propertiesToModify,
                 cancellationToken)
@@ -130,7 +130,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            await _receiver.DeferAsync(
+            await _receiver.DeferMessageAsync(
                 message,
                 propertiesToModify,
                 cancellationToken)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
@@ -105,7 +105,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            await _sessionReceiver.AbandonAsync(message, propertiesToModify, cancellationToken)
+            await _sessionReceiver.AbandonMessageAsync(message, propertiesToModify, cancellationToken)
                 .ConfigureAwait(false);
             message.IsSettled = true;
         }
@@ -126,7 +126,7 @@ namespace Azure.Messaging.ServiceBus
             ServiceBusReceivedMessage message,
             CancellationToken cancellationToken = default)
         {
-            await _sessionReceiver.CompleteAsync(
+            await _sessionReceiver.CompleteMessageAsync(
                 message,
                 cancellationToken)
             .ConfigureAwait(false);
@@ -155,7 +155,7 @@ namespace Azure.Messaging.ServiceBus
             string deadLetterErrorDescription = default,
             CancellationToken cancellationToken = default)
         {
-            await _sessionReceiver.DeadLetterAsync(
+            await _sessionReceiver.DeadLetterMessageAsync(
                 message,
                 deadLetterReason,
                 deadLetterErrorDescription,
@@ -184,7 +184,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            await _sessionReceiver.DeadLetterAsync(
+            await _sessionReceiver.DeadLetterMessageAsync(
                 message,
                 propertiesToModify,
                 cancellationToken)
@@ -202,7 +202,7 @@ namespace Azure.Messaging.ServiceBus
         /// A lock token can be found in <see cref="ServiceBusReceivedMessage.LockToken"/>,
         /// only when <see cref="ReceiveMode"/> is set to <see cref="ReceiveMode.PeekLock"/>.
         /// In order to receive this message again in the future, you will need to save the <see cref="ServiceBusReceivedMessage.SequenceNumber"/>
-        /// and receive it using <see cref="ServiceBusReceiver.ReceiveDeferredMessageAsync(long, CancellationToken)"/>.
+        /// and receive it using <see cref="ServiceBusReceiver.ReceiveDeferredMessagesAsync(IEnumerable{long}, CancellationToken)"/>.
         /// Deferring messages does not impact message's expiration, meaning that deferred messages can still expire.
         /// This operation can only be performed on messages that were received by this receiver.
         /// </remarks>
@@ -213,7 +213,7 @@ namespace Azure.Messaging.ServiceBus
             IDictionary<string, object> propertiesToModify = default,
             CancellationToken cancellationToken = default)
         {
-            await _sessionReceiver.DeferAsync(
+            await _sessionReceiver.DeferMessageAsync(
                 message,
                 propertiesToModify,
                 cancellationToken)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -84,7 +84,7 @@ namespace Azure.Messaging.ServiceBus
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
-                    ServiceBusReceivedMessage message = await Receiver.ReceiveAsync(
+                    ServiceBusReceivedMessage message = await Receiver.ReceiveMessageAsync(
                         _maxReceiveWaitTime,
                         cancellationToken).ConfigureAwait(false);
                     if (message == null)
@@ -170,7 +170,7 @@ namespace Azure.Messaging.ServiceBus
                     // don't pass the processor cancellation token
                     // as we want in flight autocompletion to be able
                     // to finish
-                    await Receiver.CompleteAsync(
+                    await Receiver.CompleteMessageAsync(
                         message.LockToken,
                         CancellationToken.None)
                         .ConfigureAwait(false);
@@ -202,7 +202,7 @@ namespace Azure.Messaging.ServiceBus
                         // don't pass the processor cancellation token
                         // as we want in flight abandon to be able
                         // to finish even if user stopped processing
-                        await Receiver.AbandonAsync(
+                        await Receiver.AbandonMessageAsync(
                             message.LockToken,
                             cancellationToken: CancellationToken.None)
                             .ConfigureAwait(false);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -386,7 +386,7 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Optional event that can be set to be notified when a session is about to be closed for processing.
-        /// This means that the most recent ReceiveAsync call timed out so there are currently no messages
+        /// This means that the most recent <see cref="ServiceBusReceiver.ReceiveMessageAsync"/> call timed out so there are currently no messages
         /// available to be received for the session.
         /// </summary>
         [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -172,8 +172,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Optional event that can be set to be notified when a session is about to be closed for processing.
-        /// This means that the most recent ReceiveAsync call timed out so there are currently no messages
-        /// available to be received for the session.
+        /// This means that the most recent <see cref="ServiceBusReceiver.ReceiveMessageAsync"/> call timed out,
+        /// so there are currently no messages available to be received for the session.
         /// </summary>
         [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
         [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -232,7 +232,7 @@ namespace Azure.Messaging.ServiceBus
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
-                    ServiceBusReceivedMessage message = await _receiver.ReceiveAsync(
+                    ServiceBusReceivedMessage message = await _receiver.ReceiveMessageAsync(
                         _maxReceiveWaitTime,
                         cancellationToken).ConfigureAwait(false);
                     if (message == null)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/CreateMessageBatchOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/CreateMessageBatchOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.ServiceBus
     ///   behaves and is sent to the Queue/Topic.
     /// </summary>
     ///
-    public class CreateBatchOptions
+    public class CreateMessageBatchOptions
     {
         /// <summary>The requested maximum size to allow for the batch, in bytes.</summary>
         private long? _maxSizeInBytes = null;
@@ -71,13 +71,13 @@ namespace Azure.Messaging.ServiceBus
         public override string ToString() => base.ToString();
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="CreateBatchOptions" />, cloning its attributes into a new instance.
+        ///   Creates a new copy of the current <see cref="CreateMessageBatchOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
-        /// <returns>A new copy of <see cref="CreateBatchOptions" />.</returns>
+        /// <returns>A new copy of <see cref="CreateMessageBatchOptions" />.</returns>
         ///
-        internal CreateBatchOptions Clone() =>
-            new CreateBatchOptions
+        internal CreateMessageBatchOptions Clone() =>
+            new CreateMessageBatchOptions
             {
                 _maxSizeInBytes = MaxSizeInBytes
             };

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
@@ -13,7 +13,7 @@ namespace Azure.Messaging.ServiceBus
     ///   intended to be sent to the Queue/Topic as a single batch.
     ///   A <see cref="ServiceBusMessageBatch"/> can be created using
     ///   <see cref="ServiceBusSender.CreateMessageBatchAsync(System.Threading.CancellationToken)"/>.
-    ///   Messages can be added to the batch using the <see cref="TryAdd"/> method on the batch.
+    ///   Messages can be added to the batch using the <see cref="TryAddMessage"/> method on the batch.
     /// </summary>
     ///
     public sealed class ServiceBusMessageBatch : IDisposable
@@ -80,12 +80,12 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns><c>true</c> if the message was added; otherwise, <c>false</c>.</returns>
         ///
-        public bool TryAdd(ServiceBusMessage message)
+        public bool TryAddMessage(ServiceBusMessage message)
         {
             lock (_syncGuard)
             {
                 AssertNotLocked();
-                return InnerBatch.TryAdd(message);
+                return InnerBatch.TryAddMessage(message);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.ServiceBus
     ///   A set of <see cref="ServiceBusMessage" /> with size constraints known up-front,
     ///   intended to be sent to the Queue/Topic as a single batch.
     ///   A <see cref="ServiceBusMessageBatch"/> can be created using
-    ///   <see cref="ServiceBusSender.CreateBatchAsync(System.Threading.CancellationToken)"/>.
+    ///   <see cref="ServiceBusSender.CreateMessageBatchAsync(System.Threading.CancellationToken)"/>.
     ///   Messages can be added to the batch using the <see cref="TryAdd"/> method on the batch.
     /// </summary>
     ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -142,18 +142,18 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   Sends a message to the associated entity of Service Bus.
         /// </summary>
+        /// <param name="message"></param>
         ///
-        /// <param name="message">A messsage to send.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public virtual async Task SendAsync(
+        public virtual async Task SendMessageAsync(
             ServiceBusMessage message,
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(message, nameof(message));
-            await SendAsync(
+            await SendMessagesAsync(
                 new ServiceBusMessage[] { message },
                 cancellationToken).ConfigureAwait(false);
         }
@@ -162,7 +162,7 @@ namespace Azure.Messaging.ServiceBus
         ///   Sends a set of messages to the associated Service Bus entity using a batched approach.
         ///   If the size of the messages exceed the maximum size of a single batch,
         ///   an exception will be triggered and the send will fail. In order to ensure that the messages
-        ///   being sent will fit in a batch, use <see cref="SendAsync(ServiceBusMessageBatch, CancellationToken)"/> instead.
+        ///   being sent will fit in a batch, use <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/> instead.
         /// </summary>
         ///
         /// <param name="messages">The set of messages to send.</param>
@@ -170,7 +170,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public virtual async Task SendAsync(
+        public virtual async Task SendMessagesAsync(
             IEnumerable<ServiceBusMessage> messages,
             CancellationToken cancellationToken = default)
         {
@@ -257,9 +257,9 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the default batch options.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
         ///
-        public virtual ValueTask<ServiceBusMessageBatch> CreateBatchAsync(CancellationToken cancellationToken = default) => CreateBatchAsync(null, cancellationToken);
+        public virtual ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default) => CreateBatchAsync(null, cancellationToken);
 
         /// <summary>
         ///   Creates a size-constraint batch to which <see cref="ServiceBusMessage" /> may be added using a try-based pattern.  If a message would
@@ -275,14 +275,14 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
         ///
         public virtual async ValueTask<ServiceBusMessageBatch> CreateBatchAsync(
-            CreateBatchOptions options,
+            CreateMessageBatchOptions options,
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsDisposed, nameof(ServiceBusSender));
-            options = options?.Clone() ?? new CreateBatchOptions();
+            options = options?.Clone() ?? new CreateMessageBatchOptions();
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.CreateMessageBatchStart(Identifier);
             ServiceBusMessageBatch batch;
@@ -307,11 +307,11 @@ namespace Azure.Messaging.ServiceBus
         ///   the associated Service Bus entity.
         /// </summary>
         ///
-        /// <param name="messageBatch">The batch of messages to send. A batch may be created using <see cref="CreateBatchAsync(CancellationToken)" />.</param>
+        /// <param name="messageBatch">The batch of messages to send. A batch may be created using <see cref="CreateMessageBatchAsync(CancellationToken)" />.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public virtual async Task SendAsync(
+        public virtual async Task SendMessagesAsync(
             ServiceBusMessageBatch messageBatch,
             CancellationToken cancellationToken = default)
         {
@@ -348,9 +348,9 @@ namespace Azure.Messaging.ServiceBus
         /// Schedules a message to appear on Service Bus at a later time.
         /// </summary>
         ///
-        /// <param name="message">The message to schedule.</param>
         /// <param name="scheduledEnqueueTime">The UTC time at which the message should be available for processing</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <param name="message"></param>
         ///
         /// <remarks>Although the message will not be available to be received until the scheduledEnqueueTime, it can still be peeked before that time.</remarks>
         /// <returns>The sequence number of the message that was scheduled.</returns>
@@ -360,31 +360,68 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(message, nameof(message));
+            long[] sequenceNumbers = await ScheduleMessagesAsync(
+                new ServiceBusMessage[] { message },
+                scheduledEnqueueTime,
+                cancellationToken)
+            .ConfigureAwait(false);
+            // if there isn't one sequence number in the array, an
+            // exception should have been thrown by this point.
+            return sequenceNumbers[0];
+        }
+
+
+
+        /// <summary>
+        /// Schedules a message to appear on Service Bus at a later time.
+        /// </summary>
+        ///
+        /// <param name="scheduledEnqueueTime">The UTC time at which the message should be available for processing</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <param name="messages"></param>
+        ///
+        /// <remarks>Although the message will not be available to be received until the scheduledEnqueueTime, it can still be peeked before that time.</remarks>
+        /// <returns>The sequence number of the message that was scheduled.</returns>
+        public virtual async Task<long[]> ScheduleMessagesAsync(
+            IEnumerable<ServiceBusMessage> messages,
+            DateTimeOffset scheduledEnqueueTime,
+            CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotNullOrEmpty(messages, nameof(messages));
             Argument.AssertNotClosed(IsDisposed, nameof(ServiceBusSender));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-            Logger.ScheduleMessageStart(Identifier, scheduledEnqueueTime.ToString(CultureInfo.InvariantCulture));
+            var messageList = messages.ToList();
+
+            Logger.ScheduleMessagesStart(
+                Identifier,
+                messageList.Count,
+                scheduledEnqueueTime.ToString(CultureInfo.InvariantCulture));
+
             using DiagnosticScope scope = CreateDiagnosticScope(
-                new ServiceBusMessage[] { message },
+                messages,
                 DiagnosticProperty.ScheduleActivityName);
             scope.Start();
 
-            long sequenceNumber;
+            long[] sequenceNumbers = null;
             try
             {
-                message.ScheduledEnqueueTime = scheduledEnqueueTime.UtcDateTime;
-                sequenceNumber = await _innerSender.ScheduleMessageAsync(message, cancellationToken).ConfigureAwait(false);
+                foreach (ServiceBusMessage message in messageList)
+                {
+                    message.ScheduledEnqueueTime = scheduledEnqueueTime.UtcDateTime;
+                }
+                sequenceNumbers = await _innerSender.ScheduleMessagesAsync(messageList, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
-                Logger.ScheduleMessageException(Identifier, exception.ToString());
+                Logger.ScheduleMessagesException(Identifier, exception.ToString());
                 scope.Failed(exception);
                 throw;
             }
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-            Logger.ScheduleMessageComplete(Identifier);
-            scope.AddAttribute(DiagnosticProperty.SequenceNumbersAttribute, sequenceNumber);
-            return sequenceNumber;
+            Logger.ScheduleMessagesComplete(Identifier);
+            scope.AddAttribute(DiagnosticProperty.SequenceNumbersAttribute, sequenceNumbers);
+            return sequenceNumbers;
         }
 
         /// <summary>
@@ -394,29 +431,43 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public virtual async Task CancelScheduledMessageAsync(
             long sequenceNumber,
+            CancellationToken cancellationToken = default) =>
+            await CancelScheduledMessagesAsync(
+                new long[] { sequenceNumber },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        /// <summary>
+        /// Cancels a message that was scheduled.
+        /// </summary>
+        /// <param name="sequenceNumbers">The <see cref="ServiceBusReceivedMessage.SequenceNumber"/> of the message to be cancelled.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        public virtual async Task CancelScheduledMessagesAsync(
+            IEnumerable<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsDisposed, nameof(ServiceBusSender));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-            Logger.CancelScheduledMessageStart(Identifier, sequenceNumber);
+            var sequenceNumberList = sequenceNumbers.ToArray();
+            Logger.CancelScheduledMessagesStart(Identifier, sequenceNumberList);
             using DiagnosticScope scope = _scopeFactory.CreateScope(
                 DiagnosticProperty.CancelActivityName,
                 DiagnosticProperty.ClientKind);
 
-            scope.AddAttribute(DiagnosticProperty.SequenceNumbersAttribute, sequenceNumber);
+            scope.AddAttribute(DiagnosticProperty.SequenceNumbersAttribute, sequenceNumbers);
             scope.Start();
             try
             {
-                await _innerSender.CancelScheduledMessageAsync(sequenceNumber, cancellationToken).ConfigureAwait(false);
+                await _innerSender.CancelScheduledMessagesAsync(sequenceNumberList, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                Logger.CancelScheduledMessageException(Identifier, ex.ToString());
+                Logger.CancelScheduledMessagesException(Identifier, ex.ToString());
                 throw;
             }
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-            Logger.CancelScheduledMessageComplete(Identifier);
+            Logger.CancelScheduledMessagesComplete(Identifier);
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -245,7 +245,7 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         ///   Creates a size-constraint batch to which <see cref="ServiceBusMessage" /> may be added using
-        ///   a <see cref="ServiceBusMessageBatch.TryAdd"/>. If a message would exceed the maximum
+        ///   a <see cref="ServiceBusMessageBatch.TryAddMessage"/>. If a message would exceed the maximum
         ///   allowable size of the batch, the batch will not allow adding the message and signal that
         ///   scenario using it return value.
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -257,9 +257,9 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the default batch options.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateMessageBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
         ///
-        public virtual ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default) => CreateBatchAsync(null, cancellationToken);
+        public virtual ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(CancellationToken cancellationToken = default) => CreateMessageBatchAsync(null, cancellationToken);
 
         /// <summary>
         ///   Creates a size-constraint batch to which <see cref="ServiceBusMessage" /> may be added using a try-based pattern.  If a message would
@@ -275,9 +275,9 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>An <see cref="ServiceBusMessageBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateMessageBatchAsync(CreateMessageBatchOptions, CancellationToken)" />
         ///
-        public virtual async ValueTask<ServiceBusMessageBatch> CreateBatchAsync(
+        public virtual async ValueTask<ServiceBusMessageBatch> CreateMessageBatchAsync(
             CreateMessageBatchOptions options,
             CancellationToken cancellationToken = default)
         {
@@ -288,7 +288,7 @@ namespace Azure.Messaging.ServiceBus
             ServiceBusMessageBatch batch;
             try
             {
-                TransportMessageBatch transportBatch = await _innerSender.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
+                TransportMessageBatch transportBatch = await _innerSender.CreateMessageBatchAsync(options, cancellationToken).ConfigureAwait(false);
                 batch = new ServiceBusMessageBatch(transportBatch);
             }
             catch (Exception ex)
@@ -348,11 +348,16 @@ namespace Azure.Messaging.ServiceBus
         /// Schedules a message to appear on Service Bus at a later time.
         /// </summary>
         ///
+        /// <param name="message">The <see cref="ServiceBusMessage"/> to schedule.</param>
         /// <param name="scheduledEnqueueTime">The UTC time at which the message should be available for processing</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <param name="message"></param>
         ///
-        /// <remarks>Although the message will not be available to be received until the scheduledEnqueueTime, it can still be peeked before that time.</remarks>
+        /// <remarks>Although the message will not be available to be received until the scheduledEnqueueTime, it can still be peeked before that time.
+        /// Messages can also be scheduled by setting <see cref="ServiceBusMessage.ScheduledEnqueueTime"/> and
+        /// using <see cref="SendMessageAsync(ServiceBusMessage, CancellationToken)"/>,
+        /// <see cref="SendMessagesAsync(IEnumerable{ServiceBusMessage}, CancellationToken)"/>, or
+        /// <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/>.</remarks>
+        ///
         /// <returns>The sequence number of the message that was scheduled.</returns>
         public virtual async Task<long> ScheduleMessageAsync(
             ServiceBusMessage message,
@@ -373,14 +378,19 @@ namespace Azure.Messaging.ServiceBus
 
 
         /// <summary>
-        /// Schedules a message to appear on Service Bus at a later time.
+        /// Schedules a set of messages to appear on Service Bus at a later time.
         /// </summary>
         ///
+        /// <param name="messages">The set of messages to schedule.</param>
         /// <param name="scheduledEnqueueTime">The UTC time at which the message should be available for processing</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <param name="messages"></param>
         ///
-        /// <remarks>Although the message will not be available to be received until the scheduledEnqueueTime, it can still be peeked before that time.</remarks>
+        /// <remarks>Although the message will not be available to be received until the scheduledEnqueueTime, it can still be peeked before that time.
+        /// Messages can also be scheduled by setting <see cref="ServiceBusMessage.ScheduledEnqueueTime"/> and
+        /// using <see cref="SendMessageAsync(ServiceBusMessage, CancellationToken)"/>,
+        /// <see cref="SendMessagesAsync(IEnumerable{ServiceBusMessage}, CancellationToken)"/>, or
+        /// <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/>.</remarks>
+        ///
         /// <returns>The sequence number of the message that was scheduled.</returns>
         public virtual async Task<long[]> ScheduleMessagesAsync(
             IEnumerable<ServiceBusMessage> messages,
@@ -438,9 +448,9 @@ namespace Azure.Messaging.ServiceBus
             .ConfigureAwait(false);
 
         /// <summary>
-        /// Cancels a message that was scheduled.
+        /// Cancels a set of messages that were scheduled.
         /// </summary>
-        /// <param name="sequenceNumbers">The <see cref="ServiceBusReceivedMessage.SequenceNumber"/> of the message to be cancelled.</param>
+        /// <param name="sequenceNumbers">The set of <see cref="ServiceBusReceivedMessage.SequenceNumber"/> of the messages to be cancelled.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public virtual async Task CancelScheduledMessagesAsync(
             IEnumerable<long> sequenceNumbers,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpMessageBatchTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpMessageBatchTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void ConstructorValidatesTheMaximumSize()
         {
-            Assert.That(() => new AmqpMessageBatch(new CreateBatchOptions { MaxSizeInBytes = null }), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpMessageBatch(new CreateMessageBatchOptions { MaxSizeInBytes = null }), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         public void ConstructorSetsTheMaximumSize()
         {
             var maximumSize = 9943;
-            var options = new CreateBatchOptions { MaxSizeInBytes = maximumSize };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = maximumSize };
 
             var batch = new AmqpMessageBatch(options);
             Assert.That(batch.MaxSizeInBytes, Is.EqualTo(maximumSize));
@@ -61,7 +61,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void TryAddValidatesTheMessage()
         {
-            var batch = new AmqpMessageBatch(new CreateBatchOptions { MaxSizeInBytes = 25 });
+            var batch = new AmqpMessageBatch(new CreateMessageBatchOptions { MaxSizeInBytes = 25 });
             Assert.That(() => batch.TryAdd(null), Throws.ArgumentNullException);
         }
 
@@ -73,7 +73,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void TryAddValidatesNotDisposed()
         {
-            var batch = new AmqpMessageBatch(new CreateBatchOptions { MaxSizeInBytes = 25 });
+            var batch = new AmqpMessageBatch(new CreateMessageBatchOptions { MaxSizeInBytes = 25 });
             batch.Dispose();
 
             Assert.That(() => batch.TryAdd(new ServiceBusMessage(new byte[0])), Throws.InstanceOf<ObjectDisposedException>());
@@ -88,7 +88,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         public void TryAddDoesNotAcceptAMessageBiggerThanTheMaximumSize()
         {
             var maximumSize = 50;
-            var options = new CreateBatchOptions { MaxSizeInBytes = maximumSize };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = maximumSize };
             var batch = new AmqpMessageBatch(options);
 
             Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[50])), Is.False, "A message of the maximum size is too large due to the reserved overhead.");
@@ -103,7 +103,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         public void TryAddAcceptsAMessageSmallerThanTheMaximumSize()
         {
             var maximumSize = 50;
-            var options = new CreateBatchOptions { MaxSizeInBytes = maximumSize };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = maximumSize };
 
             var batch = new AmqpMessageBatch(options);
 
@@ -119,7 +119,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         public void TryAddAcceptMessagesUntilTheMaximumSizeIsReached()
         {
             var maximumSize = 100;
-            var options = new CreateBatchOptions { MaxSizeInBytes = maximumSize };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = maximumSize };
             var messages = new AmqpMessage[3];
 
             var batch = new AmqpMessageBatch(options);
@@ -145,7 +145,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void TryAddSetsTheCount()
         {
-            var options = new CreateBatchOptions { MaxSizeInBytes = 5000 };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = 5000 };
             var messages = new AmqpMessage[5];
 
             for (var index = 0; index < messages.Length; ++index)
@@ -173,7 +173,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void AsEnumerableValidatesTheTypeParameter()
         {
-            var options = new CreateBatchOptions { MaxSizeInBytes = 5000 };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = 5000 };
 
             var batch = new AmqpMessageBatch(options);
             Assert.That(() => batch.AsEnumerable<AmqpMessage>(), Throws.InstanceOf<FormatException>());
@@ -188,7 +188,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         public void AsEnumerableReturnsTheMessages()
         {
             var maximumSize = 5000;
-            var options = new CreateBatchOptions { MaxSizeInBytes = maximumSize };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = maximumSize };
             var batchMessages = new ServiceBusMessage[5];
 
             var batch = new AmqpMessageBatch(options);
@@ -219,7 +219,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void ClearClearsTheCount()
         {
-            var options = new CreateBatchOptions { MaxSizeInBytes = 5000 };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = 5000 };
             var messages = new AmqpMessage[5];
 
             for (var index = 0; index < messages.Length; ++index)
@@ -250,7 +250,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void ClearClearsTheSize()
         {
-            var options = new CreateBatchOptions { MaxSizeInBytes = 5000 };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = 5000 };
             var messages = new AmqpMessage[5];
 
             for (var index = 0; index < messages.Length; ++index)
@@ -281,7 +281,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void DisposeClearsTheCount()
         {
-            var options = new CreateBatchOptions { MaxSizeInBytes = 5000 };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = 5000 };
             var messages = new AmqpMessage[5];
 
             for (var index = 0; index < messages.Length; ++index)
@@ -312,7 +312,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         [Test]
         public void DisposeClearsTheSize()
         {
-            var options = new CreateBatchOptions { MaxSizeInBytes = 5000 };
+            var options = new CreateMessageBatchOptions { MaxSizeInBytes = 5000 };
             var messages = new AmqpMessage[5];
 
             for (var index = 0; index < messages.Length; ++index)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpMessageBatchTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpMessageBatchTests.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAdd" />
+        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -62,11 +62,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         public void TryAddValidatesTheMessage()
         {
             var batch = new AmqpMessageBatch(new CreateMessageBatchOptions { MaxSizeInBytes = 25 });
-            Assert.That(() => batch.TryAdd(null), Throws.ArgumentNullException);
+            Assert.That(() => batch.TryAddMessage(null), Throws.ArgumentNullException);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAdd" />
+        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -76,11 +76,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var batch = new AmqpMessageBatch(new CreateMessageBatchOptions { MaxSizeInBytes = 25 });
             batch.Dispose();
 
-            Assert.That(() => batch.TryAdd(new ServiceBusMessage(new byte[0])), Throws.InstanceOf<ObjectDisposedException>());
+            Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Throws.InstanceOf<ObjectDisposedException>());
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAdd" />
+        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -91,11 +91,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var options = new CreateMessageBatchOptions { MaxSizeInBytes = maximumSize };
             var batch = new AmqpMessageBatch(options);
 
-            Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[50])), Is.False, "A message of the maximum size is too large due to the reserved overhead.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[50])), Is.False, "A message of the maximum size is too large due to the reserved overhead.");
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAdd" />
+        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -107,11 +107,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             var batch = new AmqpMessageBatch(options);
 
-            Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[0])), Is.True);
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Is.True);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAdd" />
+        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -128,17 +128,17 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             {
                 if (index == messages.Length - 1)
                 {
-                    Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[10])), Is.False, "The final addition should not fit in the available space.");
+                    Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[10])), Is.False, "The final addition should not fit in the available space.");
                 }
                 else
                 {
-                    Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[10])), Is.True, $"The addition for index: { index } should fit and be accepted.");
+                    Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[10])), Is.True, $"The addition for index: { index } should fit and be accepted.");
                 }
             }
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAdd" />
+        ///   Verifies functionality of the <see cref="AmqpMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -159,7 +159,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             for (var index = 0; index < messages.Length; ++index)
             {
-                Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
+                Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
             }
 
             Assert.That(batch.Count, Is.EqualTo(messages.Length), "The count should have been set when the batch was updated.");
@@ -196,7 +196,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             for (var index = 0; index < batchMessages.Length; ++index)
             {
                 batchMessages[index] = new ServiceBusMessage(new byte[0]);
-                batch.TryAdd(batchMessages[index]);
+                batch.TryAddMessage(batchMessages[index]);
             }
 
             IEnumerable<ServiceBusMessage> batchEnumerable = batch.AsEnumerable<ServiceBusMessage>();
@@ -233,7 +233,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             for (var index = 0; index < messages.Length; ++index)
             {
-                Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
+                Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
             }
 
             Assert.That(batch.Count, Is.EqualTo(messages.Length), "The count should have been set when the batch was updated.");
@@ -264,7 +264,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             for (var index = 0; index < messages.Length; ++index)
             {
-                Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
+                Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
             }
 
             Assert.That(batch.SizeInBytes, Is.GreaterThan(0), "The size should have been set when the batch was updated.");
@@ -295,7 +295,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             for (var index = 0; index < messages.Length; ++index)
             {
-                Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
+                Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
             }
 
             Assert.That(batch.Count, Is.EqualTo(messages.Length), "The count should have been set when the batch was updated.");
@@ -326,7 +326,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             for (var index = 0; index < messages.Length; ++index)
             {
-                Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
+                Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[0])), Is.True, $"The addition for index: { index } should fit and be accepted.");
             }
 
             Assert.That(batch.SizeInBytes, Is.GreaterThan(0), "The size should have been set when the batch was updated.");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -122,7 +122,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             AmqpReceiver receiver = CreateReceiver();
 
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
@@ -166,7 +166,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                .Throws(retriableException);
 
             var receiver = new AmqpReceiver(entityName, ReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.GeneralError));
@@ -220,7 +220,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                .Throws(retriableException);
 
             var receiver = new AmqpReceiver(entityName, ReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.ServiceTimeout));
@@ -283,7 +283,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
 
             var receiver = new AmqpReceiver(entityName, ReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.ServiceBusy));
@@ -340,7 +340,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                .Throws(exception);
 
             var receiver = new AmqpReceiver(entityName, ReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<ArgumentNullException>());
@@ -394,7 +394,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                .Throws(exception);
 
             var receiver = new AmqpReceiver(entityName, ReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
@@ -447,7 +447,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                .Throws(exception);
 
             var receiver = new AmqpReceiver(entityName, ReceiveMode.PeekLock, prefetchCount, mockScope.Object, retryPolicy, "someIdentifier", sessionId, isSession);
-            Assert.That(async () => await receiver.ReceiveBatchAsync(
+            Assert.That(async () => await receiver.ReceiveMessagesAsync(
                 100,
                 default,
                 cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 var sender = client.CreateSender(scope.QueueName);
 
                 var message = GetMessage(useSessions ? "sessionId" : null);
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
                 await sender.DisposeAsync();
                 ServiceBusReceiver receiver;
                 if (!useSessions)
@@ -67,7 +67,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 var sender = client.CreateSender(scope.QueueName);
 
                 var message = GetMessage(useSessions ? "sessionId" : null);
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
                 await sender.DisposeAsync();
                 ServiceBusReceiver receiver;
                 if (!useSessions)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 {
                     receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
                 }
-                var receivedMessage = await receiver.ReceiveAsync().ConfigureAwait(false);
+                var receivedMessage = await receiver.ReceiveMessageAsync().ConfigureAwait(false);
                 Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
 
                 await client.DisposeAsync();
@@ -78,7 +78,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 {
                     receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
                 }
-                var receivedMessage = await receiver.ReceiveAsync().ConfigureAwait(false);
+                var receivedMessage = await receiver.ReceiveMessageAsync().ConfigureAwait(false);
                 Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
 
                 if (!useSessions)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 }
                 int numMessages = 5;
                 var msgs = GetMessages(numMessages, sessionId);
-                await sender.SendAsync(msgs);
+                await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(useSessions, sender, msgs, listener);
 
                 ServiceBusReceiver receiver = null;
@@ -51,7 +51,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 while (remaining > 0)
                 {
                     // loop in case we don't receive all messages in one attempt
-                    var received = await receiver.ReceiveBatchAsync(remaining);
+                    var received = await receiver.ReceiveMessagesAsync(remaining);
                     receivedMsgs.AddRange(received);
                     (string Key, object Value, DiagnosticListener) receiveStart = listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.ReceiveActivityName + ".Start", receiveStart.Key);
@@ -91,7 +91,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var msgIndex = 0;
 
                 var completed = receivedMsgs[msgIndex];
-                await receiver.CompleteAsync(completed);
+                await receiver.CompleteMessageAsync(completed);
                 (string Key, object Value, DiagnosticListener) completeStart = listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.CompleteActivityName + ".Start", completeStart.Key);
                 Activity completeActivity = (Activity)completeStart.Value;
@@ -101,7 +101,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.CompleteActivityName + ".Stop", completeStop.Key);
 
                 var deferred = receivedMsgs[++msgIndex];
-                await receiver.DeferAsync(deferred);
+                await receiver.DeferMessageAsync(deferred);
                 (string Key, object Value, DiagnosticListener) deferStart = listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.DeferActivityName + ".Start", deferStart.Key);
                 Activity deferActivity = (Activity)deferStart.Value;
@@ -111,7 +111,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.DeferActivityName + ".Stop", deferStop.Key);
 
                 var deadLettered = receivedMsgs[++msgIndex];
-                await receiver.DeadLetterAsync(deadLettered);
+                await receiver.DeadLetterMessageAsync(deadLettered);
                 (string Key, object Value, DiagnosticListener) deadLetterStart = listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.DeadLetterActivityName + ".Start", deadLetterStart.Key);
                 Activity deadLetterActivity = (Activity)deadLetterStart.Value;
@@ -121,7 +121,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.DeadLetterActivityName + ".Stop", deadletterStop.Key);
 
                 var abandoned = receivedMsgs[++msgIndex];
-                await receiver.AbandonAsync(abandoned);
+                await receiver.AbandonMessageAsync(abandoned);
                 (string Key, object Value, DiagnosticListener) abandonStart = listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.AbandonActivityName + ".Start", abandonStart.Key);
                 Activity abandonActivity = (Activity)abandonStart.Value;
@@ -253,12 +253,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 }
 
                 // send a batch
-                var batch = await sender.CreateBatchAsync();
+                var batch = await sender.CreateMessageBatchAsync();
                 for (int i = 0; i < numMessages; i++)
                 {
                     batch.TryAdd(GetMessage(sessionId));
                 }
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
                 AssertSendActivities(useSessions, sender, batch.AsEnumerable<ServiceBusMessage>(), listener);
             };
         }
@@ -273,7 +273,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var messageCt = 2;
                 var msgs = GetMessages(messageCt);
-                await sender.SendAsync(msgs);
+                await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(false, sender, msgs, listener);
 
                 ServiceBusProcessor processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
@@ -326,7 +326,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var messageCt = 2;
                 var msgs = GetMessages(messageCt, "sessionId");
-                await sender.SendAsync(msgs);
+                await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(false, sender, msgs, listener);
 
                 ServiceBusSessionProcessor processor = client.CreateSessionProcessor(scope.QueueName,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -256,7 +256,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var batch = await sender.CreateMessageBatchAsync();
                 for (int i = 0; i < numMessages; i++)
                 {
-                    batch.TryAdd(GetMessage(sessionId));
+                    batch.TryAddMessage(GetMessage(sessionId));
                 }
                 await sender.SendMessagesAsync(batch);
                 AssertSendActivities(useSessions, sender, batch.AsEnumerable<ServiceBusMessage>(), listener);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -42,13 +42,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 _listener.EventsById(ServiceBusEventSource.ClientCreateStartEvent).Where(e => e.Payload.Contains(nameof(ServiceBusSender)) && e.Payload.Contains(sender.FullyQualifiedNamespace) && e.Payload.Contains(sender.EntityPath));
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchCompleteEvent, e => e.Payload.Contains(sender.Identifier));
 
                 IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkCompleteEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageStartEvent, e => e.Payload.Contains(sender.Identifier));
@@ -67,7 +67,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var remainingMessages = messageCount;
                 while (remainingMessages > 0)
                 {
-                    foreach (var item in await receiver.ReceiveBatchAsync(remainingMessages))
+                    foreach (var item in await receiver.ReceiveMessagesAsync(remainingMessages))
                     {
                         remainingMessages--;
                         messageEnum.MoveNext();
@@ -82,7 +82,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(0, remainingMessages);
                 messageEnum.Reset();
 
-                foreach (var item in await receiver.PeekBatchAsync(messageCount))
+                foreach (var item in await receiver.PeekMessagesAsync(messageCount))
                 {
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
@@ -126,13 +126,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 _listener.SingleEventById(ServiceBusEventSource.ClientCreateStartEvent, e => e.Payload.Contains(nameof(ServiceBusSender)) && e.Payload.Contains(sender.FullyQualifiedNamespace) && e.Payload.Contains(sender.EntityPath));
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchCompleteEvent, e => e.Payload.Contains(sender.Identifier));
 
                 IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, "sessionId").AsEnumerable<ServiceBusMessage>();
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkCompleteEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageStartEvent, e => e.Payload.Contains(sender.Identifier));
@@ -143,7 +143,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 // can't use a non-session receiver for session queue
                 Assert.That(
-                    async () => await receiver.ReceiveAsync(),
+                    async () => await receiver.ReceiveMessageAsync(),
                     Throws.InstanceOf<InvalidOperationException>());
 
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkStartEvent, e => e.Payload.Contains(receiver.Identifier));
@@ -156,10 +156,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkCompleteEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
 
-                var msg = await sessionReceiver.ReceiveAsync();
+                var msg = await sessionReceiver.ReceiveMessageAsync();
                 _listener.SingleEventById(ServiceBusEventSource.ReceiveMessageStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
 
-                msg = await sessionReceiver.PeekAsync();
+                msg = await sessionReceiver.PeekMessageAsync();
                 _listener.SingleEventById(ServiceBusEventSource.CreateManagementLinkStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateManagementLinkCompleteEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.PeekMessageStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
@@ -196,7 +196,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await sender.SendAsync(message);
+                    await sender.SendMessageAsync(message);
                     ts.Complete();
                 }
                 // Adding delay since transaction Commit/Rollback is an asynchronous operation.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            await sender.SendAsync(GetMessage());
+            await sender.SendMessageAsync(GetMessage());
 
             mockLogger
                 .Verify(
@@ -53,7 +53,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            await sender.SendAsync(GetMessages(5));
+            await sender.SendMessagesAsync(GetMessages(5));
 
             mockLogger
                 .Verify(
@@ -87,7 +87,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 .Throws(new Exception());
 
             Assert.That(
-                async () => await sender.SendAsync(GetMessage()),
+                async () => await sender.SendMessageAsync(GetMessage()),
                 Throws.InstanceOf<Exception>());
             mockLogger
                 .Verify(
@@ -122,12 +122,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             mockTransportSender.Setup(
                  sender => sender.CreateBatchAsync(
-                    It.IsAny<CreateBatchOptions>(),
+                    It.IsAny<CreateMessageBatchOptions>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<TransportMessageBatch>(mockTransportBatch.Object));
 
-            var batch = await sender.CreateBatchAsync();
-            await sender.SendAsync(batch);
+            var batch = await sender.CreateMessageBatchAsync();
+            await sender.SendMessagesAsync(batch);
             mockLogger
                 .Verify(
                     log => log.CreateMessageBatchStart(
@@ -162,18 +162,25 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
+            mockTransportSender.Setup(
+                sender => sender.ScheduleMessagesAsync(
+                    It.IsAny<IList<ServiceBusMessage>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new long[] { 1 }));
+
             var scheduleTime = DateTimeOffset.UtcNow.AddMinutes(1);
             await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
 
             mockLogger
                 .Verify(
-                    log => log.ScheduleMessageStart(
+                    log => log.ScheduleMessagesStart(
                         sender.Identifier,
+                        1,
                         scheduleTime.ToString(CultureInfo.InvariantCulture)),
                 Times.Once);
             mockLogger
                 .Verify(
-                    log => log.ScheduleMessageComplete(
+                    log => log.ScheduleMessagesComplete(
                         sender.Identifier),
                 Times.Once);
         }
@@ -191,8 +198,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             mockTransportSender.Setup(
-                sender => sender.ScheduleMessageAsync(
-                    It.IsAny<ServiceBusMessage>(),
+                sender => sender.ScheduleMessagesAsync(
+                    It.IsAny<IList<ServiceBusMessage>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
@@ -203,13 +210,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             mockLogger
                 .Verify(
-                    log => log.ScheduleMessageStart(
+                    log => log.ScheduleMessagesStart(
                         sender.Identifier,
+                        1,
                         scheduleTime.ToString(CultureInfo.InvariantCulture)),
                 Times.Once);
             mockLogger
                 .Verify(
-                    log => log.ScheduleMessageException(
+                    log => log.ScheduleMessagesException(
                         sender.Identifier,
                         It.IsAny<string>()),
                 Times.Once);
@@ -226,18 +234,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            var sequenceNumber = 1;
-            await sender.CancelScheduledMessageAsync(sequenceNumber);
+            long[] sequenceNumbers = new long[] { 1 };
+            await sender.CancelScheduledMessagesAsync(sequenceNumbers: sequenceNumbers);
 
             mockLogger
                 .Verify(
-                    log => log.CancelScheduledMessageStart(
+                    log => log.CancelScheduledMessagesStart(
                         sender.Identifier,
-                        sequenceNumber),
+                        sequenceNumbers),
                 Times.Once);
             mockLogger
                 .Verify(
-                    log => log.CancelScheduledMessageComplete(
+                    log => log.CancelScheduledMessagesComplete(
                         sender.Identifier),
                 Times.Once);
         }
@@ -253,27 +261,27 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            var sequenceNumber = 1;
+            long[] sequenceNumbers = new long[] { 1 };
 
             mockTransportSender.Setup(
-                sender => sender.CancelScheduledMessageAsync(
-                    sequenceNumber,
+                sender => sender.CancelScheduledMessagesAsync(
+                    It.IsAny<long[]>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             Assert.That(
-                async () => await sender.CancelScheduledMessageAsync(sequenceNumber),
+                async () => await sender.CancelScheduledMessagesAsync(sequenceNumbers: sequenceNumbers),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
                 .Verify(
-                    log => log.CancelScheduledMessageStart(
+                    log => log.CancelScheduledMessagesStart(
                         sender.Identifier,
-                        sequenceNumber),
+                        sequenceNumbers),
                 Times.Once);
             mockLogger
                 .Verify(
-                    log => log.CancelScheduledMessageException(
+                    log => log.CancelScheduledMessagesException(
                         sender.Identifier,
                         It.IsAny<string>()),
                 Times.Once);
@@ -287,7 +295,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
 
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.ReceiveBatchAsync(
+                transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
                     It.IsAny<TimeSpan?>(),
                     It.IsAny<CancellationToken>()))
@@ -300,7 +308,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
 
-            await receiver.ReceiveAsync();
+            await receiver.ReceiveMessageAsync();
 
             mockLogger
                 .Verify(
@@ -325,7 +333,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
 
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.ReceiveBatchAsync(
+                transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     maxMessages,
                     It.IsAny<TimeSpan?>(),
                     It.IsAny<CancellationToken>()))
@@ -338,7 +346,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Logger = mockLogger.Object
             };
 
-            var msgs = await receiver.ReceiveBatchAsync(maxMessages: maxMessages);
+            var msgs = await receiver.ReceiveMessagesAsync(maxMessages: maxMessages);
 
             mockLogger
                 .Verify(
@@ -364,7 +372,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
 
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.ReceiveBatchAsync(
+                transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
                     It.IsAny<TimeSpan?>(),
                     It.IsAny<CancellationToken>()))
@@ -375,7 +383,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             Assert.That(
-                async () => await receiver.ReceiveAsync(),
+                async () => await receiver.ReceiveMessageAsync(),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -402,7 +410,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
 
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.PeekBatchAtAsync(
+                transportReceiver => transportReceiver.PeekMessagesAsync(
                     It.IsAny<long?>(),
                     It.IsAny<int>(),
                     It.IsAny<CancellationToken>()))
@@ -415,20 +423,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
             var seqNumber = 5;
 
-            if (specifySeqNumber)
-            {
-                await receiver.PeekAtAsync(seqNumber);
-            }
-            else
-            {
-                await receiver.PeekAsync();
-            }
+            await receiver.PeekMessageAsync(specifySeqNumber ? seqNumber : (long?)null);
 
             mockLogger
                 .Verify(
                     log => log.PeekMessageStart(
                         receiver.Identifier,
-                        specifySeqNumber ? (long?) seqNumber : null,
+                        specifySeqNumber ? (long?)seqNumber : null,
                         1),
                 Times.Once);
             mockLogger
@@ -450,7 +451,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
 
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.PeekBatchAtAsync(
+                transportReceiver => transportReceiver.PeekMessagesAsync(
                     It.IsAny<long?>(),
                     maxMessages,
                     It.IsAny<CancellationToken>()))
@@ -465,14 +466,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             var seqNumber = 5;
             IList<ServiceBusReceivedMessage> msgs;
-            if (specifySeqNumber)
-            {
-                msgs = await receiver.PeekBatchAtAsync(seqNumber, maxMessages);
-            }
-            else
-            {
-                msgs = await receiver.PeekBatchAsync(maxMessages: maxMessages);
-            }
+            msgs = await receiver.PeekMessagesAsync(maxMessages, specifySeqNumber ? seqNumber : (long?)null);
 
             mockLogger
                 .Verify(
@@ -499,7 +493,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockConnection = GetMockConnection(mockTransportReceiver);
 
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.PeekBatchAtAsync(
+                transportReceiver => transportReceiver.PeekMessagesAsync(
                     It.IsAny<long?>(),
                     1,
                     It.IsAny<CancellationToken>()))
@@ -510,7 +504,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             Assert.That(
-                async () => await receiver.PeekAsync(),
+                async () => await receiver.PeekMessageAsync(),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -541,7 +535,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
-            await receiver.CompleteAsync(msg);
+            await receiver.CompleteMessageAsync(msg);
 
             mockLogger
                 .Verify(
@@ -576,7 +570,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
             Assert.That(
-                async () => await receiver.CompleteAsync(msg),
+                async () => await receiver.CompleteMessageAsync(msg),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -606,7 +600,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
-            await receiver.DeferAsync(msg);
+            await receiver.DeferMessageAsync(msg);
 
             mockLogger
                 .Verify(
@@ -641,7 +635,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
             Assert.That(
-                async () => await receiver.DeferAsync(msg),
+                async () => await receiver.DeferMessageAsync(msg),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -671,7 +665,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
-            await receiver.DeadLetterAsync(msg);
+            await receiver.DeadLetterMessageAsync(msg);
 
             mockLogger
                 .Verify(
@@ -708,7 +702,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
             Assert.That(
-                async () => await receiver.DeadLetterAsync(msg),
+                async () => await receiver.DeadLetterMessageAsync(msg),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -738,7 +732,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
-            await receiver.AbandonAsync(msg);
+            await receiver.AbandonMessageAsync(msg);
 
             mockLogger
                 .Verify(
@@ -773,7 +767,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
             Assert.That(
-                async () => await receiver.AbandonAsync(msg),
+                async () => await receiver.AbandonMessageAsync(msg),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -1043,11 +1037,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockTransportReceiver = new Mock<TransportReceiver>();
             var mockConnection = GetMockConnection(mockTransportReceiver);
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.ReceiveBatchAsync(
+                transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
                     It.IsAny<TimeSpan?>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult((IList<ServiceBusReceivedMessage>) new List<ServiceBusReceivedMessage>() { new ServiceBusReceivedMessage() }));
+                .Returns(Task.FromResult((IList<ServiceBusReceivedMessage>)new List<ServiceBusReceivedMessage>() { new ServiceBusReceivedMessage() }));
             var processor = new ServiceBusProcessor(mockConnection.Object, "queueName", false, new ServiceBusProcessorOptions
             {
                 MaxAutoLockRenewalDuration = TimeSpan.Zero,
@@ -1133,7 +1127,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             var mockTransportReceiver = new Mock<TransportReceiver>();
             var mockConnection = GetMockConnection(mockTransportReceiver);
             mockTransportReceiver.Setup(
-                transportReceiver => transportReceiver.ReceiveBatchAsync(
+                transportReceiver => transportReceiver.ReceiveMessagesAsync(
                     1,
                     It.IsAny<TimeSpan?>(),
                     It.IsAny<CancellationToken>()))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -121,7 +121,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 .Returns(3);
 
             mockTransportSender.Setup(
-                 sender => sender.CreateBatchAsync(
+                 sender => sender.CreateMessageBatchAsync(
                     It.IsAny<CreateMessageBatchOptions>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<TransportMessageBatch>(mockTransportBatch.Object));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestBase.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         {
             for (int i = 0; i < count; i++)
             {
-                Assert.That(() => batch.TryAdd(GetMessage(sessionId, partitionKey)), Is.True, "A message was rejected by the batch; all messages should be accepted.");
+                Assert.That(() => batch.TryAddMessage(GetMessage(sessionId, partitionKey)), Is.True, "A message was rejected by the batch; all messages should be accepted.");
             }
 
             return batch;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/ManagementClient/ServiceBusManagementClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/ManagementClient/ServiceBusManagementClientLiveTests.cs
@@ -303,13 +303,13 @@ namespace Azure.Messaging.ServiceBus.Tests.ManagementClient
             // Changing Last Accessed Time
 
             ServiceBusSender sender = sbClient.CreateSender(queueName);
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "1" });
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "2" });
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "3", ScheduledEnqueueTime = DateTime.UtcNow.AddDays(1) });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "1" });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "2" });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "3", ScheduledEnqueueTime = DateTime.UtcNow.AddDays(1) });
 
             ServiceBusReceiver receiver = sbClient.CreateReceiver(queueName);
-            ServiceBusReceivedMessage msg = await receiver.ReceiveAsync();
-            await receiver.DeadLetterAsync(msg.LockToken);
+            ServiceBusReceivedMessage msg = await receiver.ReceiveMessageAsync();
+            await receiver.DeadLetterMessageAsync(msg.LockToken);
 
             List<QueueRuntimeInfo> runtimeInfoList = new List<QueueRuntimeInfo>();
             await foreach (QueueRuntimeInfo queueRuntimeInfo in mgmtClient.GetQueuesRuntimeInfoAsync())
@@ -368,13 +368,13 @@ namespace Azure.Messaging.ServiceBus.Tests.ManagementClient
             // Changing Last Accessed Time
 
             ServiceBusSender sender = sbClient.CreateSender(topicName);
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "1" });
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "2" });
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "3", ScheduledEnqueueTime = DateTime.UtcNow.AddDays(1) });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "1" });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "2" });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "3", ScheduledEnqueueTime = DateTime.UtcNow.AddDays(1) });
 
             ServiceBusReceiver receiver = sbClient.CreateReceiver(topicName, subscriptionName);
-            ServiceBusReceivedMessage msg = await receiver.ReceiveAsync();
-            await receiver.DeadLetterAsync(msg.LockToken);
+            ServiceBusReceivedMessage msg = await receiver.ReceiveMessageAsync();
+            await receiver.DeadLetterMessageAsync(msg.LockToken);
 
             List<SubscriptionRuntimeInfo> runtimeInfoList = new List<SubscriptionRuntimeInfo>();
             await foreach (SubscriptionRuntimeInfo subscriptionRuntimeInfo in mgmtClient.GetSubscriptionsRuntimeInfoAsync(topicName))
@@ -574,19 +574,19 @@ namespace Azure.Messaging.ServiceBus.Tests.ManagementClient
 
             await using var sbClient = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
             ServiceBusSender sender = sbClient.CreateSender(queueName);
-            await sender.SendAsync(new ServiceBusMessage() { MessageId = "mid" });
+            await sender.SendMessageAsync(new ServiceBusMessage() { MessageId = "mid" });
 
             ServiceBusReceiver receiver = sbClient.CreateReceiver(destinationName);
-            ServiceBusReceivedMessage msg = await receiver.ReceiveAsync();
+            ServiceBusReceivedMessage msg = await receiver.ReceiveMessageAsync();
             Assert.NotNull(msg);
             Assert.AreEqual("mid", msg.MessageId);
-            await receiver.DeadLetterAsync(msg.LockToken);
+            await receiver.DeadLetterMessageAsync(msg.LockToken);
 
             receiver = sbClient.CreateReceiver(dlqDestinationName);
-            msg = await receiver.ReceiveAsync();
+            msg = await receiver.ReceiveMessageAsync();
             Assert.NotNull(msg);
             Assert.AreEqual("mid", msg.MessageId);
-            await receiver.CompleteAsync(msg.LockToken);
+            await receiver.CompleteMessageAsync(msg.LockToken);
 
             await mgmtClient.DeleteQueueAsync(queueName);
             await mgmtClient.DeleteQueueAsync(destinationName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -44,8 +44,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 msg.Properties.Add("DateTimeOffset", DateTimeOffset.UtcNow);
                 msg.Properties.Add("TimeSpan", TimeSpan.FromMinutes(5));
 
-                await sender.SendAsync(msg);
-                var receivedMsg = await receiver.ReceiveAsync();
+                await sender.SendMessageAsync(msg);
+                var receivedMsg = await receiver.ReceiveMessageAsync();
 
                 Assert.IsInstanceOf(typeof(byte), receivedMsg.Properties["byte"]);
                 Assert.IsInstanceOf(typeof(sbyte), receivedMsg.Properties["sbyte"]);
@@ -80,10 +80,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 var maxPayload = Enumerable.Repeat<byte>(0x20, maxMessageSize).ToArray();
                 var maxSizeMessage = new ServiceBusMessage(maxPayload);
 
-                await client.CreateSender(scope.QueueName).SendAsync(maxSizeMessage);
+                await client.CreateSender(scope.QueueName).SendMessageAsync(maxSizeMessage);
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var receivedMaxSizeMessage = await receiver.ReceiveAsync();
-                await receiver.CompleteAsync(receivedMaxSizeMessage.LockToken);
+                var receivedMaxSizeMessage = await receiver.ReceiveMessageAsync();
+                await receiver.CompleteMessageAsync(receivedMaxSizeMessage.LockToken);
                 Assert.AreEqual(maxPayload, receivedMaxSizeMessage.Body.AsBytes().ToArray());
             }
         }
@@ -109,7 +109,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 msg.SessionId = "key";
                 msg.TimeToLive = TimeSpan.FromSeconds(60);
                 msg.To = "to";
-                await sender.SendAsync(msg);
+                await sender.SendMessageAsync(msg);
 
                 var receiver = await client.CreateSessionReceiverAsync(
                     scope.QueueName,
@@ -117,7 +117,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                     {
                         ReceiveMode = ReceiveMode.ReceiveAndDelete
                     });
-                var received = await receiver.ReceiveAsync();
+                var received = await receiver.ReceiveMessageAsync();
                 AssertMessagesEqual(msg, received);
                 var toSend = new ServiceBusMessage(received);
                 AssertMessagesEqual(toSend, received);
@@ -161,7 +161,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 var body = BinaryData.FromSerializable(testBody, serializer);
                 var msg = new ServiceBusMessage(body);
 
-                await sender.SendAsync(msg);
+                await sender.SendMessageAsync(msg);
 
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var received = await receiver.ReceiveAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -164,7 +164,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 await sender.SendMessageAsync(msg);
 
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var received = await receiver.ReceiveAsync();
+                var received = await receiver.ReceiveMessageAsync();
                 var receivedBody = received.Body.Deserialize<TestBody>(serializer);
                 Assert.AreEqual(testBody.A, receivedBody.A);
                 Assert.AreEqual(testBody.B, receivedBody.B);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -29,11 +29,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // use double the number of threads so we can make sure we test that we don't
                 // retrieve more messages than expected when there are more messages available
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads * 2;
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
 
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 var options = new ServiceBusProcessorOptions
                 {
@@ -101,11 +101,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // use double the number of threads so we can make sure we test that we don't
                 // retrieve more messages than expected when there are more messages available
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads * 2;
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
 
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 var options = new ServiceBusProcessorOptions
                 {
@@ -182,11 +182,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = GetClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads;
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
 
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 var options = new ServiceBusProcessorOptions
                 {
@@ -250,11 +250,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = GetClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads;
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
 
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 var options = new ServiceBusProcessorOptions
                 {
@@ -313,10 +313,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 int numMessages = 100;
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, numMessages);
 
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
                 var options = new ServiceBusProcessorOptions
                 {
                     MaxConcurrentCalls = numThreads,
@@ -348,7 +348,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await tcs.Task;
 
                 var receiver = GetNoRetryClient().CreateReceiver(scope.QueueName);
-                var receivedMessages = await receiver.ReceiveBatchAsync(numMessages);
+                var receivedMessages = await receiver.ReceiveMessagesAsync(numMessages);
                 // can't assert on the exact amount processed due to threads that
                 // are already in flight when calling StopProcessingAsync, but we can at least verify that there are remaining messages
                 Assert.IsTrue(receivedMessages.Count > 0);
@@ -463,7 +463,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = GetClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendAsync(GetMessage());
+                await sender.SendMessageAsync(GetMessage());
                 var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoComplete = true
@@ -482,7 +482,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await tcs.Task;
                 await processor.StopProcessingAsync();
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var msg = await receiver.ReceiveAsync();
+                var msg = await receiver.ReceiveMessageAsync();
                 Assert.IsNull(msg);
             }
         }
@@ -502,7 +502,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = GetClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendAsync(GetMessage());
+                await sender.SendMessageAsync(GetMessage());
                 var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoComplete = true
@@ -548,7 +548,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await tcs.Task;
                 await processor.StopProcessingAsync();
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var msg = await receiver.ReceiveAsync(TimeSpan.FromSeconds(5));
+                var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
                 if (settleMethod == "" || settleMethod == "Abandon")
                 {
                     // if the message is abandoned (whether by user callback or

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -208,34 +208,34 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var mockReceiver = new Mock<ServiceBusReceiver>();
 
             mockReceiver
-                .Setup(receiver => receiver.AbandonAsync(
+                .Setup(receiver => receiver.AbandonMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.DeferAsync(
+                .Setup(receiver => receiver.DeferMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.CompleteAsync(
+                .Setup(receiver => receiver.CompleteMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.DeadLetterAsync(
+                .Setup(receiver => receiver.DeadLetterMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.DeadLetterAsync(
+                .Setup(receiver => receiver.DeadLetterMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -112,7 +112,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    await sender.SendAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(GetMessage(sessionId));
                     sessions.TryAdd(sessionId, null);
                 }
                 var options = new ServiceBusSessionProcessorOptions
@@ -205,7 +205,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    await sender.SendAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
                 var options = new ServiceBusSessionProcessorOptions
@@ -302,7 +302,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    await sender.SendAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
 
@@ -475,7 +475,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     sessionId = Guid.NewGuid().ToString();
-                    await sender.SendAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
 
@@ -545,14 +545,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await using var client = GetClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads;
                 for (int i = 0; i < numThreads; i++)
                 {
                     AddMessages(batch, 1, Guid.NewGuid().ToString());
                 }
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
 
                 var options = new ServiceBusSessionProcessorOptions
                 {
@@ -614,14 +614,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await using var client = GetClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads;
                 for (int i = 0; i < numThreads; i++)
                 {
                     AddMessages(batch, 1, Guid.NewGuid().ToString());
                 }
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
 
                 var options = new ServiceBusSessionProcessorOptions
                 {
@@ -693,7 +693,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = GetClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(GetMessage("sessionId"));
                 var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
                 {
                     AutoComplete = true
@@ -733,7 +733,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = GetClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(GetMessage("sessionId"));
                 var processor = client.CreateSessionProcessor(scope.QueueName);
                 var tcs = new TaskCompletionSource<bool>();
 
@@ -779,7 +779,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 if (settleMethod == "" || settleMethod == "Abandon")
                 {
                     var receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
-                    var msg = await receiver.ReceiveAsync(TimeSpan.FromSeconds(5));
+                    var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
                     Assert.IsNotNull(msg);
                 }
                 else
@@ -813,18 +813,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     var sessionId = Guid.NewGuid().ToString();
                     sessionIds.Add(sessionId);
-                    await sender.SendAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
 
                 // sending 2 more messages and not specifying these sessionIds when creating a processor,
                 // to make sure that these messages will not be received.
                 var sessionId1 = Guid.NewGuid().ToString();
-                await sender.SendAsync(GetMessage(sessionId1));
+                await sender.SendMessageAsync(GetMessage(sessionId1));
                 sessions.TryAdd(sessionId1, true);
 
                 var sessionId2 = Guid.NewGuid().ToString();
-                await sender.SendAsync(GetMessage(sessionId2));
+                await sender.SendMessageAsync(GetMessage(sessionId2));
                 sessions.TryAdd(sessionId2, true);
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -916,7 +916,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     var sessionId = Guid.NewGuid().ToString();
                     sessionIds.Add(sessionId);
                     var messages = GetMessages(messagesPerSession, sessionId);
-                    await sender.SendAsync(messages);
+                    await sender.SendMessagesAsync(messages);
                     sessions.TryAdd(sessionId, true);
                 }
 
@@ -1060,7 +1060,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
 
                 var sessionId = Guid.NewGuid().ToString();
-                await sender.SendAsync(GetMessage(sessionId));
+                await sender.SendMessageAsync(GetMessage(sessionId));
                 sessions.TryAdd(sessionId, true);
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1156,7 +1156,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
 
                 var sessionId = Guid.NewGuid().ToString();
-                await sender.SendAsync(GetMessage(sessionId));
+                await sender.SendMessageAsync(GetMessage(sessionId));
 
                 if (errorSource == ServiceBusErrorSource.AcceptMessageSession)
                 {
@@ -1332,7 +1332,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
 
                 var sessionId = Guid.NewGuid().ToString();
-                await sender.SendAsync(GetMessage(sessionId));
+                await sender.SendMessageAsync(GetMessage(sessionId));
                 sessions.TryAdd(sessionId, true);
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -201,34 +201,34 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var mockReceiver = new Mock<ServiceBusSessionReceiver>();
 
             mockReceiver
-                .Setup(receiver => receiver.AbandonAsync(
+                .Setup(receiver => receiver.AbandonMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.DeferAsync(
+                .Setup(receiver => receiver.DeferMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.CompleteAsync(
+                .Setup(receiver => receiver.CompleteMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.DeadLetterAsync(
+                .Setup(receiver => receiver.DeadLetterMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<IDictionary<string, object>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
             mockReceiver
-                .Setup(receiver => receiver.DeadLetterAsync(
+                .Setup(receiver => receiver.DeadLetterMessageAsync(
                     It.IsAny<ServiceBusReceivedMessage>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -50,10 +50,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver("queue");
             Assert.That(
-                async () => await receiver.ReceiveAsync(TimeSpan.FromSeconds(0)),
+                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(0)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
             Assert.That(
-                async () => await receiver.ReceiveAsync(TimeSpan.FromSeconds(-1)),
+                async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(-1)),
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/RuleManager/RuleManagerLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/RuleManager/RuleManagerLiveTests.cs
@@ -210,7 +210,7 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
                 await SendMessages(client, scope.TopicName);
 
                 var receiver = client.CreateReceiver(scope.TopicName, scope.SubscriptionNames.First());
-                var messages = await receiver.ReceiveBatchAsync(Orders.Length, TimeSpan.FromSeconds(10));
+                var messages = await receiver.ReceiveMessagesAsync(Orders.Length, TimeSpan.FromSeconds(10));
                 Assert.AreEqual(0, messages.Count());
             }
         }
@@ -548,7 +548,7 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
                     { "priority", Orders[i].Priority }
                 }
                 };
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
             }
         }
 
@@ -564,7 +564,7 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
             var remainingMessages = expectedOrders.Count();
             while (remainingMessages > 0)
             {
-                foreach (var item in await receiver.ReceiveBatchAsync(Orders.Length).ConfigureAwait(false))
+                foreach (var item in await receiver.ReceiveMessagesAsync(Orders.Length).ConfigureAwait(false))
                 {
                     receivedMessages.Add(item);
                     messageEnum.MoveNext();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
@@ -147,8 +147,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 // create a message batch that we can send
                 #region Snippet:ServiceBusSendAndReceiveSafeBatch
                 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-                messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-                messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+                messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+                messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
                 // send the message batch
                 await sender.SendMessagesAsync(messageBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample01_HelloWorld.cs
@@ -33,13 +33,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 // the received message is a different type as it contains some service set properties
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
                 // get the message body as a string
                 string body = receivedMessage.Body.ToString();
@@ -65,13 +65,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 #region Snippet:ServiceBusPeek
-                ServiceBusReceivedMessage peekedMessage = await receiver.PeekAsync();
+                ServiceBusReceivedMessage peekedMessage = await receiver.PeekMessageAsync();
                 #endregion
 
                 // get the message body as a string
@@ -101,7 +101,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
                 messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
                 // send the messages
-                await sender.SendAsync(messages);
+                await sender.SendMessagesAsync(messages);
                 #endregion
                 #endregion
                 #region Snippet:ServiceBusReceiveBatch
@@ -109,7 +109,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 // the received message is a different type as it contains some service set properties
-                IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveBatchAsync(maxMessages: 2);
+                IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveMessagesAsync(maxMessages: 2);
 
                 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
                 {
@@ -146,19 +146,19 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 // create a message batch that we can send
                 #region Snippet:ServiceBusSendAndReceiveSafeBatch
-                ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+                ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
                 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
                 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
                 // send the message batch
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
                 #endregion
 
                 // create a receiver that we can use to receive the messages
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 // the received message is a different type as it contains some service set properties
-                IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveBatchAsync(maxMessages: 2);
+                IList<ServiceBusReceivedMessage> receivedMessages = await receiver.ReceiveMessagesAsync(maxMessages: 2);
 
                 foreach (ServiceBusReceivedMessage receivedMessage in receivedMessages)
                 {
@@ -198,13 +198,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 // create a receiver that we can use to peek the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
-                Assert.IsNotNull(await receiver.PeekAsync());
+                Assert.IsNotNull(await receiver.PeekMessageAsync());
 
                 // cancel the scheduled messaged, thereby deleting from the service
                 #region Snippet:ServiceBusCancelScheduled
                 await sender.CancelScheduledMessageAsync(seq);
                 #endregion
-                Assert.IsNull(await receiver.PeekAsync());
+                Assert.IsNull(await receiver.PeekMessageAsync());
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample02_MessageSettlement.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample02_MessageSettlement.cs
@@ -30,18 +30,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive and settle the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 // the received message is a different type as it contains some service set properties
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
                 // complete the message, thereby deleting it from the service
-                await receiver.CompleteAsync(receivedMessage);
+                await receiver.CompleteMessageAsync(receivedMessage);
                 #endregion
-                Assert.IsNull(await GetNoRetryClient().CreateReceiver(queueName).ReceiveAsync());
+                Assert.IsNull(await GetNoRetryClient().CreateReceiver(queueName).ReceiveMessageAsync());
             }
         }
 
@@ -62,18 +62,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive and settle the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 #region Snippet:ServiceBusAbandonMessage
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
                 // abandon the message, thereby releasing the lock and allowing it to be received again by this or other receivers
-                await receiver.AbandonAsync(receivedMessage);
+                await receiver.AbandonMessageAsync(receivedMessage);
                 #endregion
-                Assert.IsNotNull(GetNoRetryClient().CreateReceiver(queueName).ReceiveAsync());
+                Assert.IsNotNull(GetNoRetryClient().CreateReceiver(queueName).ReceiveMessageAsync());
             }
         }
 
@@ -94,17 +94,17 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive and settle the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 #region Snippet:ServiceBusDeferMessage
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
                 // defer the message, thereby preventing the message from being received again without using
                 // the received deferred message API.
-                await receiver.DeferAsync(receivedMessage);
+                await receiver.DeferMessageAsync(receivedMessage);
 
                 // receive the deferred message by specifying the service set sequence number of the original
                 // received message
@@ -131,20 +131,20 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusMessage message = new ServiceBusMessage(Encoding.UTF8.GetBytes("Hello world!"));
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a receiver that we can use to receive and settle the message
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 #region Snippet:ServiceBusDeadLetterMessage
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
                 // deadletter the message, thereby preventing the message from being received again without receiving from the dead letter queue.
-                await receiver.DeadLetterAsync(receivedMessage);
+                await receiver.DeadLetterMessageAsync(receivedMessage);
 
                 // receive the dead lettered message with receiver scoped to the dead letter queue.
                 ServiceBusReceiver dlqReceiver = client.CreateDeadLetterReceiver(queueName);
-                ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveAsync();
+                ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveMessageAsync();
                 #endregion
                 Assert.IsNotNull(dlqMessage);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -34,14 +34,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 };
 
                 // send the message
-                await sender.SendAsync(message);
+                await sender.SendMessageAsync(message);
 
                 // create a session receiver that we can use to receive the message. Since we don't specify a
                 // particular session, we will get the next available session from the service.
                 ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
 
                 // the received message is a different type as it contains some service set properties
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
                 Console.WriteLine(receivedMessage.SessionId);
 
                 // we can also set arbitrary session state using this receiver
@@ -72,7 +72,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusSender sender = client.CreateSender(queueName);
 
                 // create a message batch that we can send
-                ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+                ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
                 messageBatch.TryAdd(
                     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
                     {
@@ -85,7 +85,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     });
 
                 // send the message batch
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 #region Snippet:ServiceBusReceiveFromSpecificSession
                 // create a receiver specifying a particular session
@@ -97,7 +97,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     });
 
                 // the received message is a different type as it contains some service set properties
-                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
                 Console.WriteLine(receivedMessage.SessionId);
 
                 #endregion

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -73,12 +73,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 // create a message batch that we can send
                 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-                messageBatch.TryAdd(
+                messageBatch.TryAddMessage(
                     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
                     {
                         SessionId = "Session1"
                     });
-                messageBatch.TryAdd(
+                messageBatch.TryAddMessage(
                     new ServiceBusMessage(Encoding.UTF8.GetBytes("Second"))
                     {
                         SessionId = "Session2"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
@@ -32,8 +32,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 // create a message batch that we can send
                 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-                messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
-                messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+                messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+                messageBatch.TryAddMessage(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
                 // send the message batch
                 await sender.SendMessagesAsync(messageBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample04_Processor.cs
@@ -31,12 +31,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusSender sender = client.CreateSender(queueName);
 
                 // create a message batch that we can send
-                ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+                ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
                 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
                 messageBatch.TryAdd(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 
                 // send the message batch
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 // get the options to use for configuring the processor
                 var options = new ServiceBusProcessorOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusSender sender = client.CreateSender(queueName);
 
                 // create a message batch that we can send
-                ServiceBusMessageBatch messageBatch = await sender.CreateBatchAsync();
+                ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
                 messageBatch.TryAdd(
                     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
                     {
@@ -43,7 +43,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     });
 
                 // send the message batch
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
 
                 // get the options to use for configuring the processor
                 var options = new ServiceBusSessionProcessorOptions

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample05_SessionProcessor.cs
@@ -31,12 +31,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 // create a message batch that we can send
                 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
-                messageBatch.TryAdd(
+                messageBatch.TryAddMessage(
                     new ServiceBusMessage(Encoding.UTF8.GetBytes("First"))
                     {
                         SessionId = "Session1"
                     });
-                messageBatch.TryAdd(
+                messageBatch.TryAddMessage(
                     new ServiceBusMessage(Encoding.UTF8.GetBytes("Second"))
                     {
                         SessionId = "Session2"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
@@ -25,21 +25,21 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 //@@ await using var client = new ServiceBusClient(connectionString);
                 ServiceBusSender sender = client.CreateSender(queueName);
 
-                await sender.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+                await sender.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
-                ServiceBusReceivedMessage firstMessage = await receiver.ReceiveAsync();
+                ServiceBusReceivedMessage firstMessage = await receiver.ReceiveMessageAsync();
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await sender.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
-                    await receiver.CompleteAsync(firstMessage);
+                    await sender.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+                    await receiver.CompleteMessageAsync(firstMessage);
                     ts.Complete();
                 }
                 #endregion
 
-                ServiceBusReceivedMessage secondMessage = await receiver.ReceiveAsync(TimeSpan.FromSeconds(5));
+                ServiceBusReceivedMessage secondMessage = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
 
                 Assert.NotNull(secondMessage);
-                await receiver.CompleteAsync(secondMessage);
+                await receiver.CompleteMessageAsync(secondMessage);
             };
         }
 
@@ -62,7 +62,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 //@@ await using var client = new ServiceBusClient(connectionString);
 
                 ServiceBusSender senderA = client.CreateSender(queueA);
-                await senderA.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
+                await senderA.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("First")));
 
                 ServiceBusSender senderBViaA = client.CreateSender(queueB, new ServiceBusSenderOptions
                 {
@@ -70,22 +70,22 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 });
 
                 ServiceBusReceiver receiverA = client.CreateReceiver(queueA);
-                ServiceBusReceivedMessage firstMessage = await receiverA.ReceiveAsync();
+                ServiceBusReceivedMessage firstMessage = await receiverA.ReceiveMessageAsync();
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await receiverA.CompleteAsync(firstMessage);
-                    await senderBViaA.SendAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
+                    await receiverA.CompleteMessageAsync(firstMessage);
+                    await senderBViaA.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
                     ts.Complete();
                 }
                 #endregion
 
-                ServiceBusReceivedMessage secondMessage = await receiverA.ReceiveAsync(TimeSpan.FromSeconds(5));
+                ServiceBusReceivedMessage secondMessage = await receiverA.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
 
                 Assert.Null(secondMessage);
                 ServiceBusReceiver receiverB = client.CreateReceiver(queueB);
-                secondMessage = await receiverB.ReceiveAsync(TimeSpan.FromSeconds(5));
+                secondMessage = await receiverB.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
                 Assert.NotNull(secondMessage);
-                await receiverB.CompleteAsync(secondMessage);
+                await receiverB.CompleteMessageAsync(secondMessage);
             };
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
@@ -19,7 +20,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
-                await sender.SendAsync(GetMessage());
+                await sender.SendMessageAsync(GetMessage());
             }
         }
 
@@ -30,7 +31,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential);
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendAsync(GetMessage());
+                await sender.SendMessageAsync(GetMessage());
             }
         }
 
@@ -51,7 +52,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString, options);
 
                 ServiceBusSender sender = client.CreateSender(scope.TopicName);
-                await sender.SendAsync(GetMessage());
+                await sender.SendMessageAsync(GetMessage());
             }
         }
 
@@ -72,7 +73,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString, options);
 
                 ServiceBusSender sender = client.CreateSender(scope.TopicName);
-                await sender.SendAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(GetMessage("sessionId"));
             }
         }
 
@@ -83,10 +84,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, 3);
 
-                await sender.SendAsync(messageBatch);
+                await sender.SendMessagesAsync(messageBatch);
             }
         }
 
@@ -97,10 +98,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>()));
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
             }
         }
 
@@ -111,14 +112,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
 
                 // Actual limit is 262144 bytes for a single message.
                 batch.TryAdd(new ServiceBusMessage(new byte[100000 / 3]));
                 batch.TryAdd(new ServiceBusMessage(new byte[100000 / 3]));
                 batch.TryAdd(new ServiceBusMessage(new byte[100000 / 3]));
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
             }
         }
 
@@ -129,12 +130,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
 
                 // Actual limit is 262144 bytes for a single message.
                 ServiceBusMessage message = new ServiceBusMessage(new byte[300000]);
 
-                Assert.That(async () => await sender.SendAsync(message), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.MessageSizeExceeded));
+                Assert.That(async () => await sender.SendMessageAsync(message), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.MessageSizeExceeded));
             }
         }
 
@@ -145,13 +146,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
 
                 // Actual limit is 262144 bytes for a single message.
                 Assert.That(() => batch.TryAdd(new ServiceBusMessage(new byte[200000])), Is.True, "A message was rejected by the batch; all messages should be accepted.");
                 Assert.That(() => batch.TryAdd(new ServiceBusMessage(new byte[200000])), Is.False, "A message was rejected by the batch; message size exceed.");
 
-                await sender.SendAsync(batch);
+                await sender.SendMessagesAsync(batch);
             }
         }
 
@@ -174,15 +175,40 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
-                var sequenceNum = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
+                var seq = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
 
                 await using var receiver = client.CreateReceiver(scope.QueueName);
-                ServiceBusReceivedMessage msg = await receiver.PeekAtAsync(sequenceNum);
+                ServiceBusReceivedMessage msg = await receiver.PeekMessageAsync(seq);
                 Assert.AreEqual(0, Convert.ToInt32(new TimeSpan(scheduleTime.Ticks - msg.ScheduledEnqueueTime.Ticks).TotalSeconds));
 
-                await sender.CancelScheduledMessageAsync(sequenceNum);
-                msg = await receiver.PeekAtAsync(sequenceNum);
+                await sender.CancelScheduledMessageAsync(seq);
+                msg = await receiver.PeekMessageAsync(seq);
                 Assert.IsNull(msg);
+            }
+        }
+
+        [Test]
+        public async Task ScheduleMultiple()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+                var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
+                var sequenceNums = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                foreach (long seq in sequenceNums)
+                {
+                    ServiceBusReceivedMessage msg = await receiver.PeekMessageAsync(seq);
+                    Assert.AreEqual(0, Convert.ToInt32(new TimeSpan(scheduleTime.Ticks - msg.ScheduledEnqueueTime.Ticks).TotalSeconds));
+                }
+                await sender.CancelScheduledMessagesAsync(sequenceNumbers: sequenceNums);
+                foreach (long seq in sequenceNums)
+                {
+                    ServiceBusReceivedMessage msg = await receiver.PeekMessageAsync(seq);
+                    Assert.IsNull(msg);
+                }
             }
         }
 
@@ -197,14 +223,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var sequenceNum = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
                 await sender.DisposeAsync(); // shouldn't close connection, but should close send link
 
-                Assert.That(async () => await sender.SendAsync(GetMessage()),
+                Assert.That(async () => await sender.SendMessageAsync(GetMessage()),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.ClientClosed));
                 Assert.That(async () => await sender.ScheduleMessageAsync(GetMessage(), default), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.ClientClosed));
                 Assert.That(async () => await sender.CancelScheduledMessageAsync(sequenceNum), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.ClientClosed));
 
                 // receive should still work
                 await using var receiver = client.CreateReceiver(scope.QueueName);
-                ServiceBusReceivedMessage msg = await receiver.PeekAtAsync(sequenceNum);
+                ServiceBusReceivedMessage msg = await receiver.PeekMessageAsync(sequenceNum);
                 Assert.AreEqual(0, Convert.ToInt32(new TimeSpan(scheduleTime.Ticks - msg.ScheduledEnqueueTime.Ticks).TotalSeconds));
             }
         }
@@ -218,7 +244,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 for (int i = 0; i < 10; i++)
                 {
                     await Task.Delay(1000);
-                    await sender.SendAsync(GetMessage());
+                    await sender.SendMessageAsync(GetMessage());
                 }
             }
         }
@@ -232,9 +258,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var sender = client.CreateSender(scope.QueueName);
                 // this is apparently supported. The session is ignored by the service but can be used
                 // as additional app data. Not recommended.
-                await sender.SendAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(GetMessage("sessionId"));
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var msg = await receiver.ReceiveAsync();
+                var msg = await receiver.ReceiveMessageAsync();
                 Assert.AreEqual("sessionId", msg.SessionId);
             }
         }
@@ -246,7 +272,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
                 Assert.That(
-                    async () => await sender.SendAsync(GetMessage()),
+                    async () => await sender.SendMessageAsync(GetMessage()),
                     Throws.InstanceOf<InvalidOperationException>());
             }
         }
@@ -262,7 +288,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
                 var messageCt = 10;
                 IEnumerable<ServiceBusMessage> messages = GetMessages(messageCt);
-                await sender.SendAsync(messages);
+                await sender.SendMessagesAsync(messages);
 
                 var receiver = client.CreateReceiver(scope.QueueName, new ServiceBusReceiverOptions()
                 {
@@ -273,7 +299,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 IList<ServiceBusReceivedMessage> receivedMessages = new List<ServiceBusReceivedMessage>();
                 while (remainingMessages > 0)
                 {
-                    foreach (var msg in await receiver.ReceiveBatchAsync(messageCt))
+                    foreach (var msg in await receiver.ReceiveMessagesAsync(messageCt))
                     {
                         remainingMessages--;
                         receivedMessages.Add(msg);
@@ -281,7 +307,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 }
                 foreach (ServiceBusReceivedMessage msg in receivedMessages)
                 {
-                    await sender.SendAsync(new ServiceBusMessage(msg));
+                    await sender.SendMessageAsync(new ServiceBusMessage(msg));
                 }
 
                 var messageEnum = receivedMessages.GetEnumerator();
@@ -289,7 +315,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 remainingMessages = messageCt;
                 while (remainingMessages > 0)
                 {
-                    foreach (var msg in await receiver.ReceiveBatchAsync(remainingMessages))
+                    foreach (var msg in await receiver.ReceiveMessagesAsync(remainingMessages))
                     {
                         remainingMessages--;
                         messageEnum.MoveNext();
@@ -310,7 +336,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(connectionString);
 
                 ServiceBusSender sender = client.CreateSender("FakeEntity");
-                Assert.That(async () => await sender.CreateBatchAsync(), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.MessagingEntityNotFound));
+                Assert.That(async () => await sender.CreateMessageBatchAsync(), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.MessagingEntityNotFound));
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -99,7 +99,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>()));
+                batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>()));
 
                 await sender.SendMessagesAsync(batch);
             }
@@ -115,9 +115,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
 
                 // Actual limit is 262144 bytes for a single message.
-                batch.TryAdd(new ServiceBusMessage(new byte[100000 / 3]));
-                batch.TryAdd(new ServiceBusMessage(new byte[100000 / 3]));
-                batch.TryAdd(new ServiceBusMessage(new byte[100000 / 3]));
+                batch.TryAddMessage(new ServiceBusMessage(new byte[100000 / 3]));
+                batch.TryAddMessage(new ServiceBusMessage(new byte[100000 / 3]));
+                batch.TryAddMessage(new ServiceBusMessage(new byte[100000 / 3]));
 
                 await sender.SendMessagesAsync(batch);
             }
@@ -149,8 +149,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
 
                 // Actual limit is 262144 bytes for a single message.
-                Assert.That(() => batch.TryAdd(new ServiceBusMessage(new byte[200000])), Is.True, "A message was rejected by the batch; all messages should be accepted.");
-                Assert.That(() => batch.TryAdd(new ServiceBusMessage(new byte[200000])), Is.False, "A message was rejected by the batch; message size exceed.");
+                Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(new byte[200000])), Is.True, "A message was rejected by the batch; all messages should be accepted.");
+                Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(new byte[200000])), Is.False, "A message was rejected by the batch; message size exceed.");
 
                 await sender.SendMessagesAsync(batch);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 CallBase = true
             };
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.SendAsync(message: null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.SendMessageAsync(null));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 CallBase = true
             };
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.SendAsync(messages: null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.SendMessagesAsync(messages: null));
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 CallBase = true
             };
-            await mock.Object.SendAsync(new List<ServiceBusMessage>());
+            await mock.Object.SendMessagesAsync(new List<ServiceBusMessage>());
         }
 
         [Test]
@@ -53,13 +53,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 CallBase = true
             };
             mock
-               .Setup(m => m.SendAsync(
+               .Setup(m => m.SendMessagesAsync(
                    It.Is<IEnumerable<ServiceBusMessage>>(value => value.Count() == 1),
                    It.IsAny<CancellationToken>()))
                .Returns(Task.CompletedTask)
                .Verifiable("The single send should delegate to the list send.");
 
-            await mock.Object.SendAsync(new ServiceBusMessage());
+            await mock.Object.SendMessageAsync(new ServiceBusMessage());
         }
 
         [Test]
@@ -69,7 +69,39 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 CallBase = true
             };
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.SendAsync((ServiceBusMessageBatch)null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.SendMessagesAsync((ServiceBusMessageBatch)null));
+        }
+
+        [Test]
+        public void ScheduleNullMessageShouldThrow()
+        {
+            var mock = new Mock<ServiceBusSender>()
+            {
+                CallBase = true
+            };
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.ScheduleMessageAsync(null, default));
+        }
+
+        [Test]
+        public void ScheduleNullMessageListShouldThrow()
+        {
+            var mock = new Mock<ServiceBusSender>()
+            {
+                CallBase = true
+            };
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await mock.Object.ScheduleMessagesAsync(null, default));
+        }
+
+        [Test]
+        public void ScheduleEmptyListShouldThrow()
+        {
+            var mock = new Mock<ServiceBusSender>()
+            {
+                CallBase = true
+            };
+            Assert.ThrowsAsync<ArgumentException>(async () => await mock.Object.ScheduleMessagesAsync(
+                new List<ServiceBusMessage>(),
+                default));
         }
 
         [Test]
@@ -164,7 +196,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="ServiceBusSender.SendAsync"/>
+        ///   Verifies functionality of the <see cref="ServiceBusSender.SendMessagesAsync"/>
         ///   method.
         /// </summary>
         ///
@@ -202,7 +234,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             Assert.That(batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked before sending.");
 
             var sender = new ServiceBusSender("dummy", null, mockConnection.Object);
-            var sendTask = sender.SendAsync(batch);
+            var sendTask = sender.SendMessagesAsync(batch);
 
             Assert.That(() => batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
             completionSource.TrySetResult(true);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -224,24 +224,24 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 .Setup(connection => connection.ThrowIfClosed());
 
             mockTransportBatch
-                .Setup(transport => transport.TryAdd(It.IsAny<ServiceBusMessage>()))
+                .Setup(transport => transport.TryAddMessage(It.IsAny<ServiceBusMessage>()))
                 .Returns(true);
 
             mockTransportSender
                 .Setup(transport => transport.SendBatchAsync(It.IsAny<ServiceBusMessageBatch>(), It.IsAny<CancellationToken>()))
                 .Returns(async () => await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token)));
 
-            Assert.That(batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked before sending.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked before sending.");
 
             var sender = new ServiceBusSender("dummy", null, mockConnection.Object);
             var sendTask = sender.SendMessagesAsync(batch);
 
-            Assert.That(() => batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
+            Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should be locked while sending.");
             completionSource.TrySetResult(true);
 
             await sendTask;
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-            Assert.That(batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked after sending.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The batch should not be locked after sending.");
 
             cancellationSource.Cancel();
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/ServiceBusMessageBatchTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/ServiceBusMessageBatchTests.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         }
 
         /// <summary>
-        ///   Verifies property accessors for the <see cref="ServiceBusMessageBatch.TryAdd" />
+        ///   Verifies property accessors for the <see cref="ServiceBusMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -70,7 +70,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var batch = new ServiceBusMessageBatch(mockBatch);
             var message = new ServiceBusMessage(new byte[] { 0x21 });
 
-            Assert.That(batch.TryAdd(message), Is.True, "The message should have been accepted.");
+            Assert.That(batch.TryAddMessage(message), Is.True, "The message should have been accepted.");
             Assert.That(mockBatch.TryAddCalledWith, Is.SameAs(message), "The message should have been passed with delegation.");
         }
 
@@ -90,7 +90,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         }
 
         /// <summary>
-        ///   Verifies property accessors for the <see cref="ServiceBusMessageBatch.TryAdd" />
+        ///   Verifies property accessors for the <see cref="ServiceBusMessageBatch.TryAddMessage" />
         ///   method.
         /// </summary>
         ///
@@ -116,13 +116,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var batch = new ServiceBusMessageBatch(mockBatch);
             var message = new ServiceBusMessage(new byte[] { 0x21 });
 
-            Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[] { 0x21 })), Is.True, "The message should have been accepted before locking.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[] { 0x21 })), Is.True, "The message should have been accepted before locking.");
 
             batch.Lock();
-            Assert.That(() => batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept messages when locked.");
+            Assert.That(() => batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept messages when locked.");
 
             batch.Unlock();
-            Assert.That(batch.TryAdd(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The message should have been accepted after unlocking.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(Array.Empty<byte>())), Is.True, "The message should have been accepted after unlocking.");
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var batch = new ServiceBusMessageBatch(mockBatch);
             var messageData = new ServiceBusMessage(new byte[] { 0x21 });
 
-            Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[] { 0x21 })), Is.True, "The message should have been accepted before locking.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[] { 0x21 })), Is.True, "The message should have been accepted before locking.");
 
             batch.Lock();
             Assert.That(() => batch.Clear(), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept messages when locked.");
@@ -159,7 +159,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var mockBatch = new MockTransportBatch();
             var batch = new ServiceBusMessageBatch(mockBatch);
 
-            Assert.That(batch.TryAdd(new ServiceBusMessage(new byte[] { 0x21 })), Is.True, "The message should have been accepted before locking.");
+            Assert.That(batch.TryAddMessage(new ServiceBusMessage(new byte[] { 0x21 })), Is.True, "The message should have been accepted before locking.");
 
             batch.Lock();
             Assert.That(() => batch.Dispose(), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept messages when locked.");
@@ -202,7 +202,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             public override void Dispose() => DisposeInvoked = true;
             public override void Clear() => ClearInvoked = true;
 
-            public override bool TryAdd(ServiceBusMessage message)
+            public override bool TryAddMessage(ServiceBusMessage message)
             {
                 TryAddCalledWith = message;
                 return true;


### PR DESCRIPTION
- Support schedule/cancel schedule multiple messages (https://github.com/Azure/azure-sdk-for-net/issues/9874)
- Remove use of "batch" in Peek/Receive methods.
- Add Message/Messages suffix to Peek/Send/Receive/Abandon/Defer/Complete/DeadLetter for consistency with Schedule/ReceiveDeferred
- Rename CreateBatchOptions -> CreateMessageBatchOptions