### PR TITLE
Fixed bug where BlockBlobClient and PageBlobClient would throw NullRe…

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.5.0-preview.6 (Unreleased)
-
+- Fixed bug where BlockBlobClient and PageBlobClient would throw NullReferenceExceptions when using Uri constructor.
 
 ## 12.5.0-preview.5 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -316,7 +316,7 @@ namespace Azure.Storage.Blobs.Specialized
 
         private static void AssertNoClientSideEncryption(BlobClientOptions options)
         {
-            if (options._clientSideEncryptionOptions != default)
+            if (options?._clientSideEncryptionOptions != default)
             {
                 throw Errors.ClientSideEncryption.TypeNotSupported(typeof(BlockBlobClient));
             }

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -207,7 +207,7 @@ namespace Azure.Storage.Blobs.Specialized
 
         private static void AssertNoClientSideEncryption(BlobClientOptions options)
         {
-            if (options._clientSideEncryptionOptions != default)
+            if (options?._clientSideEncryptionOptions != default)
             {
                 throw Errors.ClientSideEncryption.TypeNotSupported(typeof(PageBlobClient));
             }

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -50,6 +50,27 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void Ctor_Uri()
+        {
+            // Arrange
+            string accountName = "accountname";
+            string containerName = GetNewContainerName();
+            string blobName = GetNewBlobName();
+
+            Uri uri = new Uri($"https://{accountName}.blob.core.windows.net/{containerName}/{blobName}");
+
+            // Act
+            AppendBlobClient appendBlobClient = new AppendBlobClient(uri);
+
+            // Assert
+            BlobUriBuilder builder = new BlobUriBuilder(appendBlobClient.Uri);
+
+            Assert.AreEqual(containerName, builder.BlobContainerName);
+            Assert.AreEqual(blobName, builder.BlobName);
+            Assert.AreEqual(accountName, builder.AccountName);
+        }
+
+        [Test]
         public void Ctor_TokenAuth_Http()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -108,6 +108,27 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void Ctor_UriNonIpStyle()
+        {
+            // Arrange
+            string accountName = "accountname";
+            string containerName = GetNewContainerName();
+            string blobName = GetNewBlobName();
+
+            Uri uri = new Uri($"https://{accountName}.blob.core.windows.net/{containerName}/{blobName}");
+
+            // Act
+            BlobBaseClient blobBaseClient = new BlobBaseClient(uri);
+
+            // Assert
+            BlobUriBuilder builder = new BlobUriBuilder(blobBaseClient.Uri);
+
+            Assert.AreEqual(containerName, builder.BlobContainerName);
+            Assert.AreEqual(blobName, builder.BlobName);
+            Assert.AreEqual(accountName, builder.AccountName);
+        }
+
+        [Test]
         public void Ctor_TokenAuth_Http()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -72,6 +72,27 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void Ctor_UriNonIpStyle()
+        {
+            // Arrange
+            string accountName = "accountname";
+            string containerName = GetNewContainerName();
+            string blobName = GetNewBlobName();
+
+            Uri uri = new Uri($"https://{accountName}.blob.core.windows.net/{containerName}/{blobName}");
+
+            // Act
+            BlobClient blobClient = new BlobClient(uri);
+
+            // Assert
+            BlobUriBuilder builder = new BlobUriBuilder(blobClient.Uri);
+
+            Assert.AreEqual(containerName, builder.BlobContainerName);
+            Assert.AreEqual(blobName, builder.BlobName);
+            Assert.AreEqual(accountName, builder.AccountName);
+        }
+
+        [Test]
         public void Ctor_TokenAuth_Http()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -57,6 +57,27 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void Ctor_Uri()
+        {
+            // Arrange
+            string accountName = "accountname";
+            string containerName = GetNewContainerName();
+            string blobName = GetNewBlobName();
+
+            Uri uri = new Uri($"https://{accountName}.blob.core.windows.net/{containerName}/{blobName}");
+
+            // Act
+            BlockBlobClient blockBlobClient = new BlockBlobClient(uri);
+
+            // Assert
+            BlobUriBuilder builder = new BlobUriBuilder(blockBlobClient.Uri);
+
+            Assert.AreEqual(containerName, builder.BlobContainerName);
+            Assert.AreEqual(blobName, builder.BlobName);
+            Assert.AreEqual(accountName, builder.AccountName);
+        }
+
+        [Test]
         public void Ctor_TokenAuth_Http()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -58,6 +58,27 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void Ctor_Uri()
+        {
+            // Arrange
+            string accountName = "accountname";
+            string containerName = GetNewContainerName();
+            string blobName = GetNewBlobName();
+
+            Uri uri = new Uri($"https://{accountName}.blob.core.windows.net/{containerName}/{blobName}");
+
+            // Act
+            PageBlobClient pageBlobClient = new PageBlobClient(uri);
+
+            // Assert
+            BlobUriBuilder builder = new BlobUriBuilder(pageBlobClient.Uri);
+
+            Assert.AreEqual(containerName, builder.BlobContainerName);
+            Assert.AreEqual(blobName, builder.BlobName);
+            Assert.AreEqual(accountName, builder.AccountName);
+        }
+
+        [Test]
         public void Ctor_TokenAuth_Http()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/Ctor_Uri.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "1180037847"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/Ctor_UriAsync.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "826696057"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_UriNonIpStyle.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_UriNonIpStyle.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "40669430"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_UriNonIpStyleAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_UriNonIpStyleAsync.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "1902539983"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/Ctor_UriNonIpStyle.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/Ctor_UriNonIpStyle.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "83798732"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/Ctor_UriNonIpStyleAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/Ctor_UriNonIpStyleAsync.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "636070129"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/Ctor_Uri.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "1452172616"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/Ctor_UriAsync.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "1639814101"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/Ctor_Uri.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "1698928575"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/Ctor_UriAsync.json
@@ -1,0 +1,6 @@
+{
+  "Entries": [],
+  "Variables": {
+    "RandomSeed": "289381250"
+  }
+}


### PR DESCRIPTION
…ferenceExceptions when using Uri constructor

Resolves https://github.com/Azure/azure-sdk-for-net/issues/13232