### PR TITLE
Search: Remove Azure.Core.Experimental features

### DIFF
--- a/sdk/search/Azure.Search.Documents/Directory.Build.props
+++ b/sdk/search/Azure.Search.Documents/Directory.Build.props
@@ -3,7 +3,7 @@
   <!-- Azure.Core.Experimental feature flags -->
   <PropertyGroup>
     <!-- Enable everything by default -->
-    <UseAzureCoreExperimental Condition="'$(UseAzureCoreExperimental)' == ''">true</UseAzureCoreExperimental>
+    <UseAzureCoreExperimental Condition="'$(UseAzureCoreExperimental)' == ''">false</UseAzureCoreExperimental>
 
     <!-- Use Azure.Core.Experimental's Spatial features -->
     <!-- (Note: a number of tests will need re-recording if you disable) -->
@@ -15,7 +15,7 @@
     <DefineConstants Condition="'$(UseAzureCoreExperimentalSerializer)' == 'true'">EXPERIMENTAL_SERIALIZER;$(DefineConstants)</DefineConstants>
 
     <!-- Use Azure.Core.Experimental's DynamicData features (stubbed out in Search for now) -->
-    <UseAzureCoreExperimentalDynamic Condition="'$(UseAzureCoreExperimentalDynamic)' == ''">false</UseAzureCoreExperimentalDynamic>
+    <UseAzureCoreExperimentalDynamic Condition="'$(UseAzureCoreExperimentalDynamic)' == ''">$(UseAzureCoreExperimental)</UseAzureCoreExperimentalDynamic>
     <DefineConstants Condition="'$(UseAzureCoreExperimentalDynamic)' == 'true'">EXPERIMENTAL_DYNAMIC;$(DefineConstants)</DefineConstants>
 
     <!-- Use a Package or Project reference to Azure.Core.Experimental -->

