### PR TITLE
[FR] Renames after Arch board

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 1.0.0-preview.4 (Unreleased)
 
-### Breaking changes
+### Renames
+- Property `RequestedOn` renamed to `TrainingStartedOn` on `CustomFormModel` and `CustomFormModelInfo`.
+- Property `CompletedOn` renamed to `TrainingCompletedOn` on `CustomFormModel` and `CustomFormModelInfo`.
+
+### Other breaking changes
 
 - Property `CopyAuthorization.ExpiresOn` type is now `DateTimeOffset`.
 - `RecognizedReceipt` and `RecognizedReceiptsCollection` classes removed. Receipt field values must now be obtained from a `RecognizedForm`.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Renames
 - Property `RequestedOn` renamed to `TrainingStartedOn` on `CustomFormModel` and `CustomFormModelInfo`.
 - Property `CompletedOn` renamed to `TrainingCompletedOn` on `CustomFormModel` and `CustomFormModelInfo`.
+- Parameter `formUrl` in `StartRecognizeContent` has been renamed to `formUri`.
+- Parameters `receiptUrl` in `StartRecognizeReceipts` has been renamed to `receiptUri`.
 
 ### Other breaking changes
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Property `RequestedOn` renamed to `TrainingStartedOn` on `CustomFormModel` and `CustomFormModelInfo`.
 - Property `CompletedOn` renamed to `TrainingCompletedOn` on `CustomFormModel` and `CustomFormModelInfo`.
 - Parameter `formUrl` in `StartRecognizeContent` has been renamed to `formUri`.
-- Parameters `receiptUrl` in `StartRecognizeReceipts` has been renamed to `receiptUri`.
+- Parameter `receiptUrl` in `StartRecognizeReceipts` has been renamed to `receiptUri`.
+- Parameter `accessToken` in `CopyAuthorization.FromJson` has been renamed to `copyAuthorization`.
 
 ### Other breaking changes
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -134,7 +134,7 @@ The following section provides several code snippets illustrating common pattern
 Recognize text and table data, along with their bounding box coordinates, from documents.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-FormPageCollection formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+FormPageCollection formPages = await client.StartRecognizeContentFromUri(invoiceUri).WaitForCompletionAsync();
 foreach (FormPage page in formPages)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
