### PR TITLE
Event Hub Live Test Change

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -110,26 +110,6 @@ namespace Azure.Core.TestFramework
         /// </summary>
         public string ClientSecret => GetVariable("CLIENT_SECRET");
 
-        /// <summary>
-        ///   The authority host of the cloud to use during Live tests. Recorded.
-        /// </summary>
-        public string AuthorityHost => GetRecordedVariable("AZURE_AUTHORITY_HOST");
-
-        /// <summary>
-        ///   The service management Url of the cloud to use during Live tests. Recorded.
-        /// </summary>
-        public string ServiceManagementUrl => GetRecordedVariable("SERVICE_MANAGEMENT_URL");
-
-        /// <summary>
-        ///   The resource manager of the cloud to use during Live tests. Recorded.
-        /// </summary>
-        public string ResourceManager => GetRecordedVariable("RESOURCE_MANAGER");
-
-        /// <summary>
-        ///   The storage account endpoint suffix of the cloud to use during Live tests. Recorded.
-        /// </summary>
-        public string StorageEndpointSuffix => GetRecordedVariable("STORAGE_ENDPOINT_SUFFIX");
-
         public TokenCredential Credential
         {
             get

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -110,6 +110,26 @@ namespace Azure.Core.TestFramework
         /// </summary>
         public string ClientSecret => GetVariable("CLIENT_SECRET");
 
+        /// <summary>
+        ///   The authority host of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string AuthorityHost => GetRecordedVariable("AZURE_AUTHORITY_HOST");
+
+        /// <summary>
+        ///   The service management Url of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string ServiceManagementUrl => GetRecordedVariable("SERVICE_MANAGEMENT_URL");
+
+        /// <summary>
+        ///   The resource manager of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string ResourceManager => GetRecordedVariable("RESOURCE_MANAGER");
+
+        /// <summary>
+        ///   The storage account endpoint suffix of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string StorageEndpointSuffix => GetRecordedVariable("STORAGE_ENDPOINT_SUFFIX");
+
         public TokenCredential Credential
         {
             get

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var storageAccount = StorageTestEnvironment.Instance.StorageAccountName;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
+            var client = new StorageManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
             {
@@ -104,7 +104,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new StorageManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 BlobContainer container = await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.CreateAsync(resourceGroup, storageAccount, CreateName(), PublicAccess.None)).ConfigureAwait(false);
                 return new StorageScope(container.Name);
@@ -126,7 +126,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             static string CreateName() => $"neteventhubs{ Guid.NewGuid().ToString("N").Substring(0, 12) }";
 
-            using (var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription).ConfigureAwait(false);
                 var sku = new Sku(SkuName.StandardLRS, SkuTier.Standard);
@@ -134,7 +134,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 StorageAccount storageAccount = await ResourceManager.CreateRetryPolicy<StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters)).ConfigureAwait(false);
 
                 StorageAccountListKeysResult storageKeys = await ResourceManager.CreateRetryPolicy<StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name)).ConfigureAwait(false);
-                return new StorageTestEnvironment.StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix={ EventHubsTestEnvironment.Instance.StorageEndpointSuffix }", shouldRemoveAtCompletion: true);
+                return new StorageTestEnvironment.StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix={ StorageTestEnvironment.Instance.StorageEndpointSuffix }", shouldRemoveAtCompletion: true);
             }
         }
 
@@ -151,7 +151,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName)).ConfigureAwait(false);
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var storageAccount = StorageTestEnvironment.Instance.StorageAccountName;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
+            var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
             {
@@ -104,7 +104,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 BlobContainer container = await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.CreateAsync(resourceGroup, storageAccount, CreateName(), PublicAccess.None)).ConfigureAwait(false);
                 return new StorageScope(container.Name);
@@ -126,7 +126,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             static string CreateName() => $"neteventhubs{ Guid.NewGuid().ToString("N").Substring(0, 12) }";
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription).ConfigureAwait(false);
                 var sku = new Sku(SkuName.StandardLRS, SkuTier.Standard);
