### PR TITLE
Fixes #10814.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -478,7 +478,7 @@ namespace Azure.Storage.Blobs.Specialized
                 progressHandler,
                 accessTier,
                 cancellationToken).ConfigureAwait(false);
-            }
+        }
 
         /// <summary>
         /// The <see cref="UploadInternal"/> operation creates a new block blob,
@@ -560,7 +560,7 @@ namespace Azure.Storage.Blobs.Specialized
                         Pipeline,
                         Uri,
                         body: content,
-                        contentLength: content?.Length ?? 0,
+                        contentLength: content != null ? content.Length - content.Position : 0,
                         version: Version.ToVersionString(),
                         blobContentType: blobHttpHeaders?.ContentType,
                         blobContentEncoding: blobHttpHeaders?.ContentEncoding,

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -866,14 +866,15 @@ namespace Azure.Storage.Blobs.Specialized
                 try
                 {
                     content = content?.WithNoDispose().WithProgress(progressHandler);
-                    var range = new HttpRange(offset, content?.Length ?? null);
+                    long? contentLength = content != null ? (long?)(content.Length - content.Position) : null;
+                    var range = new HttpRange(offset, contentLength);
 
                     return await BlobRestClient.PageBlob.UploadPagesAsync(
                         ClientDiagnostics,
                         Pipeline,
                         Uri,
                         body: content,
-                        contentLength: content?.Length ?? 0,
+                        contentLength: contentLength ?? 0,
                         version: Version.ToVersionString(),
                         transactionalContentHash: transactionalContentHash,
                         timeout: default,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploadExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploadExtensions.cs
@@ -28,7 +28,7 @@ namespace Azure.Storage.Shared
             {
                 if (content.CanSeek)
                 {
-                    length = content.Length;
+                    length = content.Length - content.Position;
                     return true;
                 }
             }


### PR DESCRIPTION
This PR fixes #10814. It assumes that is possible read the Position from the Stream, which I think is true in all code paths the PR affects. If the original stream was not `Seekable` from the beginning, it will be converted to a `ChunkedStream`.

I think this fixes the issue with #10814 , but the same problem could be in other places as well.
