### PR TITLE
Improve execution time of FR Tests on playback mode

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -68,7 +68,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync();
+            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
             var formPage = formPages.Single();
 
             Assert.Greater(formPage.Lines.Count, 0);
@@ -101,7 +101,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
             Assert.IsTrue(operation.HasValue);
 
             var formPage = operation.Value.Single();
@@ -193,7 +193,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentFromUriAsync(uri);
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync();
+            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.AreEqual(2, formPages.Count);
 
@@ -224,7 +224,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentAsync(stream);
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync();
+            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.AreEqual(3, formPages.Count);
 
@@ -290,7 +290,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsFromUriAsync(uri, default);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsTrue(operation.HasValue);
 
@@ -397,7 +397,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsFromUriAsync(uri, options);
             }
 
-            RecognizedReceiptCollection recognizedReceipts = await operation.WaitForCompletionAsync();
+            RecognizedReceiptCollection recognizedReceipts = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.AreEqual(2, recognizedReceipts.Count);
 
@@ -434,7 +434,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsAsync(stream, options);
             }
 
-            RecognizedReceiptCollection recognizedReceipts = await operation.WaitForCompletionAsync();
+            RecognizedReceiptCollection recognizedReceipts = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.AreEqual(3, recognizedReceipts.Count);
 
@@ -511,7 +511,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsTrue(operation.HasValue);
             Assert.GreaterOrEqual(operation.Value.Count, 1);
@@ -561,7 +561,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
 
             var recognizedForm = recognizedForms.Single();
 
@@ -598,7 +598,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
 
             var recognizedForm = recognizedForms.Single();
 
@@ -626,7 +626,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
 
             var recognizedForm = recognizedForms.Single();
 
@@ -670,7 +670,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream);
             }
 
-            RecognizedFormCollection forms = await operation.WaitForCompletionAsync();
+            RecognizedFormCollection forms = await operation.WaitForCompletionAsync(PollingInterval);
             var fields = forms.Single().Fields;
 
             // Verify that we got back at least one null field to make sure we hit the code path we want to test.
@@ -706,7 +706,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsTrue(operation.HasValue);
             Assert.GreaterOrEqual(operation.Value.Count, 1);
@@ -757,7 +757,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.AreEqual(2, recognizedForms.Count);
 
@@ -797,7 +797,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.AreEqual(3, recognizedForms.Count);
 
@@ -852,7 +852,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             try
             {
-                await operation.WaitForCompletionAsync();
+                await operation.WaitForCompletionAsync(PollingInterval);
             }
             catch (RequestFailedException ex)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -130,7 +130,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartTrainingAsync(trainingFilesUri, labeled);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsTrue(operation.HasValue);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            CustomFormModel model = await operation.WaitForCompletionAsync();
+            CustomFormModel model = await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsNotNull(model.ModelId);
             Assert.AreEqual(CustomFormModelStatus.Ready, model.Status);
@@ -65,7 +65,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartTrainingAsync(trainingFilesUri, labeled);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsTrue(operation.HasValue);
 
@@ -109,7 +109,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var containerUrl = new Uri("https://someUrl");
 
             TrainingOperation operation = await client.StartTrainingAsync(containerUrl, useTrainingLabels: false);
-            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
 
             Assert.False(operation.HasValue);
             Assert.Throws<RequestFailedException>(() => operation.Value.GetType());
@@ -207,7 +207,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
             }
 
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(PollingInterval);
             Assert.IsTrue(operation.HasValue);
 
             CustomFormModelInfo modelCopied = operation.Value;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DisposableTrainedModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DisposableTrainedModel.cs
@@ -49,10 +49,10 @@ namespace Azure.AI.FormRecognizer.Tests
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, use a label file created in the &lt;link-to-label-tool-doc&gt; to provide training-time labels for training a model. If <c>false</c>, the model will be trained from forms only.</param>
         /// <returns>A <see cref="DisposableTrainedModel"/> instance from which the trained model ID can be obtained.</returns>
-        public static async Task<DisposableTrainedModel> TrainModelAsync(FormTrainingClient trainingClient, Uri trainingFilesUri, bool useTrainingLabels)
+        public static async Task<DisposableTrainedModel> TrainModelAsync(FormTrainingClient trainingClient, Uri trainingFilesUri, bool useTrainingLabels, TimeSpan pollingInterval)
         {
             TrainingOperation operation = await trainingClient.StartTrainingAsync(trainingFilesUri, useTrainingLabels);
-            await operation.WaitForCompletionAsync();
+            await operation.WaitForCompletionAsync(pollingInterval);
 
             Assert.IsTrue(operation.HasValue);
             Assert.AreEqual(CustomFormModelStatus.Ready, operation.Value.Status);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
@@ -11,6 +11,8 @@ namespace Azure.AI.FormRecognizer.Tests
 {
     public class FormRecognizerLiveTestBase : RecordedTestBase<FormRecognizerTestEnvironment>
     {
+        protected TimeSpan PollingInterval => TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0 : 1);
+
         public FormRecognizerLiveTestBase(bool isAsync) : base(isAsync)
         {
             Sanitizer = new FormRecognizerRecordedTestSanitizer();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
@@ -60,7 +60,7 @@ namespace Azure.AI.FormRecognizer.Tests
             // TODO: sanitize body and enable body recording here.
             using (Recording.DisableRequestBodyRecording())
             {
-                trainedModel = await DisposableTrainedModel.TrainModelAsync(trainingClient, trainingFilesUri, useTrainingLabels);
+                trainedModel = await DisposableTrainedModel.TrainModelAsync(trainingClient, trainingFilesUri, useTrainingLabels, PollingInterval);
             }
 
             return trainedModel;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/CopyModelAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/CopyModelAsync.json
@@ -7,9 +7,9 @@
         "Content-Length": "236",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "Request-Id": "|76b771fd-49dcf694548109e3.",
+        "Request-Id": "|e30c1ca6-46455b918ee43cbc.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4b85ea96ad8c6ca4a2020b674d31458f",
@@ -18,23 +18,23 @@
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "057d0c7b-611a-4fb5-8ce1-9098243647c6",
+        "apim-request-id": "e8fec1ae-e599-4421-9bf8-af7f6aa444aa",
         "Content-Length": "0",
-        "Date": "Sat, 13 Jun 2020 23:14:19 GMT",
-        "Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8",
+        "Date": "Tue, 16 Jun 2020 04:18:14 GMT",
+        "Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "164"
+        "x-envoy-upstream-service-time": "342"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8c51b37d4cd47cd1a02e2d6e697f1d06",
@@ -43,212 +43,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d22e937f-9bf7-44ad-8a03-fba4ec072156",
+        "apim-request-id": "990c118d-5cb3-4136-a6f8-471f4d74e8d1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:20 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "141"
+        "x-envoy-upstream-service-time": "5158"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-          "status": "creating",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:20Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1c5f4122e0b8d3750397ea3c96505e88",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e07ab627-a15b-4b8f-bf50-722991ad987c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:22 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-          "status": "creating",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:20Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "6f387efc77e74a661809aa5d80360323",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3c7f9271-d844-4ee0-bd56-ba78b49ec2f0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "567"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-          "status": "creating",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:20Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "0c4505e429d29dd63d7d893c6295e550",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f30e87fb-20f8-4781-ab61-6a63629cd5d3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:25 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "41"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-          "status": "creating",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:20Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "eb71a5d0ae46aa1eda1503af361753cc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b31861f0-896a-4a51-b0d9-8b623b796d58",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-          "status": "creating",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:20Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "9157c694510bd2b6a89b3169ed29e883",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c545e8a6-7cff-4c21-a111-1a1386db8e8f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:27 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "114"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-          "status": "creating",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:20Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "da8d592318c436dce69a31bd25276626",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "effb8667-ade5-403a-8fcf-96c70238494e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5099"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "68682cf9-2cdc-46f1-b208-a1d77e8436f8",
+          "modelId": "1a45f5d1-5b85-4f20-9d31-145a6d17ab0a",
           "status": "ready",
-          "createdDateTime": "2020-06-13T23:14:20Z",
-          "lastUpdatedDateTime": "2020-06-13T23:14:27Z"
+          "createdDateTime": "2020-06-16T04:18:15Z",
+          "lastUpdatedDateTime": "2020-06-16T04:18:17Z"
         },
         "trainResult": {
           "averageModelAccuracy": 0.973,
@@ -350,67 +158,259 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "Request-Id": "|76b771fe-49dcf694548109e3.",
+        "Request-Id": "|e30c1ca7-46455b918ee43cbc.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1c5f4122e0b8d3750397ea3c96505e88",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "f8ce227f-1491-4e56-afe2-cc29b031a987",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 16 Jun 2020 04:18:26 GMT",
+        "Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/350a5a9a-f820-421e-8b2b-dfc77b605862",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5136"
+      },
+      "ResponseBody": {
+        "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862",
+        "accessToken": "Sanitized",
+        "expirationDateTimeTicks": 1592367506
+      }
+    },
+    {
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copy",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|e30c1ca8-46455b918ee43cbc.",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6f387efc77e74a661809aa5d80360323",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "e3c9e403-d000-491e-94d4-30e197039a1c",
+        "Content-Length": "0",
+        "Date": "Tue, 16 Jun 2020 04:18:26 GMT",
+        "Operation-Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyresults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "239"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0c4505e429d29dd63d7d893c6295e550",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1524638c-fcd7-461a-a834-4f35f55e7e89",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 16 Jun 2020 04:18:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "33"
+      },
+      "ResponseBody": {
+        "status": "notStarted",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
+        "copyResult": {
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "eb71a5d0ae46aa1eda1503af361753cc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f99af478-457e-4247-a280-56efecb17603",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 16 Jun 2020 04:18:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "32"
+      },
+      "ResponseBody": {
+        "status": "notStarted",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
+        "copyResult": {
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9157c694510bd2b6a89b3169ed29e883",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a515358e-f3f6-4c5c-9d9f-00627e973cae",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 16 Jun 2020 04:18:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "62"
+      },
+      "ResponseBody": {
+        "status": "notStarted",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
+        "copyResult": {
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "da8d592318c436dce69a31bd25276626",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9e23e579-0639-4354-96ca-6baa1b5aa477",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 16 Jun 2020 04:18:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
+      },
+      "ResponseBody": {
+        "status": "notStarted",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
+        "copyResult": {
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9ba7bc2a543d7e44ee9e42ab7cb4bdb1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 201,
+      "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d35cf3f9-54c8-4f65-afab-e0ce649bbc16",
+        "apim-request-id": "aadd0fe6-b7f3-4070-adca-f16f00668cd8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:34 GMT",
-        "Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/300ccd7e-e64f-49b7-8f47-85e78511bba0",
+        "Date": "Tue, 16 Jun 2020 04:18:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "163"
+        "x-envoy-upstream-service-time": "35"
       },
       "ResponseBody": {
-        "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0",
-        "accessToken": "Sanitized",
-        "expirationDateTimeTicks": 1592176474
+        "status": "notStarted",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
+        "copyResult": {
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
+        }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copy",
-      "RequestMethod": "POST",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
+      "RequestMethod": "GET",
       "RequestHeaders": {
-        "Content-Length": "375",
-        "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "Request-Id": "|76b771ff-49dcf694548109e3.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "dc8b802c788a7c07ea21aa711ff9ad81",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 202,
+      "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "234b6435-f220-45c0-8fc7-9d7455c922d7",
-        "Content-Length": "0",
-        "Date": "Sat, 13 Jun 2020 23:14:34 GMT",
-        "Operation-Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyresults/31274781-0421-44a9-803e-f80ec20dcf20",
+        "apim-request-id": "0b06cfdf-66fd-465e-9eb1-ba0fd28b859c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 16 Jun 2020 04:18:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "62"
+        "x-envoy-upstream-service-time": "39"
       },
-      "ResponseBody": []
+      "ResponseBody": {
+        "status": "notStarted",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
+        "copyResult": {
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
+        }
+      }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "313f0b344d81cf45150eeb25d530b931",
@@ -419,30 +419,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6c993a52-cf78-43e1-a56e-ac9a6c19dccf",
+        "apim-request-id": "fdeaec77-b730-4118-98a5-ec05af1a3c74",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:34 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "113"
+        "x-envoy-upstream-service-time": "58"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a59080dd8a9bb19cb52ab01ba9d35ff5",
@@ -451,30 +451,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "629c539a-0a8c-4097-b4bf-a25035a824b7",
+        "apim-request-id": "fb3175a7-37ce-4ffe-826d-24868cf34162",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:35 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "74"
+        "x-envoy-upstream-service-time": "162"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7177c1f18c75df2f3bbcc77b8ce1a7b9",
@@ -483,30 +483,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be9e1de1-0239-4c70-baef-b4a92da5290d",
+        "apim-request-id": "a19e7dc6-5165-47c8-a6f1-f84b0a781bf4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:36 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "55"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9f9478680768aae56f8d7b569c292641",
@@ -515,30 +515,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "de7811ab-6d8d-40d4-b411-10e6e2e27de9",
+        "apim-request-id": "07bfaf7d-84e6-457a-b0da-aeb2193384cb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:38 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "5076"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1334f6af48b950bc50b169dfc22024d3",
@@ -547,30 +547,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13d0654f-2a47-447f-b28b-445f253e75a1",
+        "apim-request-id": "9ee767a4-a1c8-4799-8662-e7836b88f8da",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:39 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "31"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "30b3f683c03fe98cdccd02e810d84211",
@@ -579,30 +579,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f193e953-d774-4d45-8f4c-cfb588cdcabd",
+        "apim-request-id": "2557cfe8-dad2-46d5-9156-70573d5f1ec4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:40 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "49"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "96cc869593ad1f00bc434eb79e06e74e",
@@ -611,30 +611,30 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24f73762-e5fe-4e7c-97d0-eef97b091278",
+        "apim-request-id": "6907f38d-2cd3-4bc6-9df8-b6a4393a8019",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:42 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "64"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "createdDateTime": "2020-06-16T04:18:27Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:27Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a/copyResults/3d5c6389-2b25-426d-b4b0-84700c1eca27",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a5d3a868f576ee01694a37eb46d44078",
@@ -643,171 +643,45 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3eaee622-b8b8-43b1-9d81-957b6be16e63",
+        "apim-request-id": "ac8b8134-7bb5-44c7-b79c-b34d5fdd596d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:47 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5069"
+        "x-envoy-upstream-service-time": "5040"
       },
       "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
+        "status": "succeeded",
+        "createdDateTime": "2020-06-16T04:18:52.2440106Z",
+        "lastUpdatedDateTime": "2020-06-16T04:18:52.244011Z",
         "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
+          "modelId": "350a5a9a-f820-421e-8b2b-dfc77b605862"
         }
       }
     },
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
-      "RequestMethod": "GET",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/1a45f5d1-5b85-4f20-9d31-145a6d17ab0a",
+      "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|e30c1ca9-46455b918ee43cbc.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
           "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3c49586e8e54ef25f69374fc72d54bd5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bbe20ab3-97a5-4784-8a5d-1f97607aa1f9",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:48 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "54"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
-        "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "677fb3e59d05a09b84dd2d635c14d9e8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "412b1d4d-d0f9-401b-bfe3-94443301fa3f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:14:50 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-06-13T23:14:34Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:34Z",
-        "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "4649d602aabddafa83e3afe281057c93",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "8709d962-2cb4-45b6-8777-10f213bbebcc",
-        "Content-Length": "265",
-        "Content-Type": "application/json",
-        "Date": "Sat, 13 Jun 2020 23:14:52 GMT",
-        "Retry-After": "28",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the Get Copy Model Result Operation under Form Recognizer API have exceeded rate limit of your current FormRecognizer F0 pricing tier. Please retry after 28 seconds. To increase your rate limit switch to a paid tier."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8/copyResults/31274781-0421-44a9-803e-f80ec20dcf20",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "4649d602aabddafa83e3afe281057c93",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "54f38f73-7e64-49bf-8657-a60cb6388b71",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 13 Jun 2020 23:15:20 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "76"
-      },
-      "ResponseBody": {
-        "status": "succeeded",
-        "createdDateTime": "2020-06-13T23:14:59.933505Z",
-        "lastUpdatedDateTime": "2020-06-13T23:14:59.9335054Z",
-        "copyResult": {
-          "modelId": "300ccd7e-e64f-49b7-8f47-85e78511bba0"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/68682cf9-2cdc-46f1-b208-a1d77e8436f8",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "Request-Id": "|76b77200-49dcf694548109e3.",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200613.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "920661fed954d072bca8b87661c292e1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b2c02504-687d-4766-8116-428e5e5de3db",
+        "apim-request-id": "86176931-8d6e-4a42-b1fc-fcc73a15c63b",
         "Content-Length": "0",
-        "Date": "Sat, 13 Jun 2020 23:15:20 GMT",
+        "Date": "Tue, 16 Jun 2020 04:18:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "82"
+        "x-envoy-upstream-service-time": "122"
       },
       "ResponseBody": []
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/TrainingOps(False).json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/TrainingOps(False).json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Content-Length": "237",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-43221e2bf9c24c4b918eaa1ff781aa33-93864a9555892a48-00",
+        "Request-Id": "|accc7599-4e90168e2e58284a.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d4c80638f4b1ebfe01a46453d8f75f77",
         "x-ms-return-client-request-id": "true"
@@ -18,24 +18,24 @@
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "df2ce531-587b-46ae-aac2-868a2eb14b36",
+        "apim-request-id": "0412713d-582a-449d-aa91-6a40c4049f0e",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:36:40 GMT",
-        "Location": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955",
+        "Date": "Tue, 16 Jun 2020 04:11:13 GMT",
+        "Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
+        "x-envoy-upstream-service-time": "5404"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d75ec970998c57a5ab95cd3411500208",
         "x-ms-return-client-request-id": "true"
@@ -43,31 +43,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5cb1f25c-31f4-4e50-b4eb-0bd90c7be5e6",
+        "apim-request-id": "5228429d-8d6e-4ff6-a7b5-9b0737f85bad",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:40 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "146"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "cfc3c32d3e50b649fe263d95d3181211",
         "x-ms-return-client-request-id": "true"
@@ -75,31 +75,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12a794c9-ec9e-4676-ba12-3585853732be",
+        "apim-request-id": "7b5d5022-1404-4f28-ac77-0113d79d122e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:41 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "251"
+        "x-envoy-upstream-service-time": "149"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "862317feb2999e096071291c27c9d9b0",
         "x-ms-return-client-request-id": "true"
@@ -107,31 +107,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93203756-7fb6-4a46-8ffb-683cdcb0558c",
+        "apim-request-id": "79905aaf-3dd3-4fe5-9bd2-60db6eea12b6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:42 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "171"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "15255ba19033322680a8d8655b108392",
         "x-ms-return-client-request-id": "true"
@@ -139,31 +139,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b16de3b7-f0c2-422a-a688-c20dc9ff9b4d",
+        "apim-request-id": "c8f4428d-7f7c-442d-846b-de428d1b6d2f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:43 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "x-envoy-upstream-service-time": "221"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fa36bc827b2c7b6fba256edf152c8f34",
         "x-ms-return-client-request-id": "true"
@@ -171,31 +171,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b936867d-a3ba-4ba1-9ec3-e40217bab4f2",
+        "apim-request-id": "0c09ad35-454d-401e-b236-77ab14432f3a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:45 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "62"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "77f38c4cfcf36eddf1f006f1d9a3424f",
         "x-ms-return-client-request-id": "true"
@@ -203,31 +203,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e686b863-9a79-465c-abc6-40d7ad188b67",
+        "apim-request-id": "d42da1fd-1486-4282-a101-e8d001e688d2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:46 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "71"
+        "x-envoy-upstream-service-time": "75"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6a9a96eddf932684ecaa5b0e21471d53",
         "x-ms-return-client-request-id": "true"
@@ -235,31 +235,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4b6941f4-f539-429c-951d-0267518ef556",
+        "apim-request-id": "3d213fb8-a285-46d7-90e4-b4a98ba18d49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:47 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "118"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:13Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "cf18a4190c1c859fdec7083b757ea116",
         "x-ms-return-client-request-id": "true"
@@ -267,31 +267,96 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e26dea0f-9705-44d1-bc15-66deec161d43",
+        "apim-request-id": "adf64bb5-6b69-4ae9-84a6-6e46daefa239",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:48 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "54"
+        "x-envoy-upstream-service-time": "57"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:41Z"
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
+          "status": "ready",
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:21Z"
+        },
+        "keys": {
+          "clusters": {
+            "0": [
+              "Additional Notes:",
+              "Address:",
+              "Company Name:",
+              "Company Phone:",
+              "Dated As:",
+              "Details",
+              "Email:",
+              "Hero Limited",
+              "Name:",
+              "Phone:",
+              "Purchase Order",
+              "Purchase Order #:",
+              "Quantity",
+              "SUBTOTAL",
+              "Seattle, WA 93849 Phone:",
+              "Shipped From",
+              "Shipped To",
+              "TAX",
+              "TOTAL",
+              "Total",
+              "Unit Price",
+              "Vendor Name:",
+              "Website:"
+            ]
+          }
+        },
+        "trainResult": {
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            }
+          ],
+          "errors": []
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|accc759a-4e90168e2e58284a.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7ff21fe224926da108cd8b48a1cf4daa",
         "x-ms-return-client-request-id": "true"