@@ -134,7 +134,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 StorageAccount storageAccount = await ResourceManager.CreateRetryPolicy<StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters)).ConfigureAwait(false);
 
                 StorageAccountListKeysResult storageKeys = await ResourceManager.CreateRetryPolicy<StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name)).ConfigureAwait(false);
-                return new StorageTestEnvironment.StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix=core.windows.net", shouldRemoveAtCompletion: true);
+                return new StorageTestEnvironment.StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix={ EventHubsTestEnvironment.Instance.StorageEndpointSuffix }", shouldRemoveAtCompletion: true);
             }
         }
 
@@ -151,7 +151,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName)).ConfigureAwait(false);
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
@@ -55,6 +55,11 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         public string StorageConnectionString => ActiveStorageAccount.Value.ConnectionString;
 
         /// <summary>
+        ///   The storage account endpoint suffix of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string StorageEndpointSuffix => GetOptionalVariable("STORAGE_ENDPOINT_SUFFIX") ?? "core.windows.net";
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="StorageTestEnvironment"/> class.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         public string StorageConnectionString => ActiveStorageAccount.Value.ConnectionString;
 
         /// <summary>
-        ///   The storage account endpoint suffix of the cloud to use during Live tests. Recorded.
+        ///   The storage account endpoint suffix of the cloud to use during Live tests.
         /// </summary>
         public string StorageEndpointSuffix => GetOptionalVariable("STORAGE_ENDPOINT_SUFFIX") ?? "core.windows.net";
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -86,7 +86,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
+            var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
             {
@@ -148,7 +148,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             string CreateName() => $"net-eventhubs-{ Guid.NewGuid().ToString("D") }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription).ConfigureAwait(false);
 
@@ -173,7 +173,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName)).ConfigureAwait(false);
             }
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 var consumerGroups = client.ConsumerGroups.ListByEventHub
                 (
@@ -254,7 +254,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
                 eventHub = await ResourceManager.CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub)).ConfigureAwait(false);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -86,7 +86,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
+            var client = new EventHubManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
             {
@@ -148,7 +148,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             string CreateName() => $"net-eventhubs-{ Guid.NewGuid().ToString("D") }";
 
-            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription).ConfigureAwait(false);
 
@@ -173,7 +173,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName)).ConfigureAwait(false);
             }
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new EventHubManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 var consumerGroups = client.ConsumerGroups.ListByEventHub
                 (
@@ -254,7 +254,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new EventHubManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new EventHubManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
                 eventHub = await ResourceManager.CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub)).ConfigureAwait(false);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
@@ -29,6 +29,15 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <summary>The name of the environment variable used to specify an override for the Event Hub instance to use for all tests.</summary>
         private const string EventHubNameOverrideEnvironmentVariable = "EVENTHUB_OVERRIDE_EVENT_HUB_NAME";
 
+        /// <summary>The name of the environment variable used to specify azure authority host to use for all tests.</summary>
+        private const string AzureAuthorityHostEnvironmentVariable = "AZURE_AUTHORITY_HOST";
+
+        /// <summary>The name of the environment variable used to specify service management url to use for all tests.</summary>
+        private const string ServiceManagementUrlEnvironmentVariable = "SERVICE_MANAGEMENT_URL";
+
+        /// <summary>The name of the environment variable used to specify resource manager to use for all tests.</summary>
+        private const string ResourceManagerEnvironmentVariable = "RESOURCE_MANAGER";
+
         /// <summary>The default value for the maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.</summary>
         private const int DefaultPerTestExecutionLimitMinutes = 5;
 
@@ -113,6 +122,21 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <value>The shared access key, as contained within the associated connection string.</value>
         ///
         public string SharedAccessKey => ParsedConnectionString.Value.SharedAccessKey;
