### PR TITLE
AzureCliAccessTokenProvider - fix for non-Windows - import: command not found

### DIFF
--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 startInfo = new ProcessStartInfo
                 {
                     FileName = Bash,
-                    Arguments = $"{GetTokenCommand} {ResourceArgumentName} {resource}"
+                    Arguments = $"-c \"{GetTokenCommand} {ResourceArgumentName} {resource}\""
                 };
 
                 azureCliPath = $"{EnvironmentHelper.GetEnvironmentVariable(AzureCliPath)}:{AzureCliDefaultPath}";


### PR DESCRIPTION
**Situation**
User is logged into Azure CLI on Ubuntu 20.04.
Using the AzureServiceTokenProvider in a NetCore 3.1 app fails.

`Microsoft.Azure.Services.AppAuthentication Parameters: Connection String: [No connection string specified], Resource: https://storage.azure.com/, Authority: . Exception Message: Tried the following 3 methods to get an access token, but none of them worked.
      Parameters: Connection String: [No connection string specified], Resource: https://storage.azure.com/, Authority: . Exception Message: Tried to get token using Managed Service Identity. Unable to connect to the Managed Service Identity (MSI) endpoint. Please check that you are running on an Azure resource that has MSI setup.
      Parameters: Connection String: [No connection string specified], Resource: https://storage.azure.com/, Authority: . Exception Message: Tried to get token using Visual Studio. Access token could not be acquired. Environment variable LOCALAPPDATA not set.
      Parameters: Connection String: [No connection string specified], Resource: https://storage.azure.com/, Authority: . Exception Message: Tried to get token using Azure CLI. Access token could not be acquired.

/usr/bin/az: line 3: import: command not found
/usr/bin/az: line 4: import: command not found
/usr/bin/az: az: line 6: syntax error near unexpected token `('/usr/bin/az: az: line 6: `dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'src')'
`

Terminal> az account get-access-token -o json --resource "https://storage.azure.com"
works fine, see [reference](https://github.com/Azure/azure-sdk-for-net/blob/d15c59a87ad96a7de5b7e2dfb44e81af4be4acc1/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs#L25)

**Fix**

add the [bash -c option](https://linux.die.net/man/1/bash) to mitigate this problem.

> If the -c option is present, then commands are read from string. If there are arguments after the string, they are assigned to the positional parameters, starting with $0. 
