### PR TITLE
fix see href links - Part 1

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/SettingSelector.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/SettingSelector.cs
@@ -13,7 +13,7 @@ namespace Azure.Data.AppConfiguration
     /// configuration store, and optionally allows indicating which fields of
     /// each setting to retrieve.</para>
     /// <para>Literals or filters may be specified for keys and labels.</para>
-    /// <para>For more information, <see href="https://github.com/Azure/AppConfiguration/blob/master/docs/REST/kv.md#filtering"/>.</para>
+    /// <para>For more information, <see href="https://github.com/Azure/AppConfiguration/blob/master/docs/REST/kv.md#filtering">Filtering</see>.</para>
     /// </summary>
     public class SettingSelector
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Administration
         /// <summary>
         /// The latest service version supported by this client library.
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         internal const ServiceVersion LatestVersion = ServiceVersion.V7_2_Preview;
 
@@ -35,7 +35,7 @@ namespace Azure.Security.KeyVault.Administration
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultBackupClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultBackupClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Administration
         /// <summary>
         /// The latest service version supported by this client library.
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         internal const ServiceVersion LatestVersion = ServiceVersion.V7_2_Preview;
 
@@ -35,7 +35,7 @@ namespace Azure.Security.KeyVault.Administration
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Certificates
         /// <summary>
         /// The latest service version supported by this client library.
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         internal const ServiceVersion LatestVersion = ServiceVersion.V7_1_Preview;
 
@@ -40,7 +40,7 @@ namespace Azure.Security.KeyVault.Certificates
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateKeyCurveName.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateKeyCurveName.cs
@@ -24,25 +24,25 @@ namespace Azure.Security.KeyVault.Certificates
 
         /// <summary>
         /// Gets the NIST P-256 elliptic curve, AKA SECG curve SECP256R1
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static CertificateKeyCurveName P256 { get; } = new CertificateKeyCurveName("P-256");
 
         /// <summary>
         /// Gets the NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static CertificateKeyCurveName P384 { get; } = new CertificateKeyCurveName("P-384");
 
         /// <summary>
         /// Gets the NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static CertificateKeyCurveName P521 { get; } = new CertificateKeyCurveName("P-521");
 
         /// <summary>
         /// Gets the SECG SECP256K1 elliptic curve.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static CertificateKeyCurveName P256K { get; } = new CertificateKeyCurveName("P-256K");
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <summary>
         /// The latest service version supported by this client library.
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         internal const ServiceVersion LatestVersion = ServiceVersion.V7_1_Preview;
 
@@ -40,7 +40,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Keys
         /// <summary>
         /// The latest service version supported by this client library.
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         internal const ServiceVersion LatestVersion = ServiceVersion.V7_1_Preview;
 
@@ -40,7 +40,7 @@ namespace Azure.Security.KeyVault.Keys
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyCurveName.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyCurveName.cs
@@ -35,25 +35,25 @@ namespace Azure.Security.KeyVault.Keys
 
         /// <summary>
         /// Gets the NIST P-256 elliptic curve, AKA SECG curve SECP256R1
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static KeyCurveName P256 { get; } = new KeyCurveName(P256Value);
 
         /// <summary>
         /// Gets the SECG SECP256K1 elliptic curve.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static KeyCurveName P256K { get; } = new KeyCurveName(P256KValue);
 
         /// <summary>
         /// Gets the NIST P-384 elliptic curve, AKA SECG curve SECP384R1.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static KeyCurveName P384 { get; } = new KeyCurveName(P384Value);
 
         /// <summary>
         /// Gets the NIST P-521 elliptic curve, AKA SECG curve SECP521R1.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#curve-types"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/azure/key-vault/keys/about-keys#curve-types">Curve types</see>.
         /// </summary>
         public static KeyCurveName P521 { get; } = new KeyCurveName(P521Value);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Secrets
         /// <summary>
         /// The latest service version supported by this client library.
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         internal const ServiceVersion LatestVersion = ServiceVersion.V7_1_Preview;
 
@@ -40,7 +40,7 @@ namespace Azure.Security.KeyVault.Secrets
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests. For more information, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/keyvault/key-vault-versions">Key Vault versions</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs
@@ -41,7 +41,7 @@ namespace Azure.Search.Documents.Indexes
         /// <param name="credential">
         /// Required. The API key credential used to authenticate requests against the Search service.
         /// You need to use an admin key to perform any operations on the SearchIndexClient.
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
@@ -57,7 +57,7 @@ namespace Azure.Search.Documents.Indexes
         /// <param name="credential">
         /// Required. The API key credential used to authenticate requests against the Search service.
         /// You need to use an admin key to perform any operations on the SearchIndexClient.
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
@@ -41,7 +41,7 @@ namespace Azure.Search.Documents.Indexes
         /// <param name="credential">
         /// Required. The API key credential used to authenticate requests against the Search service.
         /// You need to use an admin key to perform any operations on the SearchIndexerClient.
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
@@ -57,7 +57,7 @@ namespace Azure.Search.Documents.Indexes
         /// <param name="credential">
         /// Required. The API key credential used to authenticate requests against the Search service.
         /// You need to use an admin key to perform any operations on the SearchIndexerClient.
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>

--- a/sdk/search/Azure.Search.Documents/src/SearchClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchClient.cs
@@ -101,7 +101,7 @@ namespace Azure.Search.Documents
         /// Required.  The API key credential used to authenticate requests
         /// against the search service.  You need to use an admin key to
         /// modify the documents in a Search Index.  See
-        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/>
+        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see>
         /// for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <exception cref="ArgumentNullException">
@@ -137,7 +137,7 @@ namespace Azure.Search.Documents
         /// Required.  The API key credential used to authenticate requests
         /// against the search service.  You need to use an admin key to
         /// modify the documents in a Search Index.  See
-        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/>
+        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see>
         /// for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <param name="options">
