### PR TITLE
Plugin as pipeline

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Plugins/ServiceBusPipeline.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Plugins/ServiceBusPipeline.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus.Diagnostics;
+using Azure.Messaging.ServiceBus.Plugins;
+
+namespace Azure.Messaging.ServiceBus
+{
+    internal class ServiceBusPipeline
+    {
+        private ReadOnlyMemory<ServiceBusPlugin> _pipeline;
+
+        public ServiceBusPipeline(ReadOnlyMemory<ServiceBusPlugin> pipeline)
+        {
+            _pipeline = pipeline;
+        }
+
+        public ValueTask ProcessSendAsync(ServiceBusMessage message)
+        {
+            if (_pipeline.Length > 0)
+            {
+                return _pipeline.Span[0].ProcessSendAsync(message, _pipeline.Slice(1));
+            }
+            return default;
+        }
+        public ValueTask ProcessReceiveAsync(ServiceBusReceivedMessage message)
+        {
+            if (_pipeline.Length > 0)
+            {
+                return _pipeline.Span[0].ProcessReceiveAsync(message, _pipeline.Slice(1));
+            }
+            return default;
+        }
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Plugins/ServiceBusPlugin.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Plugins/ServiceBusPlugin.cs
@@ -38,7 +38,7 @@ namespace Azure.Messaging.ServiceBus.Plugins
             string pluginType = GetType().Name;
             try
             {
-                Logger.PluginCallStarted(pluginType, message.ToString());
+                Logger.PluginCallStarted(pluginType, message.MessageId);
                 BeforeMessageSendAsync(message);
                 Logger.PluginCallCompleted(pluginType, message.MessageId);
             }
@@ -64,7 +64,7 @@ namespace Azure.Messaging.ServiceBus.Plugins
             string pluginType = GetType().Name;
             try
             {
-                Logger.PluginCallStarted(pluginType, message.ToString());
+                Logger.PluginCallStarted(pluginType, message.MessageId);
                 AfterMessageReceiveAsync(message);
                 Logger.PluginCallCompleted(pluginType, message.MessageId);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -212,28 +212,6 @@ namespace Azure.Messaging.ServiceBus
             Logger.SendMessageComplete(Identifier);
         }
 
-        //private async Task ApplyPlugins(IList<ServiceBusMessage> messages)
-        //{
-        //    foreach (ServiceBusPolicy plugin in _plugins)
-        //    {
-        //        string pluginType = plugin.GetType().Name;
-        //        foreach (ServiceBusMessage message in messages)
-        //        {
-        //            try
-        //            {
-        //                Logger.PluginCallStarted(pluginType, message.MessageId);
-        //                await plugin.ProcessOutgoingAsync(message, _plugins).ConfigureAwait(false);
-        //                Logger.PluginCallCompleted(pluginType, message.MessageId);
-        //            }
-        //            catch (Exception ex)
-        //            {
-        //                Logger.PluginCallException(pluginType, message.MessageId, ex.ToString());
-        //                throw;
-        //            }
-        //        }
-        //    }
-        //}
-
         private DiagnosticScope CreateDiagnosticScope(IEnumerable<ServiceBusMessage> messages, string activityName)
         {
             InstrumentMessages(messages);


### PR DESCRIPTION
This changes the implementation for plugins to use a pipeline under the hood such that each plugin will invoke the next one. There should be no change to observable behavior for users and there are no API changes. However, implementing it in this way allows us to easily expose the ProcessSendAsync/ProcessSendNextAsync/ProcessReceiveAsync/ProcessReceiveNextAsync if we determine that there is a need for exposing this chaining/stack-based functionality in the future.