### PR TITLE
[FormRecognizer] Attributing Cognitive Services User role to test resources

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -42,7 +42,6 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/13126")]
         public async Task FormRecognizerClientCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormRecognizerClient(useTokenCredential: true);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -35,7 +35,6 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/13126")]
         public async Task FormTrainingClientCanAuthenticateWithTokenCredential()
         {
             var client = CreateFormTrainingClient(useTokenCredential: true);

--- a/sdk/formrecognizer/test-resources.json
+++ b/sdk/formrecognizer/test-resources.json
@@ -24,6 +24,12 @@
             "defaultValue": ".cognitiveservices.azure.com",
             "type": "string"
         },
+        "testApplicationOid": {
+            "type": "string",
+            "metadata": {
+                "description": "The principal to assign the role to. This is application object id."
+            }
+        },
         "trainingDataAccount": {
             "type": "string",
             "defaultValue": "azuresdktrainingdata"
@@ -60,6 +66,7 @@
         }
     },
     "variables": {
+        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
         "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
         "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('endpointSuffix'))]"
     },
@@ -82,7 +89,7 @@
             "apiVersion": "2018-09-01-preview",
             "name": "[guid(resourceGroup().id)]",
             "properties": {
-                "roleDefinitionId": "a97b65f3-24c7-4388-baec-2e87135dc908",
+                "roleDefinitionId": "[variables('roleDefinitionId')]",
                 "principalId": "[parameters('testApplicationOid')]"
             }
         }

--- a/sdk/formrecognizer/test-resources.json
+++ b/sdk/formrecognizer/test-resources.json
@@ -76,6 +76,15 @@
             "properties": {
                 "customSubDomainName": "[variables('uniqueSubDomainName')]"
             }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2018-09-01-preview",
+            "name": "[guid(resourceGroup().id)]",
+            "properties": {
+                "roleDefinitionId": "a97b65f3-24c7-4388-baec-2e87135dc908",
+                "principalId": "[parameters('testApplicationOid')]"
+            }
         }
     ],
     "outputs": {


### PR DESCRIPTION
AAD tests started to fail because Cognitive Services User role was not being attributed to the test resource anymore (it was being attributed by default somehow). Updating the `test-resources.json` file so we can explicitly specify that this role must attributed to the created Form Recognizer resource.

Fixes #13126.