@@ -317,7 +317,7 @@ namespace Azure.Search.Documents
         /// look up specific details about that document. You can only get one
         /// document at a time.  Use Search to get multiple documents in a
         /// single request.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -327,7 +327,7 @@ namespace Azure.Search.Documents
         /// Required.  An string value that uniquely identifies each document
         /// in the index.  The key is sometimes referred to as a document ID.
         /// See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see>
         /// for the rules for constructing valid document keys.
         /// </param>
         /// <param name="options">
@@ -370,7 +370,7 @@ namespace Azure.Search.Documents
         /// look up specific details about that document. You can only get one
         /// document at a time.  Use Search to get multiple documents in a
         /// single request.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -380,7 +380,7 @@ namespace Azure.Search.Documents
         /// Required.  An string value that uniquely identifies each document
         /// in the index.  The key is sometimes referred to as a document ID.
         /// See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see>
         /// for the rules for constructing valid document keys.
         /// </param>
         /// <param name="options">
@@ -628,7 +628,7 @@ namespace Azure.Search.Documents
         #region Search
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -637,7 +637,7 @@ namespace Azure.Search.Documents
         /// <param name="searchText">
         /// A full-text search query expression;  Use "*" or omit this
         /// parameter to match all documents.  See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/>
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see>
         /// for more information about search query syntax.
         /// </param>
         /// <param name="options">
@@ -685,7 +685,7 @@ namespace Azure.Search.Documents
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -694,7 +694,7 @@ namespace Azure.Search.Documents
         /// <param name="searchText">
         /// A full-text search query expression;  Use "*" or omit this
         /// parameter to match all documents.  See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/>
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see>
         /// for more information about search query syntax.
         /// </param>
         /// <param name="options">
@@ -826,7 +826,7 @@ namespace Azure.Search.Documents
         /// if you enable suggestions on a city field, typing "sea" produces
         /// documents containing "Seattle", "Sea Tac", and "Seaside" (all
         /// actual city names) for that field.
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/searchservice/suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -883,7 +883,7 @@ namespace Azure.Search.Documents
         /// if you enable suggestions on a city field, typing "sea" produces
         /// documents containing "Seattle", "Sea Tac", and "Seaside" (all
         /// actual city names) for that field.
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/searchservice/suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -988,7 +988,7 @@ namespace Azure.Search.Documents
         /// <summary>
         /// Suggests query terms based on input text and matching documents in
         /// the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Autocomplete"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/autocomplete">Autocomplete</see>
         /// </summary>
         /// <param name="searchText">
         /// The search text on which to base autocomplete results.
@@ -1037,7 +1037,7 @@ namespace Azure.Search.Documents
         /// <summary>
         /// Suggests query terms based on input text and matching documents in
         /// the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Autocomplete"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/autocomplete">Autocomplete</see>
         /// </summary>
         /// <param name="searchText">
         /// The search text on which to base autocomplete results.
@@ -1104,7 +1104,7 @@ namespace Azure.Search.Documents
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search
         /// index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type
@@ -1158,7 +1158,7 @@ namespace Azure.Search.Documents
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search
         /// index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The .NET type that maps to the index schema. Instances of this type

--- a/sdk/search/Azure.Search.Documents/src/SearchClientBuilderExtensions.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchClientBuilderExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Azure
         /// Required.  The API key credential used to authenticate requests
         /// against the search service.  You need to use an admin key to
         /// modify the documents in a Search Index.  See
-        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/>
+        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see>
         /// for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <returns>An Azure client builder.</returns>
@@ -79,7 +79,7 @@ namespace Microsoft.Extensions.Azure
         /// Required.  The API key credential used to authenticate requests
         /// against the search service.  You need to use an admin key to
         /// modify the documents in a Search Index.  See
-        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/>
+        /// <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see>
         /// for more information about API keys in Azure Cognitive Search.
         /// </param>
         /// <returns>An Azure client builder.</returns>

--- a/sdk/search/Microsoft.Azure.Search.Common/src/Customizations/Search/SearchCredentials.cs
+++ b/sdk/search/Microsoft.Azure.Search.Common/src/Customizations/Search/SearchCredentials.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Azure.Search
 
     /// <summary>
     /// Credentials used to authenticate to a search service.
-    /// <see href="https://docs.microsoft.com/rest/api/searchservice/"/>
+    /// <see href="https://docs.microsoft.com/rest/api/searchservice/">Azure Cognitive Search Service REST</see>
     /// </summary>
     /// <remarks>
