### PR TITLE
Comment description proposal for get only mutable collection properties

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/ImportCertificateOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/ImportCertificateOptions.cs
@@ -67,7 +67,7 @@ namespace Azure.Security.KeyVault.Certificates
 
         /// <summary>
         /// Gets the tags to be applied to the imported certificate. Although this collection cannot be set, it can be modified
-        ///  or initialized with a collection initializer.
+        ///  or initialized with a <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer">collection initializer</see>.
         /// </summary>
         public IDictionary<string, string> Tags => LazyInitializer.EnsureInitialized(ref _tags);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/ImportCertificateOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/ImportCertificateOptions.cs
@@ -66,7 +66,8 @@ namespace Azure.Security.KeyVault.Certificates
         public bool? Enabled { get; set; }
 
         /// <summary>
-        /// Gets the tags to be applied to the imported certificate.
+        /// Gets the tags to be applied to the imported certificate. Although this collection cannot be set, it can be modified
+        ///  or initialized with a collection initializer.
         /// </summary>
         public IDictionary<string, string> Tags => LazyInitializer.EnsureInitialized(ref _tags);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/MergeCertificateOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/MergeCertificateOptions.cs
@@ -53,7 +53,8 @@ namespace Azure.Security.KeyVault.Certificates
         public bool? Enabled { get; set; }
 
         /// <summary>
-        /// Gets the tags to be applied to the merged certificate.
+        /// Gets the tags to be applied to the merged certificate. Although this collection cannot be set, it can be modified
+        ///  or initialized with a <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer">collection initializer</see>.
         /// </summary>
         public IDictionary<string, string> Tags => LazyInitializer.EnsureInitialized(ref _tags);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateKeyOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateKeyOptions.cs
@@ -39,7 +39,8 @@ namespace Azure.Security.KeyVault.Keys
         public bool? Enabled { get; set; }
 
         /// <summary>
-        /// Gets a dictionary of tags with specific metadata about the key.
+        /// Gets a dictionary of tags with specific metadata about the key. Although this collection cannot be set, it can be modified
+        ///  or initialized with a <see href="https://docs.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer">collection initializer</see>.
         /// </summary>
         public IDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
     }


### PR DESCRIPTION
# Summary
As described in the linked issue below, collection properties which are mutable but not settable are a point of confusion for many developers. This is a proposal for some additional hint verbiage on such properties. Appropriate patterns for mutating these collections could potentially also be added to samples, and/or as `<example>` XML doc comments as appropriate.

Whatever is ultimately decided here could be applied to any such property across this and other clients.

fixes #10580 