### PR TITLE
feat(e2e): Add script to record and update session records.

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/Record-Tests.ps1
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/Record-Tests.ps1
@@ -1,0 +1,53 @@
+﻿param(
+    [Parameter()]
+    [string] $TestName
+)
+
+$user = $env:UserName
+$fileName = "$user.config.json"
+$oldConfig = Get-Content -Path $PSScriptRoot/config/$fileName
+
+$newConfig = @"
+{
+    "TestMode":  "Record"	
+}
+"@
+
+Write-Host("Updating user config file to Record test mode`n")
+$newConfig | Out-File "$PSScriptRoot\config\$fileName"
+
+if (-not $TestName)
+{
+    # Run all tests
+    dotnet test
+}
+else
+{
+    # Run only specified test
+    dotnet test --filter FullyQualifiedName~$TestName
+}
+
+dotnet msbuild /t:UpdateSessionRecords
+
+$newConfig = @"
+{
+    "TestMode":  "Playback"	
+}
+"@
+
+Write-Host("Updating user config file to Playback test mode and checking if tests succeed.`n")
+$newConfig | Out-File "$PSScriptRoot\config\$fileName"
+
+if (-not $TestName)
+{
+    # Run all tests
+    dotnet test
+}
+else
+{
+    # Run only specified test
+    dotnet test --filter FullyQualifiedName~$TestName
+}
+
+Write-Host("Restoring to original user config file settings.`n")
+$oldConfig | Out-File "$PSScriptRoot\config\$fileName"

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/UpdateSessionRecords.ps1
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/UpdateSessionRecords.ps1
@@ -1,1 +1,0 @@
-﻿dotnet msbuild /t:UpdateSessionRecords


### PR DESCRIPTION
Adding a script that you can use to record tests automatically. The script will do the following:
1) Run tests in record mode
2) Run tests in playback mode 
3) Restore the settings file back to what it originally was (it would be Live if user has not changed anything locally)

Usage example:
.\Record-Tests.ps1 - This will record all tests.
.\Record-Tests.ps1 - TestName ComponentTests - This will only record the Components tests.

This should save all the manual steps involved in recording tests.
