### PR TITLE
Fix CHANGELOG and project files

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Release History
 
+## 4.0.3 (Unreleased)
+
+### Fixed
+
+- Fixed an issue where the issuer name was always null ([#10908](https://github.com/Azure/azure-sdk-for-net/issues/10908))
+- Fixed an issue where GetIssuerAsync would throw for issuers with contact information populated ([#10905](https://github.com/Azure/azure-sdk-for-net/issues/10905))
+- Fixed an issue where some Certificate policy properties were not serialized properly ([#11669](https://github.com/azure/azure-sdk-for-net/issues/11669))
+
 ## 4.0.2 (2020-03-18)
 
 ### Fixed
 
 - Fixed concurrency issue in our challenge-based authentication policy ([#9737](https://github.com/Azure/azure-sdk-for-net/issues/9737))
-- Fixed an issue where the issuer name was always null ([#10908](https://github.com/Azure/azure-sdk-for-net/issues/10908))
-- Fixed an issue where GetIssuerAsync would throw for issuers with contact information populated ([#10905](https://github.com/Azure/azure-sdk-for-net/issues/10905))
-- Fixed an issue where some Certificate policy properties were not serialized properly ([#11669](https://github.com/azure/azure-sdk-for-net/issues/11669))
 
 ## 4.0.1 (2020-03-03)
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Certificates client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Certificates client library</AssemblyTitle>
-    <Version>4.0.2</Version>
+    <Version>4.0.3-preview.1</Version>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -1,11 +1,6 @@
 # Release History
 
-## 4.1.0-preview.1 (2020-03-09)
-
-### Added
-
-- Add "import" value to `KeyOperation` enumeration.
-- Add `RecoverableDays` property to `KeyProperties`.
+## 4.0.4 (Unreleased)
 
 ### Minor changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Keys client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Keys client library</AssemblyTitle>
-    <Version>4.0.3</Version>
+    <Version>4.0.4-preview.1</Version>
     <PackageTags>Microsoft Azure Key Vault Keys;$(PackageCommonTags)</PackageTags>
 
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>


### PR DESCRIPTION
Fix the CHANGELOGs for Certs and Keys and fix the project files' <Version> to be ready for eventual servicing release.