### PR TITLE
fix(e2e): Cleanup unnecessary settings.

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ComponentTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ComponentTests.cs
@@ -25,9 +25,9 @@ namespace Azure.DigitalTwins.Core.Tests
 
             DigitalTwinsClient client = GetClient();
 
-            string wifiModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.WifiModelIdPrefix).ConfigureAwait(false);
-            string roomWithWifiModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.RoomWithWifiModelIdPrefix).ConfigureAwait(false);
-            string roomWithWifiTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.RoomWithWifiTwinIdPrefix).ConfigureAwait(false);
+            string wifiModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.WifiModelIdPrefix).ConfigureAwait(false);
+            string roomWithWifiModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomWithWifiModelIdPrefix).ConfigureAwait(false);
+            string roomWithWifiTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomWithWifiTwinIdPrefix).ConfigureAwait(false);
             string wifiComponentName = "wifiAccessPoint";
 
             try

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/DigitalTwinRelationshipTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/DigitalTwinRelationshipTests.cs
@@ -36,13 +36,13 @@ namespace Azure.DigitalTwins.Core.Tests
             var hvacCoolsFloorRelationshipId = "HvacToFloorRelationship";
             var roomContainedInFloorRelationshipId = "RoomToFloorRelationship";
 
-            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.FloorModelIdPrefix).ConfigureAwait(false);
-            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.RoomModelIdPrefix).ConfigureAwait(false);
-            string hvacModelId = await GetUniqueTwinIdAsync(client, TestAssetSettings.HvacModelIdPrefix).ConfigureAwait(false);
+            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.FloorModelIdPrefix).ConfigureAwait(false);
+            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomModelIdPrefix).ConfigureAwait(false);
+            string hvacModelId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.HvacModelIdPrefix).ConfigureAwait(false);
 
-            string floorTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.FloorTwinIdPrefix).ConfigureAwait(false);
-            string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.RoomTwinIdPrefix).ConfigureAwait(false);
-            string hvacTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.HvacTwinIdPrefix).ConfigureAwait(false);
+            string floorTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.FloorTwinIdPrefix).ConfigureAwait(false);
+            string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
+            string hvacTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.HvacTwinIdPrefix).ConfigureAwait(false);
 
             try
             {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/DigitalTwinTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/DigitalTwinTests.cs
@@ -25,9 +25,9 @@ namespace Azure.DigitalTwins.Core.Tests
         {
             DigitalTwinsClient client = GetClient();
 
-            string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.RoomTwinIdPrefix).ConfigureAwait(false);
-            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.FloorModelIdPrefix).ConfigureAwait(false);
-            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.RoomModelIdPrefix).ConfigureAwait(false);
+            string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
+            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.FloorModelIdPrefix).ConfigureAwait(false);
+            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomModelIdPrefix).ConfigureAwait(false);
 
             try
             {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
@@ -28,10 +28,10 @@ namespace Azure.DigitalTwins.Core.Tests
         {
             DigitalTwinsClient client = GetClient();
 
-            string buildingModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.Instance.BuildingModelId).ConfigureAwait(false);
-            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.Instance.FloorModelId).ConfigureAwait(false);
-            string hvacModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.Instance.HvacModelId).ConfigureAwait(false);
-            string wardModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.Instance.WardModelId).ConfigureAwait(false);
+            string buildingModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.BuildingModelId).ConfigureAwait(false);
+            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.FloorModelId).ConfigureAwait(false);
+            string hvacModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.HvacModelId).ConfigureAwait(false);
+            string wardModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.WardModelId).ConfigureAwait(false);
 
             try
             {
@@ -86,7 +86,7 @@ namespace Azure.DigitalTwins.Core.Tests
 
             DigitalTwinsClient client = GetClient();
 
-            string wardModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.Instance.WardModelId).ConfigureAwait(false);
+            string wardModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.WardModelId).ConfigureAwait(false);
 
             // add a model with a single value for displayName and for description, neither of which were defined as a map
             string modelWard = TestAssetsHelper.GetWardModelPayload(wardModelId);
@@ -138,7 +138,7 @@ namespace Azure.DigitalTwins.Core.Tests
 
             DigitalTwinsClient client = GetClient();
 
-            string wardModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.Instance.WardModelId).ConfigureAwait(false);
+            string wardModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.WardModelId).ConfigureAwait(false);
 
             string modelWard = TestAssetsHelper.GetWardModelPayload(wardModelId);
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/PayloadHelperUnitTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/PayloadHelperUnitTests.cs
@@ -19,10 +19,10 @@ namespace Azure.DigitalTwins.Core.Tests
         {
             // arrange
             string floorJson = TestAssetsHelper.GetFloorModelPayload(
-                TestAssetSettings.Instance.FloorModelId,
-                TestAssetSettings.Instance.RoomModelId,
-                TestAssetSettings.Instance.HvacModelId);
-            string roomJson = TestAssetsHelper.GetRoomModelPayload(TestAssetSettings.Instance.RoomModelId, TestAssetSettings.Instance.FloorModelId);
+                TestAssetDefaults.FloorModelId,
+                TestAssetDefaults.RoomModelId,
+                TestAssetDefaults.HvacModelId);
+            string roomJson = TestAssetsHelper.GetRoomModelPayload(TestAssetDefaults.RoomModelId, TestAssetDefaults.FloorModelId);
             var models = new List<string> { floorJson, roomJson };
 
             // act

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/PublishTelemetryTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/PublishTelemetryTests.cs
@@ -34,9 +34,9 @@ namespace Azure.DigitalTwins.Core.Tests
             DigitalTwinsClient client = GetClient();
 
             string wifiComponentName = "wifiAccessPoint";