-    /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+    /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
     /// </remarks>
     public class SearchCredentials : ServiceClientCredentials
     {

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/Documents/DocumentsOperationsExtensions.cs
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/Documents/DocumentsOperationsExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves the next page of search results from the search index. 
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves the next page of search results from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves the next page of search results from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves the next page of search results from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -302,14 +302,14 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a document from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
         /// <param name="key">
         /// The key of the document to retrieve; See 
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/> for the rules for constructing valid
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see> for the rules for constructing valid
         /// document keys.
         /// </param>
         /// <param name="selectedFields">
@@ -339,14 +339,14 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a document from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
         /// <param name="key">
         /// The key of the document to retrieve; See 
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/> for the rules for constructing valid
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see> for the rules for constructing valid
         /// document keys.
         /// </param>
         /// <param name="selectedFields">
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a document from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -392,7 +392,7 @@ namespace Microsoft.Azure.Search
         /// </param>
         /// <param name="key">
         /// The key of the document to retrieve; See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/> for the rules for constructing valid
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see> for the rules for constructing valid
         /// document keys.
         /// </param>
         /// <param name="selectedFields">
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a document from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -434,7 +434,7 @@ namespace Microsoft.Azure.Search
         /// </param>
         /// <param name="key">
         /// The key of the document to retrieve; See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/> for the rules for constructing valid
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see> for the rules for constructing valid
         /// document keys.
         /// </param>
         /// <param name="selectedFields">
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -508,7 +508,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be stored as documents in the index.
@@ -592,7 +592,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be stored as documents in the index.
@@ -638,14 +638,14 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
         /// <param name="searchText">
         /// A full-text search query expression; Use null or "*" to match all documents. See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/> for more information about search
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see> for more information about search
         /// query syntax.
         /// </param>
         /// <param name="searchParameters">
@@ -682,14 +682,14 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
         /// <param name="searchText">
         /// A full-text search query expression; Use null or "*" to match all documents. See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/> for more information about search
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see> for more information about search
         /// query syntax.
         /// </param>
         /// <param name="searchParameters">
@@ -731,7 +731,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -742,7 +742,7 @@ namespace Microsoft.Azure.Search
         /// </param>
         /// <param name="searchText">
         /// A full-text search query expression; Use null or "*" to match all documents. See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/> for more information about search
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see> for more information about search
         /// query syntax.
         /// </param>
         /// <param name="searchParameters">
@@ -779,7 +779,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -790,7 +790,7 @@ namespace Microsoft.Azure.Search
         /// </param>
         /// <param name="searchText">
         /// A full-text search query expression; Use null or "*" to match all documents. See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/> for more information about search
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see> for more information about search
         /// query syntax.
         /// </param>
         /// <param name="searchParameters">
@@ -832,7 +832,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Suggests query terms based on input text and matching documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -870,7 +870,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Suggests query terms based on input text and matching documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -913,7 +913,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Suggests query terms based on input text and matching documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -955,7 +955,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Suggests query terms based on input text and matching documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/Documents/IDocumentsOperations.Customization.cs
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/Documents/IDocumentsOperations.Customization.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Search
         
         /// <summary>
         /// Retrieves the next page of search results from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <param name="continuationToken">
         /// Encapsulates the state required to fetch the next page of search results from the index.
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves the next page of search results from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -152,11 +152,11 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a document from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <param name="key">
         /// The key of the document to retrieve; See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/> for the rules for constructing valid
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see> for the rules for constructing valid
         /// document keys.
         /// </param>
         /// <param name="selectedFields">
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a document from the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Lookup-Document"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/lookup-document">Lookup Document</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Search
         /// </typeparam>
         /// <param name="key">
         /// The key of the document to retrieve; See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Naming-rules"/> for the rules for constructing valid
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/naming-rules">Naming rules</see> for the rules for constructing valid
         /// document keys.
         /// </param>
         /// <param name="selectedFields">
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <param name="batch">
         /// The batch of index actions.
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Sends a batch of upload, merge, and/or delete actions to the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents">Add, Update or Delete Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be stored as documents in the index.
@@ -457,11 +457,11 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <param name="searchText">
         /// A full-text search query expression; Use null or "*" to match all documents. See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/> for more information about search
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see> for more information about search
         /// query syntax.
         /// </param>
         /// <param name="searchParameters">
@@ -502,7 +502,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Searches for documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Search-Documents"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/search-documents">Search Documents</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.Search
         /// </typeparam>
         /// <param name="searchText">
         /// A full-text search query expression; Use null or "*" to match all documents. See
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Simple-query-syntax-in-Azure-Search"/> for more information about search
+        /// <see href="https://docs.microsoft.com/azure/search/query-simple-syntax">Simple query syntax in Azure Cognitive Search</see> for more information about search
         /// query syntax.
         /// </param>
         /// <param name="searchParameters">
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Suggests query terms based on input text and matching documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <param name="searchText">
         /// The search text on which to base suggestions.
@@ -590,7 +590,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Suggests query terms based on input text and matching documents in the search index.
-        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Suggestions"/>
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/suggestions">Suggestions</see>
         /// </summary>
         /// <typeparam name="T">
         /// The CLR type that maps to the index schema. Instances of this type can be retrieved as documents

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/ISearchIndexClient.Customization.cs
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/ISearchIndexClient.Customization.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Search
         /// Gets the credentials used to authenticate to an Azure Cognitive Search service. This can be either a query API key or an admin API key.
         /// </summary>
         /// <remarks>
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </remarks>
         SearchCredentials SearchCredentials { get; }
 

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/SearchIndexClient.Customization.cs
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Customizations/SearchIndexClient.Customization.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Search
         /// Gets the credentials used to authenticate to a search service. This can be either a query API key or an admin API key.
         /// </summary>
         /// <remarks>
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </remarks>
         public SearchCredentials SearchCredentials => (SearchCredentials)Credentials;
 

--- a/sdk/search/Microsoft.Azure.Search.Service/src/Customizations/ISearchServiceClient.Customization.cs
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/Customizations/ISearchServiceClient.Customization.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Search
         /// Gets the credentials used to authenticate to a search service. This can be either a query API key or an admin API key.
         /// </summary>
         /// <remarks>
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </remarks>
         SearchCredentials SearchCredentials { get; }
     }

--- a/sdk/search/Microsoft.Azure.Search.Service/src/Customizations/SearchServiceClient.Customization.cs
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/Customizations/SearchServiceClient.Customization.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Search
         /// Gets the credentials used to authenticate to a search service. This can be either a query API key or an admin API key.
         /// </summary>
         /// <remarks>