+
+        /// <summary>
+        ///   The authority host of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string AuthorityHost => GetOptionalVariable(AzureAuthorityHostEnvironmentVariable) ?? "https://login.microsoftonline.com";
+
+        /// <summary>
+        ///   The service management Url of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public string ServiceManagementUrl => GetOptionalVariable(ServiceManagementUrlEnvironmentVariable) ?? "https://management.core.windows.net/";
+
+        /// <summary>
+        ///   The resource manager of the cloud to use during Live tests. Recorded.
+        /// </summary>
+        public Uri ResourceManager => new Uri(GetOptionalVariable(ResourceManagerEnvironmentVariable) ?? "https://management.azure.com/");
 
         /// <summary>
         ///   Initializes a new instance of <see cref="EventHubsTestEnvironment"/>.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private const string ServiceManagementUrlEnvironmentVariable = "SERVICE_MANAGEMENT_URL";
 
         /// <summary>The name of the environment variable used to specify resource manager to use for all tests.</summary>
-        private const string ResourceManagerEnvironmentVariable = "RESOURCE_MANAGER";
+        private const string ResourceManagerEnvironmentVariable = "RESOURCE_MANAGER_URL";
 
         /// <summary>The default value for the maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.</summary>
         private const int DefaultPerTestExecutionLimitMinutes = 5;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
@@ -124,17 +124,17 @@ namespace Azure.Messaging.EventHubs.Tests
         public string SharedAccessKey => ParsedConnectionString.Value.SharedAccessKey;
 
         /// <summary>
-        ///   The authority host of the cloud to use during Live tests. Recorded.
+        ///   The authority host of the cloud to use during Live tests.
         /// </summary>
         public string AuthorityHost => GetOptionalVariable(AzureAuthorityHostEnvironmentVariable) ?? "https://login.microsoftonline.com";
 
         /// <summary>
-        ///   The service management Url of the cloud to use during Live tests. Recorded.
+        ///   The service management Url of the cloud to use during Live tests.
         /// </summary>
         public string ServiceManagementUrl => GetOptionalVariable(ServiceManagementUrlEnvironmentVariable) ?? "https://management.core.windows.net/";
 
         /// <summary>
-        ///   The resource manager of the cloud to use during Live tests. Recorded.
+        ///   The resource manager of the cloud to use during Live tests.
         /// </summary>
         public Uri ResourceManager => new Uri(GetOptionalVariable(ResourceManagerEnvironmentVariable) ?? "https://management.azure.com/");
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                   string resourceGroupName,
                                                                   string subscriptionId)
         {
-            using (var client = new ResourceManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            using (var client = new ResourceManagementClient(EventHubsTestEnvironment.Instance.ResourceManager, new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
             {
                 ResourceGroup resourceGroup = await CreateRetryPolicy<ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName)).ConfigureAwait(false);
                 return resourceGroup.Location;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                   string resourceGroupName,
                                                                   string subscriptionId)
         {
-            using (var client = new ResourceManagementClient(new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            using (var client = new ResourceManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManager), new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
             {
                 ResourceGroup resourceGroup = await CreateRetryPolicy<ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName)).ConfigureAwait(false);
                 return resourceGroup.Location;
@@ -87,8 +87,8 @@ namespace Azure.Messaging.EventHubs.Tests
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
                 var credential = new ClientCredential(EventHubsTestEnvironment.Instance.ClientId, EventHubsTestEnvironment.Instance.ClientSecret);
-                var context = new AuthenticationContext($"https://login.windows.net/{ EventHubsTestEnvironment.Instance.TenantId }");
-                AuthenticationResult result = await context.AcquireTokenAsync("https://management.core.windows.net/", credential).ConfigureAwait(false);
+                var context = new AuthenticationContext($"{ EventHubsTestEnvironment.Instance.AuthorityHost }/{ EventHubsTestEnvironment.Instance.TenantId }");
+                AuthenticationResult result = await context.AcquireTokenAsync(EventHubsTestEnvironment.Instance.ServiceManagementUrl, credential).ConfigureAwait(false);
 
                 if ((string.IsNullOrEmpty(result?.AccessToken)))
                 {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var eventHubNamespace = TestUtility.EventHubsNamespace;
             var token = await AquireManagementTokenAsync();
-            var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
+            var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
 
             try
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription })
+            using (var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
                 eventHub = await CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub));
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"net-eventhubs-track-one-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var token = await AquireManagementTokenAsync();
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));
                 ;
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"neteventhubstrackone{ Guid.NewGuid().ToString("D").Substring(0, 4) }";
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.EventHubs.Tests
                 var storageAccount = await CreateRetryPolicy<StorageManagement.StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters));
 
                 var storageKeys = await CreateRetryPolicy<StorageManagement.StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name));