-            string wifiModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.WifiModelIdPrefix).ConfigureAwait(false);
-            string roomWithWifiModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.RoomWithWifiModelIdPrefix).ConfigureAwait(false);
-            string roomWithWifiTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.RoomWithWifiTwinIdPrefix).ConfigureAwait(false);
+            string wifiModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.WifiModelIdPrefix).ConfigureAwait(false);
+            string roomWithWifiModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomWithWifiModelIdPrefix).ConfigureAwait(false);
+            string roomWithWifiTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomWithWifiTwinIdPrefix).ConfigureAwait(false);
             string eventRouteId = $"someEventRouteId-{GetRandom()}";
 
             try

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
@@ -23,8 +23,8 @@ namespace Azure.DigitalTwins.Core.Tests
         {
             DigitalTwinsClient client = GetClient();
 
-            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.FloorModelIdPrefix).ConfigureAwait(false);
-            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetSettings.RoomModelIdPrefix).ConfigureAwait(false);
+            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.FloorModelIdPrefix).ConfigureAwait(false);
+            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomModelIdPrefix).ConfigureAwait(false);
 
             try
             {
@@ -35,7 +35,7 @@ namespace Azure.DigitalTwins.Core.Tests
                 await client.CreateModelsAsync(new List<string> { roomModel }).ConfigureAwait(false);
 
                 // Create a room twin, with property "IsOccupied": true
-                string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetSettings.RoomTwinIdPrefix).ConfigureAwait(false);
+                string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
                 string roomTwin = TestAssetsHelper.GetRoomTwinPayload(roomModelId);
                 await client.CreateDigitalTwinAsync(roomTwinId, roomTwin).ConfigureAwait(false);
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/TestAssetDefaults.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/TestAssetDefaults.cs
@@ -11,10 +11,8 @@ namespace Azure.DigitalTwins.Core.Tests
     /// These are the settings that will be used by the end-to-end tests tests.
     /// The json files configured in the config will load the settings specific to a user.
     /// </summary>
-    public class TestAssetSettings
+    public static class TestAssetDefaults
     {
-        public static TestAssetSettings Instance { get; private set; }
-
         /// <summary>
         /// Default Floor Twin Id prefix.
         /// </summary>
@@ -63,56 +61,26 @@ namespace Azure.DigitalTwins.Core.Tests
         /// <summary>
         /// Default Floor Model Id.
         /// </summary>
-        public string FloorModelId { get; set; }
+        public const string FloorModelId = "dtmi:example:Floor;1";
 
         /// <summary>
         /// Default Room Model Id.
         /// </summary>
-        public string RoomModelId { get; set; }
+        public const string RoomModelId = "dtmi:example:Room;1";
 
         /// <summary>
         /// Default Hvac Model Id.
         /// </summary>
-        public string HvacModelId { get; set; }
+        public const string HvacModelId = "dtmi:example:Hvac;1";
 
         /// <summary>
         /// Default Building Model Id.
         /// </summary>
-        public string BuildingModelId { get; set; }
+        public const string BuildingModelId = "dtmi:example:Building;1";
 
         /// <summary>
         /// Default Ward Model Id.
         /// </summary>
-        public string WardModelId { get; set; }
-
-        static TestAssetSettings()
-        {
-            if (Instance != null)
-            {
-                return;
-            }
-
-            // Initialize the settings related to test assets - Models and IDs
-            var testsAssetSettingsConfigBuilder = new ConfigurationBuilder();
-
-            string testAssetSettingsCommonPath = Path.Combine(
-                TestSettings.Instance.WorkingDirectory,
-                "config",
-                "common.test.assets.config.json");
-            testsAssetSettingsConfigBuilder.AddJsonFile(testAssetSettingsCommonPath);
-
-            string testAssetSettingsUserPath = Path.Combine(
-                TestSettings.Instance.WorkingDirectory,
-                "config",
-                $"{Environment.UserName}.test.assets.config.json");
-            if (File.Exists(testAssetSettingsUserPath))
-            {
-                testsAssetSettingsConfigBuilder.AddJsonFile(testAssetSettingsUserPath);
-            }
-
-            IConfiguration config = testsAssetSettingsConfigBuilder.Build();
-
-            Instance = config.Get<TestAssetSettings>();
-        }
+        public const string WardModelId = "dtmi:example:Ward;1";
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/config/common.test.assets.config.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/config/common.test.assets.config.json
@@ -1,8 +1,0 @@
-﻿{
-    "FloorModelId": "dtmi:example:Floor;1",
-    "RoomModelId": "dtmi:example:Room;1",
-    "RoomWithWifiModelId": "dtmi:example:Room;1",
-    "HvacModelId": "dtmi:example:Hvac;1",
-    "BuildingModelId": "dtmi:example:Building;1",
-    "WardModelId": "dtmi:example:Ward;1"
-}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/setup.ps1
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/setup.ps1
@@ -143,13 +143,4 @@ $protectedBytes = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, 
 Set-Content $outputFile -Value $protectedBytes -AsByteStream -Force
 Write-Host "Test environment settings stored into encrypted $outputFile"
 
-$userSettingsFileSuffix = ".test.assets.config.json"
-$userSettingsFileName = "$user$userSettingsFileSuffix"
-$userTestAssetSettingsFileName = "$PSScriptRoot\..\config\$userSettingsFileName"
-if (-not (Test-Path $userTestAssetSettingsFileName))
-{
-    Write-Host "Creating empty user test assets config file - $userSettingsFileName`n"
-    New-Item -ItemType File -Path $userTestAssetSettingsFileName -Value "{}" | Out-Null
-}
-
 Write-Host "Done!"


### PR DESCRIPTION
We previously needed test asset settings per user for model Ids as there was no delete. As we are cleaning up after each test, this should no longer be needed. So removing the complexity and converting the defaults to just constants.