### PR TITLE
Factory method to create ServiceBusReceivedMessage

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -178,6 +178,12 @@ namespace Azure.Messaging.ServiceBus
         public void Dispose() { }
         public bool TryAddMessage(Azure.Messaging.ServiceBus.ServiceBusMessage message) { throw null; }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public static partial class ServiceBusModelFactory
+    {
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public static Azure.Messaging.ServiceBus.ServiceBusReceivedMessage ServiceBusReceivedMessage(Azure.Core.BinaryData body = default(Azure.Core.BinaryData), string messageId = null, string partitionKey = null, string viaPartitionKey = null, string sessionId = null, string replyToSessionId = null, System.TimeSpan timeToLive = default(System.TimeSpan), string correlationId = null, string label = null, string to = null, string contentType = null, string replyTo = null, System.DateTimeOffset scheduledEnqueueTime = default(System.DateTimeOffset), System.Collections.Generic.IDictionary<string, object> properties = null, System.Guid lockTokenGuid = default(System.Guid), int deliveryCount = 0, System.DateTimeOffset lockedUntil = default(System.DateTimeOffset), long sequenceNumber = (long)-1, string deadLetterSource = null, long enqueuedSequenceNumber = (long)0, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset)) { throw null; }
+    }
     public partial class ServiceBusProcessor
     {
         protected ServiceBusProcessor() { }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusModelFactory.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusModelFactory.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using Azure.Core;
 
-namespace Azure.Messaging.ServiceBus.Primitives
+namespace Azure.Messaging.ServiceBus
 {
     /// <summary>
     /// This class contains methods to create certain ServiceBus models.
@@ -17,30 +19,78 @@ namespace Azure.Messaging.ServiceBus.Primitives
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ServiceBusReceivedMessage ServiceBusReceivedMessage(
-            ServiceBusMessage sentMessage,
-            bool isSettled,
-            int deliveryCount,
-            DateTimeOffset lockedUntil,
-            long sequenceNumber,
-            string deadLetterSource,
-            short partitionId,
-            long enqueuedSequenceNumber,
-            DateTimeOffset enqueuedTime,
-            Guid lockTokenGuid,
-            object bodyObject
-        ) => new ServiceBusReceivedMessage
+            BinaryData body = default,
+            string messageId = default,
+            string partitionKey = default,
+            string viaPartitionKey = default,
+            string sessionId = default,
+            string replyToSessionId = default,
+            TimeSpan timeToLive = default,
+            string correlationId = default,
+            string label = default,
+            string to = default,
+            string contentType = default,
+            string replyTo = default,
+            DateTimeOffset scheduledEnqueueTime = default,
+            IDictionary<string, object> properties = default,
+            Guid lockTokenGuid = default,
+            int deliveryCount = default,
+            DateTimeOffset lockedUntil = default,
+            long sequenceNumber = -1,
+            string deadLetterSource = default,
+            long enqueuedSequenceNumber = default,
+            DateTimeOffset enqueuedTime = default)
         {
-            SentMessage = sentMessage,
-            IsSettled = isSettled,
-            DeliveryCount = deliveryCount,
-            LockedUntil = lockedUntil,
-            SequenceNumber = sequenceNumber,
-            DeadLetterSource = deadLetterSource,
-            PartitionId = partitionId,
-            EnqueuedSequenceNumber = enqueuedSequenceNumber,
-            EnqueuedTime = enqueuedTime,
-            LockTokenGuid = lockTokenGuid,
-            BodyObject = bodyObject
-        };
+            var sentMessage = new ServiceBusMessage
+            {
+                Body = body,
+                CorrelationId = correlationId,
+                Label = label,
+                To = to,
+                ContentType = contentType,
+                ReplyTo = replyTo,
+                ScheduledEnqueueTime = scheduledEnqueueTime
+            };
+            if (messageId != default)
+            {
+                sentMessage.MessageId = messageId;
+            }
+            if (partitionKey != default)
+            {
+                sentMessage.PartitionKey = partitionKey;
+            }
+            if (viaPartitionKey != default)
+            {
+                sentMessage.ViaPartitionKey = viaPartitionKey;
+            }
+            if (sessionId != default)
+            {
+                sentMessage.SessionId = sessionId;
+            }
+            if (replyToSessionId != default)
+            {
+                sentMessage.ReplyToSessionId = replyToSessionId;
+            }
+            if (timeToLive != default)
+            {
+                sentMessage.TimeToLive = timeToLive;
+            }
+            if (properties != default)
+            {
+                sentMessage.Properties = properties;
+            }
+
+            return new ServiceBusReceivedMessage
+            {
+                SentMessage = sentMessage,
+                LockTokenGuid = lockTokenGuid,
+                DeliveryCount = deliveryCount,
+                LockedUntil = lockedUntil,
+                SequenceNumber = sequenceNumber,
+                DeadLetterSource = deadLetterSource,
+                EnqueuedSequenceNumber = enqueuedSequenceNumber,
+                EnqueuedTime = enqueuedTime
+            };
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusModelFactory.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusModelFactory.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace Azure.Messaging.ServiceBus.Primitives
+{
+    /// <summary>
+    /// This class contains methods to create certain ServiceBus models.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ServiceBusModelFactory
+    {
+        /// <summary>
+        /// Creates a new ServiceBusReceivedMessage instance for mocking.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ServiceBusReceivedMessage ServiceBusReceivedMessage(
+            ServiceBusMessage sentMessage,
+            bool isSettled,
+            int deliveryCount,
+            DateTimeOffset lockedUntil,
+            long sequenceNumber,
+            string deadLetterSource,
+            short partitionId,
+            long enqueuedSequenceNumber,
+            DateTimeOffset enqueuedTime,
+            Guid lockTokenGuid,
+            object bodyObject
+        ) => new ServiceBusReceivedMessage
+        {
+            SentMessage = sentMessage,
+            IsSettled = isSettled,
+            DeliveryCount = deliveryCount,
+            LockedUntil = lockedUntil,
+            SequenceNumber = sequenceNumber,
+            DeadLetterSource = deadLetterSource,
+            PartitionId = partitionId,
+            EnqueuedSequenceNumber = enqueuedSequenceNumber,
+            EnqueuedTime = enqueuedTime,
+            LockTokenGuid = lockTokenGuid,
+            BodyObject = bodyObject
+        };
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
@@ -235,7 +235,7 @@ namespace Azure.Messaging.ServiceBus
 
         internal Guid LockTokenGuid { get; set; }
 
-        internal object BodyObject { get; set;}
+        internal object BodyObject { get; set; }
 
         /// <summary>Gets the date and time in UTC at which the message is set to expire.</summary>
         /// <value>The message expiration time in UTC. This property is read-only.</value>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
@@ -52,5 +52,85 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             Assert.AreEqual(message.Body.ToString(Encoding.UTF32), messageBody);
             Assert.AreNotEqual(message.Body.ToString(), messageBody);
         }
+
+        [Test]
+        public void CreateReceivedMessageViaFactory()
+        {
+            var receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage();
+            Assert.AreEqual(default(BinaryData), receivedMessage.Body);
+            Assert.AreEqual(default(string), receivedMessage.MessageId);
+            Assert.AreEqual(default(string), receivedMessage.PartitionKey);
+            Assert.AreEqual(default(string), receivedMessage.ViaPartitionKey);
+            Assert.AreEqual(default(string), receivedMessage.SessionId);
+            Assert.AreEqual(default(string), receivedMessage.ReplyToSessionId);
+            Assert.AreEqual(TimeSpan.MaxValue, receivedMessage.TimeToLive);
+            Assert.AreEqual(default(string), receivedMessage.CorrelationId);
+            Assert.AreEqual(default(string), receivedMessage.Label);
+            Assert.AreEqual(default(string), receivedMessage.To);
+            Assert.AreEqual(default(string), receivedMessage.ContentType);
+            Assert.AreEqual(default(string), receivedMessage.ReplyTo);
+            Assert.AreEqual(default(DateTimeOffset), receivedMessage.ScheduledEnqueueTime);
+            Assert.IsNotNull(receivedMessage.Properties);
+            Assert.IsEmpty(receivedMessage.Properties);
+            Assert.AreEqual(default(Guid), receivedMessage.LockTokenGuid);
+            Assert.AreEqual(default(int), receivedMessage.DeliveryCount);
+            Assert.AreEqual(default(DateTimeOffset), receivedMessage.LockedUntil);
+            Assert.AreEqual(-1, receivedMessage.SequenceNumber);
+            Assert.AreEqual(default(string), receivedMessage.DeadLetterSource);
+            Assert.AreEqual(default(long), receivedMessage.EnqueuedSequenceNumber);
+            Assert.AreEqual(default(DateTimeOffset), receivedMessage.EnqueuedTime);
+
+            var fixedDate = new DateTime(2000, 1, 1);
+            receivedMessage = ServiceBusModelFactory.ServiceBusReceivedMessage(
+                new BinaryData("binaryData2468"),
+                "messageId12345",
+                "partitionKey98765",
+                "viaPartitionKey8765",
+                "sessionId8877",
+                "replyToSessionId4556",
+                TimeSpan.FromMinutes(5),
+                "correlationId8877",
+                "label4523",
+                "to9887",
+                "contentType0538",
+                "replyTo2598",
+                new DateTimeOffset(fixedDate, TimeSpan.FromHours(2)),
+                new Dictionary<string, object> {
+                    { "42", 6420 },
+                    { "properties0864", "testValue" }
+                },
+                Guid.Parse("f5ae57c7-963b-4864-ae19-32b12451e5d8"),
+                4321,
+                new DateTimeOffset(fixedDate, TimeSpan.FromMinutes(18)),
+                3456,
+                "deadLetterSource5773",
+                7632,
+                new DateTimeOffset(fixedDate, TimeSpan.FromSeconds(120))
+            );
+            Assert.AreEqual("binaryData2468", receivedMessage.Body.ToString());
+            Assert.AreEqual("messageId12345", receivedMessage.MessageId);
+            Assert.AreEqual("partitionKey98765", receivedMessage.PartitionKey);
+            Assert.AreEqual("viaPartitionKey8765", receivedMessage.ViaPartitionKey);
+            Assert.AreEqual("sessionId8877", receivedMessage.SessionId);
+            Assert.AreEqual("replyToSessionId4556", receivedMessage.ReplyToSessionId);
+            Assert.AreEqual(TimeSpan.FromMinutes(5).ToString(), receivedMessage.TimeToLive.ToString());
+            Assert.AreEqual("correlationId8877", receivedMessage.CorrelationId);
+            Assert.AreEqual("label4523", receivedMessage.Label);
+            Assert.AreEqual("to9887", receivedMessage.To);
+            Assert.AreEqual("contentType0538", receivedMessage.ContentType);
+            Assert.AreEqual("replyTo2598", receivedMessage.ReplyTo);
+            Assert.AreEqual(new DateTimeOffset(fixedDate, TimeSpan.FromHours(2)).ToString(), receivedMessage.ScheduledEnqueueTime.ToString());
+            Assert.IsNotNull(receivedMessage.Properties);
+            Assert.IsNotEmpty(receivedMessage.Properties);
+            Assert.AreEqual(new[]{ "42", "properties0864"}, receivedMessage.Properties.Keys);
+            Assert.AreEqual(new object[]{ 6420, "testValue"}, receivedMessage.Properties.Values);
+            Assert.AreEqual("f5ae57c7-963b-4864-ae19-32b12451e5d8", receivedMessage.LockTokenGuid.ToString());
+            Assert.AreEqual(4321, receivedMessage.DeliveryCount);
+            Assert.AreEqual(new DateTimeOffset(fixedDate, TimeSpan.FromMinutes(18)).ToString(), receivedMessage.LockedUntil.ToString());
+            Assert.AreEqual(3456, receivedMessage.SequenceNumber);
+            Assert.AreEqual("deadLetterSource5773", receivedMessage.DeadLetterSource);
+            Assert.AreEqual(7632, receivedMessage.EnqueuedSequenceNumber);
+            Assert.AreEqual(new DateTimeOffset(fixedDate, TimeSpan.FromSeconds(120)).ToString(), receivedMessage.EnqueuedTime.ToString());
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/11794

Added factory that has a method to build a ServiceBusReceivedMessage with all the internal setters available via parameters.