### PR TITLE
Queue Encryption deserializer bug fix

### DIFF
--- a/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 12.4.0-preview.5 (Unreleased)
+- Fixed a bug in queue client-side encryption deserialization.
 - This release contains bug fixes to improve quality.
 
 ## 12.4.0-preview.4 (2020-06)

--- a/sdk/storage/Azure.Storage.Queues/src/Models/EncryptedMessageSerializer.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Models/EncryptedMessageSerializer.cs
@@ -78,6 +78,12 @@ namespace Azure.Storage.Queues.Specialized.Models
             {
                 ReadPropertyValue(data, property);
             }
+
+            if (data.EncryptionData == default || data.EncryptedMessageText == default)
+            {
+                throw new FormatException($"Failed to find non-optional properties while deserializing `{typeof(EncryptedMessage).FullName}`.");
+            }
+
             return data;
         }
 
@@ -90,6 +96,10 @@ namespace Azure.Storage.Queues.Specialized.Models
             else if (property.NameEquals(nameof(data.EncryptionData)))
             {
                 data.EncryptionData = EncryptionDataSerializer.ReadEncryptionData(property.Value);
+            }
+            else
+            {
+                throw new FormatException($"Failed to deserialize `{typeof(EncryptedMessage).FullName}`. Unrecognized property `{property.Name}`.");
             }
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -491,11 +491,15 @@ namespace Azure.Storage.Queues.Test
             }
         }
 
-        [Test]
+        [TestCase("any old message")]
+        [TestCase("\"aa\"")] // real world example
+        [TestCase("{\"key1\":\"value1\",\"key2\":\"value2\"}")] // more typical json object, but not the actual schema we're looking for
+        [TestCase("{\"EncryptedMessageContents\":\"value1\",\"key2\":\"value2\"}")] // one required piece but not the other
+        [TestCase("{\"EncryptionData\":{},\"key2\":\"value2\"}")] // one required piece but not the other
+        [TestCase("ᛁᚳ᛫ᛗᚨᚷ᛫ᚷᛚᚨᛋ᛫ᛖᚩᛏᚪᚾ᛫ᚩᚾᛞ᛫ᚻᛁᛏ᛫ᚾᛖ᛫ᚻᛖᚪᚱᛗᛁᚪᚧ᛫ᛗᛖ")]
         [LiveOnly] // cannot seed content encryption key
-        public async Task ReadPlaintextMessage()
+        public async Task ReadPlaintextMessage(string message)
         {
-            var message = "any old message";
             var mockKey = GetIKeyEncryptionKey().Object;
             var mockKeyResolver = GetIKeyEncryptionKeyResolver(mockKey).Object;
             await using (var disposable = await GetTestEncryptedQueueAsync(new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)

--- a/sdk/storage/Azure.Storage.Queues/tests/EncryptedMessageSerializerTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/EncryptedMessageSerializerTests.cs
@@ -131,6 +131,9 @@ namespace Azure.Storage.Queues.Test
 
         [TestCase("")]
         [TestCase("\"aa\"")] // real world example
+        [TestCase("{\"key1\":\"value1\",\"key2\":\"value2\"}")] // more typical json object, but not the actual schema we're looking for
+        [TestCase("{\"EncryptedMessageContents\":\"value1\",\"key2\":\"value2\"}")] // one required piece but not the other
+        [TestCase("{\"EncryptionData\":{},\"key2\":\"value2\"}")] // one required piece but not the other
         [TestCase("this is not even valid json")]
         [TestCase("ᛁᚳ᛫ᛗᚨᚷ᛫ᚷᛚᚨᛋ᛫ᛖᚩᛏᚪᚾ᛫ᚩᚾᛞ᛫ᚻᛁᛏ᛫ᚾᛖ᛫ᚻᛖᚪᚱᛗᛁᚪᚧ᛫ᛗᛖ")]
         public void TryDeserializeGracefulOnBadInput(string input)
@@ -138,7 +141,9 @@ namespace Azure.Storage.Queues.Test
             bool tryResult = EncryptedMessageSerializer.TryDeserialize(input, out var parsedEncryptedMessage);
 
             Assert.AreEqual(false, tryResult);
-            Assert.AreEqual(default, parsedEncryptedMessage);
+            Assert.IsNull(parsedEncryptedMessage?.EncryptedMessageText);
+            Assert.IsNull(parsedEncryptedMessage?.EncryptionData);
+            Assert.IsNull(parsedEncryptedMessage);
         }
 
         #region ModelComparison


### PR DESCRIPTION
Fixed a bug where some json queue messages would cause issues with `QueueClient` read operations using client-side encryption.

Deserialization of `EncryptedMessage` now throws on any unrecognized property and throws if not all expected properties were found.