### PR TITLE
Increase test pipeline timeout 

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -4,6 +4,7 @@ extends:
   template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: keyvault
+    TimeoutInMinutes: 120
     EnvVars:
       # Runs samples with live tests.
       AZURE_KEYVAULT_TEST_MODE: Live


### PR DESCRIPTION
Nightly builds have started exceeding 60m, which is the default timeout.

https://dev.azure.com/azure-sdk/internal/_build?definitionId=234 