### PR TITLE
Feature/storage/uri builder encoding bug

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.3.0-preview.2 (Unreleased)
-
+- Fixed bug where DataLakeUriBuilder would return LastDirectoryOrFileName and DirectoryOrFilePath URL-encoded.
 
 ## 12.3.0-preview.1 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -477,8 +477,8 @@ namespace Azure.Storage.Files.DataLake
                 var builder = new DataLakeUriBuilder(Uri);
                 _fileSystemName = builder.FileSystemName;
                 _accountName = builder.AccountName;
-                _path = builder.DirectoryOrFilePath.UnescapePath();
-                _name = builder.LastDirectoryOrFileName.UnescapePath();
+                _path = builder.DirectoryOrFilePath;
+                _name = builder.LastDirectoryOrFileName;
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeUriBuilder.cs
@@ -112,7 +112,6 @@ namespace Azure.Storage.Files.DataLake
             }
         }
 
-        // Original path given by the user, unecoded.
         private string _directoryOrFilePath;
 
         /// <summary>
@@ -227,7 +226,7 @@ namespace Azure.Storage.Files.DataLake
                     }
                     else
                     {
-                        DirectoryOrFilePath = directoryOrFilePath;
+                        DirectoryOrFilePath = directoryOrFilePath.UnescapePath();
                     }
 
                 }
@@ -365,7 +364,7 @@ namespace Azure.Storage.Files.DataLake
                     else
                     {
                         // Encode path.
-                        path.Append("/").Append(_directoryOrFilePath.EscapePath());
+                        path.Append("/").Append(DirectoryOrFilePath.EscapePath());
                     }
                 }
             }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -2438,6 +2438,8 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             PathItem filePathItem = pathItems.Where(r => r.Name == expectedPath).FirstOrDefault();
 
+            DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(subDirectory.Uri);
+
             // Assert
             Assert.IsNotNull(filePathItem);
             Assert.AreEqual(subDirectoryName, subDirectory.Name);
@@ -2446,6 +2448,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(blobUri, subDirectory.Uri);
             Assert.AreEqual(blobUri, subDirectory.BlobUri);
             Assert.AreEqual(dfsUri, subDirectory.DfsUri);
