### PR TITLE
Tables: Add GetStatistics implementation

### DIFF
--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
@@ -69,6 +69,8 @@ namespace Azure.Data.Tables
         public virtual Azure.Data.Tables.TableClient GetTableClient(string tableName) { throw null; }
         public virtual Azure.Pageable<Azure.Data.Tables.Models.TableItem> GetTables(string select = null, string filter = null, int? top = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Data.Tables.Models.TableItem> GetTablesAsync(string select = null, string filter = null, int? top = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Data.Tables.Models.TableServiceStats> GetTableServiceStats(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Data.Tables.Models.TableServiceStats>> GetTableServiceStatsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response SetProperties(Azure.Data.Tables.Models.TableServiceProperties tableServiceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> SetPropertiesAsync(Azure.Data.Tables.Models.TableServiceProperties tableServiceProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }

--- a/sdk/tables/Azure.Data.Tables/src/Generated/ServiceRestClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Generated/ServiceRestClient.cs
@@ -18,7 +18,6 @@ namespace Azure.Data.Tables
     internal partial class ServiceRestClient
     {
         private string url;
-        private string secondaryUrl;
         private string version;
         private ClientDiagnostics _clientDiagnostics;
         private HttpPipeline _pipeline;
@@ -41,7 +40,6 @@ namespace Azure.Data.Tables
             }
 
             this.url = url;
-            this.secondaryUrl = url.Insert(url.IndexOf('.'), "-secondary");
             this.version = version;
             _clientDiagnostics = clientDiagnostics;
             _pipeline = pipeline;
@@ -203,7 +201,7 @@ namespace Azure.Data.Tables
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(secondaryUrl, false);
+            uri.AppendRaw(url, false);
             uri.AppendPath("/", false);
             uri.AppendQuery("restype", "service", true);
             uri.AppendQuery("comp", "stats", true);

--- a/sdk/tables/Azure.Data.Tables/src/Generated/ServiceRestClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Generated/ServiceRestClient.cs
@@ -18,6 +18,7 @@ namespace Azure.Data.Tables
     internal partial class ServiceRestClient
     {
         private string url;
+        private string secondaryUrl;
         private string version;
         private ClientDiagnostics _clientDiagnostics;
         private HttpPipeline _pipeline;
@@ -40,6 +41,7 @@ namespace Azure.Data.Tables
             }
 
             this.url = url;
+            this.secondaryUrl = url.Insert(url.IndexOf('.'), "-secondary");
             this.version = version;
             _clientDiagnostics = clientDiagnostics;
             _pipeline = pipeline;
@@ -201,7 +203,7 @@ namespace Azure.Data.Tables
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(url, false);
+            uri.AppendRaw(secondaryUrl, false);
             uri.AppendPath("/", false);
             uri.AppendQuery("restype", "service", true);
             uri.AppendQuery("comp", "stats", true);

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -16,6 +16,7 @@ namespace Azure.Data.Tables
         private readonly ClientDiagnostics _diagnostics;
         private readonly TableRestClient _tableOperations;
         private readonly ServiceRestClient _serviceOperations;
+        private readonly ServiceRestClient _secondaryServiceOperations;
         private readonly OdataMetadataFormat _format = OdataMetadataFormat.ApplicationJsonOdataFullmetadata;
         private readonly string _version;
         internal readonly bool _isPremiumEndpoint;
@@ -51,6 +52,7 @@ namespace Azure.Data.Tables
 
             options ??= new TableClientOptions();
             var endpointString = endpoint.ToString();
+            var secondaryEndpoint = endpointString.Insert(endpointString.IndexOf('.'), "-secondary");
             HttpPipeline pipeline;
 
             if (policy == default)
@@ -65,6 +67,7 @@ namespace Azure.Data.Tables
             _diagnostics = new ClientDiagnostics(options);
             _tableOperations = new TableRestClient(_diagnostics, pipeline, endpointString);
             _serviceOperations = new ServiceRestClient(_diagnostics, pipeline, endpointString);
+            _secondaryServiceOperations = new ServiceRestClient(_diagnostics, pipeline, secondaryEndpoint);
             _version = options.VersionString;
 
             string absoluteUri = endpoint.OriginalString.ToLowerInvariant();
@@ -344,13 +347,15 @@ namespace Azure.Data.Tables
             }
         }
 
+        /// <summary> Retrieves statistics related to replication for the Table service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the account. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual async Task<Response<TableServiceStats>> GetTableServiceStatsAsync(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableServiceClient)}.{nameof(GetTableServiceStats)}");
             scope.Start();
             try
             {
-                var response = await _serviceOperations.GetStatisticsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                var response = await _secondaryServiceOperations.GetStatisticsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
                 return Response.FromValue(response.Value, response.GetRawResponse());
             }
             catch (Exception ex)
@@ -360,13 +365,15 @@ namespace Azure.Data.Tables
             }
         }
 