-                return new AzureResourceProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix=core.windows.net");
+                return new AzureResourceProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix={ TestUtility.StorageEndpointSuffix }");
             }
         }
 
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var token = await AquireManagementTokenAsync();
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName));
             }
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.EventHubs.Tests
                                                                           string resourceGroupName,
                                                                           string subscriptionId)
         {
-            using (var client = new ResourceManagementClient(new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            using (var client = new ResourceManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
             {
                 var resourceGroup = await CreateRetryPolicy<Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName));
                 return resourceGroup.Location;
@@ -229,8 +229,8 @@ namespace Microsoft.Azure.EventHubs.Tests
                 || (statusCode == HttpStatusCode.ServiceUnavailable)
                 || (statusCode == HttpStatusCode.GatewayTimeout));
 
-         private static bool ShouldRetry(Exception ex) =>
-            ((IsRetriableException(ex)) || (IsRetriableException(ex?.InnerException)));
+        private static bool ShouldRetry(Exception ex) =>
+           ((IsRetriableException(ex)) || (IsRetriableException(ex?.InnerException)));
 
         private static bool IsRetriableException(Exception ex)
         {
@@ -274,8 +274,8 @@ namespace Microsoft.Azure.EventHubs.Tests
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
                 var credential = new ClientCredential(TestUtility.EventHubsClient, TestUtility.EventHubsSecret);
-                var context = new AuthenticationContext($"https://login.windows.net/{ TestUtility.EventHubsTenant }");
-                var result = await context.AcquireTokenAsync("https://management.core.windows.net/", credential);
+                var context = new AuthenticationContext($"{ TestUtility.AuthorityHost }/{ TestUtility.EventHubsTenant }");
+                var result = await context.AcquireTokenAsync(TestUtility.ServiceManagementUrl, credential);
 
                 if ((String.IsNullOrEmpty(result?.AccessToken)))
                 {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var eventHubNamespace = TestUtility.EventHubsNamespace;
             var token = await AquireManagementTokenAsync();
-            var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
+            var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
 
             try
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription })
+            using (var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
                 eventHub = await CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub));
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"net-eventhubs-track-one-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
 
-            using (var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var token = await AquireManagementTokenAsync();
 
-            using (var client = new EventHubManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));
                 ;
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"neteventhubstrackone{ Guid.NewGuid().ToString("D").Substring(0, 4) }";
 
-            using (var client = new StorageManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var token = await AquireManagementTokenAsync();
 
-            using (var client = new StorageManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName));
             }
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.EventHubs.Tests
                                                                           string resourceGroupName,
                                                                           string subscriptionId)
         {
-            using (var client = new ResourceManagementClient(new Uri(TestUtility.ResourceManager), new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            using (var client = new ResourceManagementClient(TestUtility.ResourceManager, new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
             {
                 var resourceGroup = await CreateRetryPolicy<Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName));
                 return resourceGroup.Location;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string EventHubsTenantEnvironmentVariableName = "EVENTHUB_TENANT_ID";
         internal const string EventHubsClientEnvironmentVariableName = "EVENTHUB_CLIENT_ID";
         internal const string EventHubsSecretEnvironmentVariableName = "EVENTHUB_CLIENT_SECRET";
+        internal const string AuthorityHostEnvironmentVariableName = "AZURE_AUTHORITY_HOST";
+        internal const string ServiceManagementUrlEnvironmentVariableName = "SERVICE_MANAGEMENT_URL";
+        internal const string ResourceManagerEnvironmentVariableName = "RESOURCE_MANAGER";
+        internal const string StorageEndpointSuffixEnvironmentVariableName = "STORAGE_ENDPOINT_SUFFIX";
 
         // General
         internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(180);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string EventHubsSecretEnvironmentVariableName = "EVENTHUB_CLIENT_SECRET";
         internal const string AuthorityHostEnvironmentVariableName = "AZURE_AUTHORITY_HOST";
         internal const string ServiceManagementUrlEnvironmentVariableName = "SERVICE_MANAGEMENT_URL";
-        internal const string ResourceManagerEnvironmentVariableName = "RESOURCE_MANAGER";
+        internal const string ResourceManagerEnvironmentVariableName = "RESOURCE_MANAGER_URL";
         internal const string StorageEndpointSuffixEnvironmentVariableName = "STORAGE_ENDPOINT_SUFFIX";
 
         // General

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -68,13 +68,13 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         internal static string EventHubsSecret => EventHubsSecretInstance.Value;
 
-        internal static string AuthorityHost => AuthorityHostInstance.Value;
+        internal static string AuthorityHost => AuthorityHostInstance.Value ?? "https://login.microsoftonline.com";
 
-        internal static string ServiceManagementUrl => ServiceManagementUrlInstance.Value;
+        internal static string ServiceManagementUrl => ServiceManagementUrlInstance.Value ?? "https://management.core.windows.net/";
 
-        internal static string ResourceManager => ResourceManagerInstance.Value;
+        internal static Uri ResourceManager => new Uri(ResourceManagerInstance.Value ?? "https://management.azure.com/");
 
-        internal static string StorageEndpointSuffix => StorageEndpointSuffixInstance.Value;
+        internal static string StorageEndpointSuffix => StorageEndpointSuffixInstance.Value ?? "core.windows.net";
 
         internal static string GetEntityConnectionString(string entityName) =>
             new EventHubsConnectionStringBuilder(EventHubsConnectionString) { EntityPath = entityName }.ToString();

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -28,6 +28,18 @@ namespace Microsoft.Azure.EventHubs.Tests
         private static readonly Lazy<string> EventHubsSecretInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSecretEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 
+        private static readonly Lazy<string> AuthorityHostInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.AuthorityHostEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        private static readonly Lazy<string> ServiceManagementUrlInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.ServiceManagementUrlEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        private static readonly Lazy<string> ResourceManagerInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.ResourceManagerEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        private static readonly Lazy<string> StorageEndpointSuffixInstance =
+           new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.StorageEndpointSuffixEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
         private static readonly Lazy<EventHubScope.AzureResourceProperties> ActiveEventHubsNamespace =
             new Lazy<EventHubScope.AzureResourceProperties>(CreateNamespace, LazyThreadSafetyMode.ExecutionAndPublication);
 
@@ -55,6 +67,14 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal static string EventHubsClient => EventHubsClientInstance.Value;
 
         internal static string EventHubsSecret => EventHubsSecretInstance.Value;
+
+        internal static string AuthorityHost => AuthorityHostInstance.Value;
+
+        internal static string ServiceManagementUrl => ServiceManagementUrlInstance.Value;
+
+        internal static string ResourceManager => ResourceManagerInstance.Value;
+
+        internal static string StorageEndpointSuffix => StorageEndpointSuffixInstance.Value;
 
         internal static string GetEntityConnectionString(string entityName) =>
             new EventHubsConnectionStringBuilder(EventHubsConnectionString) { EntityPath = entityName }.ToString();

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -1,8 +1,41 @@
 trigger: none
 
 extends:
-  template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+  template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests-multiple.yml
   parameters:
-    MaxParallel: 6
-    ServiceDirectory: eventhub
-    TimeoutInMinutes: 120
+    jobs:
+      # Azure Cloud
+      - ServiceDirectory: eventhub
+        MaxParallel: 6
+        TimeoutInMinutes: 120
+        ScenarioName: AzureCloud
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        EnvVars:
+          AZURE_AUTHORITY_HOST: https://login.microsoftonline.com
+          SERVICE_MANAGEMENT_URL: https://management.core.windows.net/
+          STORAGE_ENDPOINT_SUFFIX: core.windows.net
+          RESOURCE_MANAGER: https://management.azure.com/
+
+      # AzureUSGovernment
+      - ServiceDirectory: eventhub
+        MaxParallel: 6
+        TimeoutInMinutes: 120
+        ScenarioName: AzureUSGovernment
+        SubscriptionConfiguration: $(sub-config-gov-test-resources)
+        EnvVars:
+          AZURE_AUTHORITY_HOST: https://login.microsoftonline.us
+          SERVICE_MANAGEMENT_URL: https://management.core.usgovcloudapi.net/
+          STORAGE_ENDPOINT_SUFFIX: core.usgovcloudapi.net
+          RESOURCE_MANAGER: https://management.usgovcloudapi.net/
+
+      # AzureChinaCloud
+      - ServiceDirectory: eventhub
+        MaxParallel: 6
+        TimeoutInMinutes: 120
+        ScenarioName: AzureChinaCloud
+        SubscriptionConfiguration: $(sub-config-cn-test-resources)
+        EnvVars:
+          AZURE_AUTHORITY_HOST: https://login.chinacloudapi.cn
+          SERVICE_MANAGEMENT_URL: https://management.core.chinacloudapi.cn/
+          STORAGE_ENDPOINT_SUFFIX: core.chinacloudapi.cn
+          RESOURCE_MANAGER: https://management.chinacloudapi.cn

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -14,7 +14,7 @@ extends:
           AZURE_AUTHORITY_HOST: https://login.microsoftonline.com
           SERVICE_MANAGEMENT_URL: https://management.core.windows.net/
           STORAGE_ENDPOINT_SUFFIX: core.windows.net
-          RESOURCE_MANAGER: https://management.azure.com/
+          RESOURCE_MANAGER_URL: https://management.azure.com/
 
       # AzureUSGovernment
       - ServiceDirectory: eventhub
@@ -26,7 +26,7 @@ extends:
           AZURE_AUTHORITY_HOST: https://login.microsoftonline.us
           SERVICE_MANAGEMENT_URL: https://management.core.usgovcloudapi.net/
           STORAGE_ENDPOINT_SUFFIX: core.usgovcloudapi.net
-          RESOURCE_MANAGER: https://management.usgovcloudapi.net/
+          RESOURCE_MANAGER_URL: https://management.usgovcloudapi.net/
 
       # AzureChinaCloud
       - ServiceDirectory: eventhub
@@ -38,4 +38,4 @@ extends:
           AZURE_AUTHORITY_HOST: https://login.chinacloudapi.cn
           SERVICE_MANAGEMENT_URL: https://management.core.chinacloudapi.cn/
           STORAGE_ENDPOINT_SUFFIX: core.chinacloudapi.cn
-          RESOURCE_MANAGER: https://management.chinacloudapi.cn
+          RESOURCE_MANAGER_URL: https://management.chinacloudapi.cn


### PR DESCRIPTION
Change Event Hub Live Test to support run against other cloud.
besides this [issue](https://github.com/Azure/azure-sdk-for-net/issues/12964) ,`resoucemanagerclient`,`eventhubmanagerclient` and `storagemanageclient`  authenticate against default cloud. 
The fix here is to pick up setting from tests.yml.