### PR TITLE
Add CreateClientRequestIdScope method

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.3.0-preview.1 (Unreleased)
 
+### Added
+- `HttpPipeline.CreateClientRequestIdScope` method to allow setting client request id on outgoing requests.
 
 ## 1.2.2 (2020-06-04)
 

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -458,6 +458,7 @@ namespace Azure.Core.Pipeline
     {
         public HttpPipeline(Azure.Core.Pipeline.HttpPipelineTransport transport, Azure.Core.Pipeline.HttpPipelinePolicy[]? policies = null, Azure.Core.ResponseClassifier? responseClassifier = null) { }
         public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } }
+        public static System.IDisposable CreateClientRequestIdScope(string? clientRequestId) { throw null; }
         public Azure.Core.HttpMessage CreateMessage() { throw null; }
         public Azure.Core.Request CreateRequest() { throw null; }
         public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { }

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -99,3 +99,17 @@ To setup ApplicationInsights tracking for your application follow the [Start Mon
 ### OpenTelemetry with Azure Monitor, Zipkin and others
 
 Follow the [OpenTelemetry configuration guide](https://github.com/open-telemetry/opentelemetry-dotnet#configuration-with-microsoftextensionsdependencyinjection) to configure collecting distribute tracing event collection using the OpenTelemetry library.
+
+## Setting x-ms-client-request-id value sent with requests
+
+By default x-ms-client-request-id header gets a unique value per client method call. If you would like to use a specific value for a set of requests use the `HttpPipeline.CreateClientRequestIdScope` method.
+
+```C# Snippet:ClientRequestId
+var secretClient = new SecretClient(new Uri("<uri>"), new DefaultAzureCredential());
+
+using (HttpPipeline.CreateClientRequestIdScope("<custom-client-request-id>"))
+{
+    // The HTTP request resulting from the client call would have x-ms-client-request-id value set to <custom-client-request-id>
+    secretClient.GetSecret("<secret-name>");
+}
+```

--- a/sdk/core/Azure.Core/samples/Diagnostics.md
+++ b/sdk/core/Azure.Core/samples/Diagnostics.md
@@ -105,7 +105,7 @@ Follow the [OpenTelemetry configuration guide](https://github.com/open-telemetry
 By default x-ms-client-request-id header gets a unique value per client method call. If you would like to use a specific value for a set of requests use the `HttpPipeline.CreateClientRequestIdScope` method.
 
 ```C# Snippet:ClientRequestId
-var secretClient = new SecretClient(new Uri("<uri>"), new DefaultAzureCredential());
+var secretClient = new SecretClient(new Uri("http://example.com"), new DefaultAzureCredential());
 
 using (HttpPipeline.CreateClientRequestIdScope("<custom-client-request-id>"))
 {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -104,5 +104,15 @@ namespace Azure.Core.Pipeline
             Send(message, cancellationToken);
             return message.Response;
         }
+
+        /// <summary>
+        /// Creates a scope in which all outgoing requests would use the provided
+        /// </summary>
+        /// <param name="clientRequestId">The client request id value to be sent with request.</param>
+        /// <returns>The <see cref="IDisposable"/> instance that needs to be disposed when client request id shouldn't be sent anymore.</returns>
+        public static IDisposable CreateClientRequestIdScope(string? clientRequestId)
+        {
+            return ReadClientRequestIdPolicy.StartScope(clientRequestId);
+        }
     }
 }

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -110,6 +110,18 @@ namespace Azure.Core.Pipeline
         /// </summary>
         /// <param name="clientRequestId">The client request id value to be sent with request.</param>
         /// <returns>The <see cref="IDisposable"/> instance that needs to be disposed when client request id shouldn't be sent anymore.</returns>
+        /// <example>
+        /// Sample usage:
+        /// <code snippet="Snippet:ClientRequestId">
+        /// var secretClient = new SecretClient(new Uri(&quot;&lt;uri&gt;&quot;), new DefaultAzureCredential());
+        ///
+        /// using (HttpPipeline.CreateClientRequestIdScope(&quot;&lt;custom-client-request-id&gt;&quot;))
+        /// {
+        ///     // The HTTP request resulting from the client call would have x-ms-client-request-id value set to &lt;custom-client-request-id&gt;
+        ///     secretClient.GetSecret(&quot;&lt;secret-name&gt;&quot;);
+        /// }
+        /// </code>
+        /// </example>
         public static IDisposable CreateClientRequestIdScope(string? clientRequestId)
         {
             return ReadClientRequestIdPolicy.StartScope(clientRequestId);

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -113,7 +113,7 @@ namespace Azure.Core.Pipeline
         /// <example>
         /// Sample usage:
         /// <code snippet="Snippet:ClientRequestId">
-        /// var secretClient = new SecretClient(new Uri(&quot;&lt;uri&gt;&quot;), new DefaultAzureCredential());
+        /// var secretClient = new SecretClient(new Uri(&quot;http://example.com&quot;), new DefaultAzureCredential());
         ///
         /// using (HttpPipeline.CreateClientRequestIdScope(&quot;&lt;custom-client-request-id&gt;&quot;))
         /// {

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadClientRequestIdPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadClientRequestIdPolicy.cs
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading;
+
 namespace Azure.Core.Pipeline
 {
     internal class ReadClientRequestIdPolicy : HttpPipelineSynchronousPolicy
     {
+        private static readonly AsyncLocal<ClientRequestIdScope?> CurrentRequestIdScope = new AsyncLocal<ClientRequestIdScope?>();
+
         protected ReadClientRequestIdPolicy()
         {
         }
@@ -16,6 +21,35 @@ namespace Azure.Core.Pipeline
             if (message.Request.Headers.TryGetValue(ClientRequestIdPolicy.ClientRequestIdHeader, out string? value))
             {
                 message.Request.ClientRequestId = value;
+            }
+            else if (CurrentRequestIdScope.Value?.ClientRequestId != null)
+            {
+                message.Request.ClientRequestId = CurrentRequestIdScope.Value.ClientRequestId;
+            }
+        }
+
+        internal static IDisposable StartScope(string? clientRequestId)
+        {
+            CurrentRequestIdScope.Value = new ClientRequestIdScope(clientRequestId, CurrentRequestIdScope.Value);
+
+            return CurrentRequestIdScope.Value;
+        }
+
+        private class ClientRequestIdScope: IDisposable
+        {
+            private readonly ClientRequestIdScope? _parent;
+
+            internal ClientRequestIdScope(string? clientRequestId, ClientRequestIdScope? parent)
+            {
+                ClientRequestId = clientRequestId;
+                _parent = parent;
+            }
+
+            public string? ClientRequestId { get; }
+
+            public void Dispose()
+            {
+                CurrentRequestIdScope.Value = _parent;
             }
         }
     }

--- a/sdk/core/Azure.Core/tests/ClientRequestIdPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientRequestIdPolicyTests.cs
@@ -53,5 +53,47 @@ namespace Azure.Core.Tests
 
             policy.Verify();
         }
+
+        [Test]
+        public async Task ReadsRequestIdValueOfScope()
+        {
+            var transport = new MockTransport(r => new MockResponse(200));
+
+            using (HttpPipeline.CreateClientRequestIdScope("custom-id"))
+            {
+                await SendGetRequest(transport, ReadClientRequestIdPolicy.Shared);
+            }
+
+            Assert.AreEqual(transport.SingleRequest.ClientRequestId, "custom-id");
+        }
+
+        [Test]
+        public async Task ReadsRequestIdValueOfNestedScope()
+        {
+            var transport = new MockTransport(r => new MockResponse(200));
+
+
+            using (HttpPipeline.CreateClientRequestIdScope("custom-id"))
+            using (HttpPipeline.CreateClientRequestIdScope("nested-custom-id"))
+            {
+                await SendGetRequest(transport, ReadClientRequestIdPolicy.Shared);
+            }
+
+            Assert.AreEqual(transport.SingleRequest.ClientRequestId, "nested-custom-id");
+        }
+
+        [Test]
+        public async Task CanResetRequestIdValueOfParentScope()
+        {
+            var transport = new MockTransport(r => new MockResponse(200));
+
+            using (HttpPipeline.CreateClientRequestIdScope("custom-id"))
+            using (HttpPipeline.CreateClientRequestIdScope(null))
+            {
+                await SendGetRequest(transport, ReadClientRequestIdPolicy.Shared);
+            }
+
+            Assert.IsNotEmpty(transport.SingleRequest.ClientRequestId);
+        }
     }
 }

--- a/sdk/core/Azure.Core/tests/samples/LoggingSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/LoggingSamples.cs
@@ -109,10 +109,11 @@ namespace Azure.Core.Samples
         }
 
         [Test]
+        [Ignore("Only verifying that the sample builds")]
         public void ClientRequestId()
         {
             #region Snippet:ClientRequestId
-            var secretClient = new SecretClient(new Uri("<uri>"), new DefaultAzureCredential());
+            var secretClient = new SecretClient(new Uri("http://example.com"), new DefaultAzureCredential());
 
             using (HttpPipeline.CreateClientRequestIdScope("<custom-client-request-id>"))
             {

--- a/sdk/core/Azure.Core/tests/samples/LoggingSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/LoggingSamples.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Tracing;
 using System.Net.Http;
 using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
+using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using NUnit.Framework;
 
@@ -104,6 +105,20 @@ namespace Azure.Core.Samples
             #region Snippet:TraceLogging
             // Setup a listener to monitor logged events.
             using AzureEventSourceListener listener = AzureEventSourceListener.CreateTraceLogger();
+            #endregion
+        }
+
+        [Test]
+        public void ClientRequestId()
+        {
+            #region Snippet:ClientRequestId
+            var secretClient = new SecretClient(new Uri("<uri>"), new DefaultAzureCredential());
+
+            using (HttpPipeline.CreateClientRequestIdScope("<custom-client-request-id>"))
+            {
+                // The HTTP request resulting from the client call would have x-ms-client-request-id value set to <custom-client-request-id>
+                secretClient.GetSecret("<secret-name>");
+            }
             #endregion
         }
     }


### PR DESCRIPTION
I decided not to complicate the implementation just yet considering the method is a pretty well hidden static method.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/11273