-        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Cognitive Search.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys">Create and manage api-keys for an Azure Cognitive Search service</see> for more information about API keys in Azure Cognitive Search.
         /// </remarks>
         public SearchCredentials SearchCredentials => (SearchCredentials)Credentials;
 

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -60,7 +60,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this append blob.
@@ -82,7 +82,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this append blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -166,7 +166,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.
@@ -188,7 +188,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.
@@ -62,7 +62,7 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -165,7 +165,7 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the blob container in the storage account to reference.
@@ -184,7 +184,7 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container in the storage account to reference.
@@ -407,7 +407,7 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -458,7 +458,7 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -508,7 +508,7 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -559,7 +559,7 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -609,7 +609,7 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -660,7 +660,7 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -710,7 +710,7 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -761,7 +761,7 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -811,7 +811,7 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account.  If the container already exists, it is
         /// not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -896,7 +896,7 @@ namespace Azure.Storage.Blobs
         /// under the specified account, if it does not already exist.
         /// If the container with the same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -1997,7 +1997,7 @@ namespace Azure.Storage.Blobs
         /// multiple requests to the service while fetching all the values.
         /// Blobs are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2034,7 +2034,7 @@ namespace Azure.Storage.Blobs
         /// make multiple requests to the service while fetching all the
         /// values.  Blobs are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2075,7 +2075,7 @@ namespace Azure.Storage.Blobs
         /// to continue enumerating the blobs segment by segment. Blobs are
         /// ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -2180,7 +2180,7 @@ namespace Azure.Storage.Blobs
         /// <paramref name="delimiter"/> can be used to traverse a virtual
         /// hierarchy of blobs as though it were a file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2237,7 +2237,7 @@ namespace Azure.Storage.Blobs
         /// <paramref name="delimiter"/> can be used to traverse a virtual
         /// hierarchy of blobs as though it were a file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2298,7 +2298,7 @@ namespace Azure.Storage.Blobs
         /// can be used to traverse a virtual hierarchy of blobs as though
         /// it were a file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -141,7 +141,7 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         public BlobServiceClient(string connectionString)
             : this(connectionString, null)
@@ -157,7 +157,7 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline
@@ -418,7 +418,7 @@ namespace Azure.Storage.Blobs
         /// blob containers may make multiple requests to the service while fetching
         /// all the values.  Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blob containers.
@@ -451,7 +451,7 @@ namespace Azure.Storage.Blobs
         /// blob containers may make multiple requests to the service while fetching
         /// all the values.  Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blob containers.
@@ -488,7 +488,7 @@ namespace Azure.Storage.Blobs
         /// to continue enumerating the containers segment by segment.
         /// Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
         /// </summary>
         /// <param name="continuationToken">
         /// An optional string value that identifies the segment of the list
@@ -795,7 +795,7 @@ namespace Azure.Storage.Blobs
         /// the default request version for all incoming requests to the Blob
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">Set Blob Service Properties</see>.
         /// </summary>
         /// <param name="properties">The blob service properties.</param>
         /// <param name="cancellationToken">
@@ -827,7 +827,7 @@ namespace Azure.Storage.Blobs
         /// the default request version for all incoming requests to the Blob
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">Set Blob Service Properties</see>.
         /// </summary>
         /// <param name="properties">The blob service properties.</param>
         /// <param name="cancellationToken">
@@ -859,7 +859,7 @@ namespace Azure.Storage.Blobs
         /// the default request version for all incoming requests to the Blob
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">Set Blob Service Properties</see>.
         /// </summary>
         /// <param name="properties">The blob service properties.</param>
         /// <param name="async">
@@ -923,7 +923,7 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">Get Blob Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -951,7 +951,7 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">Get Blob Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -979,7 +979,7 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">Get Blob Service Stats</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1180,7 +1180,7 @@ namespace Azure.Storage.Blobs
         /// blob container under the specified account. If the container with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container to create.
@@ -1230,7 +1230,7 @@ namespace Azure.Storage.Blobs
         /// blob container under the specified account. If the container with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container to create.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -115,7 +115,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="containerName">
         /// The name of the container containing this block blob.
@@ -137,7 +137,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this block blob.
@@ -836,7 +836,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// block to be committed as part of a blob where the contents are
         /// read from the <paramref name="sourceUri" />.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-from-url"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">Put Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -913,7 +913,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// block to be committed as part of a blob where the contents are
         /// read from the <paramref name="sourceUri" />.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-from-url"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">Put Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -990,7 +990,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// block to be committed as part of a blob where the contents are
         /// read from the <paramref name="sourceUri" />.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-from-url"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">Put Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1119,7 +1119,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1186,7 +1186,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>.
+        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1253,7 +1253,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>.
+        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1374,7 +1374,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve the block list
         /// from. For more information on working with blob snapshots, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1424,7 +1424,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve the block list
         /// from. For more information on working with blob snapshots, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1474,7 +1474,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve the block list
         /// from. For more information on working with blob snapshots, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -61,7 +61,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this page blob.
@@ -83,7 +83,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this page blob.
@@ -1092,7 +1092,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="PageBlobRequestConditions"/> to add
@@ -1136,7 +1136,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="PageBlobRequestConditions"/> to add
@@ -1180,7 +1180,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="PageBlobRequestConditions"/> to add
@@ -1269,7 +1269,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshot">
         /// Specifies that the response will contain only pages that were
@@ -1326,7 +1326,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshot">
         /// Specifies that the response will contain only pages that were
@@ -1383,7 +1383,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshot">
         /// Specifies that the response will contain only pages that were
@@ -1498,7 +1498,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshotUri">
         /// This parameter only works with managed disk storage accounts.
@@ -1557,7 +1557,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob"/>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshotUri">
         /// This parameter only works with managed disk storage accounts.
@@ -1990,7 +1990,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// determine if the copy has completed.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
-        /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
+        /// and <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">Back up Azure unmanaged VM disks with incremental snapshots</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the to the source page blob as a <see cref="Uri"/> up to
@@ -2096,7 +2096,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// to determine if thecopy has completed.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
-        /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
+        /// and <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">Back up Azure unmanaged VM disks with incremental snapshots</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the to the source page blob as a <see cref="Uri"/> up to
@@ -2203,7 +2203,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// copy has completed.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
-        /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
+        /// and <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">Back up Azure unmanaged VM disks with incremental snapshots</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the to the source page blob as a <see cref="Uri"/> up to

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -365,7 +365,7 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -435,7 +435,7 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -508,7 +508,7 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -581,7 +581,7 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -1168,7 +1168,7 @@ namespace Azure.Storage.Files.DataLake
         /// of paths in this file system.  Enumerating the paths may make
         /// multiple requests to the service while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/list"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">Path - List</see>.
         /// </summary>
         /// <param name="path">
         /// Filters results to paths within the specified directory.
@@ -1213,7 +1213,7 @@ namespace Azure.Storage.Files.DataLake
         /// make multiple requests to the service while fetching all the
         /// values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/list"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">Path - List</see>.
         /// </summary>
         /// <param name="path">
         /// Filters results to paths within the specified directory.