--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -56,7 +56,6 @@ namespace Azure.Search.Documents
     public partial class SearchClientOptions : Azure.Core.ClientOptions
     {
         public SearchClientOptions(Azure.Search.Documents.SearchClientOptions.ServiceVersion version = Azure.Search.Documents.SearchClientOptions.ServiceVersion.V2019_05_06_Preview) { }
-        public Azure.Core.ObjectSerializer Serializer { get { throw null; } set { } }
         public Azure.Search.Documents.SearchClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
         {
@@ -1966,8 +1965,6 @@ namespace Azure.Search.Documents.Models
         public System.Collections.Generic.IReadOnlyList<long> GetInt64Collection(string key) { throw null; }
         public Azure.Search.Documents.Models.SearchDocument GetObject(string key) { throw null; }
         public System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Models.SearchDocument> GetObjectCollection(string key) { throw null; }
-        public Azure.Core.Spatial.PointGeometry GetPoint(string key) { throw null; }
-        public System.Collections.Generic.IReadOnlyList<Azure.Core.Spatial.PointGeometry> GetPointCollection(string key) { throw null; }
         public string GetString(string key) { throw null; }
         public System.Collections.Generic.IReadOnlyList<string> GetStringCollection(string key) { throw null; }
         public bool Remove(string key) { throw null; }

--- a/sdk/search/Azure.Search.Documents/src/SearchClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchClient.cs
@@ -196,10 +196,6 @@ namespace Azure.Search.Documents
         /// <param name="indexName">
         /// Required.  The name of the Search Index.
         /// </param>
-        /// <param name="serializer">
-        /// Gets or sets an <see cref="ObjectSerializer"/> that can be used to
-        /// customize the serialization of strongly typed models.
-        /// </param>
         /// <param name="pipeline">
         /// The authenticated <see cref="HttpPipeline"/> used for sending
         /// requests to the Search Service.
@@ -462,7 +458,7 @@ namespace Azure.Search.Documents
         /// </item>
         /// <item>
         /// <term>Edm.GeographyPoint</term>
-        /// <description> <see cref="Azure.Core.Spatial.PointGeometry"/>
+        /// <description> Azure.Core.Spatial.PointGeometry
         /// </description>
         /// </item>
         /// <item>
@@ -511,7 +507,7 @@ namespace Azure.Search.Documents
         /// </item>
         /// <item>
         /// <term>Collection(Edm.GeographyPoint)</term>
-        /// <description>sequence of <see cref="Azure.Core.Spatial.PointGeometry"/>
+        /// <description>sequence of Azure.Core.Spatial.PointGeometry
         /// (seq&lt;PointGeometry&gt; in F#)</description>
         /// </item>
         /// <item>

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/GetDocumentTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/GetDocumentTests.cs
@@ -51,16 +51,18 @@ namespace Azure.Search.Documents.Tests
                 {
                     case SearchDocument subDoc:
                         ICollection<string> subFields = SelectPopulatedFields(subDoc);
-                        if (subFields.Any())
+                        if (!subFields.Any() ||
+                            (subFields.Contains("type") && subDoc.GetString("type") == "Point"))
+                        {
+                            // Ignore empty documents or GeographyPoints represented as documents
+                            selected.Add(field);
+                        }
+                        else
                         {
                             foreach (string subField in subFields)
                             {
                                 selected.Add(MakeFieldPath(subField));
                             }
-                        }
-                        else
-                        {
-                            selected.Add(field);
                         }
                         break;
 
@@ -301,7 +303,7 @@ namespace Azure.Search.Documents.Tests
             {
                 ["hotelId"] = "1",
                 ["hotelName"] = "2015-02-11T12:58:00Z",
-                ["location"] = TestExtensions.CreatePoint(-73.975403, 40.760586), // Test that we don't confuse Geo-JSON & complex types.
+                ["location"] = TestExtensions.CreateDynamicPoint(-73.975403, 40.760586), // Test that we don't confuse Geo-JSON & complex types.
                 ["rooms"] = new[]
                 {
                     new SearchDocument
@@ -317,7 +319,7 @@ namespace Azure.Search.Documents.Tests
                 {
                     ["hotelId"] = "1",
                     ["hotelName"] = new DateTimeOffset(2015, 2, 11, 12, 58, 0, TimeSpan.Zero),
-                    ["location"] = TestExtensions.CreatePoint(-73.975403, 40.760586),
+                    ["location"] = TestExtensions.CreateDynamicPoint(-73.975403, 40.760586),
                     ["rooms"] = new[]
                     {
                         new SearchDocument

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/IndexingTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/IndexingTests.cs
@@ -150,7 +150,7 @@ namespace Azure.Search.Documents.Tests
                         ["smokingAllowed"] = true,
                         ["lastRenovationDate"] = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.FromHours(-5)),
                         ["rating"] = 4,
-                        ["location"] = TestExtensions.CreatePoint(-73.975403, 40.760586),
+                        ["location"] = TestExtensions.CreateDynamicPoint(-73.975403, 40.760586),
                         ["address"] = new SearchDocument()
                         {
                             ["streetAddress"] = "677 5th Ave",
@@ -198,7 +198,7 @@ namespace Azure.Search.Documents.Tests
                         ["smokingAllowed"] = true,
                         ["lastRenovationDate"] = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.FromHours(-5)),
                         ["rating"] = 4,
-                        ["location"] = TestExtensions.CreatePoint(-73.975403, 40.760586),
+                        ["location"] = TestExtensions.CreateDynamicPoint(-73.975403, 40.760586),
                         ["address"] = new SearchDocument()
                         {
                             ["streetAddress"] = "677 5th Ave",
@@ -883,7 +883,7 @@ namespace Azure.Search.Documents.Tests
                     ["smokingAllowed"] = true,
                     ["lastRenovationDate"] = new DateTimeOffset(1970, 1, 18, 0, 0, 0, TimeSpan.FromHours(-5)),
                     ["rating"] = 4L,
-                    ["location"] = TestExtensions.CreatePoint(-73.975403, 40.760586),
+                    ["location"] = TestExtensions.CreateDynamicPoint(-73.975403, 40.760586),
                     ["address"] = new SearchDocument
                     {
                         ["streetAddress"] = "677 5th Ave",

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.Data.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.Data.cs
@@ -9,6 +9,8 @@ using Azure.Search.Documents.Indexes.Models;
 #if EXPERIMENTAL_SPATIAL
 using Azure.Core.Spatial;
 #else
+using System.Text.Json;
+using System.Collections.Generic;
 using Microsoft.Spatial;
 #endif
 
@@ -326,8 +328,9 @@ namespace Azure.Search.Documents.Tests
         [JsonPropertyName("location")]
         public PointGeometry Location { get; set; }
 #else
-        [JsonIgnore]
-        public GeographyPoint Location { get; set; } = null;
+        [JsonPropertyName("location")]
+        [JsonConverter(typeof(GeographyPointConverter))]
+        public GeographyPoint Location { get; set; }
 #endif
 
         [JsonPropertyName("address")]
@@ -388,12 +391,102 @@ namespace Azure.Search.Documents.Tests
                 ["smokingAllowed"] = SmokingAllowed,
                 ["lastRenovationDate"] = LastRenovationDate,
                 ["rating"] = Rating,
+#if EXPERIMENTAL_SPATIAL
                 ["location"] = Location,
+#else
+                ["location"] = GeographyPointConverter.AsDocument(Location),
+#endif
                 ["address"] = Address?.AsDocument(),
                 // With no elements to infer the type during deserialization, we must assume object[].
                 ["rooms"] = Rooms?.Select(r => r.AsDocument())?.ToArray() ?? new object[0]
             };
     }
+
+#if !EXPERIMENTAL_SPATIAL
+    /// <summary>
+    /// Convert GeographyPoints to System.Text.Json or SearchDocument
+    /// representations.
+    /// </summary>
+    internal class GeographyPointConverter : JsonConverter<GeographyPoint>
+    {
+        public override GeographyPoint Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                string type = null;
+                double? longitude = null;
+                double? latitude = null;
+
+                while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    string propertyName = reader.GetString();
+                    if (reader.Read())
+                    {
+                        switch (propertyName)
+                        {
+                            case "type":
+                                type = reader.GetString();
+                                break;
+                            case "coordinates":
+                                if (reader.TokenType == JsonTokenType.StartArray &&
+                                    reader.Read() &&
+                                    reader.TokenType == JsonTokenType.Number)
+                                {
+                                    longitude = reader.GetDouble();
+                                    if (reader.Read() && reader.TokenType == JsonTokenType.Number)
+                                    {
+                                        latitude = reader.GetDouble();
+                                        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                                        {
+                                            // Skip optional altitude
+                                        }
+                                    }
+                                }
+                                break;
+                            default:
+                                reader.Skip();
+                                break;
+                        }
+                    }
+                }
+
+                if (type == "Point" && longitude != null && latitude != null)
+                {
+                    return GeographyPoint.Create(latitude.Value, longitude.Value);
+                }
+            }
+
+            throw new JsonException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, GeographyPoint value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "Point");
+            writer.WritePropertyName("coordinates");
+            writer.WriteStartArray();
+            writer.WriteNumberValue(value.Longitude);
+            writer.WriteNumberValue(value.Latitude);
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        public static SearchDocument AsDocument(GeographyPoint value)
+        {
+            if (value == null) { return null; }
+            List<double> coords = new List<double> { value.Longitude, value.Latitude };
+            if (value.Z != null)
+            {
+                coords.Add(value.Z.Value);
+            }
+            return new SearchDocument()
+            {
+                ["type"] = "Point",
+                ["coordinates"] = coords.ToArray()
+            };
+        }
+    }
+#endif
 
     // Same structure as Hotel, but without attributes that change to camelCase
     internal class UncasedHotel
@@ -412,6 +505,7 @@ namespace Azure.Search.Documents.Tests
 #if EXPERIMENTAL_SPATIAL
         public PointGeometry Location { get; set; }
 #else
+        [JsonConverter(typeof(GeographyPointConverter))]
         public GeographyPoint Location { get; set; } = null;
 #endif
         public HotelAddress Address { get; set; }

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/TestExtensions.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/TestExtensions.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 #if EXPERIMENTAL_SPATIAL
 using Azure.Core.Spatial;
 #else
+using Azure.Search.Documents.Models;
 using Microsoft.Spatial;
 #endif
 using NUnit.Framework;
@@ -163,10 +164,16 @@ namespace Azure.Search.Documents.Tests
 #if EXPERIMENTAL_SPATIAL
         public static PointGeometry CreatePoint(double longitude, double latitude) =>
             new PointGeometry(new GeometryPosition(longitude, latitude));
+
+        public static PointGeometry CreateDynamicPoint(double longitude, double latitude) =>
+            CreatePoint(longitude, latitude);
 #else
         public static GeographyPoint CreatePoint(double longitude, double latitude) =>
             // Note: GeographyPoint takes latitude first, unlike PointGeometry
             GeographyPoint.Create(latitude, longitude);
+
+        public static SearchDocument CreateDynamicPoint(double longitude, double latitude) =>
+            GeographyPointConverter.AsDocument(CreatePoint(longitude, latitude));
 #endif
     }
 }


### PR DESCRIPTION
Fixes #12816 by removing Spatial types and ObjectSerializer for now.  We will add them back when they make it into Azure.Core.

Rather than re-record the tests when swiching back to Microsoft.Spatial, I'm adding a converter to write JSON out in the same format as Azure.Core.Spatial so it'll be easier to flip back and forth if we need to.

//fyi @pakrym 