@@ -299,44 +364,45 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "337c1fd7-e60a-4d38-9851-dea8ebfc7ff6",
+        "apim-request-id": "575cef84-2a15-45c5-8ce6-bde25bea4c1e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:49 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "961"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
+          "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
           "status": "ready",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:49Z"
+          "createdDateTime": "2020-06-16T04:11:13Z",
+          "lastUpdatedDateTime": "2020-06-16T04:11:21Z"
         },
         "keys": {
           "clusters": {
             "0": [
               "Additional Notes:",
               "Address:",
-              "Address:",
               "Company Name:",
               "Company Phone:",
               "Dated As:",
+              "Details",
               "Email:",
               "Hero Limited",
               "Name:",
               "Phone:",
-              "Phone:",
-              "Purchase Order",
               "Purchase Order",
               "Purchase Order #:",
+              "Quantity",
               "SUBTOTAL",
               "Seattle, WA 93849 Phone:",
               "Shipped From",
               "Shipped To",
               "TAX",
               "TOTAL",
+              "Total",
+              "Unit Price",
               "Vendor Name:",
               "Website:"
             ]
@@ -380,14 +446,13 @@
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=full",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9b87517512abc34fa76a75eadab3918d-52e8e0854725c64f-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "35d8b2d3738be132f6148ccbd648b06e",
         "x-ms-return-client-request-id": "true"
@@ -395,94 +460,35 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "18be6324-b0c4-4c84-83fb-7f27742b3963",
+        "apim-request-id": "5407cac4-e50e-43b5-8666-3cba7dfb281c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:49 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "90"
       },
       "ResponseBody": {
-        "modelInfo": {
-          "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
-          "status": "ready",
-          "createdDateTime": "2020-04-29T19:36:41Z",
-          "lastUpdatedDateTime": "2020-04-29T19:36:49Z"
-        },
-        "keys": {
-          "clusters": {
-            "0": [
-              "Additional Notes:",
-              "Address:",
-              "Address:",
-              "Company Name:",
-              "Company Phone:",
-              "Dated As:",
-              "Email:",
-              "Hero Limited",
-              "Name:",
-              "Phone:",
-              "Phone:",
-              "Purchase Order",
-              "Purchase Order",
-              "Purchase Order #:",
-              "SUBTOTAL",
-              "Seattle, WA 93849 Phone:",
-              "Shipped From",
-              "Shipped To",
-              "TAX",
-              "TOTAL",
-              "Vendor Name:",
-              "Website:"
-            ]
+        "modelList": [
+          {
+            "modelId": "5554305d-b322-462b-8993-987dd407e3fe",
+            "status": "ready",
+            "createdDateTime": "2020-06-16T04:11:13Z",
+            "lastUpdatedDateTime": "2020-06-16T04:11:21Z"
           }
-        },
-        "trainResult": {
-          "trainingDocuments": [
-            {
-              "documentName": "Form_1.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_2.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_3.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_4.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_5.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            }
-          ],
-          "errors": []
-        }
+        ],
+        "nextLink": ""
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=full",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=summary",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|accc759b-4e90168e2e58284a.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "012c45089e54f4c102abc64f8157e40e",
         "x-ms-return-client-request-id": "true"
@@ -490,1480 +496,75 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61142c53-b918-4070-be44-91aa3127768c",
+        "apim-request-id": "c6f854dd-ea2f-4dfc-8f32-c84098978966",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:50 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "741"
+        "x-envoy-upstream-service-time": "27"
       },
       "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "00f3fe10-6a59-4c82-8ce1-afee0fb1dace",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:15:36Z",
-            "lastUpdatedDateTime": "2020-04-22T17:15:40Z"
-          },
-          {
-            "modelId": "015d3c91-4afd-4e4a-9c18-3233f91bc544",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:18:18Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:21Z"
-          },
-          {
-            "modelId": "020f55f8-a314-4551-aa94-e7ae6023c0d4",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:44:46Z",
-            "lastUpdatedDateTime": "2020-04-16T19:45:46Z"
-          },
-          {
-            "modelId": "037a2889-83e3-47a0-b81f-c49fe8661ff2",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:26:15Z",
-            "lastUpdatedDateTime": "2020-04-21T04:26:17Z"
-          },
-          {
-            "modelId": "03d247b2-ded7-4b3c-81dc-cff49b6c5503",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T20:21:31Z",
-            "lastUpdatedDateTime": "2020-04-16T20:22:02Z"
-          },
-          {
-            "modelId": "0421be9b-7f0f-4c72-a3e8-32e612b5b5e1",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:44:32Z",
-            "lastUpdatedDateTime": "2020-04-23T01:44:42Z"
-          },
-          {
-            "modelId": "058fe7a5-c0c2-47c0-9cfc-fca7bf760675",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:21Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:30Z"
-          },
-          {
-            "modelId": "05fd2bc8-7818-4964-9117-59694b4dfad5",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:31:59Z",
-            "lastUpdatedDateTime": "2020-04-28T01:32:00Z"
-          },
-          {
-            "modelId": "0a805a87-0179-417d-aacf-1a1a674c5e5c",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T23:05:14Z",
-            "lastUpdatedDateTime": "2020-04-17T23:05:14Z"
-          },
-          {
-            "modelId": "0b073ff2-3ce3-47bb-b4f0-fb27349d1a4c",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:04:50Z",
-            "lastUpdatedDateTime": "2020-04-20T23:04:59Z"
-          },
-          {
-            "modelId": "0b425ade-a82e-41f8-a7ee-fa6fb3015afb",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:07:40Z",
-            "lastUpdatedDateTime": "2020-04-16T21:07:43Z"
-          },
-          {
-            "modelId": "0bb31303-fbaa-4247-91fa-c6a4c68114e2",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T15:57:43Z",
-            "lastUpdatedDateTime": "2020-04-18T15:57:50Z"
-          },
-          {
-            "modelId": "0e00bda3-349d-497e-be80-bc77f9d496b2",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:16:03Z",
-            "lastUpdatedDateTime": "2020-04-22T17:16:07Z"
-          },
-          {
-            "modelId": "11eb138e-46a6-44da-a779-78526c2ddca7",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:31:09Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:10Z"
-          },
-          {
-            "modelId": "124949e1-d2fc-48af-bb4c-1a9c39707b67",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:33:59Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:08Z"
-          },
-          {
-            "modelId": "13b5d51c-8f10-47b0-97cf-66fb3a0931f7",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:39:39Z",
-            "lastUpdatedDateTime": "2020-04-16T19:40:35Z"
-          },
-          {
-            "modelId": "14425f4d-1180-4cf1-a2b0-f1abadde3c73",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:03:17Z",
-            "lastUpdatedDateTime": "2020-04-21T20:03:25Z"
-          },
-          {
-            "modelId": "1455d839-4b2c-474d-9a72-11d04dab7bbe",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T17:32:54Z",
-            "lastUpdatedDateTime": "2020-04-17T17:33:23Z"
-          },
-          {
-            "modelId": "15c938b2-b7f5-48c7-95b9-ed60960e1684",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:49:18Z",
-            "lastUpdatedDateTime": "2020-04-20T22:49:26Z"
-          },
-          {
-            "modelId": "17bec2df-b25c-4ae0-a658-0b0a6a59c0de",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:34:50Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:59Z"
-          },
-          {
-            "modelId": "17dfa1ce-29a3-4d2f-afb7-f38916239917",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T22:37:27Z",
-            "lastUpdatedDateTime": "2020-04-16T22:38:26Z"
-          },
-          {
-            "modelId": "185be968-e238-4dcd-bb72-3a0ae0979680",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:28:18Z",
-            "lastUpdatedDateTime": "2020-04-23T01:28:19Z"
-          },
-          {
-            "modelId": "19d98132-3aa8-4811-841c-8f5a0e366122",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T16:37:24Z",
-            "lastUpdatedDateTime": "2020-04-21T16:37:29Z"
-          },
-          {
-            "modelId": "1cf38f17-e857-4093-b3f2-39981de929dc",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:25:32Z",
-            "lastUpdatedDateTime": "2020-04-21T04:25:35Z"
-          },
-          {
-            "modelId": "1f2fa881-be5c-42a7-9bce-e8bf6f60e97f",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:08:57Z",
-            "lastUpdatedDateTime": "2020-04-21T20:09:05Z"
-          },
-          {
-            "modelId": "1f74769b-8207-49a0-a898-2e575d435503",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:32:50Z",
-            "lastUpdatedDateTime": "2020-04-17T17:32:52Z"
-          },
-          {
-            "modelId": "205b472b-adb6-4959-9943-9a9d74372ef8",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:25:06Z",
-            "lastUpdatedDateTime": "2020-04-28T01:25:06Z"
-          },
-          {
-            "modelId": "20aa7d07-b3e4-4c4a-b9a5-342d6be75092",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T16:03:38Z",
-            "lastUpdatedDateTime": "2020-04-18T16:03:47Z"
-          },
-          {
-            "modelId": "250af4a0-395b-4d66-8fa6-f14b55d3d642",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:21:40Z",
-            "lastUpdatedDateTime": "2020-04-21T04:21:41Z"
-          },
-          {
-            "modelId": "2790f874-c6c3-448e-a849-d2bc295562e4",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:35:45Z",
-            "lastUpdatedDateTime": "2020-04-23T04:35:48Z"
-          },
-          {
-            "modelId": "2828ee83-b53d-4a90-9eaf-7bc9a985b537",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:31:11Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:15Z"
-          },
-          {
-            "modelId": "2bb008d0-4487-41bb-9fd6-23d5c80e67c4",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:33:27Z",
-            "lastUpdatedDateTime": "2020-04-17T17:33:27Z"
-          },
-          {
-            "modelId": "2db46d01-e98b-43e9-b5e1-63329523bd17",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:41:22Z",
-            "lastUpdatedDateTime": "2020-04-16T21:41:30Z"
-          },
-          {
-            "modelId": "2ee3e269-8b03-4852-8880-fc191dc92013",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:30:35Z",
-            "lastUpdatedDateTime": "2020-04-28T01:30:48Z"
-          },
-          {
-            "modelId": "2eeb81f2-4b35-460d-bfdd-96efea660459",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:46:45Z",
-            "lastUpdatedDateTime": "2020-04-23T04:46:48Z"
-          },
-          {
-            "modelId": "337c4e2f-684f-493a-9a0e-eb938b691d71",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:48:05Z",
-            "lastUpdatedDateTime": "2020-04-23T04:48:13Z"
-          },
-          {
-            "modelId": "34918d65-ed45-4101-bd79-44ff5f7d511f",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T17:33:30Z",
-            "lastUpdatedDateTime": "2020-04-17T17:34:00Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzNhN2Q2NjAxLWYzMGItNDA2OS1iMmZmLWU0M2M2ZWU2OGMxNC8zYTdkNjYwMS1mMzBiLTQwNjktYjJmZi1lNDNjNmVlNjhjMTQuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh"
+        "summary": {
+          "count": 1,
+          "limit": 250,
+          "lastUpdatedDateTime": "2020-06-16T04:11:25Z"
+        }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzNhN2Q2NjAxLWYzMGItNDA2OS1iMmZmLWU0M2M2ZWU2OGMxNC8zYTdkNjYwMS1mMzBiLTQwNjktYjJmZi1lNDNjNmVlNjhjMTQuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh",
-      "RequestMethod": "GET",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe",
+      "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|accc759c-4e90168e2e58284a.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c2685e7a6ca66e8bec11887e97d696c0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 200,
+      "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c7854f65-1142-4701-b00a-2606f1dd899f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:52 GMT",
+        "apim-request-id": "5c064d25-f26b-4811-a6e1-ca00960deaec",
+        "Content-Length": "0",
+        "Date": "Tue, 16 Jun 2020 04:11:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1758"
+        "x-envoy-upstream-service-time": "31"
       },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "3adc8f9b-2503-48b7-bddc-9fe54bd07c9d",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:30:19Z",
-            "lastUpdatedDateTime": "2020-04-28T01:30:19Z"
-          },
-          {
-            "modelId": "3b9db8c5-4066-4291-90fd-7a9fe8b39757",
-            "status": "ready",
-            "createdDateTime": "2020-04-27T23:26:48Z",
-            "lastUpdatedDateTime": "2020-04-27T23:26:56Z"
-          },
-          {
-            "modelId": "3bb5e8b0-15f2-4881-b6c0-69d5213fcb35",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:03:48Z",
-            "lastUpdatedDateTime": "2020-04-21T20:03:58Z"
-          },
-          {
-            "modelId": "3de4e955-4817-459b-9fde-72d64ed7c8a8",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:34:39Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:39Z"
-          },
-          {
-            "modelId": "3e9d0537-9070-4b18-adff-101aa84d06c1",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T22:59:33Z",
-            "lastUpdatedDateTime": "2020-04-16T22:59:47Z"
-          },
-          {
-            "modelId": "41b6c2a1-ec67-421e-b191-bb15360fbe9e",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:24:31Z",
-            "lastUpdatedDateTime": "2020-04-28T21:24:33Z"
-          },
-          {
-            "modelId": "44875639-a371-4c91-9320-d023be24cd7d",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:25:18Z",
-            "lastUpdatedDateTime": "2020-04-28T01:25:27Z"
-          },
-          {
-            "modelId": "46ea9d99-596d-48da-b92d-2abe8eeee1a0",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:00:44Z",
-            "lastUpdatedDateTime": "2020-04-20T23:00:51Z"
-          },
-          {
-            "modelId": "471ead11-6cd2-43be-a5f7-7bba7d8e5d28",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:18:16Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:16Z"
-          },
-          {
-            "modelId": "48317880-6116-478f-90fc-35c3ae7a664f",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:34:14Z",
-            "lastUpdatedDateTime": "2020-04-17T23:34:23Z"
-          },
-          {
-            "modelId": "48a7a1f7-6ffa-4cb8-9974-c730c2f2b099",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T19:10:32Z",
-            "lastUpdatedDateTime": "2020-04-28T19:10:32Z"
-          },
-          {
-            "modelId": "4902dd5c-3217-465b-9857-633643540b3a",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:26:35Z",
-            "lastUpdatedDateTime": "2020-04-28T01:26:38Z"
-          },
-          {
-            "modelId": "49a21836-bae7-40ed-953d-3e72271fcd8e",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:52:57Z",
-            "lastUpdatedDateTime": "2020-04-16T21:53:27Z"
-          },
-          {
-            "modelId": "4b78183a-2417-461a-9489-4d4e97445d31",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:22:26Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:29Z"
-          },
-          {
-            "modelId": "4b9486b5-f013-4ce0-9a34-346cbd64463e",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T16:31:38Z",
-            "lastUpdatedDateTime": "2020-04-17T16:31:38Z"
-          },
-          {
-            "modelId": "4d8c9a81-c163-4071-a98c-2929a73227eb",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:15:42Z",
-            "lastUpdatedDateTime": "2020-04-20T22:15:43Z"
-          },
-          {
-            "modelId": "4dcae8f8-9e83-41a8-912b-b1481d3ece59",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T16:31:46Z",
-            "lastUpdatedDateTime": "2020-04-17T16:31:55Z"
-          },
-          {
-            "modelId": "4fe41783-1603-4ff3-86e3-1129cff18450",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:26:58Z",
-            "lastUpdatedDateTime": "2020-04-23T01:26:58Z"
-          },
-          {
-            "modelId": "4ff416e1-c78b-47b4-905d-9ba3f793115e",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:41:33Z",
-            "lastUpdatedDateTime": "2020-04-17T17:41:34Z"
-          },
-          {
-            "modelId": "5143b4cc-c53c-4746-9826-df0b9189d1e9",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:13:40Z",
-            "lastUpdatedDateTime": "2020-04-16T21:14:09Z"
-          },
-          {
-            "modelId": "55067347-fa2d-4487-a602-be4c6f969ca7",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:23:25Z",
-            "lastUpdatedDateTime": "2020-04-19T17:23:28Z"
-          },
-          {
-            "modelId": "5576286d-e809-411f-8ca0-44f91180c76e",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:32Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:35Z"
-          },
-          {
-            "modelId": "55d6055b-2530-42d9-a5da-dea84822e5b1",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:17Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:20Z"
-          },
-          {
-            "modelId": "5a31bba8-d429-480d-881e-f817623d4965",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:31:55Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:56Z"
-          },
-          {
-            "modelId": "5aa3cf28-d994-414b-bb7f-d1cdbb58a52a",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:36:09Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:18Z"
-          },
-          {
-            "modelId": "5ac44f17-f19d-46b1-8f91-be728912814e",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:33:57Z",
-            "lastUpdatedDateTime": "2020-04-20T17:33:59Z"
-          },
-          {
-            "modelId": "5e968d16-bd8f-41f6-acb0-289644ac3892",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T03:45:18Z",
-            "lastUpdatedDateTime": "2020-04-21T03:45:27Z"
-          },
-          {
-            "modelId": "60e34166-ae5f-4459-afaf-a9eb8b8d470e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:09:07Z",
-            "lastUpdatedDateTime": "2020-04-21T20:09:11Z"
-          },
-          {
-            "modelId": "61e4904b-142d-491b-a45b-0654b2da72d1",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:32:01Z",
-            "lastUpdatedDateTime": "2020-04-28T01:32:04Z"
-          },
-          {
-            "modelId": "61e9d826-0c94-404c-b74d-80c3d0d70bad",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:14:03Z",
-            "lastUpdatedDateTime": "2020-04-28T21:14:14Z"
-          },
-          {
-            "modelId": "64172e69-150a-4965-86cb-f09654cc9bb4",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:28:19Z",
-            "lastUpdatedDateTime": "2020-04-23T01:29:28Z"
-          },
-          {
-            "modelId": "6783d13c-3994-4177-b31a-796fea7f1dd8",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:26:59Z",
-            "lastUpdatedDateTime": "2020-04-23T01:27:03Z"
-          },
-          {
-            "modelId": "678a1723-ed0f-437f-8187-8fc7adf6e1d9",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:40:36Z",
-            "lastUpdatedDateTime": "2020-04-16T19:41:39Z"
-          },
-          {
-            "modelId": "6b4cc85d-7154-4d5e-b84c-282069b6d2bb",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T23:05:15Z",
-            "lastUpdatedDateTime": "2020-04-17T23:05:15Z"
-          },
-          {
-            "modelId": "6eec31df-8597-4a3c-b6d1-a75a28895290",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T17:38:37Z",
-            "lastUpdatedDateTime": "2020-04-17T17:39:07Z"
-          },
-          {
-            "modelId": "71672465-1f41-4c20-85d6-1471af059a54",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:34:01Z",
-            "lastUpdatedDateTime": "2020-04-21T04:34:04Z"
-          },
-          {
-            "modelId": "72fffb98-a9ed-4de5-a174-00d7834f46d4",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:44:38Z",
-            "lastUpdatedDateTime": "2020-04-16T19:45:42Z"
-          },
-          {
-            "modelId": "7395ff95-ab71-404b-ac08-79d81e7c95f4",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:35:01Z",
-            "lastUpdatedDateTime": "2020-04-17T23:35:07Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!204!MDAwMTA4IXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzczOTVmZjk1LWFiNzEtNDA0Yi1hYzA4LTc5ZDgxZTdjOTVmNC91c2VMYWJlbEZpbGUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
-      }
+      "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!204!MDAwMTA4IXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzczOTVmZjk1LWFiNzEtNDA0Yi1hYzA4LTc5ZDgxZTdjOTVmNC91c2VMYWJlbEZpbGUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/5554305d-b322-462b-8993-987dd407e3fe?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|accc759d-4e90168e2e58284a.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5b3f1c1c4ba33555f1e332dfade35f9f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "94231192-7831-43bb-87ca-9345a9fe422f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:53 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "568"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "748c0632-3bf4-4f54-bcc5-fee99a853e17",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:37:05Z",
-            "lastUpdatedDateTime": "2020-04-23T04:37:06Z"
-          },
-          {
-            "modelId": "765ef38e-7d5b-40bf-b6d7-b9291aa3c8af",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:16:48Z",
-            "lastUpdatedDateTime": "2020-04-21T04:17:02Z"
-          },
-          {
-            "modelId": "76d1eb1d-a70b-4497-ada1-0663b6cfb659",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T23:00:03Z",
-            "lastUpdatedDateTime": "2020-04-16T23:00:07Z"
-          },
-          {
-            "modelId": "7a67759e-f514-43c8-8aee-3829392ca1b2",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:21:52Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:01Z"
-          },
-          {
-            "modelId": "7ad9e5c7-49a7-418f-8c58-574197249e7d",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T22:48:41Z",
-            "lastUpdatedDateTime": "2020-04-17T22:48:41Z"
-          },
-          {
-            "modelId": "7b258785-ce51-45d3-a949-5a1b3cc39afe",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:15:25Z",
-            "lastUpdatedDateTime": "2020-04-28T21:15:33Z"
-          },
-          {
-            "modelId": "804bc3c6-1ccb-4e96-879a-eaf0e99a7574",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:07:37Z",
-            "lastUpdatedDateTime": "2020-04-21T20:07:46Z"
-          },
-          {
-            "modelId": "8050cdc6-f0d4-4288-b227-6a68283ac11d",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:31:16Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:28Z"
-          },
-          {
-            "modelId": "80ff7724-7f5b-4514-bb1b-6622acd48c90",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:40:45Z",
-            "lastUpdatedDateTime": "2020-04-16T21:40:50Z"
-          },
-          {
-            "modelId": "81e577e6-798c-4f98-a11f-2a14bc26a075",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:10:37Z",
-            "lastUpdatedDateTime": "2020-04-28T19:10:50Z"
-          },
-          {
-            "modelId": "868212b4-da54-4083-a19c-cb45e0cf6521",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:28:36Z",
-            "lastUpdatedDateTime": "2020-04-19T17:28:44Z"
-          },
-          {
-            "modelId": "8688ef71-cc4b-4221-a26d-44e79cae55b0",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:23:02Z",
-            "lastUpdatedDateTime": "2020-04-28T21:23:10Z"
-          },
-          {
-            "modelId": "89054483-44f5-4488-a562-b358d791e989",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:44:11Z",
-            "lastUpdatedDateTime": "2020-04-17T23:44:19Z"
-          },
-          {
-            "modelId": "89804eab-8af6-4c88-8d0b-4fc24e36d486",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:19:01Z",
-            "lastUpdatedDateTime": "2020-04-21T04:19:09Z"
-          },
-          {
-            "modelId": "89c2ef56-48b9-4123-9ea1-ea1442736f5e",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:47:45Z",
-            "lastUpdatedDateTime": "2020-04-16T21:47:54Z"
-          },
-          {
-            "modelId": "8b55ef0e-9e10-4e38-b41a-ab222924df5a",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:13:58Z",
-            "lastUpdatedDateTime": "2020-04-28T21:13:59Z"
-          },
-          {
-            "modelId": "8b9f46eb-78f4-420d-81b7-fbbde06f1354",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:42:58Z",
-            "lastUpdatedDateTime": "2020-04-23T01:42:58Z"
-          },
-          {
-            "modelId": "8c085626-8d1b-4dd2-a48f-749a7117c927",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:35:43Z",
-            "lastUpdatedDateTime": "2020-04-23T04:35:44Z"
-          },
-          {
-            "modelId": "8c3cb0b4-15ec-4155-ac36-71d06124931e",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:34:10Z",
-            "lastUpdatedDateTime": "2020-04-16T21:34:40Z"
-          },
-          {
-            "modelId": "8d3c2169-b52f-429d-a563-29d0661a4476",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:08:45Z",
-            "lastUpdatedDateTime": "2020-04-21T20:08:54Z"
-          },
-          {
-            "modelId": "912d1c3d-8bf4-425e-9df2-03439ca8d8ae",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:41Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:44Z"
-          },
-          {
-            "modelId": "91e023ac-21ae-482b-b02e-eb8d74c928f2",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:44:19Z",
-            "lastUpdatedDateTime": "2020-04-23T01:44:20Z"
-          },
-          {
-            "modelId": "92391b87-51b8-4074-bff7-2b9b0e25adf1",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T16:31:40Z",
-            "lastUpdatedDateTime": "2020-04-17T16:31:45Z"
-          },
-          {
-            "modelId": "9374c9f5-9a50-4b8c-a957-8f5e96f6dbee",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T00:09:22Z",
-            "lastUpdatedDateTime": "2020-04-18T00:09:32Z"
-          },
-          {
-            "modelId": "953a9982-1d88-4d27-a297-eed6e7c81247",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:03:32Z",
-            "lastUpdatedDateTime": "2020-04-21T20:03:41Z"
-          },
-          {
-            "modelId": "957ba8bf-3bf8-4bf8-a86e-62b5260dc1b7",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T19:12:08Z",
-            "lastUpdatedDateTime": "2020-04-28T19:12:08Z"
-          },
-          {
-            "modelId": "95d9074e-1f4f-415f-8db7-9810a8993b2c",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:23:11Z",
-            "lastUpdatedDateTime": "2020-04-28T21:23:20Z"
-          },
-          {
-            "modelId": "989bfd50-2c0c-47ea-acba-42f41ea5a171",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:21:43Z",
-            "lastUpdatedDateTime": "2020-04-21T04:21:51Z"
-          },
-          {
-            "modelId": "98d49c8c-e189-41c7-8a6f-2c3912fbb9f6",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:05:04Z",
-            "lastUpdatedDateTime": "2020-04-20T23:05:07Z"
-          },
-          {
-            "modelId": "98f642c4-3533-49e9-ae4f-4abb49038a9b",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:52:38Z",
-            "lastUpdatedDateTime": "2020-04-17T23:52:50Z"
-          },
-          {
-            "modelId": "99bac95c-3f14-478d-a77e-6b7c5788dcf2",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:52:30Z",
-            "lastUpdatedDateTime": "2020-04-16T21:52:38Z"
-          },
-          {
-            "modelId": "99ec5bbe-f195-4d79-aa4a-d36e986f54e9",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:56:44Z",
-            "lastUpdatedDateTime": "2020-04-16T21:56:53Z"
-          },
-          {
-            "modelId": "9a203331-26a6-4642-bfeb-b89e65c45b62",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:44:21Z",
-            "lastUpdatedDateTime": "2020-04-23T01:44:31Z"
-          },
-          {
-            "modelId": "9b62cfca-c605-4f4b-9f77-e2998de68c1f",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:32:53Z",
-            "lastUpdatedDateTime": "2020-04-16T21:32:56Z"
-          },
-          {
-            "modelId": "9c6f5f9d-f477-43a9-8f94-10917d6c590d",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:07:26Z",
-            "lastUpdatedDateTime": "2020-04-21T20:07:30Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzljN2I4MTI5LTkxOGMtNGViZi05MzhjLWRkNzYyNTUzNWQ5My85YzdiODEyOS05MThjLTRlYmYtOTM4Yy1kZDc2MjU1MzVkOTMuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzljN2I4MTI5LTkxOGMtNGViZi05MzhjLWRkNzYyNTUzNWQ5My85YzdiODEyOS05MThjLTRlYmYtOTM4Yy1kZDc2MjU1MzVkOTMuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "78507d2feee09cc8babd154315425c2c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "88806cb8-8f00-4483-a424-85270d20bb32",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:54 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1224"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "9c7b8129-918c-4ebf-938c-dd7625535d93",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:10:33Z",
-            "lastUpdatedDateTime": "2020-04-28T19:10:37Z"
-          },
-          {
-            "modelId": "9d61923a-0117-4d5f-b073-70dea2ed3662",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:16:16Z",
-            "lastUpdatedDateTime": "2020-04-22T17:16:19Z"
-          },
-          {
-            "modelId": "a1cd2a2b-18a4-4e85-a10d-c5e574615261",
-            "status": "invalid",
-            "createdDateTime": "2020-04-29T19:36:08Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:08Z"
-          },
-          {
-            "modelId": "a3bb3fa1-6797-418a-8a12-a8f4bcd5e250",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:30:55Z",
-            "lastUpdatedDateTime": "2020-04-21T04:30:58Z"
-          },
-          {
-            "modelId": "a4748585-90ea-4170-b240-ef2f31d01fa2",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:37:07Z",
-            "lastUpdatedDateTime": "2020-04-23T04:37:09Z"
-          },
-          {
-            "modelId": "a64d767a-524a-43b0-bb71-232820626ed8",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:24:28Z",
-            "lastUpdatedDateTime": "2020-04-28T21:24:29Z"
-          },
-          {
-            "modelId": "a6bf96f0-8c59-435e-9fd0-d044b6bf423b",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:01:04Z",
-            "lastUpdatedDateTime": "2020-04-20T23:01:11Z"
-          },
-          {
-            "modelId": "a733e166-3034-434a-9cb7-49fd6cbf0aec",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:37:18Z",
-            "lastUpdatedDateTime": "2020-04-19T17:37:26Z"
-          },
-          {
-            "modelId": "a79c549f-3741-4bf3-b2c5-4c25187983a4",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:33:37Z",
-            "lastUpdatedDateTime": "2020-04-16T21:34:09Z"
-          },
-          {
-            "modelId": "a821650f-398f-490b-bd64-57a27d7645c6",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T20:20:59Z",
-            "lastUpdatedDateTime": "2020-04-16T20:21:30Z"
-          },
-          {
-            "modelId": "a918b148-48e6-4bd7-a072-ed55a5801bda",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:26:39Z",
-            "lastUpdatedDateTime": "2020-04-28T01:26:47Z"
-          },
-          {
-            "modelId": "aa5f8b82-52da-4dbb-891a-5a2f1d32ba78",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:32:49Z",
-            "lastUpdatedDateTime": "2020-04-17T17:32:50Z"
-          },
-          {
-            "modelId": "ab989d76-e331-4d18-ae00-b3d438e20d2a",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:32:05Z",
-            "lastUpdatedDateTime": "2020-04-28T01:32:13Z"
-          },
-          {
-            "modelId": "ac865e45-ff42-4df9-9f3b-50823b8edb34",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:48:14Z",
-            "lastUpdatedDateTime": "2020-04-23T04:48:22Z"
-          },
-          {
-            "modelId": "acc5ada5-9582-4456-9143-0e9d08762ae3",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:34:47Z",
-            "lastUpdatedDateTime": "2020-04-20T22:34:53Z"
-          },
-          {
-            "modelId": "b1448051-1fb2-4112-8df9-27c3e8a1fa57",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:50:09Z",
-            "lastUpdatedDateTime": "2020-04-16T21:50:17Z"
-          },
-          {
-            "modelId": "b22e1add-1ad8-4626-8c26-c63b4cef93a6",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T23:01:26Z",
-            "lastUpdatedDateTime": "2020-04-16T23:01:35Z"
-          },
-          {
-            "modelId": "b25ba217-d9d7-4539-a4f5-4ebdc5ff061d",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:43:38Z",
-            "lastUpdatedDateTime": "2020-04-17T23:43:46Z"
-          },
-          {
-            "modelId": "b2b60877-2ced-4619-8d43-22fefe3af8c4",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:38:23Z",
-            "lastUpdatedDateTime": "2020-04-16T21:38:32Z"
-          },
-          {
-            "modelId": "b4b6add0-909c-4a36-8b2a-17b88f7e046e",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:32:12Z",
-            "lastUpdatedDateTime": "2020-04-20T17:32:20Z"
-          },
-          {
-            "modelId": "b7451731-5a5c-4d36-be64-98b5f09006e3",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T23:01:10Z",
-            "lastUpdatedDateTime": "2020-04-16T23:01:22Z"
-          },
-          {
-            "modelId": "b89c8223-5851-4b72-9a56-ebfa2bb28955",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:36:41Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:49Z"
-          },
-          {
-            "modelId": "b8b3420a-90a4-4dc8-9740-f342360e8139",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:58:44Z",
-            "lastUpdatedDateTime": "2020-04-20T22:58:52Z"
-          },
-          {
-            "modelId": "ba286c44-4a05-4298-9014-5bf4b3b1c335",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:12:10Z",
-            "lastUpdatedDateTime": "2020-04-28T19:12:13Z"
-          },
-          {
-            "modelId": "ba608e90-5b1a-432e-98d7-f213972c6d17",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:44:21Z",
-            "lastUpdatedDateTime": "2020-04-20T22:44:25Z"
-          },
-          {
-            "modelId": "ba6bfec8-773c-4009-91f8-d82f06de550e",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:05:10Z",
-            "lastUpdatedDateTime": "2020-04-20T23:05:18Z"
-          },
-          {
-            "modelId": "c0882124-a05e-410a-9252-513d96a40054",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:29:58Z",
-            "lastUpdatedDateTime": "2020-04-16T21:30:07Z"
-          },
-          {
-            "modelId": "c1796212-cec0-4f40-aa54-71437052eea0",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:04:04Z",
-            "lastUpdatedDateTime": "2020-04-21T20:04:11Z"
-          },
-          {
-            "modelId": "c2b2d617-dbe0-4425-bda3-7c8f3d039765",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:14:34Z",
-            "lastUpdatedDateTime": "2020-04-20T22:15:08Z"
-          },
-          {
-            "modelId": "c358ed4a-007d-48f1-b1dc-3ec8ece2f72e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T01:27:33Z",
-            "lastUpdatedDateTime": "2020-04-21T01:27:36Z"
-          },
-          {
-            "modelId": "c3b3f591-2ea5-4dff-a8be-19d9cdc85e0e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:25:46Z",
-            "lastUpdatedDateTime": "2020-04-21T04:25:54Z"
-          },
-          {
-            "modelId": "c3da2e51-1e6b-42eb-b490-0ffc9fa525d7",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:44:00Z",
-            "lastUpdatedDateTime": "2020-04-20T22:44:03Z"
-          },
-          {
-            "modelId": "c3dd8b56-7d5a-4af9-b0a3-dc3a54afe476",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T16:36:44Z",
-            "lastUpdatedDateTime": "2020-04-21T16:36:49Z"
-          },
-          {
-            "modelId": "c47fcc7d-6e88-4d4c-aa0a-f8bc6373611b",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T01:27:54Z",
-            "lastUpdatedDateTime": "2020-04-21T01:27:57Z"
-          },
-          {
-            "modelId": "c59c2200-3199-4d15-a327-d28e9775a0b0",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:04:35Z",
-            "lastUpdatedDateTime": "2020-04-20T23:04:38Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2M3Mjc2ZDhjLWZkMDAtNDU2Yy04MThhLWIwYmIwYmFiYzEzNy9jNzI3NmQ4Yy1mZDAwLTQ1NmMtODE4YS1iMGJiMGJhYmMxMzcuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2M3Mjc2ZDhjLWZkMDAtNDU2Yy04MThhLWIwYmIwYmFiYzEzNy9jNzI3NmQ4Yy1mZDAwLTQ1NmMtODE4YS1iMGJiMGJhYmMxMzcuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "6432051589172f6b0932d0c239abc109",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4e27b12c-88d6-4718-bc18-bd9130572fba",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:36:56 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "925"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "c7276d8c-fd00-456c-818a-b0bb0babc137",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:34:40Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:49Z"
-          },
-          {
-            "modelId": "c7c59860-85f8-421d-8233-c9f19d22f3b3",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:48:04Z",
-            "lastUpdatedDateTime": "2020-04-23T04:48:04Z"
-          },
-          {
-            "modelId": "c7eb6b1c-4e55-4a54-9b5e-edd996b3e4ef",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T15:57:19Z",
-            "lastUpdatedDateTime": "2020-04-18T15:57:27Z"
-          },
-          {
-            "modelId": "cdb41e87-7bbf-4141-87cd-117fa49c1f78",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:19:26Z",
-            "lastUpdatedDateTime": "2020-04-17T23:19:37Z"
-          },
-          {
-            "modelId": "ce9427e6-44bd-472a-9c61-626e603ae68a",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:35:50Z",
-            "lastUpdatedDateTime": "2020-04-23T04:35:58Z"
-          },
-          {
-            "modelId": "ceeca6da-0e88-4987-9297-ce47b41c959c",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:01Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:04Z"
-          },
-          {
-            "modelId": "cf183756-cc5b-4d26-a0a6-47f4f79cd3cc",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:24:34Z",
-            "lastUpdatedDateTime": "2020-04-28T21:24:46Z"
-          },
-          {
-            "modelId": "d0c42c46-3057-4922-bd85-c9e8864a6336",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:27:49Z",
-            "lastUpdatedDateTime": "2020-04-19T17:28:00Z"
-          },
-          {
-            "modelId": "d2cc2fc6-a372-4e1a-9b6e-e36c338f29b8",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:16Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:20Z"
-          },
-          {
-            "modelId": "d3f0e5e0-6ba2-4896-a2d5-e30ed128c214",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:37:10Z",
-            "lastUpdatedDateTime": "2020-04-23T04:37:19Z"
-          },
-          {
-            "modelId": "d49552e9-61a5-419f-81ab-efc99ed92206",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:22:23Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:24Z"
-          },
-          {
-            "modelId": "d4f42b47-4aae-4397-b09e-4616dbe08ecf",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:14:00Z",
-            "lastUpdatedDateTime": "2020-04-28T21:14:03Z"
-          },
-          {
-            "modelId": "d80027c2-9239-4516-b994-0510a717a046",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T19:39:53Z",
-            "lastUpdatedDateTime": "2020-04-21T19:40:01Z"
-          },
-          {
-            "modelId": "d86011f4-c2bd-4e62-b228-9c69088a306c",
-            "status": "ready",
-            "createdDateTime": "2020-04-24T19:09:56Z",
-            "lastUpdatedDateTime": "2020-04-24T19:09:59Z"
-          },
-          {
-            "modelId": "d89aa9a2-6435-4e73-a6a4-fab618e6cd0f",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T00:06:15Z",
-            "lastUpdatedDateTime": "2020-04-18T00:06:22Z"
-          },
-          {
-            "modelId": "d8adeeda-9d4c-4042-8b8e-00f89fb80a06",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:22:29Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:37Z"
-          },
-          {
-            "modelId": "d98271cb-79c8-4948-aab1-db0760d96a41",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T22:24:03Z",
-            "lastUpdatedDateTime": "2020-04-16T22:24:38Z"
-          },
-          {
-            "modelId": "d9eb9dbf-10ed-4c0a-98b9-43110b5ca90b",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:26:34Z",
-            "lastUpdatedDateTime": "2020-04-28T01:26:34Z"
-          },
-          {
-            "modelId": "da243862-d92a-4e1a-be89-6abbbe0e72a3",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:46:49Z",
-            "lastUpdatedDateTime": "2020-04-23T04:46:56Z"
-          },
-          {
-            "modelId": "dc969636-aa58-4d46-8655-e34b778ce74c",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:17:50Z",
-            "lastUpdatedDateTime": "2020-04-20T22:17:55Z"
-          },
-          {
-            "modelId": "dd31e0ca-b3b8-4d78-8db9-ea1e5b5cd385",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:18:55Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:56Z"
-          },
-          {
-            "modelId": "dd58919c-a115-49b4-adaf-1ba337e98ace",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:23:01Z",
-            "lastUpdatedDateTime": "2020-04-28T21:23:01Z"
-          },
-          {
-            "modelId": "ddee2706-1cb7-4e59-83ae-ef84e3c6f605",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:36:18Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:27Z"
-          },
-          {
-            "modelId": "de676838-679a-4655-b69b-3f59470158f6",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T22:38:29Z",
-            "lastUpdatedDateTime": "2020-04-16T22:39:29Z"
-          },
-          {
-            "modelId": "dec6bff9-8b03-47b2-9dbd-af0dc6168c4f",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:07Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:15Z"
-          },
-          {
-            "modelId": "ded716e1-05e5-44b5-b480-6e5cf4a1986a",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:14:14Z",
-            "lastUpdatedDateTime": "2020-04-16T21:14:48Z"
-          },
-          {
-            "modelId": "df119aad-4b33-48ea-a5db-2fa70e586f33",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:26Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:29Z"
-          },
-          {
-            "modelId": "dfb8b0cb-f306-4137-8125-45fe5f693d3f",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:34:59Z",
-            "lastUpdatedDateTime": "2020-04-20T22:35:04Z"
-          },
-          {
-            "modelId": "e0978111-b48b-4c1c-ba05-b45754dd7929",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:49:35Z",
-            "lastUpdatedDateTime": "2020-04-20T22:49:43Z"
-          },
-          {
-            "modelId": "e0f779ef-fb79-4b30-9e61-d8a81b45851b",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:20:17Z",
-            "lastUpdatedDateTime": "2020-04-21T04:20:26Z"
-          },
-          {
-            "modelId": "e1799957-22a8-4807-b61c-fe817b695c73",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:42:59Z",
-            "lastUpdatedDateTime": "2020-04-23T01:43:02Z"
-          },
-          {
-            "modelId": "e1bbc8ee-e163-46be-b509-025841eeda17",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:25:57Z",
-            "lastUpdatedDateTime": "2020-04-21T04:26:01Z"
-          },
-          {
-            "modelId": "e2e10bcd-007e-4b38-a34d-15bff376a1fe",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:15:23Z",
-            "lastUpdatedDateTime": "2020-04-28T21:15:24Z"
-          },
-          {
-            "modelId": "e3e496a6-f860-4547-8d46-aa94b2da9cdb",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:30:25Z",
-            "lastUpdatedDateTime": "2020-04-28T01:30:34Z"
-          },
-          {
-            "modelId": "e4033223-a848-4049-b757-033dd91f067d",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:09:18Z",
-            "lastUpdatedDateTime": "2020-04-21T20:09:22Z"
-          },
-          {
-            "modelId": "e4ae8ec5-78ed-4a14-ac11-981ae1446592",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:18:57Z",
-            "lastUpdatedDateTime": "2020-04-21T04:19:00Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2U3ODBkMGNmLWY2ZDYtNGZhNy1iOTYwLTM0YWMzNzg3MTI2ZS9lNzgwZDBjZi1mNmQ2LTRmYTctYjk2MC0zNGFjMzc4NzEyNmUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2U3ODBkMGNmLWY2ZDYtNGZhNy1iOTYwLTM0YWMzNzg3MTI2ZS9lNzgwZDBjZi1mNmQ2LTRmYTctYjk2MC0zNGFjMzc4NzEyNmUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1a4ee9b11e852ee054a3a1e535111fae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "2bc8e50b-90bc-4dd2-a3d1-670720c32035",
-        "Content-Length": "311",
-        "Content-Type": "application/json",
-        "Date": "Wed, 29 Apr 2020 19:36:56 GMT",
-        "Retry-After": "40",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the List Custom Models Operation under Form Recognizer API have exceeded rate limit of your current FormRecognizer S0 pricing tier. Please retry after 40 seconds. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2U3ODBkMGNmLWY2ZDYtNGZhNy1iOTYwLTM0YWMzNzg3MTI2ZS9lNzgwZDBjZi1mNmQ2LTRmYTctYjk2MC0zNGFjMzc4NzEyNmUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1a4ee9b11e852ee054a3a1e535111fae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8ec86899-9293-40b9-b9a7-2b2721dc7bbf",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:37:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "400"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "e780d0cf-f6d6-4fa7-b960-34ac3787126e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:17:58Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:01Z"
-          },
-          {
-            "modelId": "e91c2253-4d8e-439a-9b31-5efd8ac2e6c7",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:18:22Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:34Z"
-          },
-          {
-            "modelId": "ec3f9be7-ae7a-4537-be00-c072d57a4a05",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T20:21:32Z",
-            "lastUpdatedDateTime": "2020-04-16T20:21:40Z"
-          },
-          {
-            "modelId": "ecdf3e2c-13c0-4431-ae91-e953fa3bf227",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T02:56:55Z",
-            "lastUpdatedDateTime": "2020-04-21T02:57:06Z"
-          },
-          {
-            "modelId": "ece0bc12-4cef-42d2-af4f-5c6089797ced",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T15:50:25Z",
-            "lastUpdatedDateTime": "2020-04-18T15:50:34Z"
-          },
-          {
-            "modelId": "ed5eabc3-bfe2-4134-b7d3-4baf955d9fef",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:34:09Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:19Z"
-          },
-          {
-            "modelId": "ef3dcd6b-31c0-4d40-a437-3333e4c20fed",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:43:02Z",
-            "lastUpdatedDateTime": "2020-04-23T01:43:11Z"
-          },
-          {
-            "modelId": "f102aca8-29d9-4efe-99f2-0ed0d3dd29af",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:15:34Z",
-            "lastUpdatedDateTime": "2020-04-28T21:15:42Z"
-          },
-          {
-            "modelId": "f11f0a62-1a3c-4100-8fe7-078b7fed61d7",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:21:04Z",
-            "lastUpdatedDateTime": "2020-04-21T04:21:13Z"
-          },
-          {
-            "modelId": "f1dd0fa9-a86d-44d9-ad81-9269318a1f8a",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:17:56Z",
-            "lastUpdatedDateTime": "2020-04-16T21:18:04Z"
-          },
-          {
-            "modelId": "f2f7e43a-6610-4b21-9aab-93cce3763543",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:46:43Z",
-            "lastUpdatedDateTime": "2020-04-23T04:46:44Z"
-          },
-          {
-            "modelId": "f5e10f54-9a7b-4852-a31b-fc3642bc79ed",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T01:27:42Z",
-            "lastUpdatedDateTime": "2020-04-21T01:27:51Z"
-          },
-          {
-            "modelId": "f6899edc-da69-4989-a6b7-b8659e613fbc",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:29:30Z",
-            "lastUpdatedDateTime": "2020-04-23T01:29:38Z"
-          },
-          {
-            "modelId": "f6da502a-4992-467e-b1bf-89b6c818383a",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:31:57Z",
-            "lastUpdatedDateTime": "2020-04-20T17:32:11Z"
-          },
-          {
-            "modelId": "f7928183-3b36-493e-9992-5a4ad0925f4f",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:12:13Z",
-            "lastUpdatedDateTime": "2020-04-28T19:12:27Z"
-          },
-          {
-            "modelId": "f8717df3-8f6e-46dd-b6b8-e190363d1352",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:27:03Z",
-            "lastUpdatedDateTime": "2020-04-23T01:27:11Z"
-          },
-          {
-            "modelId": "f896ec2c-a901-49ca-a643-72e059dca277",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T22:50:07Z",
-            "lastUpdatedDateTime": "2020-04-17T22:50:07Z"
-          },
-          {
-            "modelId": "faee4509-abea-491e-b48e-eeadf853d1bc",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:15:43Z",
-            "lastUpdatedDateTime": "2020-04-22T17:15:51Z"
-          },
-          {
-            "modelId": "ff089c42-cb6f-4ec6-aaad-0056b6b71a32",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:25:08Z",
-            "lastUpdatedDateTime": "2020-04-28T01:25:12Z"
-          }
-        ],
-        "nextLink": ""
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=summary",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fff5e60ef23d7e46a9e381e900331241-03edb78578878642-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "a7ca0586fbb0a68811216ead1d05620e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "609411bd-92b9-4e43-a2f1-14c7efe322b7",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:37:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
-      },
-      "ResponseBody": {
-        "summary": {
-          "count": 200,
-          "limit": 5000,
-          "lastUpdatedDateTime": "2020-04-29T19:37:37Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-14f055a44359884f896298ceec80acc0-9cdb2058b074f048-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "2c920cfc42f3f7a725041073e785f9f7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 204,
-      "ResponseHeaders": {
-        "apim-request-id": "657250c0-0490-4a91-891d-50e669fe7392",
-        "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:37:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "98"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/b89c8223-5851-4b72-9a56-ebfa2bb28955?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f1dd9ff3eab6d24c84305cf4d05ecd54-4301b4d1182d954b-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "333b221219e0b55961a80864af32104e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "76d9f617-22f8-4fb7-b646-38acd07f6a8d",
+        "apim-request-id": "0f8cd988-ab4a-4f59-a0ba-2e0af18471cd",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:37:37 GMT",
+        "Date": "Tue, 16 Jun 2020 04:11:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "30"
       },
       "ResponseBody": {
         "error": {
           "code": "1022",
-          "message": "Model with \u0027id=b89c8223-5851-4b72-9a56-ebfa2bb28955\u0027 not found."
+          "message": "Model with \u0027id=5554305d-b322-462b-8993-987dd407e3fe\u0027 not found."
         }
       }
     }
@@ -1971,7 +572,7 @@
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
     "FORM_RECOGNIZER_BLOB_CONTAINER_SAS_URL": "https://sanitized.blob.core.windows.net",
-    "FORM_RECOGNIZER_ENDPOINT": "https://camaior-formrec.cognitiveservices.azure.com/",
+    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/",
     "RandomSeed": "864468572"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/TrainingOps(False)Async.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/TrainingOps(False)Async.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Content-Length": "237",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ad4c5ca0540f994dbec6d1ed9c2400a5-4605cf0837ebea47-00",
+        "Request-Id": "|3ca364f6-4c341012a84735f4.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "226daaa3f9acfcf864e578b5029b5ee1",
         "x-ms-return-client-request-id": "true"
@@ -18,24 +18,24 @@
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0098f1d1-5c71-4c79-876a-c0b006129a64",
+        "apim-request-id": "56478e63-569a-4f27-8a6b-092277cc866c",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:39:11 GMT",
-        "Location": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17",
+        "Date": "Tue, 16 Jun 2020 04:13:45 GMT",
+        "Location": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "94"
+        "x-envoy-upstream-service-time": "268"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c9a79a4c07789c3189d44f0e4347a194",
         "x-ms-return-client-request-id": "true"
@@ -43,31 +43,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47f68f15-1425-4a20-9280-891f4127d90b",
+        "apim-request-id": "2f1993d5-75dc-46b8-bcd3-37254608cf7f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:11 GMT",
+        "Date": "Tue, 16 Jun 2020 04:13:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "5117"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
+          "modelId": "cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
+          "createdDateTime": "2020-06-16T04:13:45Z",
+          "lastUpdatedDateTime": "2020-06-16T04:13:45Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d47645e99133398307e8fcff70324ff6",
         "x-ms-return-client-request-id": "true"
@@ -75,31 +75,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a20843e4-44b4-48b0-ad10-e878649b7509",
+        "apim-request-id": "47f1f2b4-8891-4391-9461-b72148fece50",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:12 GMT",
+        "Date": "Tue, 16 Jun 2020 04:13:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "105"
+        "x-envoy-upstream-service-time": "44"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
+          "modelId": "cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
+          "createdDateTime": "2020-06-16T04:13:45Z",
+          "lastUpdatedDateTime": "2020-06-16T04:13:45Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a1def79f37d59c1d79d099d8a9eab81c",
         "x-ms-return-client-request-id": "true"
@@ -107,31 +107,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7997ad6d-f9ab-46de-9350-49802d82a74a",
+        "apim-request-id": "88aac0e2-87a2-405f-80ec-6a63bc099bf7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:14 GMT",
+        "Date": "Tue, 16 Jun 2020 04:13:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
+          "modelId": "cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
+          "createdDateTime": "2020-06-16T04:13:45Z",
+          "lastUpdatedDateTime": "2020-06-16T04:13:45Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bccce3438a25bbad166dc2900a312b56",
         "x-ms-return-client-request-id": "true"
@@ -139,31 +139,96 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a77b4e6d-1082-4142-b956-25ad9ecc71d7",
+        "apim-request-id": "dd826995-381a-4b8d-9f48-f56c6378ecc9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:15 GMT",
+        "Date": "Tue, 16 Jun 2020 04:13:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "47"
+        "x-envoy-upstream-service-time": "5084"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
+          "modelId": "cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
+          "status": "ready",
+          "createdDateTime": "2020-06-16T04:13:45Z",
+          "lastUpdatedDateTime": "2020-06-16T04:13:56Z"
+        },
+        "keys": {
+          "clusters": {
+            "0": [
+              "Additional Notes:",
+              "Address:",
+              "Company Name:",
+              "Company Phone:",
+              "Dated As:",
+              "Details",
+              "Email:",
+              "Hero Limited",
+              "Name:",
+              "Phone:",
+              "Purchase Order",
+              "Purchase Order #:",
+              "Quantity",
+              "SUBTOTAL",
+              "Seattle, WA 93849 Phone:",
+              "Shipped From",
+              "Shipped To",
+              "TAX",
+              "TOTAL",
+              "Total",
+              "Unit Price",
+              "Vendor Name:",
+              "Website:"
+            ]
+          }
+        },
+        "trainResult": {
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            }
+          ],
+          "errors": []
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|3ca364f7-4c341012a84735f4.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4c6f58840069b2bf27da5a62f8ab8f1d",
         "x-ms-return-client-request-id": "true"
