### PR TITLE
doc(adt): remove status code from samples

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/ComponentSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/ComponentSamples.cs
@@ -36,13 +36,13 @@ namespace Azure.DigitalTwins.Core.Samples
                 .Replace(SamplesConstants.ComponentId, componentModelId);
 
             // Then we create models
-            Response<IReadOnlyList<Models.ModelData>> createModelsResponse = await client.CreateModelsAsync(
+            await client.CreateModelsAsync(
                 new[]
                 {
                     newComponentModelPayload,
                     newModelPayload
                 });
-            Console.WriteLine($"Created models with Ids {componentModelId} and {modelId}. Response status: {createModelsResponse.GetRawResponse().Status}.");
+            Console.WriteLine($"Created models {componentModelId} and {modelId}.");
 
             #region Snippet:DigitalTwinsSampleCreateBasicTwin
 
@@ -76,8 +76,8 @@ namespace Azure.DigitalTwins.Core.Samples
 
             string basicDtPayload = JsonSerializer.Serialize(basicTwin);
 
-            Response<string> createBasicDtResponse = await client.CreateDigitalTwinAsync(basicDtId, basicDtPayload);
-            Console.WriteLine($"Created digital twin with Id {basicDtId}. Response status: {createBasicDtResponse.GetRawResponse().Status}.");
+            await client.CreateDigitalTwinAsync(basicDtId, basicDtPayload);
+            Console.WriteLine($"Created digital twin '{basicDtId}'.");
 
             #endregion Snippet:DigitalTwinsSampleCreateBasicTwin
 
@@ -128,8 +128,8 @@ namespace Azure.DigitalTwins.Core.Samples
             };
             string dt2Payload = JsonSerializer.Serialize(customTwin);
 
-            Response<string> createCustomDtResponse = await client.CreateDigitalTwinAsync(customDtId, dt2Payload);
-            Console.WriteLine($"Created digital twin with Id {customDtId}. Response status: {createCustomDtResponse.GetRawResponse().Status}.");
+            await client.CreateDigitalTwinAsync(customDtId, dt2Payload);
+            Console.WriteLine($"Created digital twin '{customDtId}'.");
 
             #endregion Snippet:DigitalTwinsSampleCreateCustomTwin
 
@@ -139,29 +139,25 @@ namespace Azure.DigitalTwins.Core.Samples
             #region Snippet:DigitalTwinsSampleGetCustomDigitalTwin
 
             Response<string> getCustomDtResponse = await client.GetDigitalTwinAsync(customDtId);
-            if (getCustomDtResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
-            {
-                CustomDigitalTwin customDt = JsonSerializer.Deserialize<CustomDigitalTwin>(getCustomDtResponse.Value);
-                Console.WriteLine($"Retrieved and deserialized digital twin {customDt.Id}:\n\t" +
-                    $"ETag: {customDt.ETag}\n\t" +
-                    $"Prop1: {customDt.Prop1}\n\t" +
-                    $"Prop2: {customDt.Prop2}\n\t" +
-                    $"ComponentProp1: {customDt.Component1.ComponentProp1}\n\t" +
-                    $"ComponentProp2: {customDt.Component1.ComponentProp2}");
-            }
+            CustomDigitalTwin customDt = JsonSerializer.Deserialize<CustomDigitalTwin>(getCustomDtResponse.Value);
+            Console.WriteLine($"Retrieved and deserialized digital twin {customDt.Id}:\n\t" +
+                $"ETag: {customDt.ETag}\n\t" +
+                $"Prop1: {customDt.Prop1}\n\t" +
+                $"Prop2: {customDt.Prop2}\n\t" +
+                $"ComponentProp1: {customDt.Component1.ComponentProp1}\n\t" +
+                $"ComponentProp2: {customDt.Component1.ComponentProp2}");
 
             #endregion Snippet:DigitalTwinsSampleGetCustomDigitalTwin
 
             #region Snippet:DigitalTwinsSampleUpdateComponent
 
-            // Update Component1 by replacing the property ComponentProp1 value
+            // Update Component1 by replacing the property ComponentProp1 value,
+            // using an optional utility to build the payload.
             var componentUpdateUtility = new UpdateOperationsUtility();
             componentUpdateUtility.AppendReplaceOp("/ComponentProp1", "Some new value");
             string updatePayload = componentUpdateUtility.Serialize();
-
-            Response<string> response = await client.UpdateComponentAsync(basicDtId, "Component1", updatePayload);
-
-            Console.WriteLine($"Updated component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}");
+            await client.UpdateComponentAsync(basicDtId, "Component1", updatePayload);
+            Console.WriteLine($"Updated component for digital twin '{basicDtId}'.");
 
             #endregion Snippet:DigitalTwinsSampleUpdateComponent
 
@@ -169,9 +165,8 @@ namespace Azure.DigitalTwins.Core.Samples
 
             #region Snippet:DigitalTwinsSampleGetComponent
 
-            response = await client.GetComponentAsync(basicDtId, SamplesConstants.ComponentPath);
-
-            Console.WriteLine($"Retrieved component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}");
+            await client.GetComponentAsync(basicDtId, SamplesConstants.ComponentPath);
+            Console.WriteLine($"Retrieved component for digital twin '{basicDtId}'.");
 
             #endregion Snippet:DigitalTwinsSampleGetComponent
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
@@ -117,8 +117,8 @@ namespace Azure.DigitalTwins.Core.Samples
 
                 foreach (string modelId in models)
                 {
-                    Response deleteModelResponse = await client.DeleteModelAsync(modelId);
-                    Console.WriteLine($"Deleted model with Id {modelId}. Response status: {deleteModelResponse.Status}");
+                    await client.DeleteModelAsync(modelId);
+                    Console.WriteLine($"Deleted model '{modelId}'.");
                 }
             }
             catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
@@ -147,8 +147,8 @@ namespace Azure.DigitalTwins.Core.Samples
 
             try
             {
-                Response<IReadOnlyList<ModelData>> response = await client.CreateModelsAsync(modelsToCreate);
-                Console.WriteLine($"Created models. Response status: {response.GetRawResponse().Status}");
+                await client.CreateModelsAsync(modelsToCreate);
+                Console.WriteLine("Created models.");
             }
             catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Conflict)
             {
@@ -175,7 +175,10 @@ namespace Azure.DigitalTwins.Core.Samples
                 AsyncPageable<ModelData> allModels = client.GetModelsAsync();
                 await foreach (ModelData model in allModels)
                 {
-                    Console.WriteLine($"Retrieved model with Id {model.Id}, display name {model.DisplayName["en"]}, upload time {model.UploadTime}, and decommissioned: {model.Decommissioned}");
+                    Console.WriteLine($"Retrieved model '{model.Id}', " +
+                        $"display name '{model.DisplayName["en"]}', " +
+                        $"upload time '{model.UploadTime}', " +
+                        $"and decommissioned '{model.Decommissioned}'");
                 }
 
                 #endregion Snippet:DigitalTwinsSampleGetModels
@@ -206,7 +209,7 @@ namespace Azure.DigitalTwins.Core.Samples
                     {
                         BasicRelationship relationship = JsonSerializer.Deserialize<BasicRelationship>(relationshipJson);
                         await client.DeleteRelationshipAsync(digitalTwinId, relationship.Id);
-                        Console.WriteLine($"Found and deleted relationship with Id {relationship.Id}.");
+                        Console.WriteLine($"Found and deleted relationship '{relationship.Id}'.");
                     }
 
                     // Delete any incoming relationships
@@ -215,18 +218,17 @@ namespace Azure.DigitalTwins.Core.Samples
                     await foreach (IncomingRelationship incomingRelationship in incomingRelationships)
                     {
                         await client.DeleteRelationshipAsync(incomingRelationship.SourceId, incomingRelationship.RelationshipId);
-                        Console.WriteLine($"Found and deleted incoming relationship with Id {incomingRelationship.RelationshipId}.");
+                        Console.WriteLine($"Found and deleted incoming relationship '{incomingRelationship.RelationshipId}'.");
                     }
 
                     // Now the digital twin should be safe to delete
 
                     #region Snippet:DigitalTwinsSampleDeleteTwin
 
-                    Response deleteDigitalTwinResponse = await client.DeleteDigitalTwinAsync(digitalTwinId);
-                    Console.WriteLine($"Deleted digital twin with Id {digitalTwinId}. Response Status: {deleteDigitalTwinResponse.Status}");
+                    await client.DeleteDigitalTwinAsync(digitalTwinId);
+                    Console.WriteLine($"Deleted digital twin '{digitalTwinId}'.");
 
                     #endregion Snippet:DigitalTwinsSampleDeleteTwin
-
                 }
                 catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
                 {
@@ -234,7 +236,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 }
                 catch (RequestFailedException ex)
                 {
-                    FatalError($"Failed to delete {digitalTwinId} due to {ex.Message}");
+                    FatalError($"Failed to delete '{digitalTwinId}' due to {ex.Message}");
                 }
             }
         }
@@ -254,12 +256,12 @@ namespace Azure.DigitalTwins.Core.Samples
                 {
                     Response<string> response = await client.CreateDigitalTwinAsync(twin.Key, twin.Value);
 
-                    Console.WriteLine($"Created digital twin {twin.Key}. Create response status: {response.GetRawResponse().Status}");
-                    Console.WriteLine($"Body: {response?.Value}");
+                    Console.WriteLine($"Created digital twin '{twin.Key}'.");
+                    Console.WriteLine($"\tBody: {response?.Value}");
                 }
                 catch (Exception ex)
                 {
-                    FatalError($"Could not create digital twin {twin.Key} due to {ex}");
+                    FatalError($"Could not create digital twin '{twin.Key}' due to {ex}");
                 }
             }
         }
