### PR TITLE
[Event Hubs Client] Load Balancing Strategy

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -37,7 +37,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task EventsCanBeReadByOneProcessorClient()
+        [TestCase(LoadBalancingStrategy.Balanced)]
+        [TestCase(LoadBalancingStrategy.Greedy)]
+        public async Task EventsCanBeReadByOneProcessorClient(LoadBalancingStrategy loadBalancingStrategy)
         {
             // Setup the environment.
 
@@ -58,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var processedEvents = new ConcurrentDictionary<string, EventData>();
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250) };
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250), LoadBalancingStrategy = loadBalancingStrategy };
             var processor = CreateProcessor(scope.ConsumerGroups.First(), connectionString, options: options);
 
             processor.ProcessErrorAsync += CreateAssertingErrorHandler();

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/Azure.Messaging.EventHubs.Shared.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/Azure.Messaging.EventHubs.Shared.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{10D9CACA-DDF6-4A56-8633-8595F9805837}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{870D6ACA-B778-40AA-93B5-43CF1D25235E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,12 +47,25 @@ Global
 		{1AC14D43-837B-412F-BE15-F506B351CE72}.Release|x64.Build.0 = Release|Any CPU
 		{1AC14D43-837B-412F-BE15-F506B351CE72}.Release|x86.ActiveCfg = Release|Any CPU
 		{1AC14D43-837B-412F-BE15-F506B351CE72}.Release|x86.Build.0 = Release|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Debug|x64.Build.0 = Debug|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Debug|x86.Build.0 = Debug|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Release|x64.ActiveCfg = Release|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Release|x64.Build.0 = Release|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Release|x86.ActiveCfg = Release|Any CPU
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1AC14D43-837B-412F-BE15-F506B351CE72} = {10D9CACA-DDF6-4A56-8633-8595F9805837}
+		{870D6ACA-B778-40AA-93B5-43CF1D25235E} = {10D9CACA-DDF6-4A56-8633-8595F9805837}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F5A1E14E-F9E2-4A0C-9EB0-F91C44298DC8}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorOptions.cs
@@ -263,7 +263,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                 _partitionOwnershipExpirationInterval = PartitionOwnershipExpirationInterval,
                 Identifier = Identifier,
                 TrackLastEnqueuedEventProperties = TrackLastEnqueuedEventProperties,
-                DefaultStartingPosition = DefaultStartingPosition
+                DefaultStartingPosition = DefaultStartingPosition,
+                LoadBalancingStrategy = LoadBalancingStrategy
             };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
@@ -1160,7 +1160,11 @@ namespace Azure.Messaging.EventHubs.Primitives
                     }
 
                     var remainingTimeUntilNextCycle = await PerformLoadBalancingAsync(cycleDuration, partitionIds, cancellationToken).ConfigureAwait(false);
