### PR TITLE
Remove blob feed publishing

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -275,9 +275,3 @@ stages:
           command: push
           packagesToPush: '$(Pipeline.Workspace)/packages-signed/**/*.nupkg;!$(Pipeline.Workspace)/packages-signed/**/*.symbols.nupkg'
           publishVstsFeed: $(DevOpsFeedID)
-      - task: MSBuild@1
-        displayName: 'Publish to blobfeed'
-        condition: and(succeeded(), eq('${{ parameters.DevOpsFeedID }}', variables['DevOpsFeedID']))
-        inputs:
-          solution: '$(AzureSDKBuildToolsPath)/tools/blobfeedtool/BlobFeedPublishHelper.proj'
-          msbuildArguments: '/p:AccountKey=$(azuresdkartifacts-access-key) /p:ExpectedFeedUrl=$(BlobFeedUrl) /p:PackagesPath="$(Pipeline.Workspace)/packages-signed"'


### PR DESCRIPTION
Quit publishing to blob feed to complete transition to DevOps Artifact Pipeline.
https://github.com/Azure/azure-sdk-for-net/issues/7150