+        /// <summary> Retrieves statistics related to replication for the Table service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the account. </summary>
+        /// <param name="cancellationToken"> The cancellation token to use. </param>
         public virtual Response<TableServiceStats> GetTableServiceStats(CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableServiceClient)}.{nameof(GetTableServiceStats)}");
             scope.Start();
             try
             {
-                var response = _serviceOperations.GetStatistics(cancellationToken: cancellationToken);
+                var response = _secondaryServiceOperations.GetStatistics(cancellationToken: cancellationToken);
                 return Response.FromValue(response.Value, response.GetRawResponse());
             }
             catch (Exception ex)

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -343,5 +343,37 @@ namespace Azure.Data.Tables
                 throw;
             }
         }
+
+        public virtual async Task<Response<TableServiceStats>> GetTableServiceStatsAsync(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableServiceClient)}.{nameof(GetTableServiceStats)}");
+            scope.Start();
+            try
+            {
+                var response = await _serviceOperations.GetStatisticsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                return Response.FromValue(response.Value, response.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
+
+        public virtual Response<TableServiceStats> GetTableServiceStats(CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableServiceClient)}.{nameof(GetTableServiceStats)}");
+            scope.Start();
+            try
+            {
+                var response = _serviceOperations.GetStatistics(cancellationToken: cancellationToken);
+                return Response.FromValue(response.Value, response.GetRawResponse());
+            }
+            catch (Exception ex)
+            {
+                scope.Failed(ex);
+                throw;
+            }
+        }
     }
 }

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStats.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStats.json
@@ -8,13 +8,13 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-556f1e26914cbd4db3805aac17319c65-e3c75003442cc74c-00",
+        "traceparent": "00-d6ffdcb459b4824e805cb7121b919369-f85f7e053300104e-00",
         "User-Agent": [
           "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
           "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "18b48d8e6b05027883a854800fcc3a62",
-        "x-ms-date": "Fri, 26 Jun 2020 18:10:26 GMT",
+        "x-ms-date": "Fri, 26 Jun 2020 22:26:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -25,7 +25,7 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=fullmetadata; streaming=true; charset=utf-8",
-        "Date": "Fri, 26 Jun 2020 18:10:26 GMT",
+        "Date": "Fri, 26 Jun 2020 22:26:52 GMT",
         "Location": "https://algernon.table.core.windows.net/Tables(\u0027testtable4z4pbbv1\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
@@ -34,7 +34,7 @@
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
         "x-ms-client-request-id": "18b48d8e6b05027883a854800fcc3a62",
-        "x-ms-request-id": "c31fb96c-5002-0094-61e5-4b2884000000",
+        "x-ms-request-id": "3658a0be-8002-005c-2008-4ccab5000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
@@ -50,13 +50,13 @@
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-006b3d17716ede449f7a7d3488118348-a4155291b10d9643-00",
+        "traceparent": "00-b9f019ed964c7740aa6ddd57e2672203-39b0f0577c5de94c-00",
         "User-Agent": [
           "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
           "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "78944563ef4f091237960dc2951942e0",
-        "x-ms-date": "Fri, 26 Jun 2020 18:10:27 GMT",
+        "x-ms-date": "Fri, 26 Jun 2020 22:26:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -64,17 +64,17 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 26 Jun 2020 18:10:27 GMT",
+        "Date": "Fri, 26 Jun 2020 22:26:53 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "78944563ef4f091237960dc2951942e0",
-        "x-ms-request-id": "fba5fa5d-a002-0016-5ce5-4b085d000000",
+        "x-ms-request-id": "3208793d-1002-0013-2108-4cda86000000",
         "x-ms-version": "2019-02-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003EFri, 26 Jun 2020 18:08:59 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003EFri, 26 Jun 2020 22:25:13 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
     },
     {
       "RequestUri": "https://algernon.table.core.windows.net/Tables(\u0027testtable4z4pbbv1\u0027)",
@@ -82,13 +82,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f27932286b0c0f4f871ae8bdc22cbc22-2fe91b18efbc7a4f-00",
+        "traceparent": "00-480a71d3e8961347a062902c0de47f48-fad8c497a968d044-00",
         "User-Agent": [
           "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
           "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a284a4fbc504acf3adfc63205734acf1",
-        "x-ms-date": "Fri, 26 Jun 2020 18:10:28 GMT",
+        "x-ms-date": "Fri, 26 Jun 2020 22:26:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -97,14 +97,14 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Fri, 26 Jun 2020 18:10:27 GMT",
+        "Date": "Fri, 26 Jun 2020 22:26:53 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
         "x-ms-client-request-id": "a284a4fbc504acf3adfc63205734acf1",
-        "x-ms-request-id": "c31fb9a5-5002-0094-11e5-4b2884000000",
+        "x-ms-request-id": "3658a0f3-8002-005c-4708-4ccab5000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStats.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStats.json
@@ -1,0 +1,118 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://algernon.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json; odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-556f1e26914cbd4db3805aac17319c65-e3c75003442cc74c-00",
+        "User-Agent": [
+          "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "18b48d8e6b05027883a854800fcc3a62",
+        "x-ms-date": "Fri, 26 Jun 2020 18:10:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "testtable4z4pbbv1"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=fullmetadata; streaming=true; charset=utf-8",
+        "Date": "Fri, 26 Jun 2020 18:10:26 GMT",
+        "Location": "https://algernon.table.core.windows.net/Tables(\u0027testtable4z4pbbv1\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "18b48d8e6b05027883a854800fcc3a62",
+        "x-ms-request-id": "c31fb96c-5002-0094-61e5-4b2884000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://algernon.table.core.windows.net/$metadata#Tables/@Element",
+        "odata.type": "algernon.Tables",
+        "odata.id": "https://algernon.table.core.windows.net/Tables(\u0027testtable4z4pbbv1\u0027)",
+        "odata.editLink": "Tables(\u0027testtable4z4pbbv1\u0027)",
+        "TableName": "testtable4z4pbbv1"
+      }
+    },
+    {
+      "RequestUri": "https://algernon-secondary.table.core.windows.net/?restype=service\u0026comp=stats",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-006b3d17716ede449f7a7d3488118348-a4155291b10d9643-00",
+        "User-Agent": [
+          "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "78944563ef4f091237960dc2951942e0",
+        "x-ms-date": "Fri, 26 Jun 2020 18:10:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 26 Jun 2020 18:10:27 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "78944563ef4f091237960dc2951942e0",
+        "x-ms-request-id": "fba5fa5d-a002-0016-5ce5-4b085d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003EFri, 26 Jun 2020 18:08:59 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
+    },
+    {
+      "RequestUri": "https://algernon.table.core.windows.net/Tables(\u0027testtable4z4pbbv1\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f27932286b0c0f4f871ae8bdc22cbc22-2fe91b18efbc7a4f-00",
+        "User-Agent": [
+          "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a284a4fbc504acf3adfc63205734acf1",
+        "x-ms-date": "Fri, 26 Jun 2020 18:10:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Fri, 26 Jun 2020 18:10:27 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a284a4fbc504acf3adfc63205734acf1",
+        "x-ms-request-id": "c31fb9a5-5002-0094-11e5-4b2884000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "794343436",
+    "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "",
+    "TABLES_STORAGE_ACCOUNT_NAME": "algernon"
+  }
+}

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStatsAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStatsAsync.json
@@ -8,13 +8,13 @@
         "Content-Length": "33",
         "Content-Type": "application/json; odata=nometadata",
         "DataServiceVersion": "3.0",
-        "traceparent": "00-eefe52f8a5fa2e4683b08de911865cdc-c0e6f58f9b4ec347-00",
+        "traceparent": "00-fd84d000e7fb924380e74a1fa027351d-ee6f25be1a818140-00",
         "User-Agent": [
           "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
           "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d031a3d3d225457cd6b912f21dde3c68",
-        "x-ms-date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "x-ms-date": "Fri, 26 Jun 2020 22:26:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -25,7 +25,7 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json; odata=fullmetadata; streaming=true; charset=utf-8",
-        "Date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "Date": "Fri, 26 Jun 2020 22:26:53 GMT",
         "Location": "https://algernon.table.core.windows.net/Tables(\u0027testtableocizqdw9\u0027)",
         "Server": [
           "Windows-Azure-Table/1.0",
@@ -34,7 +34,7 @@
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
         "x-ms-client-request-id": "d031a3d3d225457cd6b912f21dde3c68",
-        "x-ms-request-id": "92e4457d-4002-0021-1be5-4bbb96000000",
+        "x-ms-request-id": "3658a10d-8002-005c-5d08-4ccab5000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": {
@@ -50,13 +50,13 @@
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b2f1c070d900ed45b256d825c0f63deb-7c764acb00f6c343-00",
+        "traceparent": "00-556829effc470040a2dee3d70cf162d8-457a20546f5fd54c-00",
         "User-Agent": [
           "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
           "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b8db4973504832b3bb38a539b01c4848",
-        "x-ms-date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "x-ms-date": "Fri, 26 Jun 2020 22:26:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -64,17 +64,17 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "Date": "Fri, 26 Jun 2020 22:26:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "b8db4973504832b3bb38a539b01c4848",
-        "x-ms-request-id": "2b650acd-c002-004d-4be5-4b3166000000",
+        "x-ms-request-id": "32087942-1002-0013-2408-4cda86000000",
         "x-ms-version": "2019-02-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003EFri, 26 Jun 2020 18:08:59 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003EFri, 26 Jun 2020 22:25:13 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
     },
     {
       "RequestUri": "https://algernon.table.core.windows.net/Tables(\u0027testtableocizqdw9\u0027)",
@@ -82,13 +82,13 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-18dc5ad85c6f614089312c8829d0c02b-2434734ac51d2149-00",
+        "traceparent": "00-348d921e2ec78c41bae0ce1f57bcef5e-ad50c45d243bf445-00",
         "User-Agent": [
           "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
           "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "29c502364d75d83d4b345a7babccd838",
-        "x-ms-date": "Fri, 26 Jun 2020 18:10:37 GMT",
+        "x-ms-date": "Fri, 26 Jun 2020 22:26:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-02-02"
       },
@@ -97,14 +97,14 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Fri, 26 Jun 2020 18:10:37 GMT",
+        "Date": "Fri, 26 Jun 2020 22:26:54 GMT",
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "X-Content-Type-Options": "nosniff",
         "x-ms-client-request-id": "29c502364d75d83d4b345a7babccd838",
-        "x-ms-request-id": "92e445d7-4002-0021-6ce5-4bbb96000000",
+        "x-ms-request-id": "3658a115-8002-005c-6308-4ccab5000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStatsAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableServiceClientLiveTests/GetTableServiceStatsReturnsStatsAsync.json
@@ -1,0 +1,118 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://algernon.table.core.windows.net/Tables?$format=application%2Fjson%3Bodata%3Dfullmetadata",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "33",
+        "Content-Type": "application/json; odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "traceparent": "00-eefe52f8a5fa2e4683b08de911865cdc-c0e6f58f9b4ec347-00",
+        "User-Agent": [
+          "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d031a3d3d225457cd6b912f21dde3c68",
+        "x-ms-date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": {
+        "TableName": "testtableocizqdw9"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=fullmetadata; streaming=true; charset=utf-8",
+        "Date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "Location": "https://algernon.table.core.windows.net/Tables(\u0027testtableocizqdw9\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "d031a3d3d225457cd6b912f21dde3c68",
+        "x-ms-request-id": "92e4457d-4002-0021-1be5-4bbb96000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://algernon.table.core.windows.net/$metadata#Tables/@Element",
+        "odata.type": "algernon.Tables",
+        "odata.id": "https://algernon.table.core.windows.net/Tables(\u0027testtableocizqdw9\u0027)",
+        "odata.editLink": "Tables(\u0027testtableocizqdw9\u0027)",
+        "TableName": "testtableocizqdw9"
+      }
+    },
+    {
+      "RequestUri": "https://algernon-secondary.table.core.windows.net/?restype=service\u0026comp=stats",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b2f1c070d900ed45b256d825c0f63deb-7c764acb00f6c343-00",
+        "User-Agent": [
+          "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b8db4973504832b3bb38a539b01c4848",
+        "x-ms-date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Fri, 26 Jun 2020 18:10:36 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "b8db4973504832b3bb38a539b01c4848",
+        "x-ms-request-id": "2b650acd-c002-004d-4be5-4b3166000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CStorageServiceStats\u003E\u003CGeoReplication\u003E\u003CStatus\u003Elive\u003C/Status\u003E\u003CLastSyncTime\u003EFri, 26 Jun 2020 18:08:59 GMT\u003C/LastSyncTime\u003E\u003C/GeoReplication\u003E\u003C/StorageServiceStats\u003E"
+    },
+    {
+      "RequestUri": "https://algernon.table.core.windows.net/Tables(\u0027testtableocizqdw9\u0027)",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-18dc5ad85c6f614089312c8829d0c02b-2434734ac51d2149-00",
+        "User-Agent": [
+          "azsdk-net-Data.Tables/1.0.0-dev.20200626.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "29c502364d75d83d4b345a7babccd838",
+        "x-ms-date": "Fri, 26 Jun 2020 18:10:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Fri, 26 Jun 2020 18:10:37 GMT",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "29c502364d75d83d4b345a7babccd838",
+        "x-ms-request-id": "92e445d7-4002-0021-6ce5-4bbb96000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "300920630",
+    "TABLES_PRIMARY_STORAGE_ACCOUNT_KEY": "",
+    "TABLES_STORAGE_ACCOUNT_NAME": "algernon"
+  }
+}

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Data.Tables.Tests
     public class TableServiceClientLiveTests : TableServiceLiveTestsBase
     {
 
-        public TableServiceClientLiveTests(bool isAsync) : base(isAsync, /* To record tests, add this argument, RecordedTestMode.Record */)
+        public TableServiceClientLiveTests(bool isAsync) : base(isAsync /* To record tests, add this argument, RecordedTestMode.Record */)
         { }
 
         /// <summary>

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Data.Tables.Tests
     public class TableServiceClientLiveTests : TableServiceLiveTestsBase
     {
 
-        public TableServiceClientLiveTests(bool isAsync) : base(isAsync /* To record tests, add this argument, RecordedTestMode.Record */)
+        public TableServiceClientLiveTests(bool isAsync) : base(isAsync, RecordedTestMode.Record /* To record tests, add this argument, RecordedTestMode.Record */)
         { }
 
         /// <summary>
@@ -120,6 +120,16 @@ namespace Azure.Data.Tables.Tests
 
             // Test each property
             CompareTableServiceProperties(responseToChange, changedResponse);
+        }
+
+        [Test]
+        public async Task GetTableServiceStatsReturnsStats()
+        {
+            // Get statistics
+            TableServiceStats stats = await service.GetTableServiceStatsAsync().ConfigureAwait(false);
+
+            // Test that the secondary location is live
+            Assert.AreEqual(new GeoReplicationStatusType("live"), stats.GeoReplication.Status);
         }
 
         private void CompareTableServiceProperties(TableServiceProperties expected, TableServiceProperties actual)

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Data.Tables.Tests
     public class TableServiceClientLiveTests : TableServiceLiveTestsBase
     {
 
-        public TableServiceClientLiveTests(bool isAsync) : base(isAsync, RecordedTestMode.Record /* To record tests, add this argument, RecordedTestMode.Record */)
+        public TableServiceClientLiveTests(bool isAsync) : base(isAsync, /* To record tests, add this argument, RecordedTestMode.Record */)
         { }
 
         /// <summary>


### PR DESCRIPTION
#11926 

- Add GetStatistics method implementation
- Test retrieves payload from service and confirms it is live
- Adds a `secondaryUrl` property to the `ServiceRestClient` that derives from the primary URL