### PR TITLE
Enable TA test 

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesWithLanguageTest.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/general",
+      "RequestUri": "https://azsdknet-test-ta.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Content-Length": "102",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8f03f08606a6c24c93d40b373cc7dcae-8dba426bf4455a42-00",
+        "traceparent": "00-deaee0846dc4164d9c7ef490b89f660e-b7b9688180bb2e44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200128.1\u002Be5639ed90e83bdfbc90235ee2d4bde3a94e1e715",
-          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.TextAnalytics/1.1.0-dev.20200624.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5c7fa00e33c5789aa2c892266f1ac0b6",
         "x-ms-return-client-request-id": "true"
@@ -26,14 +26,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b8c83feb-1d50-4196-afaf-65bc1c9c3f4e",
+        "apim-request-id": "f5c65eed-c207-4f1a-9a88-96f3e7476bb6",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
-        "Date": "Tue, 28 Jan 2020 19:10:04 GMT",
+        "Date": "Thu, 25 Jun 2020 02:34:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "20"
+        "x-envoy-upstream-service-time": "81"
       },
       "ResponseBody": {
         "documents": [
@@ -42,36 +42,37 @@
             "entities": [
               {
                 "text": "Microsoft",
-                "type": "Organization",
+                "category": "Organization",
                 "offset": 0,
                 "length": 9,
-                "score": 0.99482542276382446
+                "confidenceScore": 0.85
               },
               {
                 "text": "Bill Gates",
-                "type": "Person",
+                "category": "Person",
                 "offset": 26,
                 "length": 10,
-                "score": 0.99993896484375
+                "confidenceScore": 0.82
               },
               {
                 "text": "Paul Allen",
-                "type": "Person",
+                "category": "Person",
                 "offset": 39,
                 "length": 10,
-                "score": 0.99945086240768433
+                "confidenceScore": 0.77
               }
-            ]
+            ],
+            "warnings": []
           }
         ],
         "errors": [],
-        "modelVersion": "2019-10-01"
+        "modelVersion": "2020-04-01"
       }
     }
   ],
   "Variables": {
     "RandomSeed": "467501370",
-    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/",
-    "TEXT_ANALYTICS_API_KEY": "Sanitized"
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://azsdknet-test-ta.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesWithLanguageTestAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/general",
+      "RequestUri": "https://azsdknet-test-ta.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Content-Length": "102",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3627f4c736dc054abe8b50aff7e91d6a-0ee3b95f2b88ad41-00",
+        "traceparent": "00-b09d309e66b09947997dc8d78d182145-ac30ac3cddd01248-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200128.1\u002Be5639ed90e83bdfbc90235ee2d4bde3a94e1e715",
-          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.TextAnalytics/1.1.0-dev.20200624.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5c0c243ab38cebc9a1089bb692f33b64",
         "x-ms-return-client-request-id": "true"
@@ -26,14 +26,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f8dd745-a693-4fd0-b805-6633769fa9a5",
+        "apim-request-id": "d3bda5c5-e7db-40eb-900a-c5491283cad1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
-        "Date": "Tue, 28 Jan 2020 19:10:05 GMT",
+        "Date": "Thu, 25 Jun 2020 02:34:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "76"
       },
       "ResponseBody": {
         "documents": [
@@ -42,36 +42,37 @@
             "entities": [
               {
                 "text": "Microsoft",
-                "type": "Organization",
+                "category": "Organization",
                 "offset": 0,
                 "length": 9,
-                "score": 0.99482542276382446
+                "confidenceScore": 0.85
               },
               {
                 "text": "Bill Gates",
-                "type": "Person",
+                "category": "Person",
                 "offset": 26,
                 "length": 10,
-                "score": 0.99993896484375
+                "confidenceScore": 0.82
               },
               {
                 "text": "Paul Allen",
-                "type": "Person",
+                "category": "Person",
                 "offset": 39,
                 "length": 10,
-                "score": 0.99945086240768433
+                "confidenceScore": 0.77
               }
-            ]
+            ],
+            "warnings": []
           }
         ],
         "errors": [],
-        "modelVersion": "2019-10-01"
+        "modelVersion": "2020-04-01"
       }
     }
   ],
   "Variables": {
     "RandomSeed": "1210300364",
-    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/",
-    "TEXT_ANALYTICS_API_KEY": "Sanitized"
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://azsdknet-test-ta.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -543,7 +543,6 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
-        [Ignore ("Tracked by issue: https://github.com/Azure/azure-sdk-for-net/issues/11567")]
         public async Task RecognizeEntitiesWithLanguageTest()
         {
             TextAnalyticsClient client = GetClient();


### PR DESCRIPTION
Service team has confirmed https://github.com/Azure/azure-sdk-for-net/issues/11567#event-3479795318 has been fix, so enabling the test again.