@@ -171,31 +236,95 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "82aba288-083d-4222-93ec-ff9042123f78",
+        "apim-request-id": "ce1c0623-b650-467f-879f-bb25be0892f9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:16 GMT",
+        "Date": "Tue, 16 Jun 2020 04:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "214"
+        "x-envoy-upstream-service-time": "5154"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
+          "modelId": "cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
+          "status": "ready",
+          "createdDateTime": "2020-06-16T04:13:45Z",
+          "lastUpdatedDateTime": "2020-06-16T04:13:56Z"
+        },
+        "keys": {
+          "clusters": {
+            "0": [
+              "Additional Notes:",
+              "Address:",
+              "Company Name:",
+              "Company Phone:",
+              "Dated As:",
+              "Details",
+              "Email:",
+              "Hero Limited",
+              "Name:",
+              "Phone:",
+              "Purchase Order",
+              "Purchase Order #:",
+              "Quantity",
+              "SUBTOTAL",
+              "Seattle, WA 93849 Phone:",
+              "Shipped From",
+              "Shipped To",
+              "TAX",
+              "TOTAL",
+              "Total",
+              "Unit Price",
+              "Vendor Name:",
+              "Website:"
+            ]
+          }
+        },
+        "trainResult": {
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "errors": [],
+              "status": "succeeded"
+            }
+          ],
+          "errors": []
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=full",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8dbce02f926614d149238a67748d9147",
         "x-ms-return-client-request-id": "true"