@@ -284,7 +286,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 await foreach (string response in asyncPageableResponse)
                 {
                     BasicDigitalTwin twin = JsonSerializer.Deserialize<BasicDigitalTwin>(response);
-                    Console.WriteLine($"Found digital twin: {twin.Id}");
+                    Console.WriteLine($"Found digital twin '{twin.Id}'");
                 }
 
                 #endregion Snippet:DigitalTwinsSampleQueryTwins
@@ -316,7 +318,7 @@ namespace Azure.DigitalTwins.Core.Samples
                     foreach (string response in page.Values)
                     {
                         BasicDigitalTwin twin = JsonSerializer.Deserialize<BasicDigitalTwin>(response);
-                        Console.WriteLine($"Found digital twin: {twin.Id}");
+                        Console.WriteLine($"Found digital twin '{twin.Id}'");
                     }
                 }
 
@@ -357,11 +359,11 @@ namespace Azure.DigitalTwins.Core.Samples
                             relationship.Id,
                             serializedRelationship);
 
-                        Console.WriteLine($"Linked twin {relationship.SourceId} to twin {relationship.TargetId} as '{relationship.Name}'");
+                        Console.WriteLine($"Linked twin '{relationship.SourceId}' to twin '{relationship.TargetId}' as '{relationship.Name}'");
                     }
                     catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Conflict)
                     {
-                        Console.WriteLine($"Relationship {relationship.Id} already exists: {ex.Message}");
+                        Console.WriteLine($"Relationship '{relationship.Id}' already exists: {ex.Message}");
                     }
                 }
             }
@@ -380,7 +382,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 AsyncPageable<EventRoute> response = client.GetEventRoutesAsync();
                 await foreach (EventRoute er in response)
                 {
-                    Console.WriteLine($"Event route: {er.Id}, endpoint name: {er.EndpointName}");
+                    Console.WriteLine($"Event route '{er.Id}', endpoint name '{er.EndpointName}'");
                 }
 
                 #endregion Snippet:DigitalTwinsSampleGetEventRoutes
@@ -407,8 +409,8 @@ namespace Azure.DigitalTwins.Core.Samples
                     Filter = eventFilter
                 };
 
-                Response createEventRouteResponse = await client.CreateEventRouteAsync(_eventRouteId, eventRoute);
-                Console.WriteLine($"Created event route with Id {_eventRouteId}. Response status: {createEventRouteResponse.Status}");
+                await client.CreateEventRouteAsync(_eventRouteId, eventRoute);
+                Console.WriteLine($"Created event route '{_eventRouteId}'.");
 
                 #endregion Snippet:DigitalTwinsSampleCreateEventRoute
             }
@@ -428,14 +430,14 @@ namespace Azure.DigitalTwins.Core.Samples
             {
                 #region Snippet:DigitalTwinsSampleDeleteEventRoute
 
-                Response response = await client.DeleteEventRouteAsync(_eventRouteId);
-                Console.WriteLine($"Deleted event route with Id {_eventRouteId}. Response status: {response.Status}");
+                await client.DeleteEventRouteAsync(_eventRouteId);
+                Console.WriteLine($"Deleted event route '{_eventRouteId}'.");
 
                 #endregion Snippet:DigitalTwinsSampleDeleteEventRoute
             }
             catch (Exception ex)
             {
-                FatalError($"Could not delete event routes due to {ex.Message}");
+                FatalError($"Could not delete event routes due to: {ex.Message}");
             }
         }
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/ModelLifecycleSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/ModelLifecycleSamples.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Azure.DigitalTwins.Core;
@@ -42,8 +41,8 @@ namespace Azure.DigitalTwins.Samples
             {
                 #region Snippet:DigitalTwinsSampleCreateModels
 
-                Response<IReadOnlyList<ModelData>> response = await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
-                Console.WriteLine($"Created models with Ids {componentModelId} and {sampleModelId}. Response status: {response.GetRawResponse().Status}");
+                await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
+                Console.WriteLine($"Created models '{componentModelId}' and '{sampleModelId}'.");
 
                 #endregion Snippet:DigitalTwinsSampleCreateModels
             }
@@ -61,11 +60,10 @@ namespace Azure.DigitalTwins.Samples
             {
                 #region Snippet:DigitalTwinsSampleGetModel
 
-                Response<ModelData> sampleModel = await client.GetModelAsync(sampleModelId);
-                Console.WriteLine($"Retrieved model with Id {sampleModelId}. Response status: {sampleModel.GetRawResponse().Status}");
+                Response<ModelData> sampleModelResponse = await client.GetModelAsync(sampleModelId);
+                Console.WriteLine($"Retrieved model '{sampleModelResponse.Value.Id}'.");
 
                 #endregion Snippet:DigitalTwinsSampleGetModel
-
             }
             catch (Exception ex)
             {
@@ -78,12 +76,12 @@ namespace Azure.DigitalTwins.Samples
 
             try
             {
-                Response decommissionModelResponse = await client.DecommissionModelAsync(sampleModelId);
-                Console.WriteLine($"Decommissioned model with Id {sampleModelId}. Response status: {decommissionModelResponse.Status}");
+                await client.DecommissionModelAsync(sampleModelId);
+                Console.WriteLine($"Decommissioned model '{sampleModelId}'.");
             }
             catch (RequestFailedException ex)
             {
-                FatalError($"Failed to decommision model with Id {sampleModelId} due to:\n{ex}");
+                FatalError($"Failed to decommision model '{sampleModelId}' due to:\n{ex}");
             }
 
             #endregion Snippet:DigitalTwinsSampleDecommisionModel
@@ -94,12 +92,12 @@ namespace Azure.DigitalTwins.Samples
 
             try
             {
-                Response deleteModelResponse = await client.DeleteModelAsync(sampleModelId);
-                Console.WriteLine($"Deleted model with Id {sampleModelId}. Response status: {deleteModelResponse.Status}");
+                await client.DeleteModelAsync(sampleModelId);
+                Console.WriteLine($"Deleted model '{sampleModelId}'.");
             }
             catch (Exception ex)
             {
-                FatalError($"Failed to delete model with Id {sampleModelId} due to:\n{ex}");
+                FatalError($"Failed to delete model '{sampleModelId}' due to:\n{ex}");
             }
 
             #endregion Snippet:DigitalTwinsSampleDeleteModel

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/Program.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/Program.cs
@@ -32,7 +32,7 @@ namespace Azure.DigitalTwins.Core.Samples
                         Environment.Exit(1);
                     });
 
-            // Instantiate the client            
+            // Instantiate the client
             DigitalTwinsClient dtClient = GetDigitalTwinsClient(
                     options.TenantId,
                     options.ClientId,
@@ -60,7 +60,7 @@ namespace Azure.DigitalTwins.Core.Samples
         /// <summary>
         /// Illustrates how to construct a <see cref="DigitalTwinsClient"/>, using the <see cref="DefaultAzureCredential"/>
         /// implementation of <see cref="Azure.Core.TokenCredential"/>.
-        /// </summary>        
+        /// </summary>
         /// <param name="adtEndpoint">The endpoint of the digital twins instance.</param>
         private static DigitalTwinsClient GetDigitalTwinsClient(string tenantId, string clientId, string clientSecret, string adtEndpoint)
         {
@@ -74,7 +74,7 @@ namespace Azure.DigitalTwins.Core.Samples
             // DefaultAzureCredential supports different authentication mechanisms and determines the appropriate credential type based of the environment it is executing in.
             // It attempts to use multiple credential types in an order until it finds a working credential.
             var tokenCredential = new DefaultAzureCredential();
-            
+
             var client = new DigitalTwinsClient(
                 new Uri(adtEndpoint),
                 tokenCredential);
@@ -82,6 +82,6 @@ namespace Azure.DigitalTwins.Core.Samples
             #endregion Snippet:DigitalTwinsSampleCreateServiceClientWithClientSecret
 
             return client;
-        }       
+        }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/PublishTelemetrySamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/PublishTelemetrySamples.cs
@@ -41,22 +41,22 @@ namespace Azure.DigitalTwins.Samples
             await client
                 .CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
 
-            Console.WriteLine($"Successfully created models with Ids: {componentModelId}, {modelId}");
+            Console.WriteLine($"Successfully created models '{componentModelId}' and '{modelId}'");
 
             // Create digital twin with Component payload.
             string twinPayload = SamplesConstants.TemporaryTwinPayload
                 .Replace(SamplesConstants.ModelId, modelId);
 
             await client.CreateDigitalTwinAsync(twinId, twinPayload);