@@ -1261,7 +1261,7 @@ namespace Azure.Storage.Files.DataLake
         /// to continue enumerating the paths segment by segment. Paths are
         /// ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/list"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">Path - List</see>.
         /// </summary>
         /// <param name="path">
         /// Filters results to paths within the specified directory.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -420,7 +420,7 @@ namespace Azure.Storage.Files.DataLake
         /// file systems may make multiple requests to the service while fetching
         /// all the values.  File systems are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the file systems.
@@ -453,7 +453,7 @@ namespace Azure.Storage.Files.DataLake
         /// files systems may make multiple requests to the service while fetching
         /// all the values.  File systems are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the file systems.
@@ -487,7 +487,7 @@ namespace Azure.Storage.Files.DataLake
         /// file system under the specified account. If the file systen with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="fileSystemName">
         /// The name of the file system to create.
@@ -552,7 +552,7 @@ namespace Azure.Storage.Files.DataLake
         /// file system under the specified account. If the file system with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
         /// </summary>
         /// <param name="fileSystemName">
         /// The name of the file system to create.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -117,7 +117,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -136,7 +136,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -253,7 +253,7 @@ namespace Azure.Storage.Files.Shares
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
         /// </summary>
         /// <remarks>
         /// Pass null or empty string to remove the snapshot returning a URL to the base share.
@@ -309,7 +309,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -345,7 +345,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -381,7 +381,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -454,7 +454,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -489,7 +489,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -524,7 +524,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -701,7 +701,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -729,7 +729,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -757,7 +757,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -820,7 +820,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a read-only snapshot of a share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -849,7 +849,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a read-only snapshot of a share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -878,7 +878,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a read-only snapshot of a share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -939,7 +939,7 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -969,7 +969,7 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -999,7 +999,7 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -1066,7 +1066,7 @@ namespace Azure.Storage.Files.Shares
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">Get Share Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1092,7 +1092,7 @@ namespace Azure.Storage.Files.Shares
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">Get Share Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1118,7 +1118,7 @@ namespace Azure.Storage.Files.Shares
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">Get Share Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1174,7 +1174,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">Set Share Properties</see>.
         /// </summary>
         /// <param name="quotaInGB">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
         /// <param name="cancellationToken">
@@ -1201,7 +1201,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">Set Share Properties</see>.
         /// </summary>
         /// <param name="quotaInGB">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
         /// <param name="cancellationToken">
@@ -1228,7 +1228,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">Set Share Properties</see>.
         /// </summary>
         /// <param name="quotaInGB">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
         /// <param name="async">
@@ -1289,7 +1289,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified share as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">Set Share Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -1319,7 +1319,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified share as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">Set Share Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -1349,7 +1349,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified share as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">Set Share Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -1411,7 +1411,7 @@ namespace Azure.Storage.Files.Shares
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">Get Share ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1437,7 +1437,7 @@ namespace Azure.Storage.Files.Shares
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">Get Share ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1463,7 +1463,7 @@ namespace Azure.Storage.Files.Shares
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">Get Share ACL</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1520,7 +1520,7 @@ namespace Azure.Storage.Files.Shares
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">Set Share ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1552,7 +1552,7 @@ namespace Azure.Storage.Files.Shares
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">Set Share ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1584,7 +1584,7 @@ namespace Azure.Storage.Files.Shares
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">Set Share ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1645,7 +1645,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Retrieves statistics related to the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">Get Share Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1669,7 +1669,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Retrieves statistics related to the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">Get Share Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1693,7 +1693,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Retrieves statistics related to the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">Get Share Stats</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1954,7 +1954,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateDirectory"/> operation creates a new
         /// directory in this share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to create.
@@ -2003,7 +2003,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateDirectoryAsync"/> operation creates a new
         /// directory in this share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to create.
@@ -2054,7 +2054,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteDirectory"/> operation removes the specified empty
         /// directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to delete.
@@ -2082,7 +2082,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteDirectoryAsync"/> operation removes the specified empty
         /// directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to delete.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -147,7 +147,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -168,7 +168,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -297,7 +297,7 @@ namespace Azure.Storage.Files.Shares
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
         /// </summary>
         /// <remarks>
         /// Pass null or empty string to remove the snapshot returning a URL to the base directory.
@@ -356,7 +356,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Create"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -396,7 +396,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateAsync"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -436,7 +436,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateInternal"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -525,7 +525,7 @@ namespace Azure.Storage.Files.Shares
         /// if it does not already exists.  If the directory already exists, it is not
         /// modified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -565,7 +565,7 @@ namespace Azure.Storage.Files.Shares
         /// if it does not already exists.  If the directory already exists, it is not
         /// modified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -605,7 +605,7 @@ namespace Azure.Storage.Files.Shares
         /// if it does not already exists.  If the directory already exists, it is not
         /// modified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -786,7 +786,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExists"/> operation removes the specified
         /// empty directory, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -808,7 +808,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExistsAsync"/> operation removes the specified
         /// empty directory, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -830,7 +830,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExistsInternal"/> operation removes the specified
         /// empty directory, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -889,7 +889,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="Delete"/> operation removes the specified empty directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -911,7 +911,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation removes the specified empty directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -934,7 +934,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteInternal"/> operation removes the specified
         /// empty directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -994,7 +994,7 @@ namespace Azure.Storage.Files.Shares
         /// directory. The data returned does not include the directory's
         /// list of subdirectories or files.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">Get Directory Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1021,7 +1021,7 @@ namespace Azure.Storage.Files.Shares
         /// directory. The data returned does not include the directory's
         /// list of subdirectories or files.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">Get Directory Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1048,7 +1048,7 @@ namespace Azure.Storage.Files.Shares
         /// directory. The data returned does not include the directory's
         /// list of subdirectories or files.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">Get Directory Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1114,7 +1114,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">Set Directory Properties</see>.
         /// </summary>
         /// <param name="smbProperties">
         /// Optional SMB properties to set for the directory.
