### PR TITLE
Binary data api updates

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -5,24 +5,27 @@ namespace Azure.Core
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public BinaryData(System.ReadOnlyMemory<byte> data) { throw null; }
+        public BinaryData(System.ReadOnlySpan<byte> data) { throw null; }
         public BinaryData(string data) { throw null; }
-        public BinaryData(string data, System.Text.Encoding encoding) { throw null; }
-        public System.ReadOnlyMemory<byte> AsBytes() { throw null; }
+        public System.ReadOnlyMemory<byte> Bytes { get { throw null; } }
         public System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(Azure.Core.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<T> DeserializeAsync<T>(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public T Deserialize<T>(Azure.Core.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public T Deserialize<T>(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object? obj) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> FromSerializableAsync<T>(T data, Azure.Core.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static Azure.Core.BinaryData FromSerializable<T>(T data, Azure.Core.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static Azure.Core.BinaryData FromMemory(System.ReadOnlyMemory<byte> data) { throw null; }
         public static Azure.Core.BinaryData FromStream(System.IO.Stream stream) { throw null; }
         public static System.Threading.Tasks.Task<Azure.Core.BinaryData> FromStreamAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public static implicit operator System.ReadOnlyMemory<byte> (Azure.Core.BinaryData data) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> SerializeAsync<T>(T data, Azure.Core.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Core.BinaryData> SerializeAsync<T>(T data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static Azure.Core.BinaryData Serialize<T>(T data, Azure.Core.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static Azure.Core.BinaryData Serialize<T>(T data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.IO.Stream ToStream() { throw null; }
         public override string ToString() { throw null; }
-        public string ToString(System.Text.Encoding encoding) { throw null; }
     }
     public partial class DynamicJson : System.Dynamic.IDynamicMetaObjectProvider
     {

--- a/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
@@ -42,7 +42,8 @@ namespace Azure.Core
         public ReadOnlyMemory<byte> Bytes { get; }
 
         /// <summary>
-        /// Creates a binary data instance from bytes.
+        /// Creates a binary data instance by making a copy
+        /// of the passed in bytes.
         /// </summary>
         /// <param name="data">Byte data.</param>
         public BinaryData(ReadOnlySpan<byte> data)
@@ -51,7 +52,8 @@ namespace Azure.Core
         }
 
         /// <summary>
-        /// Creates a binary data instance from bytes.
+        /// Creates a binary data instance by wrapping the
+        /// passed in bytes.
         /// </summary>
         /// <param name="data">Byte data.</param>
         private BinaryData(ReadOnlyMemory<byte> data)
@@ -126,7 +128,7 @@ namespace Azure.Core
 
         /// <summary>
         /// Creates a BinaryData instance from the specified data using
-        /// the specified type using the <see cref="JsonObjectSerializer"/>.
+        /// the <see cref="JsonObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type of the data.</typeparam>
         /// <param name="data">The data to use.</param>
@@ -138,8 +140,8 @@ namespace Azure.Core
             Serialize<T>(data, new JsonObjectSerializer(), cancellationToken);
 
         /// <summary>
-        /// Creates a BinaryData instance from the specified data using
-        /// the specified type using the <see cref="JsonObjectSerializer"/>.
+        /// Creates a BinaryData instance from the specified data
+        /// using the <see cref="JsonObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type of the data.</typeparam>
         /// <param name="data">The data to use.</param>
@@ -150,10 +152,9 @@ namespace Azure.Core
             CancellationToken cancellationToken = default) =>
             await SerializeInternalAsync<T>(data, new JsonObjectSerializer(), true, cancellationToken).ConfigureAwait(false);
 
-
         /// <summary>
         /// Creates a BinaryData instance from the specified data using
-        /// the specified type.
+        /// the provided <see cref="ObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type of the data.</typeparam>
         /// <param name="data">The data to use.</param>
@@ -169,7 +170,7 @@ namespace Azure.Core
 
         /// <summary>
         /// Creates a BinaryData instance from the specified data using
-        /// the specified type.
+        /// the provided <see cref="ObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type of the data.</typeparam>
         /// <param name="data">The data to use.</param>
@@ -233,7 +234,8 @@ namespace Azure.Core
         }
 
         /// <summary>
-        /// Converts the BinaryData to the specified type.
+        /// Converts the BinaryData to the specified type using
+        /// the provided <see cref="ObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type that the data should be
         /// converted to.</typeparam>
@@ -245,7 +247,8 @@ namespace Azure.Core
             DeserializeInternalAsync<T>(serializer, false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Converts the BinaryData to the specified type using <see cref="JsonObjectSerializer"/>.
+        /// Converts the BinaryData to the specified type using the
+        /// <see cref="JsonObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type that the data should be
         /// converted to.</typeparam>
@@ -259,7 +262,8 @@ namespace Azure.Core
             await DeserializeInternalAsync<T>(new JsonObjectSerializer(), true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        /// Converts the BinaryData to the specified type using <see cref="JsonObjectSerializer"/>.
+        /// Converts the BinaryData to the specified type using the
+        /// <see cref="JsonObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type that the data should be
         /// converted to.</typeparam>
@@ -269,7 +273,8 @@ namespace Azure.Core
             DeserializeInternalAsync<T>(new JsonObjectSerializer(), false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Converts the BinaryData to the specified type.
+        /// Converts the BinaryData to the specified type using the
+        /// provided <see cref="ObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type that the data should be
         /// converted to.</typeparam>

--- a/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
@@ -13,50 +13,70 @@ using Azure.Core.Pipeline;
 namespace Azure.Core
 {
     /// <summary>
-    /// Abstraction for a payload of binary data.
+    /// A lightweight abstraction for a payload of UTF-8 encoded bytes. This type integrates with <see cref="ObjectSerializer"/>
+    /// to allow for serializing and deserializing payloads.
+    ///
+    /// The ownership model of the underlying bytes varies depending on how the instance is constructed:
+    ///
+    /// If created using the static factory method, <see cref="FromMemory(ReadOnlyMemory{byte})"/>,
+    /// the passed in bytes will be wrapped, rather than copied. This is useful in scenarios where performance
+    /// is critical and/or ownership of the bytes is controlled completely by the consumer, thereby allowing the
+    /// enforcement of whatever ownership model is needed.
+    ///
+    /// If created using the <see cref="BinaryData(ReadOnlySpan{byte})"/> constructor, <see cref="BinaryData"/> will
+    /// maintain its own copy of the underlying bytes. This usage is geared more towards scenarios where the ownership
+    /// of the bytes might be ambiguous to users of the consuming code. By making a copy of the bytes, the payload is
+    /// guaranteed to be immutable.
+    ///
+    /// For all other constructors and static factory methods, BinaryData will assume ownership of the underlying bytes.
     /// </summary>
     public readonly struct BinaryData
     {
         private const int CopyToBufferSize = 81920;
 
+        private static readonly UTF8Encoding s_encoding = new UTF8Encoding(false);
+
         /// <summary>
         /// The backing store for the <see cref="BinaryData"/> instance.
         /// </summary>
-        internal ReadOnlyMemory<byte> Data { get; }
+        public ReadOnlyMemory<byte> Bytes { get; }
 
         /// <summary>
         /// Creates a binary data instance from bytes.
         /// </summary>
         /// <param name="data">Byte data.</param>
-        public BinaryData(ReadOnlyMemory<byte> data)
+        public BinaryData(ReadOnlySpan<byte> data)
         {
-            Data = data;
+            Bytes = data.ToArray();
         }
 
         /// <summary>
-        /// Creates a binary data instance from a string
-        /// using UTF-8 encoding.
+        /// Creates a binary data instance from bytes.
+        /// </summary>
+        /// <param name="data">Byte data.</param>
+        private BinaryData(ReadOnlyMemory<byte> data)
+        {
+            Bytes = data;
+        }
+        /// <summary>
+        /// Creates a binary data instance from a string by converting
+        /// the string to bytes using UTF-8 encoding.
         /// </summary>
         /// <param name="data">The string data.</param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
         public BinaryData(string data)
-            : this(data, Encoding.UTF8)
         {
+            Bytes = s_encoding.GetBytes(data);
         }
 
         /// <summary>
-        /// Creates a binary data instance from a string
-        /// using the specified encoding.
+        /// Creates a binary data instance by wrapping the passed in
+        /// <see cref="ReadOnlyMemory{Byte}"/>.
         /// </summary>
-        /// <param name="data">The string data.</param>
-        /// <param name="encoding">The encoding to use when converting
-        /// the data to bytes.</param>
+        /// <param name="data"></param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
-        public BinaryData(string data, Encoding encoding)
-        {
-            Argument.AssertNotNull(encoding, nameof(encoding));
-            Data = encoding.GetBytes(data);
-        }
+        public static BinaryData FromMemory(ReadOnlyMemory<byte> data) =>
+            new BinaryData(data);
 
         /// <summary>
         /// Creates a binary data instance from the specified stream.
@@ -64,7 +84,7 @@ namespace Azure.Core
         /// <param name="stream">Stream containing the data.</param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
         public static BinaryData FromStream(Stream stream) =>
-            CreateAsync(stream, false).EnsureCompleted();
+            FromStreamAsync(stream, false).EnsureCompleted();
 
         /// <summary>
         /// Creates a binary data instance from the specified stream.
@@ -76,9 +96,9 @@ namespace Azure.Core
         public static async Task<BinaryData> FromStreamAsync(
             Stream stream,
             CancellationToken cancellationToken = default) =>
-            await CreateAsync(stream, true, cancellationToken).ConfigureAwait(false);
+            await FromStreamAsync(stream, true, cancellationToken).ConfigureAwait(false);
 
-        private static async Task<BinaryData> CreateAsync(
+        private static async Task<BinaryData> FromStreamAsync(
             Stream stream,
             bool async,
             CancellationToken cancellationToken = default)
@@ -100,25 +120,36 @@ namespace Azure.Core
                 {
                     stream.CopyTo(memoryStream);
                 }
-                return new BinaryData(memoryStream.ToArray());
+                return new BinaryData((ReadOnlyMemory<byte>) memoryStream.ToArray());
             }
         }
 
         /// <summary>
         /// Creates a BinaryData instance from the specified data using
-        /// the specified type.
+        /// the specified type using the <see cref="JsonObjectSerializer"/>.
         /// </summary>
         /// <typeparam name="T">The type of the data.</typeparam>
         /// <param name="data">The data to use.</param>
-        /// <param name="serializer">The serializer to serialize
-        /// the data.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during serialization.</param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
-        public static BinaryData FromSerializable<T>(
+        public static BinaryData Serialize<T>(
             T data,
-            ObjectSerializer serializer,
             CancellationToken cancellationToken = default) =>
-            FromSerializableAsync<T>(data, serializer, false, cancellationToken).EnsureCompleted();
+            Serialize<T>(data, new JsonObjectSerializer(), cancellationToken);
+
+        /// <summary>
+        /// Creates a BinaryData instance from the specified data using
+        /// the specified type using the <see cref="JsonObjectSerializer"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the data.</typeparam>
+        /// <param name="data">The data to use.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during serialization.</param>
+        /// <returns>A <see cref="BinaryData"/> instance.</returns>
+        public static async Task<BinaryData> SerializeAsync<T>(
+            T data,
+            CancellationToken cancellationToken = default) =>
+            await SerializeInternalAsync<T>(data, new JsonObjectSerializer(), true, cancellationToken).ConfigureAwait(false);
+
 
         /// <summary>
         /// Creates a BinaryData instance from the specified data using
@@ -130,13 +161,29 @@ namespace Azure.Core
         /// the data.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during serialization.</param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
-        public static async Task<BinaryData> FromSerializableAsync<T>(
+        public static BinaryData Serialize<T>(
             T data,
             ObjectSerializer serializer,
             CancellationToken cancellationToken = default) =>
-            await FromSerializableAsync<T>(data, serializer, true, cancellationToken).ConfigureAwait(false);
+            SerializeInternalAsync<T>(data, serializer, false, cancellationToken).EnsureCompleted();
 
-        private static async Task<BinaryData> FromSerializableAsync<T>(
+        /// <summary>
+        /// Creates a BinaryData instance from the specified data using
+        /// the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the data.</typeparam>
+        /// <param name="data">The data to use.</param>
+        /// <param name="serializer">The serializer to serialize
+        /// the data.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during serialization.</param>
+        /// <returns>A <see cref="BinaryData"/> instance.</returns>
+        public static async Task<BinaryData> SerializeAsync<T>(
+            T data,
+            ObjectSerializer serializer,
+            CancellationToken cancellationToken = default) =>
+            await SerializeInternalAsync<T>(data, serializer, true, cancellationToken).ConfigureAwait(false);
+
+        private static async Task<BinaryData> SerializeInternalAsync<T>(
             T data,
             ObjectSerializer serializer,
             bool async,
@@ -152,42 +199,23 @@ namespace Azure.Core
             {
                 serializer.Serialize(memoryStream, data, typeof(T), cancellationToken);
             }
-            return new BinaryData(memoryStream.ToArray());
+            return new BinaryData((ReadOnlyMemory<byte>) memoryStream.ToArray());
         }
 
         /// <summary>
         /// Converts the BinaryData to a string using UTF-8.
         /// </summary>
         /// <returns>The string representation of the data.</returns>
-        public override string ToString() =>
-           ToString(Encoding.UTF8);
-
-        /// <summary>
-        /// Converts the BinaryData to a string using the specified
-        /// encoding.
-        /// </summary>
-        /// <param name="encoding">The encoding to use when decoding
-        /// the bytes.</param>
-        /// <returns>The string representation of the data.</returns>
-        public string ToString(
-            Encoding encoding)
+        public override string ToString()
         {
-            Argument.AssertNotNull(encoding, nameof(encoding));
             if (MemoryMarshal.TryGetArray(
-                Data,
+                Bytes,
                 out ArraySegment<byte> data))
             {
-                return encoding.GetString(data.Array, data.Offset, data.Count);
+                return s_encoding.GetString(data.Array, data.Offset, data.Count);
             }
-            return encoding.GetString(Data.ToArray());
+            return s_encoding.GetString(Bytes.ToArray());
         }
-
-        /// <summary>
-        /// Converts the BinaryData to bytes.
-        /// </summary>
-        /// <returns>The data as bytes.</returns>
-        public ReadOnlyMemory<byte> AsBytes() =>
-            Data;
 
         /// <summary>
         /// Converts the BinaryData to a stream.
@@ -196,12 +224,12 @@ namespace Azure.Core
         public Stream ToStream()
         {
             if (MemoryMarshal.TryGetArray(
-                Data,
+                Bytes,
                 out ArraySegment<byte> data))
             {
                 return new MemoryStream(data.Array, data.Offset, data.Count);
             }
-            return new MemoryStream(Data.ToArray());
+            return new MemoryStream(Bytes.ToArray());
         }
 
         /// <summary>
@@ -214,7 +242,31 @@ namespace Azure.Core
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during deserialization.</param>
         ///<returns>The data converted to the specified type.</returns>
         public T Deserialize<T>(ObjectSerializer serializer, CancellationToken cancellationToken = default) =>
-            DeserializeAsync<T>(serializer, false, cancellationToken).EnsureCompleted();
+            DeserializeInternalAsync<T>(serializer, false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        /// Converts the BinaryData to the specified type using <see cref="JsonObjectSerializer"/>.
+        /// </summary>
+        /// <typeparam name="T">The type that the data should be
+        /// converted to.</typeparam>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during deserialization.</param>
+        ///<returns>The data cast to the specified type. If the cast cannot
+        ///be performed, an <see cref="InvalidCastException"/> will be
+        ///thrown.</returns>
+        /// TODO - add cancellation token support
+        /// once ObjectSerializer.DeserializeAsync adds it.
+        public async ValueTask<T> DeserializeAsync<T>(CancellationToken cancellationToken = default) =>
+            await DeserializeInternalAsync<T>(new JsonObjectSerializer(), true, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        /// Converts the BinaryData to the specified type using <see cref="JsonObjectSerializer"/>.
+        /// </summary>
+        /// <typeparam name="T">The type that the data should be
+        /// converted to.</typeparam>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during deserialization.</param>
+        ///<returns>The data converted to the specified type.</returns>
+        public T Deserialize<T>(CancellationToken cancellationToken = default) =>
+            DeserializeInternalAsync<T>(new JsonObjectSerializer(), false, cancellationToken).EnsureCompleted();
 
         /// <summary>
         /// Converts the BinaryData to the specified type.
@@ -230,9 +282,9 @@ namespace Azure.Core
         /// TODO - add cancellation token support
         /// once ObjectSerializer.DeserializeAsync adds it.
         public async ValueTask<T> DeserializeAsync<T>(ObjectSerializer serializer, CancellationToken cancellationToken = default) =>
-            await DeserializeAsync<T>(serializer, true, cancellationToken).ConfigureAwait(false);
+            await DeserializeInternalAsync<T>(serializer, true, cancellationToken).ConfigureAwait(false);
 
-        private async ValueTask<T> DeserializeAsync<T>(
+        private async ValueTask<T> DeserializeInternalAsync<T>(
             ObjectSerializer serializer,
             bool async,
             CancellationToken cancellationToken)
@@ -258,7 +310,7 @@ namespace Azure.Core
         /// <param name="data"></param>
         public static implicit operator ReadOnlyMemory<byte>(
             BinaryData data) =>
-            data.AsBytes();
+            data.Bytes;
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -266,13 +318,13 @@ namespace Azure.Core
         {
             if (obj is BinaryData data)
             {
-                return data.Data.Equals(Data);
+                return data.Bytes.Equals(Bytes);
             }
             return false;
         }
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() =>
-            Data.GetHashCode();
+            Bytes.GetHashCode();
     }
 }

--- a/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
@@ -13,7 +13,7 @@ using Azure.Core.Pipeline;
 namespace Azure.Core
 {
     /// <summary>
-    /// A lightweight abstraction for a payload of UTF-8 encoded bytes. This type integrates with <see cref="ObjectSerializer"/>
+    /// A lightweight abstraction for a payload of bytes. This type integrates with <see cref="ObjectSerializer"/>
     /// to allow for serializing and deserializing payloads.
     ///
     /// The ownership model of the underlying bytes varies depending on how the instance is constructed:
@@ -66,6 +66,7 @@ namespace Azure.Core
         /// </summary>
         /// <param name="data">The string data.</param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
+        /// <remarks>The byte order mark is not included as part of the encoding process.</remarks>
         public BinaryData(string data)
         {
             Bytes = s_encoding.GetBytes(data);
@@ -256,8 +257,6 @@ namespace Azure.Core
         ///<returns>The data cast to the specified type. If the cast cannot
         ///be performed, an <see cref="InvalidCastException"/> will be
         ///thrown.</returns>
-        /// TODO - add cancellation token support
-        /// once ObjectSerializer.DeserializeAsync adds it.
         public async ValueTask<T> DeserializeAsync<T>(CancellationToken cancellationToken = default) =>
             await DeserializeInternalAsync<T>(new JsonObjectSerializer(), true, cancellationToken).ConfigureAwait(false);
 
@@ -284,8 +283,6 @@ namespace Azure.Core
         ///<returns>The data cast to the specified type. If the cast cannot
         ///be performed, an <see cref="InvalidCastException"/> will be
         ///thrown.</returns>
-        /// TODO - add cancellation token support
-        /// once ObjectSerializer.DeserializeAsync adds it.
         public async ValueTask<T> DeserializeAsync<T>(ObjectSerializer serializer, CancellationToken cancellationToken = default) =>
             await DeserializeInternalAsync<T>(serializer, true, cancellationToken).ConfigureAwait(false);
 
@@ -317,7 +314,12 @@ namespace Azure.Core
             BinaryData data) =>
             data.Bytes;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Two BinaryData objects are equal if the memory regions point to the same array and have the same length.
+        /// The method does not check to see if the contents are equal.
+        /// </summary>
+        /// <param name="obj">The BinaryData to compare.</param>
+        /// <returns>true if the current instance and other are equal; otherwise, false.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj)
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -152,7 +152,6 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusMessage(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage receivedMessage) { }
         public ServiceBusMessage(System.ReadOnlyMemory<byte> body) { }
         public ServiceBusMessage(string body) { }
-        public ServiceBusMessage(string body, System.Text.Encoding encoding) { }
         public Azure.Core.BinaryData Body { get { throw null; } set { } }
         public string ContentType { get { throw null; } set { } }
         public string CorrelationId { get { throw null; } set { } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -154,7 +154,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         public static AmqpMessage SBMessageToAmqpMessage(SBMessage sbMessage)
         {
-            ReadOnlyMemory<byte> bodyBytes = sbMessage.Body.AsBytes();
+            ReadOnlyMemory<byte> bodyBytes = sbMessage.Body;
             var body = new ArraySegment<byte>((bodyBytes.IsEmpty) ? Array.Empty<byte>() : bodyBytes.ToArray());
             var amqpMessage = AmqpMessage.Create(new Data { Value = body });
             amqpMessage.Properties.MessageId = sbMessage.MessageId;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core.Experimental" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
@@ -32,6 +31,9 @@
     <Compile Include="$(AzureCoreSharedSources)ValueStopwatch.cs" Link="SharedSource\Azure.Core\ValueStopwatch.cs" />
     <Compile Include="$(AzureCoreSharedSources)PageResponseEnumerator.cs" Link="SharedSource\Azure.Core\PageResponseEnumerator.cs" />
 
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/EntityScopeFactory.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/EntityScopeFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 
 namespace Azure.Messaging.ServiceBus.Diagnostics

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -36,20 +36,9 @@ namespace Azure.Messaging.ServiceBus
         /// Creates a new message from the specified string, using UTF-8 encoding.
         /// </summary>
         /// <param name="body">The payload of the message as a string.</param>
-        public ServiceBusMessage(string body) :
-            this(body, Encoding.UTF8)
+        public ServiceBusMessage(string body)
         {
-        }
-
-        /// <summary>
-        /// Creates a new message from the specified string, using the specified encoding.
-        /// </summary>
-        /// <param name="body">The payload of the message as a string.</param>
-        /// <param name="encoding">The encoding to use for the body.</param>
-        public ServiceBusMessage(string body, Encoding encoding)
-        {
-            Argument.AssertNotNull(encoding, nameof(encoding));
-            Body = new BinaryData(body, encoding);
+            Body = new BinaryData(body);
             Properties = new Dictionary<string, object>();
         }
 
@@ -59,7 +48,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="body">The payload of the message in bytes.</param>
         public ServiceBusMessage(ReadOnlyMemory<byte> body)
         {
-            Body = new BinaryData(body);
+            Body = BinaryData.FromMemory(body);
             Properties = new Dictionary<string, object>();
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
@@ -63,7 +63,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var convertedSbMessage = AmqpMessageConverter.AmqpMessageToSBMessage(amqpMessage);
 
             Assert.AreEqual("SomeUserProperty", convertedSbMessage.Properties["UserProperty"]);
-            Assert.AreEqual(messageBody, convertedSbMessage.Body.AsBytes().ToArray());
+            Assert.AreEqual(messageBody, convertedSbMessage.Body.Bytes.ToArray());
             Assert.AreEqual(messageId, convertedSbMessage.MessageId);
             Assert.AreEqual(partitionKey, convertedSbMessage.PartitionKey);
             Assert.AreEqual(viaPartitionKey, convertedSbMessage.ViaPartitionKey);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -158,7 +158,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                     B = 5,
                     C = false
                 };
-                var body = BinaryData.FromSerializable(testBody, serializer);
+                var body = BinaryData.Serialize(testBody, serializer);
                 var msg = new ServiceBusMessage(body);
 
                 await sender.SendMessageAsync(msg);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -84,7 +84,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var receivedMaxSizeMessage = await receiver.ReceiveMessageAsync();
                 await receiver.CompleteMessageAsync(receivedMaxSizeMessage.LockToken);
-                Assert.AreEqual(maxPayload, receivedMaxSizeMessage.Body.AsBytes().ToArray());
+                Assert.AreEqual(maxPayload, receivedMaxSizeMessage.Body.Bytes.ToArray());
             }
         }
 
@@ -124,7 +124,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
 
                 void AssertMessagesEqual(ServiceBusMessage sentMessage, ServiceBusReceivedMessage received)
                 {
-                    Assert.IsTrue(received.Body.AsBytes().ToArray().SequenceEqual(sentMessage.Body.AsBytes().ToArray()));
+                    Assert.IsTrue(received.Body.Bytes.ToArray().SequenceEqual(sentMessage.Body.Bytes.ToArray()));
                     Assert.AreEqual(received.ContentType, sentMessage.ContentType);
                     Assert.AreEqual(received.CorrelationId, sentMessage.CorrelationId);
                     Assert.AreEqual(received.Label, sentMessage.Label);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
@@ -46,11 +46,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             var messageBody = "some message";
             var message = new ServiceBusMessage(messageBody);
             Assert.AreEqual(message.Body.ToString(), messageBody);
-            Assert.AreEqual(message.Body.ToString(), messageBody);
-
-            message = new ServiceBusMessage(messageBody, Encoding.UTF32);
-            Assert.AreEqual(message.Body.ToString(Encoding.UTF32), messageBody);
-            Assert.AreNotEqual(message.Body.ToString(), messageBody);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 byte[] state = await receiver.GetSessionStateAsync();
 
                 #endregion
-                Assert.AreEqual(Encoding.UTF8.GetBytes("Hello world!"), receivedMessage.Body.AsBytes().ToArray());
+                Assert.AreEqual(Encoding.UTF8.GetBytes("Hello world!"), receivedMessage.Body.Bytes.ToArray());
                 Assert.AreEqual("mySessionId", receivedMessage.SessionId);
                 Assert.AreEqual(Encoding.UTF8.GetBytes("some state"), state);
             }
@@ -101,7 +101,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 Console.WriteLine(receivedMessage.SessionId);
 
                 #endregion
-                Assert.AreEqual(Encoding.UTF8.GetBytes("Second"), receivedMessage.Body.AsBytes().ToArray());
+                Assert.AreEqual(Encoding.UTF8.GetBytes("Second"), receivedMessage.Body.Bytes.ToArray());
                 Assert.AreEqual("Session2", receivedMessage.SessionId);
             }
         }


### PR DESCRIPTION
- Remove encoding (UTF-8 is assumed)
- Remove BOM
- Add ctor taking ReadOnlySpan
- Add FromMemory factory method that wraps ReadOnlyMemory
- Rename FromSerializable to Serialize (now this differs with the other From* factory methods)
- Add Serialize/Deserialize overloads that don't have ObjectSerializer param
- Replace AsBytes method with Bytes property
- Explain ownership model in doc comments
- Updates to Service Bus based on these changes (notably removing the public constructor for a ServiceBusMessage that takes an encoding)