-            Console.WriteLine($"Created digital twin {twinId}.");
+            Console.WriteLine($"Created digital twin '{twinId}'.");
 
             try
             {
                 #region Snippet:DigitalTwinsSamplePublishTelemetry
 
                 // construct your json telemetry payload by hand.
-                Response publishTelemetryResponse = await client.PublishTelemetryAsync(twinId, "{\"Telemetry1\": 5}");
-                Console.WriteLine($"Published telemetry message to twin with Id {twinId}. Response status: {publishTelemetryResponse.Status}");
+                await client.PublishTelemetryAsync(twinId, "{\"Telemetry1\": 5}");
+                Console.WriteLine($"Published telemetry message to twin '{twinId}'.");
 
                 #endregion Snippet:DigitalTwinsSamplePublishTelemetry
 
@@ -65,19 +65,19 @@ namespace Azure.DigitalTwins.Samples
                 // construct your json telemetry payload by serializing a dictionary.
                 var telemetryPayload = new Dictionary<string, int>
                 {
-                    { "ComponentTelemetry1", 9}
+                    { "ComponentTelemetry1", 9 }
                 };
-                Response publishTelemetryToComponentResponse = await client.PublishComponentTelemetryAsync(
+                await client.PublishComponentTelemetryAsync(
                     twinId,
                     "Component1",
                     JsonSerializer.Serialize(telemetryPayload));
-                Console.WriteLine($"Published component telemetry message to twin with Id {twinId}. Response status: {publishTelemetryToComponentResponse.Status}");
+                Console.WriteLine($"Published component telemetry message to twin '{twinId}'.");
 
                 #endregion Snippet:DigitalTwinsSamplePublishComponentTelemetry
             }
             catch (Exception ex)
             {
-                FatalError($"Failed to publish a telemetry message due to {ex.Message}");
+                FatalError($"Failed to publish a telemetry message due to: {ex.Message}");
             }
 
             try
@@ -95,7 +95,7 @@ namespace Azure.DigitalTwins.Samples
             }
             catch (RequestFailedException ex)
             {
-                FatalError($"Failed to delete due to {ex.Message}");
+                FatalError($"Failed to delete due to: {ex.Message}");
             }
         }
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/RelationshipSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/RelationshipSamples.cs
@@ -31,12 +31,12 @@ namespace Azure.DigitalTwins.Core.Samples
                 .Replace(SamplesConstants.RelationshipName, "contains")
                 .Replace(SamplesConstants.RelationshipTargetModelId, "dtmi:samples:SampleFloor;1");
 
-            Response<IReadOnlyList<Models.ModelData>> createBuildingModelResponse = await client.CreateModelsAsync(
+            await client.CreateModelsAsync(
                 new[]
                 {
                     buildingModelPayload
                 });
-            Console.WriteLine($"Created model with Id dtmi:samples:SampleBuilding;1. Response status: {createBuildingModelResponse.GetRawResponse().Status}.");
+            Console.WriteLine($"Created model 'dtmi:samples:SampleBuilding;1'.");
 
             // Create a floor digital twin model.
             string floorModelPayload = SamplesConstants.TemporaryModelWithRelationshipPayload
@@ -45,12 +45,8 @@ namespace Azure.DigitalTwins.Core.Samples
                 .Replace(SamplesConstants.RelationshipName, "containedIn")
                 .Replace(SamplesConstants.RelationshipTargetModelId, "dtmi:samples:SampleBuilding;1");
 
-            Response<IReadOnlyList<Models.ModelData>> createFloorModelResponse = await client.CreateModelsAsync(
-                new[]
-                {
-                    floorModelPayload
-                });
-            Console.WriteLine($"Created model with Id dtmi:samples:SampleFloor;1. Response status: {createFloorModelResponse.GetRawResponse().Status}.");
+            await client.CreateModelsAsync(new[] { floorModelPayload });
+            Console.WriteLine($"Created model 'dtmi:samples:SampleFloor;1.'");
 
             // Create a building digital twin.
             var buildingDigitalTwin = new BasicDigitalTwin
@@ -60,8 +56,8 @@ namespace Azure.DigitalTwins.Core.Samples
             };
 
             string buildingDigitalTwinPayload = JsonSerializer.Serialize(buildingDigitalTwin);
-            Response<string> createBuildingDigitalTwinResponse = await client.CreateDigitalTwinAsync("buildingTwinId", buildingDigitalTwinPayload);
-            Console.WriteLine($"Created a digital twin with Id buildingTwinId. Response status: {createBuildingDigitalTwinResponse.GetRawResponse().Status}.");
+            await client.CreateDigitalTwinAsync("buildingTwinId", buildingDigitalTwinPayload);
+            Console.WriteLine($"Created twin 'buildingTwinId'.");
 
             // Create a floor digital.
             var floorDigitalTwin = new BasicDigitalTwin
@@ -71,10 +67,11 @@ namespace Azure.DigitalTwins.Core.Samples
             };
 
             string floorDigitalTwinPayload = JsonSerializer.Serialize(floorDigitalTwin);
-            Response<string> createFloorDigitalTwinResponse = await client.CreateDigitalTwinAsync("floorTwinId", floorDigitalTwinPayload);
-            Console.WriteLine($"Created a digital twin with Id floorTwinId. Response status: {createFloorDigitalTwinResponse.GetRawResponse().Status}.");
+            await client.CreateDigitalTwinAsync("floorTwinId", floorDigitalTwinPayload);
+            Console.WriteLine($"Created twin 'floorTwinId'.");
 
             // Create a relationship between building and floor using the BasicRelationship serialization helper.
+
             #region Snippet:DigitalTwinsSampleCreateBasicRelationship
 
             var buildingFloorRelationshipPayload = new BasicRelationship
@@ -91,21 +88,20 @@ namespace Azure.DigitalTwins.Core.Samples
             };
 
             string serializedRelationship = JsonSerializer.Serialize(buildingFloorRelationshipPayload);
-            Response<string> createRelationshipResponse = await client.CreateRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId", serializedRelationship);
-            Console.WriteLine($"Created a digital twin relationship with Id buildingFloorRelationshipId from digital twin with Id buildingTwinId to digital twin with Id floorTwinId. " +
-                $"Response status: {createRelationshipResponse.GetRawResponse().Status}.");
+            await client.CreateRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId", serializedRelationship);
+            Console.WriteLine($"Created a digital twin relationship 'buildingFloorRelationshipId' from twin 'buildingTwinId' to twin 'floorTwinId'.");
 
             #endregion Snippet:DigitalTwinsSampleCreateBasicRelationship
 
             // You can get a relationship and deserialize it into a BasicRelationship.