@@ -1149,7 +1149,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">Set Directory Properties</see>.
         /// </summary>
         /// <param name="smbProperties">
         /// Optional SMB properties to set for the directory.
@@ -1184,7 +1184,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">Set Directory Properties</see>.
         /// </summary>
         /// <param name="smbProperties">
         /// Optional SMB properties to set for the directory.
@@ -1264,7 +1264,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">Set Directory Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -1293,7 +1293,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataAsync"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">Set Directory Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -1322,7 +1322,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataInternal"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">Set Directory Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -1386,7 +1386,7 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the files and directories may make multiple requests
         /// to the service while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">List Directories and Files</see>.
         /// </summary>
         /// <param name="prefix">
         /// Optional string that filters the results to return only
@@ -1415,7 +1415,7 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the files and directories may make multiple requests
         /// to the service while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">List Directories and Files</see>.
         /// </summary>
         /// <param name="prefix">
         /// Optional string that filters the results to return only
@@ -1443,7 +1443,7 @@ namespace Azure.Storage.Files.Shares
         /// single segment of files and subdirectories in this directory, starting
         /// from the specified <paramref name="marker"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">List Directories and Files</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -1527,7 +1527,7 @@ namespace Azure.Storage.Files.Shares
         /// handles may make multiple requests to the service while fetching
         /// all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1555,7 +1555,7 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the handles may make multiple requests to the service
         /// while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1581,7 +1581,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="GetHandlesAsync"/> operation returns a list of open
         /// handles on a directory or a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -1668,7 +1668,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -1713,7 +1713,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -1759,7 +1759,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1796,7 +1796,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1833,7 +1833,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1896,7 +1896,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -1981,7 +1981,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateSubdirectory"/> operation creates a new
         /// subdirectory under this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="metadata">
@@ -2026,7 +2026,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateSubdirectoryAsync"/> operation creates a new
         /// subdirectory under this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="metadata">
@@ -2074,7 +2074,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteSubdirectory"/> operation removes the
         /// specified empty subdirectory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="cancellationToken">
@@ -2097,7 +2097,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteSubdirectoryAsync"/> operation removes the
         /// specified empty subdirectory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="cancellationToken">
