### PR TITLE
Relax the upped bound for Microsoft.IdentityModel.* dependencies.

### DIFF
--- a/sdk/mgmtcommon/Auth/Az.Auth/Az.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
+++ b/sdk/mgmtcommon/Auth/Az.Auth/Az.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
@@ -10,7 +10,7 @@
 	<PackageReleaseNotes>
       <![CDATA[
         Fixes:
-        - Relaxed upped bound for Microsoft.IdentityModel.* dependencies
+        - Relaxed the upped bound for Microsoft.IdentityModel.* dependencies.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/sdk/mgmtcommon/Auth/Az.Auth/Az.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
+++ b/sdk/mgmtcommon/Auth/Az.Auth/Az.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
@@ -5,11 +5,12 @@
     <Description>Provides ADAL based authentication for Azure management client libraries</Description>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.Authentication</AssemblyName>
     <AssemblyTitle>Authentication for Azure Management Clients</AssemblyTitle>
-    <Version>2.4.0</Version>    
+    <Version>2.4.1</Version>    
     <PackageTags>Microsoft AutoRest ClientRuntime Authentication $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
 	<PackageReleaseNotes>
       <![CDATA[
-        1) Added support for KeyVault/dSMS assisted Cert Rotation 
+        Fixes:
+        - Relaxed upped bound for Microsoft.IdentityModel.* dependencies
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>
@@ -36,17 +37,17 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[4.3.0, 6.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[5.1.2, 6.0.0)" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[4.3.0, 6.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[5.1.2, 6.0.0)" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[4.3.0, 6.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[5.1.2, 6.0.0)" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/11617


This change by itself is quite safe because it doesn't affect the resolved Microsoft.IdentityModel.* versions.

The second question is if the library would work with the 6.* version of `Microsoft.IdentityModel.Tokens`:

We are not affected by any breaking changes and they claimed to be minor corner cases only.

We can work with Identity team to fix incompatibilities if we find them.

Confirmed working with 6.6.0.