+
             #region Snippet:DigitalTwinsSampleGetBasicRelationship
 
             Response<string> getBasicRelationshipResponse = await client.GetRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId");
             if (getBasicRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
             {
                 BasicRelationship basicRelationship = JsonSerializer.Deserialize<BasicRelationship>(getBasicRelationshipResponse.Value);
-                Console.WriteLine($"Retrieved relationship with Id {basicRelationship.Id} from digital twin with Id {basicRelationship.SourceId}. " +
-                    $"Response status: {getBasicRelationshipResponse.GetRawResponse().Status}.\n\t" +
+                Console.WriteLine($"Retrieved relationship '{basicRelationship.Id}' from twin {basicRelationship.SourceId}.\n\t" +
                     $"Prop1: {basicRelationship.CustomProperties["Prop1"]}\n\t" +
                     $"Prop2: {basicRelationship.CustomProperties["Prop2"]}");
             }
@@ -116,6 +112,7 @@ namespace Azure.DigitalTwins.Core.Samples
             // This requires less code or knowledge of the type for interaction.
 
             // Create a relationship between floorTwinId and buildingTwinId using a custom data type.
+
             #region Snippet:DigitalTwinsSampleCreateCustomRelationship
 
             var floorBuildingRelationshipPayload = new CustomRelationship
@@ -130,36 +127,32 @@ namespace Azure.DigitalTwins.Core.Samples
             string serializedCustomRelationship = JsonSerializer.Serialize(floorBuildingRelationshipPayload);
 
             Response<string> createCustomRelationshipResponse = await client.CreateRelationshipAsync("floorTwinId", "floorBuildingRelationshipId", serializedCustomRelationship);
-            Console.WriteLine($"Created a digital twin relationship with Id floorBuildingRelationshipId from digital twin with Id floorTwinId to digital twin with Id buildingTwinId. " +
-                $"Response status: {createCustomRelationshipResponse.GetRawResponse().Status}.");
+            Console.WriteLine($"Created a digital twin relationship 'floorBuildingRelationshipId' from twin 'floorTwinId' to twin 'buildingTwinId'.");
 
             #endregion Snippet:DigitalTwinsSampleCreateCustomRelationship
 
             // Getting and deserializing a relationship into a custom data type is extremely easy.
+
             #region Snippet:DigitalTwinsSampleGetCustomRelationship
 
             Response<string> getCustomRelationshipResponse = await client.GetRelationshipAsync("floorTwinId", "floorBuildingRelationshipId");
-            if (getCustomRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
-            {
-                CustomRelationship getCustomRelationship = JsonSerializer.Deserialize<CustomRelationship>(getCustomRelationshipResponse.Value);
-                Console.WriteLine($"Retrieved and deserialized relationship with Id {getCustomRelationship.Id} from digital twin with Id {getCustomRelationship.SourceId}. " +
-                    $"Response status: {getCustomRelationshipResponse.GetRawResponse().Status}.\n\t" +
-                    $"Prop1: {getCustomRelationship.Prop1}\n\t" +
-                    $"Prop2: {getCustomRelationship.Prop2}");
-            }
+            CustomRelationship getCustomRelationship = JsonSerializer.Deserialize<CustomRelationship>(getCustomRelationshipResponse.Value);
+            Console.WriteLine($"Retrieved and deserialized relationship '{getCustomRelationship.Id}' from twin '{getCustomRelationship.SourceId}'.\n\t" +
+                $"Prop1: {getCustomRelationship.Prop1}\n\t" +
+                $"Prop2: {getCustomRelationship.Prop2}");
 
             #endregion Snippet:DigitalTwinsSampleGetCustomRelationship
 
             // Get all relationships in the graph where buildingTwinId is the source of the relationship.
+
             #region Snippet:DigitalTwinsSampleGetAllRelationships
 
             AsyncPageable<string> relationships = client.GetRelationshipsAsync("buildingTwinId");
-
             await foreach (var relationshipJson in relationships)
             {
                 BasicRelationship relationship = JsonSerializer.Deserialize<BasicRelationship>(relationshipJson);
-                Console.WriteLine($"Found relationship with Id {relationship.Id} with a digital twin source Id {relationship.SourceId} and " +
-                    $"a digital twin target Id {relationship.TargetId}. \n\t " +
+                Console.WriteLine($"Retrieved relationship '{relationship.Id}' with source {relationship.SourceId}' and " +
+                    $"target {relationship.TargetId}.\n\t" +
                     $"Prop1: {relationship.CustomProperties["Prop1"]}\n\t" +
                     $"Prop2: {relationship.CustomProperties["Prop2"]}");
             }
@@ -167,29 +160,30 @@ namespace Azure.DigitalTwins.Core.Samples
             #endregion Snippet:DigitalTwinsSampleGetAllRelationships
 
             // Get all incoming relationships in the graph where buildingTwinId is the target of the relationship.
+
             #region Snippet:DigitalTwinsSampleGetIncomingRelationships
 
             AsyncPageable<IncomingRelationship> incomingRelationships = client.GetIncomingRelationshipsAsync("buildingTwinId");
 
             await foreach (IncomingRelationship incomingRelationship in incomingRelationships)
             {
-                Console.WriteLine($"Found an incoming relationship with Id {incomingRelationship.RelationshipId} coming from a digital twin with Id {incomingRelationship.SourceId}.");
+                Console.WriteLine($"Found an incoming relationship '{incomingRelationship.RelationshipId}' from '{incomingRelationship.SourceId}'.");
             }
 
             #endregion Snippet:DigitalTwinsSampleGetIncomingRelationships
 
             // Delete the contains relationship, created earlier in the sample code, from building to floor.
-            
+
             #region Snippet:DigitalTwinsSampleDeleteRelationship
 
-            Response deleteBuildingRelationshipResponse = await client.DeleteRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId");
-            Console.WriteLine($"Deleted relationship with Id buildingFloorRelationshipId. Status response: {deleteBuildingRelationshipResponse.Status}.");
+            await client.DeleteRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId");
+            Console.WriteLine($"Deleted relationship 'buildingFloorRelationshipId'.");
 
             #endregion Snippet:DigitalTwinsSampleDeleteRelationship
 
             // Delete the containedIn relationship, created earlier in the sample code, from floor to building.
-            Response deleteFloorRelationshipResponse = await client.DeleteRelationshipAsync("floorTwinId", "floorBuildingRelationshipId");
-            Console.WriteLine($"Deleted relationship with Id floorBuildingRelationshipId. Status response: {deleteFloorRelationshipResponse.Status}.");
+            await client.DeleteRelationshipAsync("floorTwinId", "floorBuildingRelationshipId");
+            Console.WriteLine($"Deleted relationship 'floorBuildingRelationshipId'.");
 
             // Clean up.
             try
@@ -200,7 +194,7 @@ namespace Azure.DigitalTwins.Core.Samples
             }
             catch (RequestFailedException ex)
             {
-                Console.WriteLine($"Failed to delete digital twin due to {ex}.");
+                Console.WriteLine($"Failed to delete twin due to {ex}.");
             }
 
             try

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
@@ -56,8 +56,8 @@ Let's create models using the code below. You need to pass in `List<string>` con
 Check out sample models [here](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DTDL/Models).
 
 ```C# Snippet:DigitalTwinsSampleCreateModels
-Response<IReadOnlyList<ModelData>> response = await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
-Console.WriteLine($"Created models with Ids {componentModelId} and {sampleModelId}. Response status: {response.GetRawResponse().Status}");
+await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
+Console.WriteLine($"Created models '{componentModelId}' and '{sampleModelId}'.");
 ```
 
 ### List models
@@ -68,15 +68,18 @@ Using `GetModelsAsync`, all created models are returned as `AsyncPageable<ModelD
 AsyncPageable<ModelData> allModels = client.GetModelsAsync();
 await foreach (ModelData model in allModels)
 {
-    Console.WriteLine($"Retrieved model with Id {model.Id}, display name {model.DisplayName["en"]}, upload time {model.UploadTime}, and decommissioned: {model.Decommissioned}");
+    Console.WriteLine($"Retrieved model '{model.Id}', " +
+        $"display name '{model.DisplayName["en"]}', " +
+        $"upload time '{model.UploadTime}', " +
+        $"and decommissioned '{model.Decommissioned}'");
 }
 ```
 
 Use `GetModelAsync` with model's unique identifier to get a specific model.
 
 ```C# Snippet:DigitalTwinsSampleGetModel
-Response<ModelData> sampleModel = await client.GetModelAsync(sampleModelId);
-Console.WriteLine($"Retrieved model with Id {sampleModelId}. Response status: {sampleModel.GetRawResponse().Status}");
+Response<ModelData> sampleModelResponse = await client.GetModelAsync(sampleModelId);
+Console.WriteLine($"Retrieved model '{sampleModelResponse.Value.Id}'.");
 ```
 
 ### Decommission models
@@ -86,12 +89,12 @@ To decommision a model, pass in a model Id for the model you want to decommision
 ```C# Snippet:DigitalTwinsSampleDecommisionModel
 try
 {
-    Response decommissionModelResponse = await client.DecommissionModelAsync(sampleModelId);
-    Console.WriteLine($"Decommissioned model with Id {sampleModelId}. Response status: {decommissionModelResponse.Status}");
+    await client.DecommissionModelAsync(sampleModelId);
+    Console.WriteLine($"Decommissioned model '{sampleModelId}'.");
 }
 catch (RequestFailedException ex)
 {
-    FatalError($"Failed to decommision model with Id {sampleModelId} due to:\n{ex}");
+    FatalError($"Failed to decommision model '{sampleModelId}' due to:\n{ex}");
 }
 ```
 
@@ -102,12 +105,12 @@ To delete a model, pass in a model Id for the model you want to delete.
 ```C# Snippet:DigitalTwinsSampleDeleteModel
 try
 {
-    Response deleteModelResponse = await client.DeleteModelAsync(sampleModelId);
-    Console.WriteLine($"Deleted model with Id {sampleModelId}. Response status: {deleteModelResponse.Status}");
+    await client.DeleteModelAsync(sampleModelId);
+    Console.WriteLine($"Deleted model '{sampleModelId}'.");
 }
 catch (Exception ex)
 {
-    FatalError($"Failed to delete model with Id {sampleModelId} due to:\n{ex}");
+    FatalError($"Failed to delete model '{sampleModelId}' due to:\n{ex}");
 }
 ```
 
@@ -151,8 +154,8 @@ var basicTwin = new BasicDigitalTwin
 
 string basicDtPayload = JsonSerializer.Serialize(basicTwin);
 
-Response<string> createBasicDtResponse = await client.CreateDigitalTwinAsync(basicDtId, basicDtPayload);
-Console.WriteLine($"Created digital twin with Id {basicDtId}. Response status: {createBasicDtResponse.GetRawResponse().Status}.");
+await client.CreateDigitalTwinAsync(basicDtId, basicDtPayload);
+Console.WriteLine($"Created digital twin '{basicDtId}'.");
 ```
 
 Alternatively, you can create your own custom data types to serialize and deserialize your digital twins.
@@ -174,8 +177,8 @@ var customTwin = new CustomDigitalTwin
 };
 string dt2Payload = JsonSerializer.Serialize(customTwin);
 
-Response<string> createCustomDtResponse = await client.CreateDigitalTwinAsync(customDtId, dt2Payload);
-Console.WriteLine($"Created digital twin with Id {customDtId}. Response status: {createCustomDtResponse.GetRawResponse().Status}.");
+await client.CreateDigitalTwinAsync(customDtId, dt2Payload);
+Console.WriteLine($"Created digital twin '{customDtId}'.");
 ```
 
 ### Get and deserialize a digital twin
@@ -208,16 +211,13 @@ Custom types provide the best possible experience.
 
 ```C# Snippet:DigitalTwinsSampleGetCustomDigitalTwin
 Response<string> getCustomDtResponse = await client.GetDigitalTwinAsync(customDtId);
-if (getCustomDtResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
-{
-    CustomDigitalTwin customDt = JsonSerializer.Deserialize<CustomDigitalTwin>(getCustomDtResponse.Value);
-    Console.WriteLine($"Retrieved and deserialized digital twin {customDt.Id}:\n\t" +
-        $"ETag: {customDt.ETag}\n\t" +
-        $"Prop1: {customDt.Prop1}\n\t" +
-        $"Prop2: {customDt.Prop2}\n\t" +
-        $"ComponentProp1: {customDt.Component1.ComponentProp1}\n\t" +
-        $"ComponentProp2: {customDt.Component1.ComponentProp2}");
-}
+CustomDigitalTwin customDt = JsonSerializer.Deserialize<CustomDigitalTwin>(getCustomDtResponse.Value);
+Console.WriteLine($"Retrieved and deserialized digital twin {customDt.Id}:\n\t" +
+    $"ETag: {customDt.ETag}\n\t" +
+    $"Prop1: {customDt.Prop1}\n\t" +
+    $"Prop2: {customDt.Prop2}\n\t" +
+    $"ComponentProp1: {customDt.Component1.ComponentProp1}\n\t" +
+    $"ComponentProp2: {customDt.Component1.ComponentProp2}");
 ```
 
 ### Query digital twins
@@ -235,7 +235,7 @@ AsyncPageable<string> asyncPageableResponse = client.QueryAsync("SELECT * FROM d
 await foreach (string response in asyncPageableResponse)
 {
     BasicDigitalTwin twin = JsonSerializer.Deserialize<BasicDigitalTwin>(response);
-    Console.WriteLine($"Found digital twin: {twin.Id}");
+    Console.WriteLine($"Found digital twin '{twin.Id}'");
 }
 ```
 
@@ -265,7 +265,7 @@ await foreach (Page<string> page in asyncPageableResponseWithCharge.AsPages())
     foreach (string response in page.Values)
     {
         BasicDigitalTwin twin = JsonSerializer.Deserialize<BasicDigitalTwin>(response);
-        Console.WriteLine($"Found digital twin: {twin.Id}");
+        Console.WriteLine($"Found digital twin '{twin.Id}'");
     }
 }
 ```
@@ -275,8 +275,8 @@ await foreach (Page<string> page in asyncPageableResponseWithCharge.AsPages())
 Delete a digital twin simply by providing Id of a digital twin as below.
 
 ```C# Snippet:DigitalTwinsSampleDeleteTwin
-Response deleteDigitalTwinResponse = await client.DeleteDigitalTwinAsync(digitalTwinId);
-Console.WriteLine($"Deleted digital twin with Id {digitalTwinId}. Response Status: {deleteDigitalTwinResponse.Status}");
+await client.DeleteDigitalTwinAsync(digitalTwinId);
+Console.WriteLine($"Deleted digital twin '{digitalTwinId}'.");
 ```
 
 ## Get and update digital twin components
@@ -286,14 +286,13 @@ Console.WriteLine($"Deleted digital twin with Id {digitalTwinId}. Response Statu
 To update a component or in other words to replace, remove and/or add a component property or subproperty within Digital Twin, you would need Id of a digital twin, component name and application/json-patch+json operations to be performed on the specified digital twin's component. Here is the sample code on how to do it.
 
 ```C# Snippet:DigitalTwinsSampleUpdateComponent
-// Update Component1 by replacing the property ComponentProp1 value
+// Update Component1 by replacing the property ComponentProp1 value,
+// using an optional utility to build the payload.
 var componentUpdateUtility = new UpdateOperationsUtility();
 componentUpdateUtility.AppendReplaceOp("/ComponentProp1", "Some new value");
 string updatePayload = componentUpdateUtility.Serialize();
-
-Response<string> response = await client.UpdateComponentAsync(basicDtId, "Component1", updatePayload);
-
-Console.WriteLine($"Updated component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}");
+await client.UpdateComponentAsync(basicDtId, "Component1", updatePayload);
+Console.WriteLine($"Updated component for digital twin '{basicDtId}'.");
 ```
 
 ### Get digital twin components
@@ -301,9 +300,8 @@ Console.WriteLine($"Updated component for digital twin with Id {basicDtId}. Resp
 Get a component by providing name of a component and Id of digital twin to which it belongs.
 
 ```C# Snippet:DigitalTwinsSampleGetComponent
-response = await client.GetComponentAsync(basicDtId, SamplesConstants.ComponentPath);
-
-Console.WriteLine($"Retrieved component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}");
+await client.GetComponentAsync(basicDtId, SamplesConstants.ComponentPath);
+Console.WriteLine($"Retrieved component for digital twin '{basicDtId}'.");
 ```
 
 ## Create, get,  list and delete digital twin relationships
@@ -330,9 +328,8 @@ var buildingFloorRelationshipPayload = new BasicRelationship
 };
 
 string serializedRelationship = JsonSerializer.Serialize(buildingFloorRelationshipPayload);
-Response<string> createRelationshipResponse = await client.CreateRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId", serializedRelationship);
-Console.WriteLine($"Created a digital twin relationship with Id buildingFloorRelationshipId from digital twin with Id buildingTwinId to digital twin with Id floorTwinId. " +
-    $"Response status: {createRelationshipResponse.GetRawResponse().Status}.");
+await client.CreateRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId", serializedRelationship);
+Console.WriteLine($"Created a digital twin relationship 'buildingFloorRelationshipId' from twin 'buildingTwinId' to twin 'floorTwinId'.");
 ```
 
 Alternatively, you can create your own custom data types to serialize and deserialize your relationships.
@@ -352,8 +349,7 @@ var floorBuildingRelationshipPayload = new CustomRelationship
 string serializedCustomRelationship = JsonSerializer.Serialize(floorBuildingRelationshipPayload);
 
 Response<string> createCustomRelationshipResponse = await client.CreateRelationshipAsync("floorTwinId", "floorBuildingRelationshipId", serializedCustomRelationship);
-Console.WriteLine($"Created a digital twin relationship with Id floorBuildingRelationshipId from digital twin with Id floorTwinId to digital twin with Id buildingTwinId. " +
-    $"Response status: {createCustomRelationshipResponse.GetRawResponse().Status}.");
+Console.WriteLine($"Created a digital twin relationship 'floorBuildingRelationshipId' from twin 'floorTwinId' to twin 'buildingTwinId'.");
 ```
 
 ### Get and deserialize a digital twin relationship
@@ -364,8 +360,7 @@ Response<string> getBasicRelationshipResponse = await client.GetRelationshipAsyn
 if (getBasicRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
 {
     BasicRelationship basicRelationship = JsonSerializer.Deserialize<BasicRelationship>(getBasicRelationshipResponse.Value);
-    Console.WriteLine($"Retrieved relationship with Id {basicRelationship.Id} from digital twin with Id {basicRelationship.SourceId}. " +
-        $"Response status: {getBasicRelationshipResponse.GetRawResponse().Status}.\n\t" +
+    Console.WriteLine($"Retrieved relationship '{basicRelationship.Id}' from twin {basicRelationship.SourceId}.\n\t" +
         $"Prop1: {basicRelationship.CustomProperties["Prop1"]}\n\t" +
         $"Prop2: {basicRelationship.CustomProperties["Prop2"]}");
 }
@@ -374,14 +369,10 @@ if (getBasicRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.
 Getting and deserializing a digital twin relationship into a custom data type is as easy.
 ```C# Snippet:DigitalTwinsSampleGetCustomRelationship
 Response<string> getCustomRelationshipResponse = await client.GetRelationshipAsync("floorTwinId", "floorBuildingRelationshipId");
-if (getCustomRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
-{
-    CustomRelationship getCustomRelationship = JsonSerializer.Deserialize<CustomRelationship>(getCustomRelationshipResponse.Value);
-    Console.WriteLine($"Retrieved and deserialized relationship with Id {getCustomRelationship.Id} from digital twin with Id {getCustomRelationship.SourceId}. " +
-        $"Response status: {getCustomRelationshipResponse.GetRawResponse().Status}.\n\t" +
-        $"Prop1: {getCustomRelationship.Prop1}\n\t" +
-        $"Prop2: {getCustomRelationship.Prop2}");
-}
+CustomRelationship getCustomRelationship = JsonSerializer.Deserialize<CustomRelationship>(getCustomRelationshipResponse.Value);
+Console.WriteLine($"Retrieved and deserialized relationship '{getCustomRelationship.Id}' from twin '{getCustomRelationship.SourceId}'.\n\t" +
+    $"Prop1: {getCustomRelationship.Prop1}\n\t" +
+    $"Prop2: {getCustomRelationship.Prop2}");
 ```
 
 ### List digital twin relationships
@@ -390,12 +381,11 @@ if (getCustomRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode
 
 ```C# Snippet:DigitalTwinsSampleGetAllRelationships
 AsyncPageable<string> relationships = client.GetRelationshipsAsync("buildingTwinId");
-
 await foreach (var relationshipJson in relationships)
 {
     BasicRelationship relationship = JsonSerializer.Deserialize<BasicRelationship>(relationshipJson);
-    Console.WriteLine($"Found relationship with Id {relationship.Id} with a digital twin source Id {relationship.SourceId} and " +
-        $"a digital twin target Id {relationship.TargetId}. \n\t " +
+    Console.WriteLine($"Retrieved relationship '{relationship.Id}' with source {relationship.SourceId}' and " +
+        $"target {relationship.TargetId}.\n\t" +
         $"Prop1: {relationship.CustomProperties["Prop1"]}\n\t" +
         $"Prop2: {relationship.CustomProperties["Prop2"]}");
 }
@@ -408,7 +398,7 @@ AsyncPageable<IncomingRelationship> incomingRelationships = client.GetIncomingRe
 
 await foreach (IncomingRelationship incomingRelationship in incomingRelationships)
 {
-    Console.WriteLine($"Found an incoming relationship with Id {incomingRelationship.RelationshipId} coming from a digital twin with Id {incomingRelationship.SourceId}.");
+    Console.WriteLine($"Found an incoming relationship '{incomingRelationship.RelationshipId}' from '{incomingRelationship.SourceId}'.");
 }
 ```
 
@@ -417,8 +407,8 @@ await foreach (IncomingRelationship incomingRelationship in incomingRelationship
 To delete all outgoing relationships for a digital twin, simply iterate over the relationships and delete them iteratively.
 
 ```C# Snippet:DigitalTwinsSampleDeleteRelationship
-Response deleteBuildingRelationshipResponse = await client.DeleteRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId");
-Console.WriteLine($"Deleted relationship with Id buildingFloorRelationshipId. Status response: {deleteBuildingRelationshipResponse.Status}.");
+await client.DeleteRelationshipAsync("buildingTwinId", "buildingFloorRelationshipId");
+Console.WriteLine($"Deleted relationship 'buildingFloorRelationshipId'.");
 ```
 
 ## Create, list, and delete event routes of digital twins
@@ -434,8 +424,8 @@ var eventRoute = new EventRoute(eventhubEndpointName)
     Filter = eventFilter
 };
 
-Response createEventRouteResponse = await client.CreateEventRouteAsync(_eventRouteId, eventRoute);
-Console.WriteLine($"Created event route with Id {_eventRouteId}. Response status: {createEventRouteResponse.Status}");
+await client.CreateEventRouteAsync(_eventRouteId, eventRoute);
+Console.WriteLine($"Created event route '{_eventRouteId}'.");
 ```
 
 For more information on the event route filter language, see the "how to manage routes" [filter events documentation](https://github.com/Azure/azure-digital-twins/blob/private-preview/Documentation/how-to-manage-routes.md#filter-events).
@@ -448,7 +438,7 @@ List a specific event route given event route Id or all event routes setting opt
 AsyncPageable<EventRoute> response = client.GetEventRoutesAsync();
 await foreach (EventRoute er in response)
 {
-    Console.WriteLine($"Event route: {er.Id}, endpoint name: {er.EndpointName}");
+    Console.WriteLine($"Event route '{er.Id}', endpoint name '{er.EndpointName}'");
 }
 ```
 
@@ -457,8 +447,8 @@ await foreach (EventRoute er in response)
 Delete an event route given event route Id.
 
 ```C# Snippet:DigitalTwinsSampleDeleteEventRoute
-Response response = await client.DeleteEventRouteAsync(_eventRouteId);
-Console.WriteLine($"Deleted event route with Id {_eventRouteId}. Response status: {response.Status}");
+await client.DeleteEventRouteAsync(_eventRouteId);
+Console.WriteLine($"Deleted event route '{_eventRouteId}'.");
 ```
 
 ### Publish telemetry messages for a digital twin
@@ -467,8 +457,8 @@ To publish a telemetry message for a digital twin, you need to provide the digit
 
 ```C# Snippet:DigitalTwinsSamplePublishTelemetry
 // construct your json telemetry payload by hand.
-Response publishTelemetryResponse = await client.PublishTelemetryAsync(twinId, "{\"Telemetry1\": 5}");
-Console.WriteLine($"Published telemetry message to twin with Id {twinId}. Response status: {publishTelemetryResponse.Status}");
+await client.PublishTelemetryAsync(twinId, "{\"Telemetry1\": 5}");
+Console.WriteLine($"Published telemetry message to twin '{twinId}'.");
 ```
 
 You can also publish a telemetry message for a specific component in a digital twin. In addition to the digital twin Id and payload, you need to specify the target component Id.
@@ -477,11 +467,11 @@ You can also publish a telemetry message for a specific component in a digital t
 // construct your json telemetry payload by serializing a dictionary.
 var telemetryPayload = new Dictionary<string, int>
 {
-    { "ComponentTelemetry1", 9}
+    { "ComponentTelemetry1", 9 }
 };
-Response publishTelemetryToComponentResponse = await client.PublishComponentTelemetryAsync(
+await client.PublishComponentTelemetryAsync(
     twinId,
     "Component1",
     JsonSerializer.Serialize(telemetryPayload));
-Console.WriteLine($"Published component telemetry message to twin with Id {twinId}. Response status: {publishTelemetryToComponentResponse.Status}");
+Console.WriteLine($"Published component telemetry message to twin '{twinId}'.");
 ```

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -124,16 +124,13 @@ namespace Azure.DigitalTwins.Core
         ///
         /// <code snippet="Snippet:DigitalTwinsSampleGetCustomDigitalTwin">
         /// Response&lt;string&gt; getCustomDtResponse = await client.GetDigitalTwinAsync(customDtId);
-        /// if (getCustomDtResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
-        /// {
-        ///     CustomDigitalTwin customDt = JsonSerializer.Deserialize&lt;CustomDigitalTwin&gt;(getCustomDtResponse.Value);
-        ///     Console.WriteLine($&quot;Retrieved and deserialized digital twin {customDt.Id}:\n\t&quot; +
-        ///         $&quot;ETag: {customDt.ETag}\n\t&quot; +
-        ///         $&quot;Prop1: {customDt.Prop1}\n\t&quot; +
-        ///         $&quot;Prop2: {customDt.Prop2}\n\t&quot; +
-        ///         $&quot;ComponentProp1: {customDt.Component1.ComponentProp1}\n\t&quot; +
-        ///         $&quot;ComponentProp2: {customDt.Component1.ComponentProp2}&quot;);
-        /// }
+        /// CustomDigitalTwin customDt = JsonSerializer.Deserialize&lt;CustomDigitalTwin&gt;(getCustomDtResponse.Value);
+        /// Console.WriteLine($&quot;Retrieved and deserialized digital twin {customDt.Id}:\n\t&quot; +
+        ///     $&quot;ETag: {customDt.ETag}\n\t&quot; +
+        ///     $&quot;Prop1: {customDt.Prop1}\n\t&quot; +
+        ///     $&quot;Prop2: {customDt.Prop2}\n\t&quot; +
+        ///     $&quot;ComponentProp1: {customDt.Component1.ComponentProp1}\n\t&quot; +
+        ///     $&quot;ComponentProp2: {customDt.Component1.ComponentProp2}&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<string>> GetDigitalTwinAsync(string digitalTwinId, CancellationToken cancellationToken = default)
@@ -200,8 +197,8 @@ namespace Azure.DigitalTwins.Core
         /// };
         /// string dt2Payload = JsonSerializer.Serialize(customTwin);
         ///
-        /// Response&lt;string&gt; createCustomDtResponse = await client.CreateDigitalTwinAsync(customDtId, dt2Payload);
-        /// Console.WriteLine($&quot;Created digital twin with Id {customDtId}. Response status: {createCustomDtResponse.GetRawResponse().Status}.&quot;);
+        /// await client.CreateDigitalTwinAsync(customDtId, dt2Payload);
+        /// Console.WriteLine($&quot;Created digital twin &apos;{customDtId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<string>> CreateDigitalTwinAsync(string digitalTwinId, string digitalTwin, CancellationToken cancellationToken = default)
@@ -251,8 +248,8 @@ namespace Azure.DigitalTwins.Core
         /// </remarks>
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSampleDeleteTwin">
-        /// Response deleteDigitalTwinResponse = await client.DeleteDigitalTwinAsync(digitalTwinId);
-        /// Console.WriteLine($&quot;Deleted digital twin with Id {digitalTwinId}. Response Status: {deleteDigitalTwinResponse.Status}&quot;);
+        /// await client.DeleteDigitalTwinAsync(digitalTwinId);
+        /// Console.WriteLine($&quot;Deleted digital twin &apos;{digitalTwinId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response> DeleteDigitalTwinAsync(string digitalTwinId, RequestOptions requestOptions = default, CancellationToken cancellationToken = default)
@@ -351,9 +348,8 @@ namespace Azure.DigitalTwins.Core
         /// </exception>
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSampleGetComponent">
-        /// response = await client.GetComponentAsync(basicDtId, SamplesConstants.ComponentPath);
-        ///
-        /// Console.WriteLine($&quot;Retrieved component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}&quot;);
+        /// await client.GetComponentAsync(basicDtId, SamplesConstants.ComponentPath);
+        /// Console.WriteLine($&quot;Retrieved component for digital twin &apos;{basicDtId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<string>> GetComponentAsync(string digitalTwinId, string componentPath, CancellationToken cancellationToken = default)
@@ -405,14 +401,13 @@ namespace Azure.DigitalTwins.Core
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="componentPath"/> is <c>null</c>.
         /// </exception>
         /// <code snippet="Snippet:DigitalTwinsSampleUpdateComponent">
-        /// // Update Component1 by replacing the property ComponentProp1 value
+        /// // Update Component1 by replacing the property ComponentProp1 value,
+        /// // using an optional utility to build the payload.
         /// var componentUpdateUtility = new UpdateOperationsUtility();
         /// componentUpdateUtility.AppendReplaceOp(&quot;/ComponentProp1&quot;, &quot;Some new value&quot;);
         /// string updatePayload = componentUpdateUtility.Serialize();
-        ///
-        /// Response&lt;string&gt; response = await client.UpdateComponentAsync(basicDtId, &quot;Component1&quot;, updatePayload);
-        ///
-        /// Console.WriteLine($&quot;Updated component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}&quot;);
+        /// await client.UpdateComponentAsync(basicDtId, &quot;Component1&quot;, updatePayload);
+        /// Console.WriteLine($&quot;Updated component for digital twin &apos;{basicDtId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<string>> UpdateComponentAsync(string digitalTwinId, string componentPath, string componentUpdateOperations, RequestOptions requestOptions = default, CancellationToken cancellationToken = default)
@@ -473,12 +468,11 @@ namespace Azure.DigitalTwins.Core
         /// This sample demonstrates iterating over outgoing relationships and deserializing relationship strings into BasicRelationship objects.
         /// <code snippet="Snippet:DigitalTwinsSampleGetAllRelationships">
         /// AsyncPageable&lt;string&gt; relationships = client.GetRelationshipsAsync(&quot;buildingTwinId&quot;);
-        ///
         /// await foreach (var relationshipJson in relationships)
         /// {
         ///     BasicRelationship relationship = JsonSerializer.Deserialize&lt;BasicRelationship&gt;(relationshipJson);
-        ///     Console.WriteLine($&quot;Found relationship with Id {relationship.Id} with a digital twin source Id {relationship.SourceId} and &quot; +
-        ///         $&quot;a digital twin target Id {relationship.TargetId}. \n\t &quot; +
+        ///     Console.WriteLine($&quot;Retrieved relationship &apos;{relationship.Id}&apos; with source {relationship.SourceId}&apos; and &quot; +
+        ///         $&quot;target {relationship.TargetId}.\n\t&quot; +
         ///         $&quot;Prop1: {relationship.CustomProperties[&quot;Prop1&quot;]}\n\t&quot; +
         ///         $&quot;Prop2: {relationship.CustomProperties[&quot;Prop2&quot;]}&quot;);
         /// }
@@ -608,7 +602,7 @@ namespace Azure.DigitalTwins.Core
         ///
         /// await foreach (IncomingRelationship incomingRelationship in incomingRelationships)
         /// {
-        ///     Console.WriteLine($&quot;Found an incoming relationship with Id {incomingRelationship.RelationshipId} coming from a digital twin with Id {incomingRelationship.SourceId}.&quot;);
+        ///     Console.WriteLine($&quot;Found an incoming relationship &apos;{incomingRelationship.RelationshipId}&apos; from &apos;{incomingRelationship.SourceId}&apos;.&quot;);
         /// }
         /// </code>
         /// </example>
@@ -726,14 +720,10 @@ namespace Azure.DigitalTwins.Core
         /// This sample demonstrates getting and deserializing a digital twin relationship into a custom data type.
         /// <code snippet="Snippet:DigitalTwinsSampleGetCustomRelationship">
         /// Response&lt;string&gt; getCustomRelationshipResponse = await client.GetRelationshipAsync(&quot;floorTwinId&quot;, &quot;floorBuildingRelationshipId&quot;);
-        /// if (getCustomRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
-        /// {
-        ///     CustomRelationship getCustomRelationship = JsonSerializer.Deserialize&lt;CustomRelationship&gt;(getCustomRelationshipResponse.Value);
-        ///     Console.WriteLine($&quot;Retrieved and deserialized relationship with Id {getCustomRelationship.Id} from digital twin with Id {getCustomRelationship.SourceId}. &quot; +
-        ///         $&quot;Response status: {getCustomRelationshipResponse.GetRawResponse().Status}.\n\t&quot; +
-        ///         $&quot;Prop1: {getCustomRelationship.Prop1}\n\t&quot; +
-        ///         $&quot;Prop2: {getCustomRelationship.Prop2}&quot;);
-        /// }
+        /// CustomRelationship getCustomRelationship = JsonSerializer.Deserialize&lt;CustomRelationship&gt;(getCustomRelationshipResponse.Value);
+        /// Console.WriteLine($&quot;Retrieved and deserialized relationship &apos;{getCustomRelationship.Id}&apos; from twin &apos;{getCustomRelationship.SourceId}&apos;.\n\t&quot; +
+        ///     $&quot;Prop1: {getCustomRelationship.Prop1}\n\t&quot; +
+        ///     $&quot;Prop2: {getCustomRelationship.Prop2}&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<string>> GetRelationshipAsync(string digitalTwinId, string relationshipId, CancellationToken cancellationToken = default)
@@ -848,8 +838,7 @@ namespace Azure.DigitalTwins.Core
         /// string serializedCustomRelationship = JsonSerializer.Serialize(floorBuildingRelationshipPayload);
         ///
         /// Response&lt;string&gt; createCustomRelationshipResponse = await client.CreateRelationshipAsync(&quot;floorTwinId&quot;, &quot;floorBuildingRelationshipId&quot;, serializedCustomRelationship);
-        /// Console.WriteLine($&quot;Created a digital twin relationship with Id floorBuildingRelationshipId from digital twin with Id floorTwinId to digital twin with Id buildingTwinId. &quot; +
-        ///     $&quot;Response status: {createCustomRelationshipResponse.GetRawResponse().Status}.&quot;);
+        /// Console.WriteLine($&quot;Created a digital twin relationship &apos;floorBuildingRelationshipId&apos; from twin &apos;floorTwinId&apos; to twin &apos;buildingTwinId&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<string>> CreateRelationshipAsync(string digitalTwinId, string relationshipId, string relationship, CancellationToken cancellationToken = default)
@@ -956,7 +945,10 @@ namespace Azure.DigitalTwins.Core
         /// AsyncPageable&lt;ModelData&gt; allModels = client.GetModelsAsync();
         /// await foreach (ModelData model in allModels)
         /// {
-        ///     Console.WriteLine($&quot;Retrieved model with Id {model.Id}, display name {model.DisplayName[&quot;en&quot;]}, upload time {model.UploadTime}, and decommissioned: {model.Decommissioned}&quot;);
+        ///     Console.WriteLine($&quot;Retrieved model &apos;{model.Id}&apos;, &quot; +
+        ///         $&quot;display name &apos;{model.DisplayName[&quot;en&quot;]}&apos;, &quot; +
+        ///         $&quot;upload time &apos;{model.UploadTime}&apos;, &quot; +
+        ///         $&quot;and decommissioned &apos;{model.Decommissioned}&apos;&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1068,8 +1060,8 @@ namespace Azure.DigitalTwins.Core
         /// </exception>
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSampleGetModel">
-        /// Response&lt;ModelData&gt; sampleModel = await client.GetModelAsync(sampleModelId);
-        /// Console.WriteLine($&quot;Retrieved model with Id {sampleModelId}. Response status: {sampleModel.GetRawResponse().Status}&quot;);
+        /// Response&lt;ModelData&gt; sampleModelResponse = await client.GetModelAsync(sampleModelId);
+        /// Console.WriteLine($&quot;Retrieved model &apos;{sampleModelResponse.Value.Id}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<ModelData>> GetModelAsync(string modelId, CancellationToken cancellationToken = default)
@@ -1128,12 +1120,12 @@ namespace Azure.DigitalTwins.Core
         /// <code snippet="Snippet:DigitalTwinsSampleDecommisionModel">
         /// try
         /// {
-        ///     Response decommissionModelResponse = await client.DecommissionModelAsync(sampleModelId);
-        ///     Console.WriteLine($&quot;Decommissioned model with Id {sampleModelId}. Response status: {decommissionModelResponse.Status}&quot;);
+        ///     await client.DecommissionModelAsync(sampleModelId);
+        ///     Console.WriteLine($&quot;Decommissioned model &apos;{sampleModelId}&apos;.&quot;);
         /// }
         /// catch (RequestFailedException ex)
         /// {
-        ///     FatalError($&quot;Failed to decommision model with Id {sampleModelId} due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to decommision model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1194,8 +1186,8 @@ namespace Azure.DigitalTwins.Core
         /// </remarks>
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSampleCreateModels">
-        /// Response&lt;IReadOnlyList&lt;ModelData&gt;&gt; response = await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
-        /// Console.WriteLine($&quot;Created models with Ids {componentModelId} and {sampleModelId}. Response status: {response.GetRawResponse().Status}&quot;);
+        /// await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
+        /// Console.WriteLine($&quot;Created models &apos;{componentModelId}&apos; and &apos;{sampleModelId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response<IReadOnlyList<ModelData>>> CreateModelsAsync(IEnumerable<string> models, CancellationToken cancellationToken = default)
@@ -1260,12 +1252,12 @@ namespace Azure.DigitalTwins.Core
         /// <code snippet="Snippet:DigitalTwinsSampleDeleteModel">
         /// try
         /// {
-        ///     Response deleteModelResponse = await client.DeleteModelAsync(sampleModelId);
-        ///     Console.WriteLine($&quot;Deleted model with Id {sampleModelId}. Response status: {deleteModelResponse.Status}&quot;);
+        ///     await client.DeleteModelAsync(sampleModelId);
+        ///     Console.WriteLine($&quot;Deleted model &apos;{sampleModelId}&apos;.&quot;);
         /// }
         /// catch (Exception ex)
         /// {
-        ///     FatalError($&quot;Failed to delete model with Id {sampleModelId} due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to delete model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1331,7 +1323,7 @@ namespace Azure.DigitalTwins.Core
         /// await foreach (string response in asyncPageableResponse)
         /// {
         ///     BasicDigitalTwin twin = JsonSerializer.Deserialize&lt;BasicDigitalTwin&gt;(response);
-        ///     Console.WriteLine($&quot;Found digital twin: {twin.Id}&quot;);
+        ///     Console.WriteLine($&quot;Found digital twin &apos;{twin.Id}&apos;&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1464,7 +1456,7 @@ namespace Azure.DigitalTwins.Core
         /// AsyncPageable&lt;EventRoute&gt; response = client.GetEventRoutesAsync();
         /// await foreach (EventRoute er in response)
         /// {
-        ///     Console.WriteLine($&quot;Event route: {er.Id}, endpoint name: {er.EndpointName}&quot;);
+        ///     Console.WriteLine($&quot;Event route &apos;{er.Id}&apos;, endpoint name &apos;{er.EndpointName}&apos;&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1624,8 +1616,8 @@ namespace Azure.DigitalTwins.Core
         ///     Filter = eventFilter
         /// };
         ///
-        /// Response createEventRouteResponse = await client.CreateEventRouteAsync(_eventRouteId, eventRoute);
-        /// Console.WriteLine($&quot;Created event route with Id {_eventRouteId}. Response status: {createEventRouteResponse.Status}&quot;);
+        /// await client.CreateEventRouteAsync(_eventRouteId, eventRoute);
+        /// Console.WriteLine($&quot;Created event route &apos;{_eventRouteId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response> CreateEventRouteAsync(string eventRouteId, EventRoute eventRoute, CancellationToken cancellationToken = default)
@@ -1674,8 +1666,8 @@ namespace Azure.DigitalTwins.Core
         /// </exception>
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSampleDeleteEventRoute">
-        /// Response response = await client.DeleteEventRouteAsync(_eventRouteId);
-        /// Console.WriteLine($&quot;Deleted event route with Id {_eventRouteId}. Response status: {response.Status}&quot;);
+        /// await client.DeleteEventRouteAsync(_eventRouteId);
+        /// Console.WriteLine($&quot;Deleted event route &apos;{_eventRouteId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response> DeleteEventRouteAsync(string eventRouteId, CancellationToken cancellationToken = default)
@@ -1728,8 +1720,8 @@ namespace Azure.DigitalTwins.Core
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSamplePublishTelemetry">
         /// // construct your json telemetry payload by hand.
-        /// Response publishTelemetryResponse = await client.PublishTelemetryAsync(twinId, &quot;{\&quot;Telemetry1\&quot;: 5}&quot;);
-        /// Console.WriteLine($&quot;Published telemetry message to twin with Id {twinId}. Response status: {publishTelemetryResponse.Status}&quot;);
+        /// await client.PublishTelemetryAsync(twinId, &quot;{\&quot;Telemetry1\&quot;: 5}&quot;);
+        /// Console.WriteLine($&quot;Published telemetry message to twin &apos;{twinId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response> PublishTelemetryAsync(string digitalTwinId, string payload, TelemetryOptions options = default, CancellationToken cancellationToken = default)
@@ -1796,13 +1788,13 @@ namespace Azure.DigitalTwins.Core
         /// // construct your json telemetry payload by serializing a dictionary.
         /// var telemetryPayload = new Dictionary&lt;string, int&gt;
         /// {
-        ///     { &quot;ComponentTelemetry1&quot;, 9}
+        ///     { &quot;ComponentTelemetry1&quot;, 9 }
         /// };
-        /// Response publishTelemetryToComponentResponse = await client.PublishComponentTelemetryAsync(
+        /// await client.PublishComponentTelemetryAsync(
         ///     twinId,
         ///     &quot;Component1&quot;,
         ///     JsonSerializer.Serialize(telemetryPayload));
-        /// Console.WriteLine($&quot;Published component telemetry message to twin with Id {twinId}. Response status: {publishTelemetryToComponentResponse.Status}&quot;);
+        /// Console.WriteLine($&quot;Published component telemetry message to twin &apos;{twinId}&apos;.&quot;);
         /// </code>
         /// </example>
         public virtual Task<Response> PublishComponentTelemetryAsync(string digitalTwinId, string componentName, string payload, TelemetryOptions options = default, CancellationToken cancellationToken = default)

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Queries/QueryChargeHelper.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Queries/QueryChargeHelper.cs
@@ -48,7 +48,7 @@ namespace Azure.DigitalTwins.Core
         ///     foreach (string response in page.Values)
         ///     {
         ///         BasicDigitalTwin twin = JsonSerializer.Deserialize&lt;BasicDigitalTwin&gt;(response);
-        ///         Console.WriteLine($&quot;Found digital twin: {twin.Id}&quot;);
+        ///         Console.WriteLine($&quot;Found digital twin &apos;{twin.Id}&apos;&quot;);
         ///     }
         /// }
         /// </code>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/BasicDigitalTwin.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/BasicDigitalTwin.cs
@@ -46,8 +46,8 @@ namespace Azure.DigitalTwins.Core.Serialization
     ///
     /// string basicDtPayload = JsonSerializer.Serialize(basicTwin);
     ///
-    /// Response&lt;string&gt; createBasicDtResponse = await client.CreateDigitalTwinAsync(basicDtId, basicDtPayload);
-    /// Console.WriteLine($&quot;Created digital twin with Id {basicDtId}. Response status: {createBasicDtResponse.GetRawResponse().Status}.&quot;);
+    /// await client.CreateDigitalTwinAsync(basicDtId, basicDtPayload);
+    /// Console.WriteLine($&quot;Created digital twin &apos;{basicDtId}&apos;.&quot;);
     /// </code>
     ///
     /// Here's an example of  how to use the BasicDigitalTwin helper class to get and deserialize a digital twin.

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/BasicRelationship.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/BasicRelationship.cs
@@ -31,9 +31,8 @@ namespace Azure.DigitalTwins.Core.Serialization
     /// };
     ///
     /// string serializedRelationship = JsonSerializer.Serialize(buildingFloorRelationshipPayload);
-    /// Response&lt;string&gt; createRelationshipResponse = await client.CreateRelationshipAsync(&quot;buildingTwinId&quot;, &quot;buildingFloorRelationshipId&quot;, serializedRelationship);
-    /// Console.WriteLine($&quot;Created a digital twin relationship with Id buildingFloorRelationshipId from digital twin with Id buildingTwinId to digital twin with Id floorTwinId. &quot; +
-    ///     $&quot;Response status: {createRelationshipResponse.GetRawResponse().Status}.&quot;);
+    /// await client.CreateRelationshipAsync(&quot;buildingTwinId&quot;, &quot;buildingFloorRelationshipId&quot;, serializedRelationship);
+    /// Console.WriteLine($&quot;Created a digital twin relationship &apos;buildingFloorRelationshipId&apos; from twin &apos;buildingTwinId&apos; to twin &apos;floorTwinId&apos;.&quot;);
     /// </code>
     ///
     /// Here's an example of how to use the BasicRelationship helper class to get and deserialize a relationship.
@@ -43,8 +42,7 @@ namespace Azure.DigitalTwins.Core.Serialization
     /// if (getBasicRelationshipResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
     /// {
     ///     BasicRelationship basicRelationship = JsonSerializer.Deserialize&lt;BasicRelationship&gt;(getBasicRelationshipResponse.Value);
-    ///     Console.WriteLine($&quot;Retrieved relationship with Id {basicRelationship.Id} from digital twin with Id {basicRelationship.SourceId}. &quot; +
-    ///         $&quot;Response status: {getBasicRelationshipResponse.GetRawResponse().Status}.\n\t&quot; +
+    ///     Console.WriteLine($&quot;Retrieved relationship &apos;{basicRelationship.Id}&apos; from twin {basicRelationship.SourceId}.\n\t&quot; +
     ///         $&quot;Prop1: {basicRelationship.CustomProperties[&quot;Prop1&quot;]}\n\t&quot; +
     ///         $&quot;Prop2: {basicRelationship.CustomProperties[&quot;Prop2&quot;]}&quot;);
     /// }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/UpdateOperationsUtility.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/UpdateOperationsUtility.cs
@@ -14,14 +14,13 @@ namespace Azure.DigitalTwins.Core.Serialization
     /// </remarks>
     /// <example>
     /// <code snippet="Snippet:DigitalTwinsSampleUpdateComponent">
-    /// // Update Component1 by replacing the property ComponentProp1 value
+    /// // Update Component1 by replacing the property ComponentProp1 value,
+    /// // using an optional utility to build the payload.
     /// var componentUpdateUtility = new UpdateOperationsUtility();
     /// componentUpdateUtility.AppendReplaceOp(&quot;/ComponentProp1&quot;, &quot;Some new value&quot;);
     /// string updatePayload = componentUpdateUtility.Serialize();
-    ///
-    /// Response&lt;string&gt; response = await client.UpdateComponentAsync(basicDtId, &quot;Component1&quot;, updatePayload);
-    ///
-    /// Console.WriteLine($&quot;Updated component for digital twin with Id {basicDtId}. Response status: {response.GetRawResponse().Status}&quot;);
+    /// await client.UpdateComponentAsync(basicDtId, &quot;Component1&quot;, updatePayload);
+    /// Console.WriteLine($&quot;Updated component for digital twin &apos;{basicDtId}&apos;.&quot;);
     /// </code>
     /// </example>
     public class UpdateOperationsUtility


### PR DESCRIPTION
Guidance from Pavel is to de-emphasize status code checks for non-exceptional responses. This means, in many cases, we don't even care about the response.

Also removed wordiness in console output.