@@ -2123,7 +2123,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2186,7 +2186,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2247,7 +2247,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2310,7 +2310,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2374,7 +2374,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFile(string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="conditions">
@@ -2405,7 +2405,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFile(string, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="cancellationToken">
@@ -2434,7 +2434,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFile(string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="conditions">
@@ -2467,7 +2467,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFileAsync(string, CancellationToken)"/>
         /// operation immediately removesthe file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="cancellationToken">

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -161,7 +161,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -182,7 +182,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -307,7 +307,7 @@ namespace Azure.Storage.Files.Shares
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="shareSnapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
         /// </summary>
         /// <remarks>
         /// Pass null or empty string to remove the snapshot returning a URL to the base file.
@@ -343,7 +343,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -402,7 +402,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -459,7 +459,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -518,7 +518,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -575,7 +575,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -800,7 +800,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExists"/> operation immediately removes the file from the storage account,
         /// if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -830,7 +830,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExists"/> operation immediately removes the file from the storage account,
         /// if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -860,7 +860,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExistsInternal"/> operation immediately removes the file from the storage account,
         /// if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -923,7 +923,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -993,7 +993,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1036,7 +1036,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1106,7 +1106,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1149,7 +1149,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1257,7 +1257,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1291,7 +1291,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1323,7 +1323,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1357,7 +1357,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1389,7 +1389,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1457,7 +1457,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Download(HttpRange, bool, ShareFileRequestConditions, CancellationToken)"/>
         /// operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1505,7 +1505,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Download(HttpRange, bool, CancellationToken)"/> operation reads
         /// or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1551,7 +1551,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DownloadAsync(HttpRange, bool, ShareFileRequestConditions, CancellationToken)"/>
         /// operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1599,7 +1599,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DownloadAsync(HttpRange, bool, CancellationToken)"/> operation reads
         /// or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1644,7 +1644,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="DownloadInternal"/> operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1750,7 +1750,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="StartDownloadAsync"/> operation starts to read or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1820,7 +1820,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Delete(ShareFileRequestConditions, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -1850,7 +1850,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Delete(CancellationToken)"/> operation immediately
         /// removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1878,7 +1878,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteAsync(ShareFileRequestConditions, CancellationToken)"/> operation
         /// immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -1908,7 +1908,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteAsync(CancellationToken)"/> operation
         /// immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1935,7 +1935,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="DeleteInternal"/> operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2002,7 +2002,7 @@ namespace Azure.Storage.Files.Shares
         /// and system properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2035,7 +2035,7 @@ namespace Azure.Storage.Files.Shares
         /// and system properties for the file. It does not return the
         /// content of the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2065,7 +2065,7 @@ namespace Azure.Storage.Files.Shares
         /// operation returns all user-defined metadata, standard HTTP properties, and system
         /// properties for the file. It does not return the content of the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2098,7 +2098,7 @@ namespace Azure.Storage.Files.Shares
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2129,7 +2129,7 @@ namespace Azure.Storage.Files.Shares
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2201,7 +2201,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeaders(long?, ShareFileHttpHeaders, FileSmbProperties, string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation sets system properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2256,7 +2256,7 @@ namespace Azure.Storage.Files.Shares
         /// operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2308,7 +2308,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersAsync(long?, ShareFileHttpHeaders, FileSmbProperties, string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation sets system properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2362,7 +2362,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersAsync(long?, ShareFileHttpHeaders, FileSmbProperties, string, CancellationToken)"/>
         /// operation sets system properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2414,7 +2414,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2520,7 +2520,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata(Metadata, ShareFileRequestConditions, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2556,7 +2556,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata(Metadata, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2590,7 +2590,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataAsync(Metadata, ShareFileRequestConditions, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2626,7 +2626,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata(Metadata, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2660,7 +2660,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2729,7 +2729,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClearRange"/>
         /// operation clears the <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and end of the range must be specified.
@@ -2766,7 +2766,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClearRangeAsync"/>
         /// operation clears the <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and end of the range must be specified.
@@ -2802,7 +2802,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRangeInternal"/> operation clears the
         /// <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
 
         /// <param name="range">
@@ -2877,7 +2877,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRange(HttpRange, Stream, byte[], IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be written. Both the start and end of the range must be specified.
@@ -2935,7 +2935,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRangeAsync(HttpRange, Stream, byte[], IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be written. Both the start and end of the range must be specified.
@@ -2993,7 +2993,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRange(ShareFileRangeWriteType, HttpRange, Stream, byte[], IProgress{long}, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -3050,7 +3050,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRange(ShareFileRangeWriteType, HttpRange, Stream, byte[], IProgress{long}, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -3107,7 +3107,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRangeInternal"/> operation writes
         /// <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
 
         /// <param name="range">
@@ -3471,7 +3471,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Upload(Stream, IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3515,7 +3515,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Upload(Stream, IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3557,7 +3557,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadAsync(Stream, IProgress{long}, ShareFileRequestConditions, CancellationToken)"/> operation writes
         /// <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3601,7 +3601,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadAsync(Stream, IProgress{long}, CancellationToken)"/> operation writes
         /// <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3643,7 +3643,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadInternal"/> operation writes
         /// <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -3769,7 +3769,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3805,7 +3805,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3839,7 +3839,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3875,7 +3875,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3909,7 +3909,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3981,7 +3981,7 @@ namespace Azure.Storage.Files.Shares
         /// handles may make multiple requests to the service while fetching
         /// all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4005,7 +4005,7 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the handles may make multiple requests to the service
         /// while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4027,7 +4027,7 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="GetHandlesInternal"/> operation returns a list of open
         /// handles on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
         /// </summary>
         /// <remarks>
         /// </remarks>
@@ -4109,7 +4109,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -4153,7 +4153,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -4197,7 +4197,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4228,7 +4228,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4259,7 +4259,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -4311,7 +4311,7 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -101,7 +101,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         public ShareServiceClient(string connectionString)
             : this(connectionString, null)
@@ -117,7 +117,7 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline
@@ -218,7 +218,7 @@ namespace Azure.Storage.Files.Shares
         /// make multiple requests to the service while fetching all the
         /// values.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-shares"/>.
+        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">List Shares</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies traits to include in the <see cref="ShareItem"/>s.
@@ -255,7 +255,7 @@ namespace Azure.Storage.Files.Shares
         /// make multiple requests to the service while fetching all the
         /// values.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-shares"/>.
+        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">List Shares</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies traits to include in the <see cref="ShareItem"/>s.
@@ -295,7 +295,7 @@ namespace Azure.Storage.Files.Shares
         /// empty to make subsequent calls to <see cref="GetSharesAsync"/>
         /// to continue enumerating the shares segment by segment.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-shares"/>.
+        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">List Shares</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -506,7 +506,7 @@ namespace Azure.Storage.Files.Shares
         /// the default request version for all incoming requests to the File
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">Set File Service Properties</see>.
         /// </summary>
         /// <param name="properties">The file service properties.</param>
         /// <param name="cancellationToken">
@@ -537,7 +537,7 @@ namespace Azure.Storage.Files.Shares
         /// the default request version for all incoming requests to the File
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">Set File Service Properties</see>.
         /// </summary>
         /// <param name="properties">The file service properties.</param>
         /// <param name="cancellationToken">
@@ -568,7 +568,7 @@ namespace Azure.Storage.Files.Shares
         /// the default request version for all incoming requests to the File
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-file-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">Set File Service Properties</see>.
         /// </summary>
         /// <param name="properties">The file service properties.</param>
         /// <param name="async">
@@ -627,7 +627,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to create.
@@ -667,7 +667,7 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to create.
@@ -710,7 +710,7 @@ namespace Azure.Storage.Files.Shares
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to delete.
@@ -743,7 +743,7 @@ namespace Azure.Storage.Files.Shares
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to delete.

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -150,7 +150,7 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="queueName">
         /// The name of the queue in the storage account to reference.
@@ -169,7 +169,7 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="queueName">
         /// The name of the queue in the storage account to reference.
@@ -343,7 +343,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional <see cref="Metadata"/>.
@@ -366,7 +366,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional <see cref="Metadata"/>.
@@ -389,7 +389,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional <see cref="Metadata"/>.
@@ -449,7 +449,7 @@ namespace Azure.Storage.Queues
         /// operation creates a new queue under the specified account.  If the queue already exists, it is
         /// not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this queue.
@@ -479,7 +479,7 @@ namespace Azure.Storage.Queues
         /// operation creates a new queue under the specified account.  If the queue already exists, it is
         /// not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this queue.
@@ -509,7 +509,7 @@ namespace Azure.Storage.Queues
         /// operation creates a new queue under the specified account.  If the queue already exists, it is
         /// not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this queue.
@@ -788,7 +788,7 @@ namespace Azure.Storage.Queues
         #region Delete
         /// <summary>
         /// Deletes a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -805,7 +805,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -822,7 +822,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -875,7 +875,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">Get Queue Metadata</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -893,7 +893,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">Get Queue Metadata</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -911,7 +911,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">Get Queue Metadata</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -963,7 +963,7 @@ namespace Azure.Storage.Queues
         #region SetMetadata
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">Set Queue Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// <see cref="Metadata"/>
@@ -985,7 +985,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">Set Queue Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// <see cref="Metadata"/>
@@ -1007,7 +1007,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">Set Queue Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// <see cref="Metadata"/>
@@ -1060,7 +1060,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">Get Queue ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -1078,7 +1078,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">Get Queue ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -1096,7 +1096,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">Get Queue ACL</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1143,7 +1143,7 @@ namespace Azure.Storage.Queues
         #region SetAccessPolicy
         /// <summary>
         /// SetAccessPolicyAsync sets stored access policies for the queue that may be used with Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">Set Queue ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// IEnumerable of <see cref="QueueSignedIdentifier"/>
@@ -1165,7 +1165,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// SetAccessPolicyAsync sets stored access policies for the queue that may be used with Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">Set Queue ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// IEnumerable of <see cref="QueueSignedIdentifier"/>
@@ -1187,7 +1187,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// SetAccessPolicyInternal sets stored access policies for the queue that may be used with Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">Set Queue ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// IEnumerable of <see cref="QueueSignedIdentifier"/>
@@ -1239,7 +1239,7 @@ namespace Azure.Storage.Queues
         #region ClearMessages
         /// <summary>
         /// Deletes all messages from a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">Clear Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>.
@@ -1256,7 +1256,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes all messages from a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">Clear Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>.
@@ -1273,7 +1273,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes all messages from a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">Clear Messages</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1322,7 +1322,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1338,7 +1338,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1355,7 +1355,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1375,7 +1375,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1395,7 +1395,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1428,7 +1428,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1461,7 +1461,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1536,7 +1536,7 @@ namespace Azure.Storage.Queues
         #region ReceiveMessages
         /// <summary>
         /// Receives one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <returns>
         /// <see cref="Response{T}"/> where T is an array of <see cref="QueueMessage"/>
@@ -1545,7 +1545,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <returns>
         /// <see cref="Response{T}"/> where T is an array of <see cref="QueueMessage"/>
@@ -1556,7 +1556,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Receives one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/>
@@ -1571,7 +1571,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/>
@@ -1587,7 +1587,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Receives one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32.
@@ -1615,7 +1615,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32.
@@ -1643,7 +1643,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32.
@@ -1722,7 +1722,7 @@ namespace Azure.Storage.Queues
         #region PeekMessages
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">Peek Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to peek from the queue, up to a maximum of 32.
@@ -1745,7 +1745,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">Peek Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to peek from the queue, up to a maximum of 32.
@@ -1768,7 +1768,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">Peek Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to peek from the queue, up to a maximum of 32.
@@ -1849,7 +1849,7 @@ namespace Azure.Storage.Queues
         #region DeleteMessage
         /// <summary>
         /// Permanently removes the specified message from its queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">Delete Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to delete.</param>
         /// <param name="popReceipt">
@@ -1874,7 +1874,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Permanently removes the specified message from its queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">Delete Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to delete.</param>
         /// <param name="popReceipt">
@@ -1899,7 +1899,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Permanently removes the specified message from its queue.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">Delete Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to delete.</param>
         /// <param name="popReceipt">
@@ -1957,7 +1957,7 @@ namespace Azure.Storage.Queues
         #region UpdateMessage
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/update-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">Update Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to update.</param>
         /// <param name="popReceipt">
@@ -1994,7 +1994,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/update-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">Update Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to update.</param>
         /// <param name="popReceipt">
@@ -2031,7 +2031,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/update-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">Update Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Updated message text.

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -109,7 +109,7 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         public QueueServiceClient(string connectionString)
             : this(connectionString, null)
@@ -125,7 +125,7 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline
@@ -253,7 +253,7 @@ namespace Azure.Storage.Queues
         /// queues may make multiple requests to the service while fetching
         /// all the values.  Queue names are returned in lexicographic order.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-queues1"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">List Queues</see>
         /// </summary>
         /// <param name="traits">
         /// Optional trait options for shaping the queues.
@@ -280,7 +280,7 @@ namespace Azure.Storage.Queues
         /// queues may make multiple requests to the service while fetching
         /// all the values.  Queue names are returned in lexicographic order.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-queues1"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">List Queues</see>
         /// </summary>
         /// <param name="traits">
         /// Optional trait options for shaping the queues.
@@ -307,7 +307,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Returns a single segment of containers starting from the specified marker.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-queues1"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">List Queues</see>
         /// </summary>
         /// <param name="marker">
         /// Marker from the previous request.
@@ -393,7 +393,7 @@ namespace Azure.Storage.Queues
         #region GetProperties
         /// <summary>
         /// Gets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">Get Queue Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -410,7 +410,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Gets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">Get Queue Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -427,7 +427,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Gets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">Get Queue Service Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -474,7 +474,7 @@ namespace Azure.Storage.Queues
         #region SetProperties
         /// <summary>
         /// Sets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">Set Queue Service Properties</see>.
         /// </summary>
         /// <param name="properties">
         /// <see cref="QueueServiceProperties"/>
@@ -496,7 +496,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">Set Queue Service Properties</see>.
         /// </summary>
         /// <param name="properties">
         /// <see cref="QueueServiceProperties"/>
@@ -518,7 +518,7 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-service-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">Set Queue Service Properties</see>.
         /// </summary>
         /// <param name="properties">
         /// <see cref="QueueServiceProperties"/>
@@ -574,7 +574,7 @@ namespace Azure.Storage.Queues
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication is enabled for the storage account.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">Get Queue Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -593,7 +593,7 @@ namespace Azure.Storage.Queues
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication is enabled for the storage account.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">Get Queue Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -612,7 +612,7 @@ namespace Azure.Storage.Queues
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication is enabled for the storage account.
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">Get Queue Service Stats</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -660,7 +660,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to create.
@@ -688,7 +688,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-queue4"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to create.
@@ -718,7 +718,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Deletes a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to delete.
@@ -738,7 +738,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Deletes a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to delete.


### PR DESCRIPTION
While browsing the docs, I've noticed several missing links such as 
https://docs.microsoft.com/en-us/dotnet/api/azure.storage.files.shares.sharefileclient.-ctor?view=azure-dotnet#Azure_Storage_Files_Shares_ShareFileClient__ctor_System_String_System_String_System_String_

![image](https://user-images.githubusercontent.com/12971179/85086577-ddeda480-b18f-11ea-9397-d3ea7cde1096.png)

When I was working on dotnet-api-docs, the expected syntax includes the link text as well (which also helps with SEO). I also removed the en-us locale from links that contained that.