+
+            Assert.AreEqual(subDirectoryName, dataLakeUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(expectedPath, dataLakeUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(blobUri, dataLakeUriBuilder.ToUri());
         }
 
         [Test]
@@ -2478,6 +2484,8 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             PathItem filePathItem = pathItems.Where(r => r.Name == expectedPath).FirstOrDefault();
 
+            DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(file.Uri);
+
             // Assert
             Assert.IsNotNull(filePathItem);
             Assert.AreEqual(fileName, file.Name);
@@ -2486,6 +2494,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(blobUri, file.Uri);
             Assert.AreEqual(blobUri, file.BlobUri);
             Assert.AreEqual(dfsUri, file.DfsUri);
+
+            Assert.AreEqual(fileName, dataLakeUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(expectedPath, dataLakeUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(blobUri, dataLakeUriBuilder.ToUri());
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -1708,6 +1708,8 @@ namespace Azure.Storage.Files.DataLake.Tests
                 pathItems.Add(pathItem);
             }
 
+            DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(directory.Uri);
+
             // Assert
             Assert.AreEqual(directoryName, pathItems[0].Name);
             Assert.AreEqual(directoryName, directory.Name);
@@ -1716,6 +1718,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(blobUri, directory.Uri);
             Assert.AreEqual(blobUri, directory.BlobUri);
             Assert.AreEqual(dfsUri, directory.DfsUri);
+
+            Assert.AreEqual(directoryName, dataLakeUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(directoryName, dataLakeUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(blobUri, dataLakeUriBuilder.ToUri());
         }
 
         [Test]
@@ -1740,6 +1746,8 @@ namespace Azure.Storage.Files.DataLake.Tests
                 pathItems.Add(pathItem);
             }
 
+            DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(file.Uri);
+
             // Assert
             Assert.AreEqual(fileName, pathItems[0].Name);
             Assert.AreEqual(fileName, file.Name);
@@ -1748,6 +1756,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(blobUri, file.Uri);
             Assert.AreEqual(blobUri, file.BlobUri);
             Assert.AreEqual(dfsUri, file.DfsUri);
+
+            Assert.AreEqual(fileName, dataLakeUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(fileName, dataLakeUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(blobUri, dataLakeUriBuilder.ToUri());
         }
 
         private IEnumerable<AccessConditionParameters> Conditions_Data

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.3.0-preview.2 (Unreleased)
-
+- Fixed bug where ShareUriBuilder would return LastDirectoryOrFileName and DirectoryOrFilePath URL-encoded.
 
 ## 12.3.0-preview.1 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -326,7 +326,6 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareFileClient GetFileClient(string fileName)
         {
             ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri);
-            shareUriBuilder.DirectoryOrFilePath = shareUriBuilder.DirectoryOrFilePath.UnescapePath();
             shareUriBuilder.DirectoryOrFilePath += $"/{fileName}";
             return new ShareFileClient(
                 shareUriBuilder.ToUri(),
@@ -346,7 +345,6 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareDirectoryClient GetSubdirectoryClient(string subdirectoryName)
         {
             ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri);
-            shareUriBuilder.DirectoryOrFilePath = shareUriBuilder.DirectoryOrFilePath.UnescapePath();
             shareUriBuilder.DirectoryOrFilePath += $"/{subdirectoryName}";
             return new ShareDirectoryClient(
                 shareUriBuilder.ToUri(),
@@ -363,10 +361,10 @@ namespace Azure.Storage.Files.Shares
             if (_name == null || _shareName == null || _accountName == null || _path == null)
             {
                 var builder = new ShareUriBuilder(Uri);
-                _name = builder.LastDirectoryOrFileName.UnescapePath();
+                _name = builder.LastDirectoryOrFileName;
                 _shareName = builder.ShareName;
                 _accountName = builder.AccountName;
-                _path = builder.DirectoryOrFilePath.UnescapePath();
+                _path = builder.DirectoryOrFilePath;
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -333,10 +333,10 @@ namespace Azure.Storage.Files.Shares
             if (_name == null || _shareName == null || _accountName == null || _path == null)
             {
                 var builder = new ShareUriBuilder(Uri);
-                _name = builder.LastDirectoryOrFileName.UnescapePath();
+                _name = builder.LastDirectoryOrFileName;
                 _shareName = builder.ShareName;
                 _accountName = builder.AccountName;
-                _path = builder.DirectoryOrFilePath.UnescapePath();
+                _path = builder.DirectoryOrFilePath;
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
@@ -212,7 +212,7 @@ namespace Azure.Storage.Files.Shares
                     ShareName = path.Substring(startIndex, shareEndIndex - startIndex);
 
                     // The directory/file path name is after the share slash
-                    DirectoryOrFilePath = path.Substring(shareEndIndex + 1).Trim('/');
+                    DirectoryOrFilePath = path.Substring(shareEndIndex + 1).Trim('/').UnescapePath();
                 }
             }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -968,6 +968,8 @@ namespace Azure.Storage.Files.Shares.Test
 
             await sasFile.GetPropertiesAsync();
 
+            ShareUriBuilder shareUriBuilder = new ShareUriBuilder(fileFromConstructor.Uri);
+
             // Assert
             Assert.AreEqual(createResponse.Value.ETag, propertiesResponse.Value.ETag);
 
@@ -981,6 +983,10 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.AreEqual(fileName, fileFromConstructor.Name);
             Assert.AreEqual(path, fileFromConstructor.Path);
             Assert.AreEqual(expectedUri, fileFromConstructor.Uri);
+
+            Assert.AreEqual(fileName, shareUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(path, shareUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(expectedUri, shareUriBuilder.ToUri());
         }
 
         [Test]
@@ -1018,6 +1024,8 @@ namespace Azure.Storage.Files.Shares.Test
                 shareFileItems.Add(shareFileItem);
             }
 
+            ShareUriBuilder shareUriBuilder = new ShareUriBuilder(directoryFromConstructor.Uri);
+
             // Assert
             Assert.AreEqual(createResponse.Value.ETag, propertiesResponse.Value.ETag);
 
@@ -1031,6 +1039,10 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.AreEqual(subDirectoryName, directoryFromConstructor.Name);
             Assert.AreEqual(path, directoryFromConstructor.Path);
             Assert.AreEqual(expectedUri, directoryFromConstructor.Uri);
+
+            Assert.AreEqual(subDirectoryName, shareUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(path, shareUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(expectedUri, shareUriBuilder.ToUri());
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -865,6 +865,8 @@ namespace Azure.Storage.Files.Shares.Test
                 shareFileItems.Add(shareFileItem);
             }
 
+            ShareUriBuilder shareUriBuilder = new ShareUriBuilder(directoryFromConstructor.Uri);
+
             // Assert
             Assert.AreEqual(createResponse.Value.ETag, propertiesResponse.Value.ETag);
 
@@ -878,6 +880,10 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.AreEqual(directoryName, directoryFromConstructor.Name);
             Assert.AreEqual(directoryName, directoryFromConstructor.Path);
             Assert.AreEqual(expectedUri, directoryFromConstructor.Uri);
+
+            Assert.AreEqual(directoryName, shareUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(directoryName, shareUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual(expectedUri, shareUriBuilder.ToUri());
         }
     }
 }


### PR DESCRIPTION
Fixed bug where DataLakeUriBuilder and ShareUriBuilder would return unintentionally encoded File and Directory Names.