@@ -203,31 +332,35 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "609745d9-33ee-44b1-aa24-83feaec36c32",
+        "apim-request-id": "9c590d3d-ac39-475d-9507-fd9ef763b9ce",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:18 GMT",
+        "Date": "Tue, 16 Jun 2020 04:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "325"
+        "x-envoy-upstream-service-time": "78"
       },
       "ResponseBody": {
-        "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
-        }
+        "modelList": [
+          {
+            "modelId": "cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
+            "status": "ready",
+            "createdDateTime": "2020-06-16T04:13:45Z",
+            "lastUpdatedDateTime": "2020-06-16T04:13:56Z"
+          }
+        ],
+        "nextLink": ""
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=summary",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|3ca364f8-4c341012a84735f4.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "505342a56c7b43b22319954a304bc36b",
         "x-ms-return-client-request-id": "true"
@@ -235,1781 +368,75 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80814321-6c73-4890-894a-b0b6cf748c02",
+        "apim-request-id": "ed5feb74-5525-4053-9c6e-43742a4ca3ed",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:19 GMT",
+        "Date": "Tue, 16 Jun 2020 04:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "40"
       },
       "ResponseBody": {
-        "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
+        "summary": {
+          "count": 1,
+          "limit": 250,
+          "lastUpdatedDateTime": "2020-06-16T04:14:06Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
-      "RequestMethod": "GET",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9",
+      "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|3ca364f9-4c341012a84735f4.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2961a4de9e75f2f0875a024575583d9a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 200,
+      "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "52258f39-6bde-4541-9fa7-52083901a071",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:21 GMT",
+        "apim-request-id": "3b128b4e-d408-4d2b-9f95-fdbf364f9028",
+        "Content-Length": "0",
+        "Date": "Tue, 16 Jun 2020 04:14:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "691"
+        "x-envoy-upstream-service-time": "52"
       },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:12Z"
-        }
-      }
+      "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
+      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/cba28d82-ca6d-42bb-a0a2-9dca61794dd9?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
+        "Request-Id": "|3ca364fa-4c341012a84735f4.",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200615.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b5bd12483e58c3a22d79694cfc86e4fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "de80e68d-79a5-418d-816c-016fe036d2c3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:22 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "173"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "ready",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:21Z"
-        },
-        "keys": {
-          "clusters": {
-            "0": [
-              "Additional Notes:",
-              "Address:",
-              "Address:",
-              "Company Name:",
-              "Company Phone:",
-              "Dated As:",
-              "Email:",
-              "Hero Limited",
-              "Name:",
-              "Phone:",
-              "Purchase Order",
-              "Purchase Order",
-              "Purchase Order #:",
-              "SUBTOTAL",
-              "Seattle, WA 93849 Phone:",
-              "Shipped From",
-              "Shipped To",
-              "TAX",
-              "TOTAL",
-              "Vendor Name:",
-              "Website:"
-            ]
-          }
-        },
-        "trainResult": {
-          "trainingDocuments": [
-            {
-              "documentName": "Form_1.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_2.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_3.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_4.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_5.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            }
-          ],
-          "errors": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-19349e708ee05b4b8b0f4e9f52921414-ae9a048e29f42b41-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "d0891f60672b06d25260c9206a6dcdcb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9aa1b519-892a-421f-b026-835af41e552f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:22 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "137"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-          "status": "ready",
-          "createdDateTime": "2020-04-29T19:39:12Z",
-          "lastUpdatedDateTime": "2020-04-29T19:39:21Z"
-        },
-        "keys": {
-          "clusters": {
-            "0": [
-              "Additional Notes:",
-              "Address:",
-              "Address:",
-              "Company Name:",
-              "Company Phone:",
-              "Dated As:",
-              "Email:",
-              "Hero Limited",
-              "Name:",
-              "Phone:",
-              "Purchase Order",
-              "Purchase Order",
-              "Purchase Order #:",
-              "SUBTOTAL",
-              "Seattle, WA 93849 Phone:",
-              "Shipped From",
-              "Shipped To",
-              "TAX",
-              "TOTAL",
-              "Vendor Name:",
-              "Website:"
-            ]
-          }
-        },
-        "trainResult": {
-          "trainingDocuments": [
-            {
-              "documentName": "Form_1.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_2.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_3.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_4.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            },
-            {
-              "documentName": "Form_5.jpg",
-              "pages": 1,
-              "errors": [],
-              "status": "succeeded"
-            }
-          ],
-          "errors": []
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=full",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1d02fadb0e8d9f13029dfcfc35a3f500",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e2056857-7a01-4965-84ed-b6b8d340e0a4",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "649"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "00f3fe10-6a59-4c82-8ce1-afee0fb1dace",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:15:36Z",
-            "lastUpdatedDateTime": "2020-04-22T17:15:40Z"
-          },
-          {
-            "modelId": "015d3c91-4afd-4e4a-9c18-3233f91bc544",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:18:18Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:21Z"
-          },
-          {
-            "modelId": "020f55f8-a314-4551-aa94-e7ae6023c0d4",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:44:46Z",
-            "lastUpdatedDateTime": "2020-04-16T19:45:46Z"
-          },
-          {
-            "modelId": "037a2889-83e3-47a0-b81f-c49fe8661ff2",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:26:15Z",
-            "lastUpdatedDateTime": "2020-04-21T04:26:17Z"
-          },
-          {
-            "modelId": "03d247b2-ded7-4b3c-81dc-cff49b6c5503",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T20:21:31Z",
-            "lastUpdatedDateTime": "2020-04-16T20:22:02Z"
-          },
-          {
-            "modelId": "0421be9b-7f0f-4c72-a3e8-32e612b5b5e1",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:44:32Z",
-            "lastUpdatedDateTime": "2020-04-23T01:44:42Z"
-          },
-          {
-            "modelId": "058fe7a5-c0c2-47c0-9cfc-fca7bf760675",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:21Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:30Z"
-          },
-          {
-            "modelId": "05fd2bc8-7818-4964-9117-59694b4dfad5",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:31:59Z",
-            "lastUpdatedDateTime": "2020-04-28T01:32:00Z"
-          },
-          {
-            "modelId": "0a805a87-0179-417d-aacf-1a1a674c5e5c",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T23:05:14Z",
-            "lastUpdatedDateTime": "2020-04-17T23:05:14Z"
-          },
-          {
-            "modelId": "0b073ff2-3ce3-47bb-b4f0-fb27349d1a4c",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:04:50Z",
-            "lastUpdatedDateTime": "2020-04-20T23:04:59Z"
-          },
-          {
-            "modelId": "0b425ade-a82e-41f8-a7ee-fa6fb3015afb",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:07:40Z",
-            "lastUpdatedDateTime": "2020-04-16T21:07:43Z"
-          },
-          {
-            "modelId": "0bb31303-fbaa-4247-91fa-c6a4c68114e2",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T15:57:43Z",
-            "lastUpdatedDateTime": "2020-04-18T15:57:50Z"
-          },
-          {
-            "modelId": "0e00bda3-349d-497e-be80-bc77f9d496b2",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:16:03Z",
-            "lastUpdatedDateTime": "2020-04-22T17:16:07Z"
-          },
-          {
-            "modelId": "11eb138e-46a6-44da-a779-78526c2ddca7",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:31:09Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:10Z"
-          },
-          {
-            "modelId": "124949e1-d2fc-48af-bb4c-1a9c39707b67",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:33:59Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:08Z"
-          },
-          {
-            "modelId": "13b5d51c-8f10-47b0-97cf-66fb3a0931f7",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:39:39Z",
-            "lastUpdatedDateTime": "2020-04-16T19:40:35Z"
-          },
-          {
-            "modelId": "14425f4d-1180-4cf1-a2b0-f1abadde3c73",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:03:17Z",
-            "lastUpdatedDateTime": "2020-04-21T20:03:25Z"
-          },
-          {
-            "modelId": "1455d839-4b2c-474d-9a72-11d04dab7bbe",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T17:32:54Z",
-            "lastUpdatedDateTime": "2020-04-17T17:33:23Z"
-          },
-          {
-            "modelId": "15c938b2-b7f5-48c7-95b9-ed60960e1684",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:49:18Z",
-            "lastUpdatedDateTime": "2020-04-20T22:49:26Z"
-          },
-          {
-            "modelId": "17bec2df-b25c-4ae0-a658-0b0a6a59c0de",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:34:50Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:59Z"
-          },
-          {
-            "modelId": "17dfa1ce-29a3-4d2f-afb7-f38916239917",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T22:37:27Z",
-            "lastUpdatedDateTime": "2020-04-16T22:38:26Z"
-          },
-          {
-            "modelId": "185be968-e238-4dcd-bb72-3a0ae0979680",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:28:18Z",
-            "lastUpdatedDateTime": "2020-04-23T01:28:19Z"
-          },
-          {
-            "modelId": "19d98132-3aa8-4811-841c-8f5a0e366122",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T16:37:24Z",
-            "lastUpdatedDateTime": "2020-04-21T16:37:29Z"
-          },
-          {
-            "modelId": "1cf38f17-e857-4093-b3f2-39981de929dc",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:25:32Z",
-            "lastUpdatedDateTime": "2020-04-21T04:25:35Z"
-          },
-          {
-            "modelId": "1f2fa881-be5c-42a7-9bce-e8bf6f60e97f",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:08:57Z",
-            "lastUpdatedDateTime": "2020-04-21T20:09:05Z"
-          },
-          {
-            "modelId": "1f74769b-8207-49a0-a898-2e575d435503",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:32:50Z",
-            "lastUpdatedDateTime": "2020-04-17T17:32:52Z"
-          },
-          {
-            "modelId": "205b472b-adb6-4959-9943-9a9d74372ef8",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:25:06Z",
-            "lastUpdatedDateTime": "2020-04-28T01:25:06Z"
-          },
-          {
-            "modelId": "20aa7d07-b3e4-4c4a-b9a5-342d6be75092",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T16:03:38Z",
-            "lastUpdatedDateTime": "2020-04-18T16:03:47Z"
-          },
-          {
-            "modelId": "250af4a0-395b-4d66-8fa6-f14b55d3d642",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:21:40Z",
-            "lastUpdatedDateTime": "2020-04-21T04:21:41Z"
-          },
-          {
-            "modelId": "2790f874-c6c3-448e-a849-d2bc295562e4",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:35:45Z",
-            "lastUpdatedDateTime": "2020-04-23T04:35:48Z"
-          },
-          {
-            "modelId": "2828ee83-b53d-4a90-9eaf-7bc9a985b537",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:31:11Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:15Z"
-          },
-          {
-            "modelId": "2bb008d0-4487-41bb-9fd6-23d5c80e67c4",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:33:27Z",
-            "lastUpdatedDateTime": "2020-04-17T17:33:27Z"
-          },
-          {
-            "modelId": "2db46d01-e98b-43e9-b5e1-63329523bd17",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:41:22Z",
-            "lastUpdatedDateTime": "2020-04-16T21:41:30Z"
-          },
-          {
-            "modelId": "2ee3e269-8b03-4852-8880-fc191dc92013",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:30:35Z",
-            "lastUpdatedDateTime": "2020-04-28T01:30:48Z"
-          },
-          {
-            "modelId": "2eeb81f2-4b35-460d-bfdd-96efea660459",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:46:45Z",
-            "lastUpdatedDateTime": "2020-04-23T04:46:48Z"
-          },
-          {
-            "modelId": "337c4e2f-684f-493a-9a0e-eb938b691d71",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:48:05Z",
-            "lastUpdatedDateTime": "2020-04-23T04:48:13Z"
-          },
-          {
-            "modelId": "34918d65-ed45-4101-bd79-44ff5f7d511f",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T17:33:30Z",
-            "lastUpdatedDateTime": "2020-04-17T17:34:00Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzM3NmEwNDlmLTg4NDQtNGY0OC04NGYyLTc4MmRmNTQ0ODRmYS8zNzZhMDQ5Zi04ODQ0LTRmNDgtODRmMi03ODJkZjU0NDg0ZmEuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzM3NmEwNDlmLTg4NDQtNGY0OC04NGYyLTc4MmRmNTQ0ODRmYS8zNzZhMDQ5Zi04ODQ0LTRmNDgtODRmMi03ODJkZjU0NDg0ZmEuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "55e503756dcfe06e40b762f7758159c0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ddfebcb2-32c3-4e0e-aede-5d445314f547",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:24 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "932"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "3adc8f9b-2503-48b7-bddc-9fe54bd07c9d",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:30:19Z",
-            "lastUpdatedDateTime": "2020-04-28T01:30:19Z"
-          },
-          {
-            "modelId": "3b9db8c5-4066-4291-90fd-7a9fe8b39757",
-            "status": "ready",
-            "createdDateTime": "2020-04-27T23:26:48Z",
-            "lastUpdatedDateTime": "2020-04-27T23:26:56Z"
-          },
-          {
-            "modelId": "3bb5e8b0-15f2-4881-b6c0-69d5213fcb35",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:03:48Z",
-            "lastUpdatedDateTime": "2020-04-21T20:03:58Z"
-          },
-          {
-            "modelId": "3de4e955-4817-459b-9fde-72d64ed7c8a8",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:34:39Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:39Z"
-          },
-          {
-            "modelId": "3e9d0537-9070-4b18-adff-101aa84d06c1",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T22:59:33Z",
-            "lastUpdatedDateTime": "2020-04-16T22:59:47Z"
-          },
-          {
-            "modelId": "41b6c2a1-ec67-421e-b191-bb15360fbe9e",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:24:31Z",
-            "lastUpdatedDateTime": "2020-04-28T21:24:33Z"
-          },
-          {
-            "modelId": "44875639-a371-4c91-9320-d023be24cd7d",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:25:18Z",
-            "lastUpdatedDateTime": "2020-04-28T01:25:27Z"
-          },
-          {
-            "modelId": "46ea9d99-596d-48da-b92d-2abe8eeee1a0",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:00:44Z",
-            "lastUpdatedDateTime": "2020-04-20T23:00:51Z"
-          },
-          {
-            "modelId": "471ead11-6cd2-43be-a5f7-7bba7d8e5d28",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:18:16Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:16Z"
-          },
-          {
-            "modelId": "48317880-6116-478f-90fc-35c3ae7a664f",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:34:14Z",
-            "lastUpdatedDateTime": "2020-04-17T23:34:23Z"
-          },
-          {
-            "modelId": "48a7a1f7-6ffa-4cb8-9974-c730c2f2b099",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T19:10:32Z",
-            "lastUpdatedDateTime": "2020-04-28T19:10:32Z"
-          },
-          {
-            "modelId": "4902dd5c-3217-465b-9857-633643540b3a",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:26:35Z",
-            "lastUpdatedDateTime": "2020-04-28T01:26:38Z"
-          },
-          {
-            "modelId": "49a21836-bae7-40ed-953d-3e72271fcd8e",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:52:57Z",
-            "lastUpdatedDateTime": "2020-04-16T21:53:27Z"
-          },
-          {
-            "modelId": "4b78183a-2417-461a-9489-4d4e97445d31",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:22:26Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:29Z"
-          },
-          {
-            "modelId": "4b9486b5-f013-4ce0-9a34-346cbd64463e",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T16:31:38Z",
-            "lastUpdatedDateTime": "2020-04-17T16:31:38Z"
-          },
-          {
-            "modelId": "4d8c9a81-c163-4071-a98c-2929a73227eb",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:15:42Z",
-            "lastUpdatedDateTime": "2020-04-20T22:15:43Z"
-          },
-          {
-            "modelId": "4dcae8f8-9e83-41a8-912b-b1481d3ece59",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T16:31:46Z",
-            "lastUpdatedDateTime": "2020-04-17T16:31:55Z"
-          },
-          {
-            "modelId": "4fe41783-1603-4ff3-86e3-1129cff18450",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:26:58Z",
-            "lastUpdatedDateTime": "2020-04-23T01:26:58Z"
-          },
-          {
-            "modelId": "4ff416e1-c78b-47b4-905d-9ba3f793115e",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:41:33Z",
-            "lastUpdatedDateTime": "2020-04-17T17:41:34Z"
-          },
-          {
-            "modelId": "5143b4cc-c53c-4746-9826-df0b9189d1e9",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:13:40Z",
-            "lastUpdatedDateTime": "2020-04-16T21:14:09Z"
-          },
-          {
-            "modelId": "55067347-fa2d-4487-a602-be4c6f969ca7",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:23:25Z",
-            "lastUpdatedDateTime": "2020-04-19T17:23:28Z"
-          },
-          {
-            "modelId": "5576286d-e809-411f-8ca0-44f91180c76e",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:32Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:35Z"
-          },
-          {
-            "modelId": "55d6055b-2530-42d9-a5da-dea84822e5b1",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:17Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:20Z"
-          },
-          {
-            "modelId": "5a31bba8-d429-480d-881e-f817623d4965",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:31:55Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:56Z"
-          },
-          {
-            "modelId": "5aa3cf28-d994-414b-bb7f-d1cdbb58a52a",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:36:09Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:18Z"
-          },
-          {
-            "modelId": "5ac44f17-f19d-46b1-8f91-be728912814e",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T17:33:57Z",
-            "lastUpdatedDateTime": "2020-04-20T17:33:59Z"
-          },
-          {
-            "modelId": "5e968d16-bd8f-41f6-acb0-289644ac3892",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T03:45:18Z",
-            "lastUpdatedDateTime": "2020-04-21T03:45:27Z"
-          },
-          {
-            "modelId": "60e34166-ae5f-4459-afaf-a9eb8b8d470e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:09:07Z",
-            "lastUpdatedDateTime": "2020-04-21T20:09:11Z"
-          },
-          {
-            "modelId": "61e4904b-142d-491b-a45b-0654b2da72d1",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:32:01Z",
-            "lastUpdatedDateTime": "2020-04-28T01:32:04Z"
-          },
-          {
-            "modelId": "61e9d826-0c94-404c-b74d-80c3d0d70bad",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:14:03Z",
-            "lastUpdatedDateTime": "2020-04-28T21:14:14Z"
-          },
-          {
-            "modelId": "64172e69-150a-4965-86cb-f09654cc9bb4",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:28:19Z",
-            "lastUpdatedDateTime": "2020-04-23T01:29:28Z"
-          },
-          {
-            "modelId": "6783d13c-3994-4177-b31a-796fea7f1dd8",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:26:59Z",
-            "lastUpdatedDateTime": "2020-04-23T01:27:03Z"
-          },
-          {
-            "modelId": "678a1723-ed0f-437f-8187-8fc7adf6e1d9",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:40:36Z",
-            "lastUpdatedDateTime": "2020-04-16T19:41:39Z"
-          },
-          {
-            "modelId": "6b4cc85d-7154-4d5e-b84c-282069b6d2bb",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T23:05:15Z",
-            "lastUpdatedDateTime": "2020-04-17T23:05:15Z"
-          },
-          {
-            "modelId": "6eec31df-8597-4a3c-b6d1-a75a28895290",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T17:38:37Z",
-            "lastUpdatedDateTime": "2020-04-17T17:39:07Z"
-          },
-          {
-            "modelId": "71672465-1f41-4c20-85d6-1471af059a54",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:34:01Z",
-            "lastUpdatedDateTime": "2020-04-21T04:34:04Z"
-          },
-          {
-            "modelId": "72fffb98-a9ed-4de5-a174-00d7834f46d4",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T19:44:38Z",
-            "lastUpdatedDateTime": "2020-04-16T19:45:42Z"
-          },
-          {
-            "modelId": "7395ff95-ab71-404b-ac08-79d81e7c95f4",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:35:01Z",
-            "lastUpdatedDateTime": "2020-04-17T23:35:07Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!204!MDAwMTA4IXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzczOTVmZjk1LWFiNzEtNDA0Yi1hYzA4LTc5ZDgxZTdjOTVmNC91c2VMYWJlbEZpbGUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!204!MDAwMTA4IXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzczOTVmZjk1LWFiNzEtNDA0Yi1hYzA4LTc5ZDgxZTdjOTVmNC91c2VMYWJlbEZpbGUuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "02709eabc78452710ce9ce8e6bd6d1ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c4c01bcd-81e7-4182-b3d7-a62ceb419ff1",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:25 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "612"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "748c0632-3bf4-4f54-bcc5-fee99a853e17",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:37:05Z",
-            "lastUpdatedDateTime": "2020-04-23T04:37:06Z"
-          },
-          {
-            "modelId": "765ef38e-7d5b-40bf-b6d7-b9291aa3c8af",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:16:48Z",
-            "lastUpdatedDateTime": "2020-04-21T04:17:02Z"
-          },
-          {
-            "modelId": "76d1eb1d-a70b-4497-ada1-0663b6cfb659",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T23:00:03Z",
-            "lastUpdatedDateTime": "2020-04-16T23:00:07Z"
-          },
-          {
-            "modelId": "7a67759e-f514-43c8-8aee-3829392ca1b2",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:21:52Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:01Z"
-          },
-          {
-            "modelId": "7ad9e5c7-49a7-418f-8c58-574197249e7d",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T22:48:41Z",
-            "lastUpdatedDateTime": "2020-04-17T22:48:41Z"
-          },
-          {
-            "modelId": "7b258785-ce51-45d3-a949-5a1b3cc39afe",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:15:25Z",
-            "lastUpdatedDateTime": "2020-04-28T21:15:33Z"
-          },
-          {
-            "modelId": "804bc3c6-1ccb-4e96-879a-eaf0e99a7574",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:07:37Z",
-            "lastUpdatedDateTime": "2020-04-21T20:07:46Z"
-          },
-          {
-            "modelId": "8050cdc6-f0d4-4288-b227-6a68283ac11d",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:31:16Z",
-            "lastUpdatedDateTime": "2020-04-20T17:31:28Z"
-          },
-          {
-            "modelId": "80ff7724-7f5b-4514-bb1b-6622acd48c90",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:40:45Z",
-            "lastUpdatedDateTime": "2020-04-16T21:40:50Z"
-          },
-          {
-            "modelId": "81e577e6-798c-4f98-a11f-2a14bc26a075",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:10:37Z",
-            "lastUpdatedDateTime": "2020-04-28T19:10:50Z"
-          },
-          {
-            "modelId": "868212b4-da54-4083-a19c-cb45e0cf6521",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:28:36Z",
-            "lastUpdatedDateTime": "2020-04-19T17:28:44Z"
-          },
-          {
-            "modelId": "8688ef71-cc4b-4221-a26d-44e79cae55b0",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:23:02Z",
-            "lastUpdatedDateTime": "2020-04-28T21:23:10Z"
-          },
-          {
-            "modelId": "876ba309-8bc1-4cc1-adde-6a156a84cc9f",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:37:39Z",
-            "lastUpdatedDateTime": "2020-04-29T19:38:42Z"
-          },
-          {
-            "modelId": "89054483-44f5-4488-a562-b358d791e989",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:44:11Z",
-            "lastUpdatedDateTime": "2020-04-17T23:44:19Z"
-          },
-          {
-            "modelId": "89804eab-8af6-4c88-8d0b-4fc24e36d486",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:19:01Z",
-            "lastUpdatedDateTime": "2020-04-21T04:19:09Z"
-          },
-          {
-            "modelId": "89c2ef56-48b9-4123-9ea1-ea1442736f5e",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:47:45Z",
-            "lastUpdatedDateTime": "2020-04-16T21:47:54Z"
-          },
-          {
-            "modelId": "8b55ef0e-9e10-4e38-b41a-ab222924df5a",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:13:58Z",
-            "lastUpdatedDateTime": "2020-04-28T21:13:59Z"
-          },
-          {
-            "modelId": "8b9f46eb-78f4-420d-81b7-fbbde06f1354",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:42:58Z",
-            "lastUpdatedDateTime": "2020-04-23T01:42:58Z"
-          },
-          {
-            "modelId": "8c085626-8d1b-4dd2-a48f-749a7117c927",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:35:43Z",
-            "lastUpdatedDateTime": "2020-04-23T04:35:44Z"
-          },
-          {
-            "modelId": "8c3cb0b4-15ec-4155-ac36-71d06124931e",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:34:10Z",
-            "lastUpdatedDateTime": "2020-04-16T21:34:40Z"
-          },
-          {
-            "modelId": "8d3c2169-b52f-429d-a563-29d0661a4476",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:08:45Z",
-            "lastUpdatedDateTime": "2020-04-21T20:08:54Z"
-          },
-          {
-            "modelId": "912d1c3d-8bf4-425e-9df2-03439ca8d8ae",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:41Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:44Z"
-          },
-          {
-            "modelId": "91e023ac-21ae-482b-b02e-eb8d74c928f2",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T01:44:19Z",
-            "lastUpdatedDateTime": "2020-04-23T01:44:20Z"
-          },
-          {
-            "modelId": "92391b87-51b8-4074-bff7-2b9b0e25adf1",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T16:31:40Z",
-            "lastUpdatedDateTime": "2020-04-17T16:31:45Z"
-          },
-          {
-            "modelId": "9374c9f5-9a50-4b8c-a957-8f5e96f6dbee",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T00:09:22Z",
-            "lastUpdatedDateTime": "2020-04-18T00:09:32Z"
-          },
-          {
-            "modelId": "953a9982-1d88-4d27-a297-eed6e7c81247",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:03:32Z",
-            "lastUpdatedDateTime": "2020-04-21T20:03:41Z"
-          },
-          {
-            "modelId": "957ba8bf-3bf8-4bf8-a86e-62b5260dc1b7",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T19:12:08Z",
-            "lastUpdatedDateTime": "2020-04-28T19:12:08Z"
-          },
-          {
-            "modelId": "95d9074e-1f4f-415f-8db7-9810a8993b2c",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:23:11Z",
-            "lastUpdatedDateTime": "2020-04-28T21:23:20Z"
-          },
-          {
-            "modelId": "989bfd50-2c0c-47ea-acba-42f41ea5a171",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:21:43Z",
-            "lastUpdatedDateTime": "2020-04-21T04:21:51Z"
-          },
-          {
-            "modelId": "98d49c8c-e189-41c7-8a6f-2c3912fbb9f6",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:05:04Z",
-            "lastUpdatedDateTime": "2020-04-20T23:05:07Z"
-          },
-          {
-            "modelId": "98f642c4-3533-49e9-ae4f-4abb49038a9b",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:52:38Z",
-            "lastUpdatedDateTime": "2020-04-17T23:52:50Z"
-          },
-          {
-            "modelId": "99bac95c-3f14-478d-a77e-6b7c5788dcf2",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:52:30Z",
-            "lastUpdatedDateTime": "2020-04-16T21:52:38Z"
-          },
-          {
-            "modelId": "99ec5bbe-f195-4d79-aa4a-d36e986f54e9",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:56:44Z",
-            "lastUpdatedDateTime": "2020-04-16T21:56:53Z"
-          },
-          {
-            "modelId": "9a203331-26a6-4642-bfeb-b89e65c45b62",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:44:21Z",
-            "lastUpdatedDateTime": "2020-04-23T01:44:31Z"
-          },
-          {
-            "modelId": "9b62cfca-c605-4f4b-9f77-e2998de68c1f",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:32:53Z",
-            "lastUpdatedDateTime": "2020-04-16T21:32:56Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzljNmY1ZjlkLWY0NzctNDNhOS04Zjk0LTEwOTE3ZDZjNTkwZC85YzZmNWY5ZC1mNDc3LTQzYTktOGY5NC0xMDkxN2Q2YzU5MGQuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzLzljNmY1ZjlkLWY0NzctNDNhOS04Zjk0LTEwOTE3ZDZjNTkwZC85YzZmNWY5ZC1mNDc3LTQzYTktOGY5NC0xMDkxN2Q2YzU5MGQuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "66abc86a78876efc8b21dcd6ab1b2980",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "98f0e4aa-fd5f-45cf-a69a-769850505058",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:39:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "877"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "9c6f5f9d-f477-43a9-8f94-10917d6c590d",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:07:26Z",
-            "lastUpdatedDateTime": "2020-04-21T20:07:30Z"
-          },
-          {
-            "modelId": "9c7b8129-918c-4ebf-938c-dd7625535d93",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:10:33Z",
-            "lastUpdatedDateTime": "2020-04-28T19:10:37Z"
-          },
-          {
-            "modelId": "9d61923a-0117-4d5f-b073-70dea2ed3662",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:16:16Z",
-            "lastUpdatedDateTime": "2020-04-22T17:16:19Z"
-          },
-          {
-            "modelId": "a1cd2a2b-18a4-4e85-a10d-c5e574615261",
-            "status": "invalid",
-            "createdDateTime": "2020-04-29T19:36:08Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:08Z"
-          },
-          {
-            "modelId": "a3bb3fa1-6797-418a-8a12-a8f4bcd5e250",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:30:55Z",
-            "lastUpdatedDateTime": "2020-04-21T04:30:58Z"
-          },
-          {
-            "modelId": "a4748585-90ea-4170-b240-ef2f31d01fa2",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:37:07Z",
-            "lastUpdatedDateTime": "2020-04-23T04:37:09Z"
-          },
-          {
-            "modelId": "a64d767a-524a-43b0-bb71-232820626ed8",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:24:28Z",
-            "lastUpdatedDateTime": "2020-04-28T21:24:29Z"
-          },
-          {
-            "modelId": "a6bf96f0-8c59-435e-9fd0-d044b6bf423b",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:01:04Z",
-            "lastUpdatedDateTime": "2020-04-20T23:01:11Z"
-          },
-          {
-            "modelId": "a733e166-3034-434a-9cb7-49fd6cbf0aec",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:37:18Z",
-            "lastUpdatedDateTime": "2020-04-19T17:37:26Z"
-          },
-          {
-            "modelId": "a79c549f-3741-4bf3-b2c5-4c25187983a4",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:33:37Z",
-            "lastUpdatedDateTime": "2020-04-16T21:34:09Z"
-          },
-          {
-            "modelId": "a821650f-398f-490b-bd64-57a27d7645c6",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T20:20:59Z",
-            "lastUpdatedDateTime": "2020-04-16T20:21:30Z"
-          },
-          {
-            "modelId": "a918b148-48e6-4bd7-a072-ed55a5801bda",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:26:39Z",
-            "lastUpdatedDateTime": "2020-04-28T01:26:47Z"
-          },
-          {
-            "modelId": "aa5f8b82-52da-4dbb-891a-5a2f1d32ba78",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T17:32:49Z",
-            "lastUpdatedDateTime": "2020-04-17T17:32:50Z"
-          },
-          {
-            "modelId": "ab989d76-e331-4d18-ae00-b3d438e20d2a",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:32:05Z",
-            "lastUpdatedDateTime": "2020-04-28T01:32:13Z"
-          },
-          {
-            "modelId": "ac865e45-ff42-4df9-9f3b-50823b8edb34",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:48:14Z",
-            "lastUpdatedDateTime": "2020-04-23T04:48:22Z"
-          },
-          {
-            "modelId": "acc5ada5-9582-4456-9143-0e9d08762ae3",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:34:47Z",
-            "lastUpdatedDateTime": "2020-04-20T22:34:53Z"
-          },
-          {
-            "modelId": "b1448051-1fb2-4112-8df9-27c3e8a1fa57",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:50:09Z",
-            "lastUpdatedDateTime": "2020-04-16T21:50:17Z"
-          },
-          {
-            "modelId": "b22e1add-1ad8-4626-8c26-c63b4cef93a6",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T23:01:26Z",
-            "lastUpdatedDateTime": "2020-04-16T23:01:35Z"
-          },
-          {
-            "modelId": "b25ba217-d9d7-4539-a4f5-4ebdc5ff061d",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:43:38Z",
-            "lastUpdatedDateTime": "2020-04-17T23:43:46Z"
-          },
-          {
-            "modelId": "b2b60877-2ced-4619-8d43-22fefe3af8c4",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:38:23Z",
-            "lastUpdatedDateTime": "2020-04-16T21:38:32Z"
-          },
-          {
-            "modelId": "b4b6add0-909c-4a36-8b2a-17b88f7e046e",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:32:12Z",
-            "lastUpdatedDateTime": "2020-04-20T17:32:20Z"
-          },
-          {
-            "modelId": "b7451731-5a5c-4d36-be64-98b5f09006e3",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T23:01:10Z",
-            "lastUpdatedDateTime": "2020-04-16T23:01:22Z"
-          },
-          {
-            "modelId": "b8b3420a-90a4-4dc8-9740-f342360e8139",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:58:44Z",
-            "lastUpdatedDateTime": "2020-04-20T22:58:52Z"
-          },
-          {
-            "modelId": "ba286c44-4a05-4298-9014-5bf4b3b1c335",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:12:10Z",
-            "lastUpdatedDateTime": "2020-04-28T19:12:13Z"
-          },
-          {
-            "modelId": "ba608e90-5b1a-432e-98d7-f213972c6d17",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:44:21Z",
-            "lastUpdatedDateTime": "2020-04-20T22:44:25Z"
-          },
-          {
-            "modelId": "ba6bfec8-773c-4009-91f8-d82f06de550e",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:05:10Z",
-            "lastUpdatedDateTime": "2020-04-20T23:05:18Z"
-          },
-          {
-            "modelId": "c0882124-a05e-410a-9252-513d96a40054",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:29:58Z",
-            "lastUpdatedDateTime": "2020-04-16T21:30:07Z"
-          },
-          {
-            "modelId": "c1796212-cec0-4f40-aa54-71437052eea0",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:04:04Z",
-            "lastUpdatedDateTime": "2020-04-21T20:04:11Z"
-          },
-          {
-            "modelId": "c2b2d617-dbe0-4425-bda3-7c8f3d039765",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:14:34Z",
-            "lastUpdatedDateTime": "2020-04-20T22:15:08Z"
-          },
-          {
-            "modelId": "c358ed4a-007d-48f1-b1dc-3ec8ece2f72e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T01:27:33Z",
-            "lastUpdatedDateTime": "2020-04-21T01:27:36Z"
-          },
-          {
-            "modelId": "c3b3f591-2ea5-4dff-a8be-19d9cdc85e0e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:25:46Z",
-            "lastUpdatedDateTime": "2020-04-21T04:25:54Z"
-          },
-          {
-            "modelId": "c3da2e51-1e6b-42eb-b490-0ffc9fa525d7",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:44:00Z",
-            "lastUpdatedDateTime": "2020-04-20T22:44:03Z"
-          },
-          {
-            "modelId": "c3dd8b56-7d5a-4af9-b0a3-dc3a54afe476",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T16:36:44Z",
-            "lastUpdatedDateTime": "2020-04-21T16:36:49Z"
-          },
-          {
-            "modelId": "c47fcc7d-6e88-4d4c-aa0a-f8bc6373611b",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T01:27:54Z",
-            "lastUpdatedDateTime": "2020-04-21T01:27:57Z"
-          },
-          {
-            "modelId": "c59c2200-3199-4d15-a327-d28e9775a0b0",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T23:04:35Z",
-            "lastUpdatedDateTime": "2020-04-20T23:04:38Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2M3Mjc2ZDhjLWZkMDAtNDU2Yy04MThhLWIwYmIwYmFiYzEzNy9jNzI3NmQ4Yy1mZDAwLTQ1NmMtODE4YS1iMGJiMGJhYmMxMzcuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2M3Mjc2ZDhjLWZkMDAtNDU2Yy04MThhLWIwYmIwYmFiYzEzNy9jNzI3NmQ4Yy1mZDAwLTQ1NmMtODE4YS1iMGJiMGJhYmMxMzcuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "97513c44f332ad7c929349e59fe0746a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "5746afc0-9a27-485c-a029-2a32570776e5",
-        "Content-Length": "311",
-        "Content-Type": "application/json",
-        "Date": "Wed, 29 Apr 2020 19:39:26 GMT",
-        "Retry-After": "39",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the List Custom Models Operation under Form Recognizer API have exceeded rate limit of your current FormRecognizer S0 pricing tier. Please retry after 39 seconds. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!232!MDAwMTMwIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2M3Mjc2ZDhjLWZkMDAtNDU2Yy04MThhLWIwYmIwYmFiYzEzNy9jNzI3NmQ4Yy1mZDAwLTQ1NmMtODE4YS1iMGJiMGJhYmMxMzcuZ3ohMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "97513c44f332ad7c929349e59fe0746a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8fb2f6f0-9093-4650-9c85-a92ea674e91f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:40:06 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1083"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "c7276d8c-fd00-456c-818a-b0bb0babc137",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:34:40Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:49Z"
-          },
-          {
-            "modelId": "c7c59860-85f8-421d-8233-c9f19d22f3b3",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:48:04Z",
-            "lastUpdatedDateTime": "2020-04-23T04:48:04Z"
-          },
-          {
-            "modelId": "c7eb6b1c-4e55-4a54-9b5e-edd996b3e4ef",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T15:57:19Z",
-            "lastUpdatedDateTime": "2020-04-18T15:57:27Z"
-          },
-          {
-            "modelId": "cdb41e87-7bbf-4141-87cd-117fa49c1f78",
-            "status": "ready",
-            "createdDateTime": "2020-04-17T23:19:26Z",
-            "lastUpdatedDateTime": "2020-04-17T23:19:37Z"
-          },
-          {
-            "modelId": "ce9427e6-44bd-472a-9c61-626e603ae68a",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:35:50Z",
-            "lastUpdatedDateTime": "2020-04-23T04:35:58Z"
-          },
-          {
-            "modelId": "ceeca6da-0e88-4987-9297-ce47b41c959c",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:01Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:04Z"
-          },
-          {
-            "modelId": "cf183756-cc5b-4d26-a0a6-47f4f79cd3cc",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:24:34Z",
-            "lastUpdatedDateTime": "2020-04-28T21:24:46Z"
-          },
-          {
-            "modelId": "d0c42c46-3057-4922-bd85-c9e8864a6336",
-            "status": "ready",
-            "createdDateTime": "2020-04-19T17:27:49Z",
-            "lastUpdatedDateTime": "2020-04-19T17:28:00Z"
-          },
-          {
-            "modelId": "d2cc2fc6-a372-4e1a-9b6e-e36c338f29b8",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:17:16Z",
-            "lastUpdatedDateTime": "2020-04-22T17:17:20Z"
-          },
-          {
-            "modelId": "d3f0e5e0-6ba2-4896-a2d5-e30ed128c214",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:37:10Z",
-            "lastUpdatedDateTime": "2020-04-23T04:37:19Z"
-          },
-          {
-            "modelId": "d49552e9-61a5-419f-81ab-efc99ed92206",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:22:23Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:24Z"
-          },
-          {
-            "modelId": "d4f42b47-4aae-4397-b09e-4616dbe08ecf",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:14:00Z",
-            "lastUpdatedDateTime": "2020-04-28T21:14:03Z"
-          },
-          {
-            "modelId": "d6f44b38-5246-49b5-9557-b06e1977aa17",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:39:12Z",
-            "lastUpdatedDateTime": "2020-04-29T19:39:21Z"
-          },
-          {
-            "modelId": "d80027c2-9239-4516-b994-0510a717a046",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T19:39:53Z",
-            "lastUpdatedDateTime": "2020-04-21T19:40:01Z"
-          },
-          {
-            "modelId": "d86011f4-c2bd-4e62-b228-9c69088a306c",
-            "status": "ready",
-            "createdDateTime": "2020-04-24T19:09:56Z",
-            "lastUpdatedDateTime": "2020-04-24T19:09:59Z"
-          },
-          {
-            "modelId": "d89aa9a2-6435-4e73-a6a4-fab618e6cd0f",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T00:06:15Z",
-            "lastUpdatedDateTime": "2020-04-18T00:06:22Z"
-          },
-          {
-            "modelId": "d8adeeda-9d4c-4042-8b8e-00f89fb80a06",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:22:29Z",
-            "lastUpdatedDateTime": "2020-04-21T04:22:37Z"
-          },
-          {
-            "modelId": "d98271cb-79c8-4948-aab1-db0760d96a41",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T22:24:03Z",
-            "lastUpdatedDateTime": "2020-04-16T22:24:38Z"
-          },
-          {
-            "modelId": "d9eb9dbf-10ed-4c0a-98b9-43110b5ca90b",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T01:26:34Z",
-            "lastUpdatedDateTime": "2020-04-28T01:26:34Z"
-          },
-          {
-            "modelId": "da243862-d92a-4e1a-be89-6abbbe0e72a3",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T04:46:49Z",
-            "lastUpdatedDateTime": "2020-04-23T04:46:56Z"
-          },
-          {
-            "modelId": "dc969636-aa58-4d46-8655-e34b778ce74c",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:17:50Z",
-            "lastUpdatedDateTime": "2020-04-20T22:17:55Z"
-          },
-          {
-            "modelId": "dd31e0ca-b3b8-4d78-8db9-ea1e5b5cd385",
-            "status": "invalid",
-            "createdDateTime": "2020-04-21T04:18:55Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:56Z"
-          },
-          {
-            "modelId": "dd58919c-a115-49b4-adaf-1ba337e98ace",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:23:01Z",
-            "lastUpdatedDateTime": "2020-04-28T21:23:01Z"
-          },
-          {
-            "modelId": "ddee2706-1cb7-4e59-83ae-ef84e3c6f605",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:36:18Z",
-            "lastUpdatedDateTime": "2020-04-29T19:36:27Z"
-          },
-          {
-            "modelId": "de676838-679a-4655-b69b-3f59470158f6",
-            "status": "invalid",
-            "createdDateTime": "2020-04-16T22:38:29Z",
-            "lastUpdatedDateTime": "2020-04-16T22:39:29Z"
-          },
-          {
-            "modelId": "dec6bff9-8b03-47b2-9dbd-af0dc6168c4f",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:07Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:15Z"
-          },
-          {
-            "modelId": "ded716e1-05e5-44b5-b480-6e5cf4a1986a",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:14:14Z",
-            "lastUpdatedDateTime": "2020-04-16T21:14:48Z"
-          },
-          {
-            "modelId": "df119aad-4b33-48ea-a5db-2fa70e586f33",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:10:26Z",
-            "lastUpdatedDateTime": "2020-04-21T20:10:29Z"
-          },
-          {
-            "modelId": "dfb8b0cb-f306-4137-8125-45fe5f693d3f",
-            "status": "invalid",
-            "createdDateTime": "2020-04-20T22:34:59Z",
-            "lastUpdatedDateTime": "2020-04-20T22:35:04Z"
-          },
-          {
-            "modelId": "e0978111-b48b-4c1c-ba05-b45754dd7929",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T22:49:35Z",
-            "lastUpdatedDateTime": "2020-04-20T22:49:43Z"
-          },
-          {
-            "modelId": "e0f779ef-fb79-4b30-9e61-d8a81b45851b",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:20:17Z",
-            "lastUpdatedDateTime": "2020-04-21T04:20:26Z"
-          },
-          {
-            "modelId": "e1799957-22a8-4807-b61c-fe817b695c73",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:42:59Z",
-            "lastUpdatedDateTime": "2020-04-23T01:43:02Z"
-          },
-          {
-            "modelId": "e1bbc8ee-e163-46be-b509-025841eeda17",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:25:57Z",
-            "lastUpdatedDateTime": "2020-04-21T04:26:01Z"
-          },
-          {
-            "modelId": "e2e10bcd-007e-4b38-a34d-15bff376a1fe",
-            "status": "invalid",
-            "createdDateTime": "2020-04-28T21:15:23Z",
-            "lastUpdatedDateTime": "2020-04-28T21:15:24Z"
-          },
-          {
-            "modelId": "e3e496a6-f860-4547-8d46-aa94b2da9cdb",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:30:25Z",
-            "lastUpdatedDateTime": "2020-04-28T01:30:34Z"
-          },
-          {
-            "modelId": "e4033223-a848-4049-b757-033dd91f067d",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T20:09:18Z",
-            "lastUpdatedDateTime": "2020-04-21T20:09:22Z"
-          }
-        ],
-        "nextLink": "https://camaior-formrec.cognitiveservices.azure.com:443/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2U0YWU4ZWM1LTc4ZWQtNGExNC1hYzExLTk4MWFlMTQ0NjU5Mi9lNGFlOGVjNS03OGVkLTRhMTQtYWMxMS05ODFhZTE0NDY1OTIuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2U0YWU4ZWM1LTc4ZWQtNGExNC1hYzExLTk4MWFlMTQ0NjU5Mi9lNGFlOGVjNS03OGVkLTRhMTQtYWMxMS05ODFhZTE0NDY1OTIuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "ac8db4e5f2d53238a1027762eb9aa6f0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 429,
-      "ResponseHeaders": {
-        "apim-request-id": "ef6610d2-de04-45e6-b62b-a05578d9d7c7",
-        "Content-Length": "309",
-        "Content-Type": "application/json",
-        "Date": "Wed, 29 Apr 2020 19:40:06 GMT",
-        "Retry-After": "1",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "429",
-          "message": "Requests to the List Custom Models Operation under Form Recognizer API have exceeded rate limit of your current FormRecognizer S0 pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?nextLink=2!236!MDAwMTMyIXN1YnNjcmlwdGlvbnMvMjY4ZTc5YWQ1OWFmNDA4OGE5NTFhMjE4OWQ1YjZlMjMvbW9kZWxzL2U0YWU4ZWM1LTc4ZWQtNGExNC1hYzExLTk4MWFlMTQ0NjU5Mi9lNGFlOGVjNS03OGVkLTRhMTQtYWMxMS05ODFhZTE0NDY1OTIuanNvbiEwMDAwMjghOTk5OS0xMi0zMVQyMzo1OTo1OS45OTk5OTk5WiE-",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "ac8db4e5f2d53238a1027762eb9aa6f0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6641b38b-ad7a-45ef-8dd2-a6f6d85b5a4c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:40:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "923"
-      },
-      "ResponseBody": {
-        "modelList": [
-          {
-            "modelId": "e4ae8ec5-78ed-4a14-ac11-981ae1446592",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:18:57Z",
-            "lastUpdatedDateTime": "2020-04-21T04:19:00Z"
-          },
-          {
-            "modelId": "e780d0cf-f6d6-4fa7-b960-34ac3787126e",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:17:58Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:01Z"
-          },
-          {
-            "modelId": "e91c2253-4d8e-439a-9b31-5efd8ac2e6c7",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:18:22Z",
-            "lastUpdatedDateTime": "2020-04-21T04:18:34Z"
-          },
-          {
-            "modelId": "eb3bc365-396c-4914-be43-d9532512974a",
-            "status": "invalid",
-            "createdDateTime": "2020-04-29T19:37:38Z",
-            "lastUpdatedDateTime": "2020-04-29T19:37:38Z"
-          },
-          {
-            "modelId": "ec3f9be7-ae7a-4537-be00-c072d57a4a05",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T20:21:32Z",
-            "lastUpdatedDateTime": "2020-04-16T20:21:40Z"
-          },
-          {
-            "modelId": "ecdf3e2c-13c0-4431-ae91-e953fa3bf227",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T02:56:55Z",
-            "lastUpdatedDateTime": "2020-04-21T02:57:06Z"
-          },
-          {
-            "modelId": "ece0bc12-4cef-42d2-af4f-5c6089797ced",
-            "status": "ready",
-            "createdDateTime": "2020-04-18T15:50:25Z",
-            "lastUpdatedDateTime": "2020-04-18T15:50:34Z"
-          },
-          {
-            "modelId": "ed5eabc3-bfe2-4134-b7d3-4baf955d9fef",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:34:09Z",
-            "lastUpdatedDateTime": "2020-04-20T17:34:19Z"
-          },
-          {
-            "modelId": "ef3dcd6b-31c0-4d40-a437-3333e4c20fed",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:43:02Z",
-            "lastUpdatedDateTime": "2020-04-23T01:43:11Z"
-          },
-          {
-            "modelId": "f102aca8-29d9-4efe-99f2-0ed0d3dd29af",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T21:15:34Z",
-            "lastUpdatedDateTime": "2020-04-28T21:15:42Z"
-          },
-          {
-            "modelId": "f11f0a62-1a3c-4100-8fe7-078b7fed61d7",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T04:21:04Z",
-            "lastUpdatedDateTime": "2020-04-21T04:21:13Z"
-          },
-          {
-            "modelId": "f1dd0fa9-a86d-44d9-ad81-9269318a1f8a",
-            "status": "ready",
-            "createdDateTime": "2020-04-16T21:17:56Z",
-            "lastUpdatedDateTime": "2020-04-16T21:18:04Z"
-          },
-          {
-            "modelId": "f2f7e43a-6610-4b21-9aab-93cce3763543",
-            "status": "invalid",
-            "createdDateTime": "2020-04-23T04:46:43Z",
-            "lastUpdatedDateTime": "2020-04-23T04:46:44Z"
-          },
-          {
-            "modelId": "f422d22e-dbbd-497b-ad9d-c303ed4fde93",
-            "status": "ready",
-            "createdDateTime": "2020-04-29T19:38:44Z",
-            "lastUpdatedDateTime": "2020-04-29T19:38:52Z"
-          },
-          {
-            "modelId": "f5e10f54-9a7b-4852-a31b-fc3642bc79ed",
-            "status": "ready",
-            "createdDateTime": "2020-04-21T01:27:42Z",
-            "lastUpdatedDateTime": "2020-04-21T01:27:51Z"
-          },
-          {
-            "modelId": "f6899edc-da69-4989-a6b7-b8659e613fbc",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:29:30Z",
-            "lastUpdatedDateTime": "2020-04-23T01:29:38Z"
-          },
-          {
-            "modelId": "f6da502a-4992-467e-b1bf-89b6c818383a",
-            "status": "ready",
-            "createdDateTime": "2020-04-20T17:31:57Z",
-            "lastUpdatedDateTime": "2020-04-20T17:32:11Z"
-          },
-          {
-            "modelId": "f7928183-3b36-493e-9992-5a4ad0925f4f",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T19:12:13Z",
-            "lastUpdatedDateTime": "2020-04-28T19:12:27Z"
-          },
-          {
-            "modelId": "f8717df3-8f6e-46dd-b6b8-e190363d1352",
-            "status": "ready",
-            "createdDateTime": "2020-04-23T01:27:03Z",
-            "lastUpdatedDateTime": "2020-04-23T01:27:11Z"
-          },
-          {
-            "modelId": "f896ec2c-a901-49ca-a643-72e059dca277",
-            "status": "invalid",
-            "createdDateTime": "2020-04-17T22:50:07Z",
-            "lastUpdatedDateTime": "2020-04-17T22:50:07Z"
-          },
-          {
-            "modelId": "faee4509-abea-491e-b48e-eeadf853d1bc",
-            "status": "ready",
-            "createdDateTime": "2020-04-22T17:15:43Z",
-            "lastUpdatedDateTime": "2020-04-22T17:15:51Z"
-          },
-          {
-            "modelId": "ff089c42-cb6f-4ec6-aaad-0056b6b71a32",
-            "status": "ready",
-            "createdDateTime": "2020-04-28T01:25:08Z",
-            "lastUpdatedDateTime": "2020-04-28T01:25:12Z"
-          }
-        ],
-        "nextLink": ""
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models?op=summary",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bc3f0104f04dec45a3156faca80ad4c1-3fe4bcd3be1f9246-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "2f494dc03984777b4cfed4f42e17cfaa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "80304e9b-b3dd-41a2-b06a-afe3c9b36956",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:40:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "56"
-      },
-      "ResponseBody": {
-        "summary": {
-          "count": 203,
-          "limit": 5000,
-          "lastUpdatedDateTime": "2020-04-29T19:40:09Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3d92df3bbf91ef4d95043717219f63d4-c91bfcee8b01a542-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "f6f072ad7d8e52ab031ef5307c1ac2f7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 204,
-      "ResponseHeaders": {
-        "apim-request-id": "c57ae55b-d912-4bca-91a0-0342a213b408",
-        "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:40:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d6f44b38-5246-49b5-9557-b06e1977aa17?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c90a6639c982443ba45276f626517bb-530359bad0f9d54f-00",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "522458ec4597abe5381560d71d43048a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "apim-request-id": "fe695108-16e2-40d7-939c-d4d492aa150c",
+        "apim-request-id": "5ac8a5fe-e6bf-4b4b-998f-2f37bee4e74a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:40:08 GMT",
+        "Date": "Tue, 16 Jun 2020 04:14:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "21"
+        "x-envoy-upstream-service-time": "35"
       },
       "ResponseBody": {
         "error": {
           "code": "1022",
-          "message": "Model with \u0027id=d6f44b38-5246-49b5-9557-b06e1977aa17\u0027 not found."
+          "message": "Model with \u0027id=cba28d82-ca6d-42bb-a0a2-9dca61794dd9\u0027 not found."
         }
       }
     }
@@ -2017,7 +444,7 @@
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
     "FORM_RECOGNIZER_BLOB_CONTAINER_SAS_URL": "https://sanitized.blob.core.windows.net",
-    "FORM_RECOGNIZER_ENDPOINT": "https://camaior-formrec.cognitiveservices.azure.com/",
+    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/",
     "RandomSeed": "89722803"
   }
 }


### PR DESCRIPTION
- Re record some test that had `Retry-After` 
- Set a polling interval of `0` when on playback mode.

Estimated execution times:
- Training tests: 
  - Before: 4.2min
  - After: 1s
- FormRecognizer tests:
  - Before: 7.7 min
  - After: 1.5s

Thanks to @AlexanderSher for the investigation!