### PR TITLE
[Event Hubs Client] Restructure Reading from a Single Partition

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -70,6 +70,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                 case TaskCanceledException _:
                     return new EventHubsException(true, eventHubName, Resources.CouldNotCreateLink, EventHubsException.FailureReason.ServiceCommunicationProblem, instance);
 
+                case ObjectDisposedException _:
+                    return new EventHubsException(false, eventHubName, Resources.CouldNotCreateLink, EventHubsException.FailureReason.ClientClosed, instance);
+
                 default:
                     return instance;
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpExceptionExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpExceptionExtensionsTests.cs
@@ -198,5 +198,22 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(exception, Is.SameAs(sourceException), "The exception should not have been translated.");
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateConnectionCloseDuringLinkCreationException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateConnectionCloseDuringLinkCreationExceptionDetectsTheConnectionClosedObjectDisposedException()
+        {
+            var sourceException = new ObjectDisposedException("foo");
+            var exception = (sourceException.TranslateConnectionCloseDuringLinkCreationException("dummy") as EventHubsException);
+
+            Assert.That(exception, Is.Not.Null, "The exception should have been translated to an Event Hubs exception.");
+            Assert.That(exception.IsTransient, Is.False, "The translation exception should not allow retries.");
+            Assert.That(exception.Reason, Is.EqualTo(EventHubsException.FailureReason.ClientClosed), "The translated exception should have the correct failure reason.");
+            Assert.That(exception.InnerException, Is.EqualTo(sourceException), "The translated exception should wrap the source exception.");
+        }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to restructure the approach used to read events from a single partition.  Previously, the background publishing mechanism was
used to try to ensure a smooth streaming of events to the iterator at the cost of a longer pipeline and potentially higher memory use.  This was needed, in large part, because no options were exposed for influencing the prefetch buffer and batch size.

With the prefetch count and batch size now configurable, developers are able to better tune the performance of reading to suit their specific application
scenarios, allowing a more efficient and direct use of a transport consumer to read events and obviating the need for background publishing.

# Last Upstream Rebase

Wednesday, July 1, 11:44am (EDT)

# References and Related Issues 

- [Restructure `EventHubConsumerClient.ReadEventsFromPartitionAsync`](https://github.com/Azure/azure-sdk-for-net/issues/11765) (#11765)