@@ -163,7 +163,7 @@ Recognize and extract form fields and other content from your custom forms, usin
 ```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
 foreach (RecognizedForm form in forms)
 {
     Console.WriteLine($"Form of type: {form.FormType}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -283,8 +283,8 @@ CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl)
 Console.WriteLine($"Custom Model Info:");
 Console.WriteLine($"    Model Id: {model.ModelId}");
 Console.WriteLine($"    Model Status: {model.Status}");
-Console.WriteLine($"    Requested on: {model.RequestedOn}");
-Console.WriteLine($"    Completed on: {model.CompletedOn}");
+Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
+Console.WriteLine($"    Training model Completed on: {model.TrainingCompletedOn}");
 
 foreach (CustomFormSubmodel submodel in model.Submodels)
 {
@@ -320,8 +320,8 @@ foreach (CustomFormModelInfo modelInfo in models.Take(10))
     Console.WriteLine($"Custom Model Info:");
     Console.WriteLine($"    Model Id: {modelInfo.ModelId}");
     Console.WriteLine($"    Model Status: {modelInfo.Status}");
-    Console.WriteLine($"    Requested on: {modelInfo.RequestedOn}");
-    Console.WriteLine($"    Completed on: {modelInfo.CompletedOn}");
+    Console.WriteLine($"    Training model started on: {modelInfo.TrainingStartedOn}");
+    Console.WriteLine($"    Training model completed on: {modelInfo.TrainingCompletedOn}");
 }
 
 // Create a new model to store in the account

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -284,7 +284,7 @@ Console.WriteLine($"Custom Model Info:");
 Console.WriteLine($"    Model Id: {model.ModelId}");
 Console.WriteLine($"    Model Status: {model.Status}");
 Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
-Console.WriteLine($"    Training model Completed on: {model.TrainingCompletedOn}");
+Console.WriteLine($"    Training model completed on: {model.TrainingCompletedOn}");
 
 foreach (CustomFormSubmodel submodel in model.Submodels)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize the content from a given file at a URI, use the `StartRecognizeContentFromUri` method. The returned value is a collection of `FormPage` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-FormPageCollection formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+FormPageCollection formPages = await client.StartRecognizeContentFromUri(invoiceUri).WaitForCompletionAsync();
 foreach (FormPage page in formPages)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeCustomForms.md
@@ -24,7 +24,7 @@ To recognize form fields and other content from your custom forms from a given f
 ```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
 foreach (RecognizedForm form in forms)
 {
     Console.WriteLine($"Form of type: {form.FormType}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method. The returned value is a collection of `RecognizedReceipt` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
 
 // To see the list of the supported fields returned by service and its corresponding types, consult:
 // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
@@ -56,7 +56,7 @@ public Receipt(RecognizedForm recognizedForm)
 Here we illustrate how to use the `Receipt` wrapper class described above.
 
 ```C# Snippet:FormRecognizerSampleStronglyTypingARecognizedForm
-RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
 
 foreach (RecognizedForm recognizedForm in recognizedForms)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample5_TrainModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample5_TrainModel.md
@@ -34,7 +34,7 @@ Console.WriteLine($"Custom Model Info:");
 Console.WriteLine($"    Model Id: {model.ModelId}");
 Console.WriteLine($"    Model Status: {model.Status}");
 Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
-Console.WriteLine($"    Training model Completed on: {model.TrainingCompletedOn}");
+Console.WriteLine($"    Training model completed on: {model.TrainingCompletedOn}");
 
 foreach (CustomFormSubmodel submodel in model.Submodels)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample5_TrainModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample5_TrainModel.md
@@ -33,8 +33,8 @@ CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl)
 Console.WriteLine($"Custom Model Info:");
 Console.WriteLine($"    Model Id: {model.ModelId}");
 Console.WriteLine($"    Model Status: {model.Status}");
-Console.WriteLine($"    Requested on: {model.RequestedOn}");
-Console.WriteLine($"    Completed on: {model.CompletedOn}");
+Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
+Console.WriteLine($"    Training model Completed on: {model.TrainingCompletedOn}");
 
 foreach (CustomFormSubmodel submodel in model.Submodels)
 {
@@ -68,8 +68,8 @@ CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl)
 Console.WriteLine($"Custom Model Info:");
 Console.WriteLine($"    Model Id: {model.ModelId}");
 Console.WriteLine($"    Model Status: {model.Status}");
-Console.WriteLine($"    Requested on: {model.RequestedOn}");
-Console.WriteLine($"    Completed on: {model.CompletedOn}");
+Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
+Console.WriteLine($"    Training model completed on: {model.TrainingCompletedOn}");
 
 foreach (CustomFormSubmodel submodel in model.Submodels)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
@@ -41,8 +41,8 @@ foreach (CustomFormModelInfo modelInfo in models.Take(10))
     Console.WriteLine($"Custom Model Info:");
     Console.WriteLine($"    Model Id: {modelInfo.ModelId}");
     Console.WriteLine($"    Model Status: {modelInfo.Status}");
-    Console.WriteLine($"    Requested on: {modelInfo.RequestedOn}");
-    Console.WriteLine($"    Completed on: {modelInfo.CompletedOn}");
+    Console.WriteLine($"    Training model started on: {modelInfo.TrainingStartedOn}");
+    Console.WriteLine($"    Training model completed on: {modelInfo.TrainingCompletedOn}");
 }
 
 // Create a new model to store in the account

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyAuthorization.cs
@@ -37,10 +37,10 @@ namespace Azure.AI.FormRecognizer.Training
         /// <summary>
         /// Deserializes an opaque string into a <see cref="CopyAuthorization"/> object.
         /// </summary>
-        /// <param name="accessToken">Opaque string with the access token information for a specific model.</param>
-        public static CopyAuthorization FromJson(string accessToken)
+        /// <param name="copyAuthorization">Opaque string with the copy authorization information for a specific model.</param>
+        public static CopyAuthorization FromJson(string copyAuthorization)
         {
-            CopyAuthorizationParse parse = JsonSerializer.Deserialize<CopyAuthorizationParse>(accessToken);
+            CopyAuthorizationParse parse = JsonSerializer.Deserialize<CopyAuthorizationParse>(copyAuthorization);
             return new CopyAuthorization(
                 parse.modelId,
                 parse.accessToken,

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
@@ -16,8 +16,8 @@ namespace Azure.AI.FormRecognizer.Training
         {
             ModelId = model.ModelInfo.ModelId.ToString();
             Status = model.ModelInfo.Status;
-            RequestedOn = model.ModelInfo.CreatedDateTime;
-            CompletedOn = model.ModelInfo.LastUpdatedDateTime;
+            TrainingStartedOn = model.ModelInfo.CreatedDateTime;
+            TrainingCompletedOn = model.ModelInfo.LastUpdatedDateTime;
             Submodels = ConvertToSubmodels(model);
             TrainingDocuments = ConvertToTrainingDocuments(model.TrainResult);
             Errors = ConvertToFormRecognizerError(model.TrainResult);
@@ -34,14 +34,14 @@ namespace Azure.AI.FormRecognizer.Training
         public CustomFormModelStatus Status { get; }
 
         /// <summary>
-        /// The date and time (UTC) when the training model request started.
+        /// The date and time (UTC) when model training was started.
         /// </summary>
-        public DateTimeOffset RequestedOn { get; }
+        public DateTimeOffset TrainingStartedOn { get; }
 
         /// <summary>
         /// The date and time (UTC) when model training completed.
         /// </summary>
-        public DateTimeOffset CompletedOn { get; }
+        public DateTimeOffset TrainingCompletedOn { get; }
 
         /// <summary>
         /// A list of submodels that are part of this model, each of which can recognize and extract fields from a different type of form.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModelInfo.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModelInfo.cs
@@ -13,16 +13,16 @@ namespace Azure.AI.FormRecognizer.Training
         internal CustomFormModelInfo(ModelInfo_internal modelInfo)
         {
             ModelId = modelInfo.ModelId.ToString();
-            RequestedOn = modelInfo.CreatedDateTime;
-            CompletedOn = modelInfo.LastUpdatedDateTime;
+            TrainingStartedOn = modelInfo.CreatedDateTime;
+            TrainingCompletedOn = modelInfo.LastUpdatedDateTime;
             Status = modelInfo.Status;
         }
 
-        internal CustomFormModelInfo(string modelId, DateTimeOffset requestedOn, DateTimeOffset completedOn, CustomFormModelStatus status)
+        internal CustomFormModelInfo(string modelId, DateTimeOffset trainingStartedOn, DateTimeOffset trainingCompletedOn, CustomFormModelStatus status)
         {
             ModelId = modelId;
-            RequestedOn = requestedOn;
-            CompletedOn = completedOn;
+            TrainingStartedOn = trainingStartedOn;
+            TrainingCompletedOn = trainingCompletedOn;
             Status = status;
         }
 
@@ -37,13 +37,13 @@ namespace Azure.AI.FormRecognizer.Training
         public CustomFormModelStatus Status { get; }
 
         /// <summary>
-        /// The date and time (UTC) when the training model request started.
+        /// The date and time (UTC) when model training was started.
         /// </summary>
-        public DateTimeOffset RequestedOn { get; }
+        public DateTimeOffset TrainingStartedOn { get; }
 
         /// <summary>
         /// The date and time (UTC) when model training completed.
         /// </summary>
-        public DateTimeOffset CompletedOn { get; }
+        public DateTimeOffset TrainingCompletedOn { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -163,17 +163,17 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Recognizes layout elements from one or more passed-in forms.
         /// </summary>
-        /// <param name="formUrl">The absolute URI of the remote file to recognize elements from.</param>
+        /// <param name="formUri">The absolute URI of the remote file to recognize elements from.</param>
         /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeContentOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeContentOperation"/>.Value upon successful
         /// completion will contain layout elements extracted from the form.</returns>
         [ForwardsClientCalls]
-        public virtual RecognizeContentOperation StartRecognizeContentFromUri(Uri formUrl, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeContentOperation StartRecognizeContentFromUri(Uri formUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(formUrl, nameof(formUrl));
+            Argument.AssertNotNull(formUri, nameof(formUri));
 
-            SourcePath_internal sourcePath = new SourcePath_internal(formUrl.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal(formUri.AbsoluteUri);
             Response response = ServiceClient.AnalyzeLayoutAsync(sourcePath, cancellationToken);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -183,17 +183,17 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Recognizes layout elements from one or more passed-in forms.
         /// </summary>
-        /// <param name="formUrl">The absolute URI of the remote file to recognize elements from.</param>
+        /// <param name="formUri">The absolute URI of the remote file to recognize elements from.</param>
         /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeContentOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeContentOperation"/>.Value upon successful
         /// completion will contain layout elements extracted from the form.</returns>
         [ForwardsClientCalls]
-        public virtual async Task<RecognizeContentOperation> StartRecognizeContentFromUriAsync(Uri formUrl, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeContentOperation> StartRecognizeContentFromUriAsync(Uri formUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(formUrl, nameof(formUrl));
+            Argument.AssertNotNull(formUri, nameof(formUri));
 
-            SourcePath_internal sourcePath = new SourcePath_internal(formUrl.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal(formUri.AbsoluteUri);
             Response response = await ServiceClient.AnalyzeLayoutAsyncAsync(sourcePath, cancellationToken).ConfigureAwait(false);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -251,19 +251,19 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Recognizes values from one or more receipts.
         /// </summary>
-        /// <param name="receiptUrl">The absolute URI of the remote file to recognize values from.</param>
+        /// <param name="receiptUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeReceiptsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeReceiptsOperation"/>.Value upon successful
         /// completion will contain the extracted receipt.</returns>
         [ForwardsClientCalls]
-        public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsFromUriAsync(Uri receiptUrl, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsFromUriAsync(Uri receiptUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(receiptUrl, nameof(receiptUrl));
+            Argument.AssertNotNull(receiptUri, nameof(receiptUri));
 
             recognizeOptions ??= new RecognizeOptions();
 
-            SourcePath_internal sourcePath = new SourcePath_internal(receiptUrl.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal(receiptUri.AbsoluteUri);
             Response response = await ServiceClient.AnalyzeReceiptAsyncAsync(includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken).ConfigureAwait(false);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -273,19 +273,19 @@ namespace Azure.AI.FormRecognizer
         /// <summary>
         /// Recognizes values from one or more receipts.
         /// </summary>
-        /// <param name="receiptUrl">The absolute URI of the remote file to recognize values from.</param>
+        /// <param name="receiptUri">The absolute URI of the remote file to recognize values from.</param>
         /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeReceiptsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeReceiptsOperation"/>.Value upon successful
         /// completion will contain the extracted receipt.</returns>
         [ForwardsClientCalls]
-        public virtual RecognizeReceiptsOperation StartRecognizeReceiptsFromUri(Uri receiptUrl, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeReceiptsOperation StartRecognizeReceiptsFromUri(Uri receiptUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(receiptUrl, nameof(receiptUrl));
+            Argument.AssertNotNull(receiptUri, nameof(receiptUri));
 
             recognizeOptions ??= new RecognizeOptions();
 
-            SourcePath_internal sourcePath = new SourcePath_internal(receiptUrl.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal(receiptUri.AbsoluteUri);
             Response response = ServiceClient.AnalyzeReceiptAsync(includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -67,8 +67,8 @@ namespace Azure.AI.FormRecognizer.Tests
             CustomFormModel model = operation.Value;
 
             Assert.IsNotNull(model.ModelId);
-            Assert.IsNotNull(model.RequestedOn);
-            Assert.IsNotNull(model.CompletedOn);
+            Assert.IsNotNull(model.TrainingStartedOn);
+            Assert.IsNotNull(model.TrainingCompletedOn);
             Assert.AreEqual(CustomFormModelStatus.Ready, model.Status);
             Assert.IsNotNull(model.Errors);
             Assert.AreEqual(0, model.Errors.Count);
@@ -143,8 +143,8 @@ namespace Azure.AI.FormRecognizer.Tests
             CustomFormModel resultModel = await client.GetCustomModelAsync(trainedModel.ModelId);
 
             Assert.AreEqual(trainedModel.ModelId, resultModel.ModelId);
-            Assert.AreEqual(trainedModel.RequestedOn, resultModel.RequestedOn);
-            Assert.AreEqual(trainedModel.CompletedOn, resultModel.CompletedOn);
+            Assert.AreEqual(trainedModel.TrainingStartedOn, resultModel.TrainingStartedOn);
+            Assert.AreEqual(trainedModel.TrainingCompletedOn, resultModel.TrainingCompletedOn);
             Assert.AreEqual(CustomFormModelStatus.Ready, resultModel.Status);
             Assert.AreEqual(trainedModel.Status, resultModel.Status);
             Assert.AreEqual(trainedModel.Errors.Count, resultModel.Errors.Count);
@@ -178,8 +178,8 @@ namespace Azure.AI.FormRecognizer.Tests
             CustomFormModelInfo modelInfo = client.GetCustomModelsAsync().ToEnumerableAsync().Result.FirstOrDefault();
 
             Assert.IsNotNull(modelInfo.ModelId);
-            Assert.IsNotNull(modelInfo.RequestedOn);
-            Assert.IsNotNull(modelInfo.CompletedOn);
+            Assert.IsNotNull(modelInfo.TrainingStartedOn);
+            Assert.IsNotNull(modelInfo.TrainingCompletedOn);
             Assert.IsNotNull(modelInfo.Status);
 
             AccountProperties accountP = await client.GetAccountPropertiesAsync();
@@ -220,8 +220,8 @@ namespace Azure.AI.FormRecognizer.Tests
 
             CustomFormModelInfo modelCopied = operation.Value;
 
-            Assert.IsNotNull(modelCopied.CompletedOn);
-            Assert.IsNotNull(modelCopied.RequestedOn);
+            Assert.IsNotNull(modelCopied.TrainingCompletedOn);
+            Assert.IsNotNull(modelCopied.TrainingStartedOn);
             Assert.AreEqual(targetAuth.ModelId, modelCopied.ModelId);
             Assert.AreNotEqual(trainedModel.ModelId, modelCopied.ModelId);
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
@@ -20,11 +20,11 @@ namespace Azure.AI.FormRecognizer.Samples
 
             FormRecognizerClient client = new FormRecognizerClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string invoiceUri = FormRecognizerTestEnvironment.CreateUriString("Invoice_1.pdf");
+            Uri invoiceUri = FormRecognizerTestEnvironment.CreateUri("Invoice_1.pdf");
 
             #region Snippet:FormRecognizerSampleRecognizeContentFromUri
 
-            FormPageCollection formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+            FormPageCollection formPages = await client.StartRecognizeContentFromUri(invoiceUri).WaitForCompletionAsync();
             foreach (FormPage page in formPages)
             {
                 Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromUri.cs
@@ -32,13 +32,13 @@ namespace Azure.AI.FormRecognizer.Samples
 
             FormRecognizerClient client = new FormRecognizerClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string formUri = FormRecognizerTestEnvironment.CreateUriString("Form_1.jpg");
+            Uri formUri = FormRecognizerTestEnvironment.CreateUri("Form_1.jpg");
             string modelId = model.ModelId;
 
             #region Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
             //@@ string modelId = "<modelId>";
 
-            RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+            RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
             foreach (RecognizedForm form in forms)
             {
                 Console.WriteLine($"Form of type: {form.FormType}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
@@ -21,10 +21,10 @@ namespace Azure.AI.FormRecognizer.Samples
 
             FormRecognizerClient client = new FormRecognizerClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string receiptUri = FormRecognizerTestEnvironment.CreateUriString("contoso-receipt.jpg");
+            Uri receiptUri = FormRecognizerTestEnvironment.CreateUri("contoso-receipt.jpg");
 
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-            RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+            RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
 
             // To see the list of the supported fields returned by service and its corresponding types, consult:
             // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample4_StronglyTypingARecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample4_StronglyTypingARecognizedForm.cs
@@ -20,10 +20,10 @@ namespace Azure.AI.FormRecognizer.Samples
 
             FormRecognizerClient client = new FormRecognizerClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string receiptUri = FormRecognizerTestEnvironment.CreateUriString("contoso-receipt.jpg");
+            Uri receiptUri = FormRecognizerTestEnvironment.CreateUri("contoso-receipt.jpg");
 
             #region Snippet:FormRecognizerSampleStronglyTypingARecognizedForm
-            RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
 
             foreach (RecognizedForm recognizedForm in recognizedForms)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
@@ -29,8 +29,8 @@ namespace Azure.AI.FormRecognizer.Samples
             Console.WriteLine($"Custom Model Info:");
             Console.WriteLine($"    Model Id: {model.ModelId}");
             Console.WriteLine($"    Model Status: {model.Status}");
-            Console.WriteLine($"    Requested on: {model.RequestedOn}");
-            Console.WriteLine($"    Completed on: {model.CompletedOn}");
+            Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
+            Console.WriteLine($"    Training model Completed on: {model.TrainingCompletedOn}");
 
             foreach (CustomFormSubmodel submodel in model.Submodels)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
@@ -30,7 +30,7 @@ namespace Azure.AI.FormRecognizer.Samples
             Console.WriteLine($"    Model Id: {model.ModelId}");
             Console.WriteLine($"    Model Status: {model.Status}");
             Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
-            Console.WriteLine($"    Training model Completed on: {model.TrainingCompletedOn}");
+            Console.WriteLine($"    Training model completed on: {model.TrainingCompletedOn}");
 
             foreach (CustomFormSubmodel submodel in model.Submodels)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample6_TrainModelWithFormsAndLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample6_TrainModelWithFormsAndLabels.cs
@@ -32,8 +32,8 @@ namespace Azure.AI.FormRecognizer.Samples
             Console.WriteLine($"Custom Model Info:");
             Console.WriteLine($"    Model Id: {model.ModelId}");
             Console.WriteLine($"    Model Status: {model.Status}");
-            Console.WriteLine($"    Requested on: {model.RequestedOn}");
-            Console.WriteLine($"    Completed on: {model.CompletedOn}");
+            Console.WriteLine($"    Training model started on: {model.TrainingStartedOn}");
+            Console.WriteLine($"    Training model completed on: {model.TrainingCompletedOn}");
 
             foreach (CustomFormSubmodel submodel in model.Submodels)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModels.cs
@@ -37,8 +37,8 @@ namespace Azure.AI.FormRecognizer.Samples
                 Console.WriteLine($"Custom Model Info:");
                 Console.WriteLine($"    Model Id: {modelInfo.ModelId}");
                 Console.WriteLine($"    Model Status: {modelInfo.Status}");
-                Console.WriteLine($"    Requested on: {modelInfo.RequestedOn}");
-                Console.WriteLine($"    Completed on: {modelInfo.CompletedOn}");
+                Console.WriteLine($"    Training model started on: {modelInfo.TrainingStartedOn}");
+                Console.WriteLine($"    Training model completed on: {modelInfo.TrainingCompletedOn}");
             }
 
             // Create a new model to store in the account

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
@@ -35,8 +35,8 @@ namespace Azure.AI.FormRecognizer.Samples
                 Console.WriteLine($"Custom Model Info:");
                 Console.WriteLine($"    Model Id: {modelInfo.ModelId}");
                 Console.WriteLine($"    Model Status: {modelInfo.Status}");
-                Console.WriteLine($"    Requested on: {modelInfo.RequestedOn}");
-                Console.WriteLine($"    Completed on: : {modelInfo.CompletedOn}");
+                Console.WriteLine($"    Training model started on: {modelInfo.TrainingStartedOn}");
+                Console.WriteLine($"    Training model completed on: : {modelInfo.TrainingCompletedOn}");
             }
 
             // Create a new model to store in the account


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13034
- `RequestedOn` and `CompletedOn` renamed to `TrainingStartedOn` and `TrainingCompletedOn`
- Rename parameters `FormUrl` to `FormUri`
- Rename parameter `accessToken` on `CopyAuthorization.FromJson`