### PR TITLE
[FormRecognizer] Add info differentiating async and sync methods in README

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -121,16 +121,20 @@ Please note that models can also be trained using a graphical user interface suc
 
 Because analyzing and training form documents takes time, these operations are implemented as [**long-running operations**][dotnet_lro_guidelines].  Long-running operations consist of an initial request sent to the service to start an operation, followed by polling the service at intervals to determine whether the operation has completed or failed, and if it has succeeded, to get the result.
 
-For long running operations in the Azure SDK, the client exposes a `Start<operation-name>` method that returns an `Operation<T>`.  You can use the extension method `WaitForCompletionAsync()` to wait for the operation to complete and obtain its result.  A sample code snippet is provided to illustrate using long-running operations [below](#recognize-receipts).
+For long running operations in the Azure SDK, the client exposes a `Start<operation-name>` method that returns an `Operation<T>`.  You can use the extension method `WaitForCompletionAsync()` to wait for the operation to complete and obtain its result.  A sample code snippet is provided to illustrate using long-running operations [below](#recognize-content).
 
 ## Examples
-The following section provides several code snippets illustrating common patterns used in the Form Recognizer .NET API.
+The following section provides several code snippets illustrating common patterns used in the Form Recognizer .NET API. Most of the snippets below make use of asynchronous service calls, but keep in mind that the Azure.AI.FormRecognizer package supports both synchronous and asynchronous APIs.
 
+### Async examples
 * [Recognize Content](#recognize-content)
 * [Recognize Custom Forms](#recognize-custom-forms)
 * [Recognize Receipts](#recognize-receipts)
 * [Train a Model](#train-a-model)
 * [Manage Custom Models](#manage-custom-models)
+
+### Sync examples
+* [Manage Custom Models Synchronously](#manage-custom-models-synchronously)
 
 ### Recognize Content
 Recognize text and table data, along with their bounding box coordinates, from documents.
@@ -308,7 +312,7 @@ foreach (CustomFormSubmodel submodel in model.Submodels)
 ### Manage Custom Models
 Manage the custom models stored in your account.
 
-```C# Snippet:FormRecognizerSampleManageCustomModels
+```C# Snippet:FormRecognizerSampleManageCustomModelsAsync
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
@@ -352,6 +356,12 @@ foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
 
 // Delete the model from the account.
 client.DeleteModel(model.ModelId);
+```
+
+### Manage Custom Models Synchronously
+Manage the custom models stored in your account with a synchronous API. Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
+
+```C# Snippet:FormRecognizerSampleManageCustomModels
 ```
 
 ## Troubleshooting

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -140,7 +140,7 @@ The following section provides several code snippets illustrating common pattern
 Recognize text and table data, along with their bounding box coordinates, from documents.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-FormPageCollection formPages = await client.StartRecognizeContentFromUri(invoiceUri).WaitForCompletionAsync();
+FormPageCollection formPages = await client.StartRecognizeContentFromUriAsync(invoiceUri).WaitForCompletionAsync();
 foreach (FormPage page in formPages)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
@@ -169,7 +169,7 @@ Recognize and extract form fields and other content from your custom forms, usin
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
+RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUriAsync(modelId, formUri).WaitForCompletionAsync();
 foreach (RecognizedForm form in forms)
 {
     Console.WriteLine($"Form of type: {form.FormType}");
@@ -194,7 +194,7 @@ Recognize data from US sales receipts using a prebuilt model.
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileStream
 using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 {
-    RecognizedFormCollection receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+    RecognizedFormCollection receipts = await client.StartRecognizeReceiptsAsync(stream).WaitForCompletionAsync();
 
     // To see the list of the supported fields returned by service and its corresponding types, consult:
     // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
@@ -316,6 +316,55 @@ Manage the custom models stored in your account.
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
+AccountProperties accountProperties = await client.GetAccountPropertiesAsync();
+Console.WriteLine($"Account has {accountProperties.CustomModelCount} models.");
+Console.WriteLine($"It can have at most {accountProperties.CustomModelLimit} models.");
+
+// List the models currently stored in the account.
+AsyncPageable<CustomFormModelInfo> models = client.GetCustomModelsAsync();
+
+await foreach (CustomFormModelInfo modelInfo in models)
+{
+    Console.WriteLine($"Custom Model Info:");
+    Console.WriteLine($"    Model Id: {modelInfo.ModelId}");
+    Console.WriteLine($"    Model Status: {modelInfo.Status}");
+    Console.WriteLine($"    Training model started on: {modelInfo.TrainingStartedOn}");
+    Console.WriteLine($"    Training model completed on: : {modelInfo.TrainingCompletedOn}");
+}
+
+// Create a new model to store in the account
+CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+
+// Get the model that was just created
+CustomFormModel modelCopy = await client.GetCustomModelAsync(model.ModelId);
+
+Console.WriteLine($"Custom Model {modelCopy.ModelId} recognizes the following form types:");
+
+foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
+{
+    Console.WriteLine($"Submodel Form Type: {submodel.FormType}");
+    foreach (CustomFormModelField field in submodel.Fields.Values)
+    {
+        Console.Write($"    FieldName: {field.Name}");
+        if (field.Label != null)
+        {
+            Console.Write($", FieldLabel: {field.Label}");
+        }
+        Console.WriteLine("");
+    }
+}
+
+// Delete the model from the account.
+await client.DeleteModelAsync(model.ModelId);
+```
+
+### Manage Custom Models Synchronously
+Manage the custom models stored in your account with a synchronous API. Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
+
+```C# Snippet:FormRecognizerSampleManageCustomModels
+FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+
+// Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
 AccountProperties accountProperties = client.GetAccountProperties();
 Console.WriteLine($"Account has {accountProperties.CustomModelCount} models.");
 Console.WriteLine($"It can have at most {accountProperties.CustomModelLimit} models.");
@@ -333,7 +382,7 @@ foreach (CustomFormModelInfo modelInfo in models.Take(10))
 }
 
 // Create a new model to store in the account
-CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
 // Get the model that was just created
 CustomFormModel modelCopy = client.GetCustomModel(model.ModelId);
@@ -356,12 +405,6 @@ foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
 
 // Delete the model from the account.
 client.DeleteModel(model.ModelId);
-```
-
-### Manage Custom Models Synchronously
-Manage the custom models stored in your account with a synchronous API. Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
-
-```C# Snippet:FormRecognizerSampleManageCustomModels
 ```
 
 ## Troubleshooting

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -333,7 +333,7 @@ await foreach (CustomFormModelInfo modelInfo in models)
 }
 
 // Create a new model to store in the account
-CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
 // Get the model that was just created
 CustomFormModel modelCopy = await client.GetCustomModelAsync(model.ModelId);
@@ -359,7 +359,7 @@ await client.DeleteModelAsync(model.ModelId);
 ```
 
 ### Manage Custom Models Synchronously
-Manage the custom models stored in your account with a synchronous API. Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
+Manage the custom models stored in your account with a synchronous API. Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart. For more information on long-running operations, see [Long-Running Operations](#long-running-operations).
 
 ```C# Snippet:FormRecognizerSampleManageCustomModels
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -162,7 +162,7 @@ foreach (FormPage page in formPages)
 ### Recognize Custom Forms
 Recognize and extract form fields and other content from your custom forms, using models you train with your own form types.
 
-```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
+```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
 RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
@@ -275,7 +275,7 @@ using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 ### Train a Model
 Train a machine-learned model on your own form types. The resulting model will be able to recognize values from the types of forms it was trained on.
 
-```C# Snippet:FormRecognizerSample4TrainModelWithForms
+```C# Snippet:FormRecognizerSampleTrainModelWithForms
 // For this sample, you can use the training forms found in the `trainingFiles` folder.
 // Upload the forms to your storage container and then generate a container SAS URL.
 // For instructions on setting up forms for training in an Azure Storage Blob Container, see
@@ -308,7 +308,7 @@ foreach (CustomFormSubmodel submodel in model.Submodels)
 ### Manage Custom Models
 Manage the custom models stored in your account.
 
-```C# Snippet:FormRecognizerSample6ManageCustomModels
+```C# Snippet:FormRecognizerSampleManageCustomModels
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize the content from a given file at a URI, use the `StartRecognizeContentFromUri` method. The returned value is a collection of `FormPage` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-FormPageCollection formPages = await client.StartRecognizeContentFromUri(invoiceUri).WaitForCompletionAsync();
+FormPageCollection formPages = await client.StartRecognizeContentFromUriAsync(invoiceUri).WaitForCompletionAsync();
 foreach (FormPage page in formPages)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeCustomForms.md
@@ -21,7 +21,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 
 To recognize form fields and other content from your custom forms from a given file at a URI, use the `StartRecognizeCustomFormsFromUri` method. The returned value is a collection of `RecognizedForm` objects -- one for each page in the submitted document.
 
-```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
+```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
 RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeCustomForms.md
@@ -24,7 +24,7 @@ To recognize form fields and other content from your custom forms from a given f
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
+RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUriAsync(modelId, formUri).WaitForCompletionAsync();
 foreach (RecognizedForm form in forms)
 {
     Console.WriteLine($"Form of type: {form.FormType}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method. The returned value is a collection of `RecognizedForm` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
+RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
 // To see the list of the supported fields returned by service and its corresponding types, consult:
 // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
@@ -56,7 +56,7 @@ public Receipt(RecognizedForm recognizedForm)
 Here we illustrate how to use the `Receipt` wrapper class described above.
 
 ```C# Snippet:FormRecognizerSampleStronglyTypingARecognizedForm
-RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
+RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
 foreach (RecognizedForm recognizedForm in recognizedForms)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample5_TrainModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample5_TrainModel.md
@@ -23,7 +23,7 @@ var client = new FormTrainingClient(new Uri(endpoint), credential);
 
 Train custom models to recognize all fields and values found in your custom forms. A `CustomFormModel` is returned indicating the form types the model will recognize, and the fields it will extract from each form type.
 
-```C# Snippet:FormRecognizerSample4TrainModelWithForms
+```C# Snippet:FormRecognizerSampleTrainModelWithForms
 // For this sample, you can use the training forms found in the `trainingFiles` folder.
 // Upload the forms to your storage container and then generate a container SAS URL.
 // For instructions on setting up forms for training in an Azure Storage Blob Container, see
@@ -57,7 +57,7 @@ foreach (CustomFormSubmodel submodel in model.Submodels)
 
 Train custom models to recognize specific fields and values you specify by labeling your custom forms. A `CustomFormModel` is returned indicating the fields the model will extract, as well as the estimated accuracy for each field.
 
-```C# Snippet:FormRecognizerSample5TrainModelWithFormsAndLabels
+```C# Snippet:FormRecognizerSampleTrainModelWithFormsAndLabels
 // For this sample, you can use the training forms found in the `trainingFiles` folder.
 // Upload the forms to your storage container and then generate a container SAS URL.
 // For instructions to set up forms for training in an Azure Storage Blob Container, please see:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
@@ -31,6 +31,56 @@ Operations that can be executed are:
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
+AccountProperties accountProperties = await client.GetAccountPropertiesAsync();
+Console.WriteLine($"Account has {accountProperties.CustomModelCount} models.");
+Console.WriteLine($"It can have at most {accountProperties.CustomModelLimit} models.");
+
+// List the models currently stored in the account.
+AsyncPageable<CustomFormModelInfo> models = client.GetCustomModelsAsync();
+
+await foreach (CustomFormModelInfo modelInfo in models)
+{
+    Console.WriteLine($"Custom Model Info:");
+    Console.WriteLine($"    Model Id: {modelInfo.ModelId}");
+    Console.WriteLine($"    Model Status: {modelInfo.Status}");
+    Console.WriteLine($"    Training model started on: {modelInfo.TrainingStartedOn}");
+    Console.WriteLine($"    Training model completed on: : {modelInfo.TrainingCompletedOn}");
+}
+
+// Create a new model to store in the account
+CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+
+// Get the model that was just created
+CustomFormModel modelCopy = await client.GetCustomModelAsync(model.ModelId);
+
+Console.WriteLine($"Custom Model {modelCopy.ModelId} recognizes the following form types:");
+
+foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
+{
+    Console.WriteLine($"Submodel Form Type: {submodel.FormType}");
+    foreach (CustomFormModelField field in submodel.Fields.Values)
+    {
+        Console.Write($"    FieldName: {field.Name}");
+        if (field.Label != null)
+        {
+            Console.Write($", FieldLabel: {field.Label}");
+        }
+        Console.WriteLine("");
+    }
+}
+
+// Delete the model from the account.
+await client.DeleteModelAsync(model.ModelId);
+```
+
+## Manage Custom Models Synchronously
+
+Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
+
+```C# Snippet:FormRecognizerSampleManageCustomModels
+FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+
+// Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
 AccountProperties accountProperties = client.GetAccountProperties();
 Console.WriteLine($"Account has {accountProperties.CustomModelCount} models.");
 Console.WriteLine($"It can have at most {accountProperties.CustomModelLimit} models.");
@@ -48,7 +98,7 @@ foreach (CustomFormModelInfo modelInfo in models.Take(10))
 }
 
 // Create a new model to store in the account
-CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
 // Get the model that was just created
 CustomFormModel modelCopy = client.GetCustomModel(model.ModelId);
@@ -71,13 +121,6 @@ foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
 
 // Delete the model from the account.
 client.DeleteModel(model.ModelId);
-```
-
-## Manage Custom Models Synchronously
-
-Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
-
-```C# Snippet:FormRecognizerSampleManageCustomModels
 ```
 
 To see the full example source files, see:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
@@ -25,7 +25,9 @@ Operations that can be executed are:
 - Get a specific model using the model's Id.
 - Delete a model from the resource account.
 
-```C# Snippet:FormRecognizerSampleManageCustomModels
+## Manage Custom Models Asynchronously
+
+```C# Snippet:FormRecognizerSampleManageCustomModelsAsync
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
@@ -69,6 +71,13 @@ foreach (CustomFormSubmodel submodel in modelCopy.Submodels)
 
 // Delete the model from the account.
 client.DeleteModel(model.ModelId);
+```
+
+## Manage Custom Models Synchronously
+
+Note that we are still making an asynchronous call to `WaitForCompletionAsync` for training, since this method does not have a synchronous counterpart.
+
+```C# Snippet:FormRecognizerSampleManageCustomModels
 ```
 
 To see the full example source files, see:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
@@ -25,7 +25,7 @@ Operations that can be executed are:
 - Get a specific model using the model's Id.
 - Delete a model from the resource account.
 
-```C# Snippet:FormRecognizerSample6ManageCustomModels
+```C# Snippet:FormRecognizerSampleManageCustomModels
 FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
 // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample6_ManageCustomModels.md
@@ -48,7 +48,7 @@ await foreach (CustomFormModelInfo modelInfo in models)
 }
 
 // Create a new model to store in the account
-CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
 // Get the model that was just created
 CustomFormModel modelCopy = await client.GetCustomModelAsync(model.ModelId);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample7_CopyCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample7_CopyCustomModel.md
@@ -20,7 +20,7 @@ You can set `endpoint` and `apiKey` based on an environment variable, a configur
 ### Source client
 The source client that contains the custom model we want to copy.
 
-```C# Snippet:FormRecognizerSample6CreateCopySourceClient
+```C# Snippet:FormRecognizerSampleCreateCopySourceClient
 string endpoint = "<source_endpoint>";
 string apiKey = "<source_apiKey>";
 var sourcecredential = new AzureKeyCredential(apiKey);
@@ -30,7 +30,7 @@ var sourceClient = new FormTrainingClient(new Uri(endpoint), sourcecredential);
 ### Target client
 The target client where we want to copy the custom model to.
 
-```C# Snippet:FormRecognizerSample6CreateCopyTargetClient
+```C# Snippet:FormRecognizerSampleCreateCopyTargetClient
 string endpoint = "<target_endpoint>";
 string apiKey = "<target_apiKey>";
 var targetCredential = new AzureKeyCredential(apiKey);
@@ -39,26 +39,26 @@ var targetClient = new FormTrainingClient(new Uri(endpoint), targetCredential);
 
 ### Authorize the copy
 Before starting the copy, we need to get a `CopyAuthorization` from the target Form Recognizer resource that will give us permission to execute the copy.
-```C# Snippet:FormRecognizerSample6GetCopyAuthorization
+```C# Snippet:FormRecognizerSampleGetCopyAuthorization
 string resourceId = "<resourceId>";
 string resourceRegion = "<region>";
 CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, resourceRegion);
 ```
 
 `CopyAuthorization` provides the convenience method `ToJson` that will serialize the authorization properties into a json format string.
-```C# Snippet:FormRecognizerSample6ToJson
+```C# Snippet:FormRecognizerSampleToJson
 string jsonTargetAuth = targetAuth.ToJson();
 ```
 
 To deserealize a string that contains authorizaiton information, use the `FromJson` method from `CopyAuthorization`.
-```C# Snippet:FormRecognizerSample6FromJson
+```C# Snippet:FormRecognizerSampleFromJson
 CopyAuthorization targetCopyAuth = CopyAuthorization.FromJson(jsonTargetAuth);
 ```
 
 ### Execute the copy
 Now that we have authorization from the target Form Recognizer resource, we execute the copy from the `sourceClient` where the model to copy lives.
 
-```C# Snippet:FormRecognizerSample6CopyModel
+```C# Snippet:FormRecognizerSampleCopyModel
 string modelId = "<source_modelId>";
 CustomFormModelInfo newModel = await sourceClient.StartCopyModelAsync(modelId, targetCopyAuth).WaitForCompletionAsync();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample10_DifferentiateOutputModelsTrainedWithAndWithoutLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample10_DifferentiateOutputModelsTrainedWithAndWithoutLabels.cs
@@ -34,11 +34,11 @@ namespace Azure.AI.FormRecognizer.Samples
             FormTrainingClient trainingClient = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             // Model trained with labels
-            CustomFormModel modelTrainedWithLabels = await trainingClient.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: true).WaitForCompletionAsync();
+            CustomFormModel modelTrainedWithLabels = await trainingClient.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: true).WaitForCompletionAsync();
 
             using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
             {
-                RecognizedFormCollection forms = await client.StartRecognizeCustomForms(modelTrainedWithLabels.ModelId, stream).WaitForCompletionAsync();
+                RecognizedFormCollection forms = await client.StartRecognizeCustomFormsAsync(modelTrainedWithLabels.ModelId, stream).WaitForCompletionAsync();
 
                 // With a form recognized by a model trained with labels, the 'field.Name' key will be the label
                 // that you gave it at training time.
@@ -88,11 +88,11 @@ namespace Azure.AI.FormRecognizer.Samples
             FormTrainingClient trainingClient = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             // Model trained without labels
-            CustomFormModel modelTrainedWithoutLabels = await trainingClient.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel modelTrainedWithoutLabels = await trainingClient.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
             using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
             {
-                RecognizedFormCollection forms = await client.StartRecognizeCustomForms(modelTrainedWithoutLabels.ModelId, stream).WaitForCompletionAsync();
+                RecognizedFormCollection forms = await client.StartRecognizeCustomFormsAsync(modelTrainedWithoutLabels.ModelId, stream).WaitForCompletionAsync();
 
                 // With a form recognized by a model trained without labels, the 'field.Name' property will be denoted
                 // by a numeric index. To look for the labels identified during the training step,

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromFile.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
             {
-                FormPageCollection formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+                FormPageCollection formPages = await client.StartRecognizeContentAsync(stream).WaitForCompletionAsync();
                 foreach (FormPage page in formPages)
                 {
                     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeContentFromUri
 
-            FormPageCollection formPages = await client.StartRecognizeContentFromUri(invoiceUri).WaitForCompletionAsync();
+            FormPageCollection formPages = await client.StartRecognizeContentFromUriAsync(invoiceUri).WaitForCompletionAsync();
             foreach (FormPage page in formPages)
             {
                 Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromFile.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.Samples
             // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/label-tool
 
             FormTrainingClient trainingClient = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            CustomFormModel model = await trainingClient.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel model = await trainingClient.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
             // Proceed with the custom form recognition.
 
@@ -38,7 +38,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
             {
-                RecognizedFormCollection forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+                RecognizedFormCollection forms = await client.StartRecognizeCustomFormsAsync(modelId, stream).WaitForCompletionAsync();
                 foreach (RecognizedForm form in forms)
                 {
                     Console.WriteLine($"Form of type: {form.FormType}");
@@ -58,7 +58,7 @@ namespace Azure.AI.FormRecognizer.Samples
             }
 
             // Delete the model on completion to clean environment.
-            trainingClient.DeleteModel(model.ModelId);
+            await trainingClient.DeleteModelAsync(model.ModelId);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromUri.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.FormRecognizer.Samples
             // https://docs.microsoft.com/azure/cognitive-services/form-recognizer/quickstarts/label-tool
 
             FormTrainingClient trainingClient = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            CustomFormModel model = await trainingClient.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel model = await trainingClient.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
             // Proceed with the custom form recognition.
 
@@ -38,7 +38,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
             //@@ string modelId = "<modelId>";
 
-            RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();
+            RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUriAsync(modelId, formUri).WaitForCompletionAsync();
             foreach (RecognizedForm form in forms)
             {
                 Console.WriteLine($"Form of type: {form.FormType}");
@@ -58,7 +58,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
 
             // Delete the model on completion to clean environment.
-            trainingClient.DeleteModel(model.ModelId);
+            await trainingClient.DeleteModelAsync(model.ModelId);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeCustomFormsFromUri.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.FormRecognizer.Samples
             Uri formUri = FormRecognizerTestEnvironment.CreateUri("Form_1.jpg");
             string modelId = model.ModelId;
 
-            #region Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
+            #region Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
             //@@ string modelId = "<modelId>";
 
             RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, formUri).WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:FormRecognizerSample1CreateClient
+            #region Snippet:FormRecognizerSampleCreateClient
             FormRecognizerClient client = new FormRecognizerClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
             #endregion
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
@@ -29,7 +29,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileStream
             using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
             {
-                RecognizedFormCollection receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+                RecognizedFormCollection receipts = await client.StartRecognizeReceiptsAsync(stream).WaitForCompletionAsync();
 
                 // To see the list of the supported fields returned by service and its corresponding types, consult:
                 // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Samples
             Uri receiptUri = FormRecognizerTestEnvironment.CreateUri("contoso-receipt.jpg");
 
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-            RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
+            RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
             // To see the list of the supported fields returned by service and its corresponding types, consult:
             // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample4_StronglyTypingARecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample4_StronglyTypingARecognizedForm.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Samples
             Uri receiptUri = FormRecognizerTestEnvironment.CreateUri("contoso-receipt.jpg");
 
             #region Snippet:FormRecognizerSampleStronglyTypingARecognizedForm
-            RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUri(receiptUri).WaitForCompletionAsync();
+            RecognizedFormCollection recognizedForms = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
             foreach (RecognizedForm recognizedForm in recognizedForms)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.FormRecognizer.Samples
             string apiKey = TestEnvironment.ApiKey;
             string trainingFileUrl = TestEnvironment.BlobContainerSasUrl;
 
-            #region Snippet:FormRecognizerSample4TrainModelWithForms
+            #region Snippet:FormRecognizerSampleTrainModelWithForms
             // For this sample, you can use the training forms found in the `trainingFiles` folder.
             // Upload the forms to your storage container and then generate a container SAS URL.
             // For instructions on setting up forms for training in an Azure Storage Blob Container, see

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample5_TrainModelWithForms.cs
@@ -50,7 +50,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
 
             // Delete the model on completion to clean environment.
-            client.DeleteModel(model.ModelId);
+            await client.DeleteModelAsync(model.ModelId);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample6_TrainModelWithFormsAndLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample6_TrainModelWithFormsAndLabels.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.FormRecognizer.Samples
             string apiKey = TestEnvironment.ApiKey;
             string trainingFileUrl = TestEnvironment.BlobContainerSasUrl;
 
-            #region Snippet:FormRecognizerSample5TrainModelWithFormsAndLabels
+            #region Snippet:FormRecognizerSampleTrainModelWithFormsAndLabels
             // For this sample, you can use the training forms found in the `trainingFiles` folder.
             // Upload the forms to your storage container and then generate a container SAS URL.
             // For instructions to set up forms for training in an Azure Storage Blob Container, please see:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample6_TrainModelWithFormsAndLabels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample6_TrainModelWithFormsAndLabels.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #endregion
 
             // Delete the model on completion to clean environment.
-            client.DeleteModel(model.ModelId);
+            await client.DeleteModelAsync(model.ModelId);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModels.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer.Samples
             }
 
             // Create a new model to store in the account
-            CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
             // Get the model that was just created
             CustomFormModel modelCopy = client.GetCustomModel(model.ModelId);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModels.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModels.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.Samples
             string apiKey = TestEnvironment.ApiKey;
             string trainingFileUrl = TestEnvironment.BlobContainerSasUrl;
 
-            #region Snippet:FormRecognizerSample6ManageCustomModels
+            #region Snippet:FormRecognizerSampleManageCustomModels
 
             FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
@@ -19,6 +19,8 @@ namespace Azure.AI.FormRecognizer.Samples
             string apiKey = TestEnvironment.ApiKey;
             string trainingFileUrl = TestEnvironment.BlobContainerSasUrl;
 
+            #region Snippet:FormRecognizerSampleManageCustomModelsAsync
+
             FormTrainingClient client = new FormTrainingClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             // Check number of models in the FormRecognizer account, and the maximum number of models that can be stored.
@@ -39,7 +41,7 @@ namespace Azure.AI.FormRecognizer.Samples
             }
 
             // Create a new model to store in the account
-            CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
             // Get the model that was just created
             CustomFormModel modelCopy = await client.GetCustomModelAsync(model.ModelId);
@@ -62,6 +64,8 @@ namespace Azure.AI.FormRecognizer.Samples
 
             // Delete the model from the account.
             await client.DeleteModelAsync(model.ModelId);
+
+            #endregion
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Tests;
 using Azure.AI.FormRecognizer.Training;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample7_ManageCustomModelsAsync.cs
@@ -41,7 +41,7 @@ namespace Azure.AI.FormRecognizer.Samples
             }
 
             // Create a new model to store in the account
-            CustomFormModel model = await client.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel model = await client.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
 
             // Get the model that was just created
             CustomFormModel modelCopy = await client.GetCustomModelAsync(model.ModelId);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample8_CopyModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample8_CopyModel.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             // For the purpose of this sample, we are going to create a trained model to copy. Please note that
             // if you already have a model, this is not neccesary.
-            CustomFormModel model = await sourceClient.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
+            CustomFormModel model = await sourceClient.StartTrainingAsync(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
             string modelId = model.ModelId;
 
             #region Snippet:FormRecognizerSampleCreateCopyTargetClient

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample8_CopyModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample8_CopyModel.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.Samples
             string resourceRegion = TestEnvironment.TargetResourceRegion;
 
 
-            #region Snippet:FormRecognizerSample6CreateCopySourceClient
+            #region Snippet:FormRecognizerSampleCreateCopySourceClient
             //@@ string endpoint = "<source_endpoint>";
             //@@ string apiKey = "<source_apiKey>";
             var sourcecredential = new AzureKeyCredential(apiKey);
@@ -34,28 +34,28 @@ namespace Azure.AI.FormRecognizer.Samples
             CustomFormModel model = await sourceClient.StartTraining(new Uri(trainingFileUrl), useTrainingLabels: false).WaitForCompletionAsync();
             string modelId = model.ModelId;
 
-            #region Snippet:FormRecognizerSample6CreateCopyTargetClient
+            #region Snippet:FormRecognizerSampleCreateCopyTargetClient
             //@@ string endpoint = "<target_endpoint>";
             //@@ string apiKey = "<target_apiKey>";
             var targetCredential = new AzureKeyCredential(apiKey);
             var targetClient = new FormTrainingClient(new Uri(endpoint), targetCredential);
             #endregion
 
-            #region Snippet:FormRecognizerSample6GetCopyAuthorization
+            #region Snippet:FormRecognizerSampleGetCopyAuthorization
             //@@ string resourceId = "<resourceId>";
             //@@ string resourceRegion = "<region>";
             CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, resourceRegion);
             #endregion
 
-            #region Snippet:FormRecognizerSample6ToJson
+            #region Snippet:FormRecognizerSampleToJson
             string jsonTargetAuth = targetAuth.ToJson();
             #endregion
 
-            #region Snippet:FormRecognizerSample6FromJson
+            #region Snippet:FormRecognizerSampleFromJson
             CopyAuthorization targetCopyAuth = CopyAuthorization.FromJson(jsonTargetAuth);
             #endregion
 
-            #region Snippet:FormRecognizerSample6CopyModel
+            #region Snippet:FormRecognizerSampleCopyModel
             //@@ string modelId = "<source_modelId>";
             CustomFormModelInfo newModel = await sourceClient.StartCopyModelAsync(modelId, targetCopyAuth).WaitForCompletionAsync();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample9_BoundingBox.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample9_BoundingBox.cs
@@ -34,7 +34,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
             {
-                FormPageCollection formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+                FormPageCollection formPages = await client.StartRecognizeContentAsync(stream).WaitForCompletionAsync();
                 foreach (FormPage page in formPages)
                 {
                     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");


### PR DESCRIPTION
Defaulting snippets in README to async, but explicitly keeping a section to illustrate the sync API.

Fixes #11475.