-                    await Task.Delay(remainingTimeUntilNextCycle, cancellationToken).ConfigureAwait(false);
+
+                    if (remainingTimeUntilNextCycle != TimeSpan.Zero)
+                    {
+                        await Task.Delay(remainingTimeUntilNextCycle, cancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 // Cancellation has been requested; throw the corresponding exception to maintain consistent behavior.
@@ -1195,7 +1199,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="partitionIds">The valid set of partition identifiers for the Event Hub to which the processor is associated.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
         ///
-        /// <returns>The interval that callers should delay before invoking the next load balancing cycle.</returns>
+        /// <returns>The interval that callers should delay before invoking the next load balancing cycle; <see cref="TimeSpan.Zero"/> if callers should invoke the next cycle immediately.</returns>
         ///
         private async Task<TimeSpan> PerformLoadBalancingAsync(ValueStopwatch cycleDuration,
                                                                string[] partitionIds,
@@ -1210,10 +1214,10 @@ namespace Azure.Messaging.EventHubs.Primitives
             // a fire-and-forget manner.  The processor does not assume responsibility for observing or surfacing exceptions
             // that may occur in the handler, so the associated task is intentionally unobserved.
 
+            var claimedOwnership = default(EventProcessorPartitionOwnership);
+
             if ((partitionIds != default) && (partitionIds.Length > 0))
             {
-                var claimedOwnership = default(EventProcessorPartitionOwnership);
-
                 try
                 {
                     claimedOwnership = await LoadBalancer.RunLoadBalancingAsync(partitionIds, cancellationToken).ConfigureAwait(false);
@@ -1275,6 +1279,14 @@ namespace Azure.Messaging.EventHubs.Primitives
                     }
                 }))
                 .ConfigureAwait(false);
+
+            // If load balancing is greedy and there was a partition claimed, then signal that there should be no delay before
+            // invoking the next load balancing cycle.
+
+            if ((Options.LoadBalancingStrategy == LoadBalancingStrategy.Greedy) && (!LoadBalancer.IsBalanced))
+            {
+                return TimeSpan.Zero;
+            }
 
             // Wait the remaining time, if any, to start the next cycle.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorOptionsTests.cs
@@ -53,6 +53,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier should match.");
             Assert.That(clone.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "Tracking of last enqueued events should match.");
             Assert.That(clone.DefaultStartingPosition, Is.EqualTo(options.DefaultStartingPosition), "The default starting position should match.");
+            Assert.That(clone.LoadBalancingStrategy, Is.EqualTo(options.LoadBalancingStrategy), "The load balancing strategy should match.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -562,7 +562,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Timeout(300_000)] // TEMP:  Using 5 minutes as an arbitrary safety timeout while troubleshooting a suspected test hang.
         public async Task BackgroundProcessingStopsProcessingAllPartitionsWhenShutdown()
         {
             using var cancellationSource = new CancellationTokenSource();
@@ -1540,5 +1539,272 @@ namespace Azure.Messaging.EventHubs.Tests
 
             cancellationSource.Cancel();
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   background processing loop.
+        /// </summary>
+        ///
+        [Test]
+        public async Task LoadBalancingAppliesTheGreedyStrategy()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var firstPartiton = "27";
+            var secondPartition = "15";
+            var partitionIds = new[] { "0", secondPartition, firstPartiton };
+            var ownedPartitions = new List<string>();
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromDays(5), LoadBalancingStrategy = LoadBalancingStrategy.Greedy };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockConsumer = new Mock<TransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.OwnedPartitionIds)
+                .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.IsBalanced)
+                .Returns(() => ownedPartitions.Count >= 2);
+
+            mockLoadBalancer
+                .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(firstPartiton);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = firstPartiton });
+                })
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(secondPartition);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = secondPartition });
+                })
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return new ValueTask<EventProcessorPartitionOwnership>(default(EventProcessorPartitionOwnership));
+                });
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { new EventData(new byte[] { 0x34 }) });
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should have started.");
+
+            // Wait for the load balancer to be called multiple times; if the completion source is set before cancellation, then
+            // the load balancing update interval is not being applied and the greedy strategy is overriding.
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+            cancellationSource.Cancel();
+
+            Assert.That(ownedPartitions.Count, Is.EqualTo(2), "There should be two owned partitions.");
+            Assert.That(ownedPartitions.Contains(firstPartiton), Is.True, "The first partition should be owned.");
+            Assert.That(ownedPartitions.Contains(secondPartition), Is.True, "The second partition should be owned.");
+
+            mockLoadBalancer
+                .Verify(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()), Times.Exactly(3), "The load balancer did not run the correct number of cycles.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   background processing loop.
+        /// </summary>
+        ///
+        [Test]
+        public async Task LoadBalancingWhenGreedyAppliesTheTimeoutAfterBalance()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionIds = new[] { "0", "1", "2" };
+            var ownedPartitions = new List<string>();
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromDays(5), LoadBalancingStrategy = LoadBalancingStrategy.Greedy };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockConsumer = new Mock<TransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.OwnedPartitionIds)
+                .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.IsBalanced)
+                .Returns(() => ownedPartitions.Count >= 1);
+
+            mockLoadBalancer
+                .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(partitionIds[2]);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionIds[2] });
+                })
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(partitionIds[0]);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = partitionIds[0] });
+                })
+                .Returns(() =>
+                {
+                  completionSource.TrySetResult(true);
+                  return new ValueTask<EventProcessorPartitionOwnership>(default(EventProcessorPartitionOwnership));
+                });
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { new EventData(new byte[] { 0x34 }) });
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should have started.");
+
+            // The load balancer should be called until no partition was claimed and then the interval should be applied; because the interval
+            // is unreasonably long, the final call to the load balancer should not occur and the completion source should never be set.
+
+            var delayTask = Task.Delay(TimeSpan.FromSeconds(1), cancellationSource.Token);
+            var completedTask = await Task.WhenAny(completionSource.Task, delayTask);
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(completedTask, Is.SameAs(delayTask), "The completion source should have timed out because the load balancing interval should not have passed.");
+
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+            cancellationSource.Cancel();
+
+            Assert.That(ownedPartitions.Count, Is.EqualTo(1), "There should be a single owned partition.");
+            Assert.That(ownedPartitions.Contains(partitionIds[2]), Is.True, "The last partition should be owned.");
+
+            // Because the load balancer is signaling that it is in a balanced state after the first claim, there should be no
+            // attempts to claim again within the time period allowed by the test.
+
+            mockLoadBalancer
+                .Verify(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()), Times.Once(), "The load balancer did not run the correct number of cycles.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   background processing loop.
+        /// </summary>
+        ///
+        [Test]
+        public async Task LoadBalancingAppliesTheBalancedStrategy()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var firstPartiton = "27";
+            var secondPartition = "15";
+            var partitionIds = new[] { "0", secondPartition, firstPartiton };
+            var ownedPartitions = new List<string>();
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromDays(5), LoadBalancingStrategy = LoadBalancingStrategy.Balanced };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockConsumer = new Mock<TransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.OwnedPartitionIds)
+                .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .SetupGet(lb => lb.IsBalanced)
+                .Returns(() => ownedPartitions.Count == 2);
+
+            mockLoadBalancer
+                .SetupSequence(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(firstPartiton);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = firstPartiton });
+                })
+                .Returns(() =>
+                {
+                    ownedPartitions.Add(secondPartition);
+                    return new ValueTask<EventProcessorPartitionOwnership>(new EventProcessorPartitionOwnership { PartitionId = secondPartition });
+                })
+                .Returns(() =>
+                {
+                  completionSource.TrySetResult(true);
+                  return new ValueTask<EventProcessorPartitionOwnership>(default(EventProcessorPartitionOwnership));
+                });
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { new EventData(new byte[] { 0x34 }) });
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should have started.");
+
+            // The load balancer should be called once and then the interval should be applied; because the interval is unreasonably long,
+            // the final call to the load balancer should not occur and the completion source should never be set.
+
+            var delayTask = Task.Delay(TimeSpan.FromSeconds(1), cancellationSource.Token);
+            var completedTask = await Task.WhenAny(completionSource.Task, delayTask);
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(completedTask, Is.SameAs(delayTask), "The completion source should have timed out because the load balancing interval should not have passed.");
+
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+            cancellationSource.Cancel();
+
+            Assert.That(ownedPartitions.Count, Is.EqualTo(1), "There should be a single owned partition.");
+            Assert.That(ownedPartitions[0], Is.EqualTo(firstPartiton), "The first partition should be owned.");
+
+            mockLoadBalancer
+                .Verify(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()), Times.Once(), "The load balancer did not run a single cycle.");
+        }
+
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the load balancing strategy, allowing a greedy approach to claiming partitions in addition to the default balanced approach.

# Last Upstream Rebase

Wednesday, July 1, 3:22pm (EDT)

# References and Related Issues 

- [Implement Event Processor load balancing strategy improvements](https://github.com/Azure/azure-sdk-for-net/issues/11768) (#11768)
- [Load Balancing Improvements Design](https://gist.github.com/srnagar/366cb66279406db738f8eff82fbfb851)