### PR TITLE
Update versions for Key Vault servicing release

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.3 (Unreleased)
+## 4.0.3 (2020-07-09)
 
 ### Fixed
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Certificates client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Certificates client library</AssemblyTitle>
-    <Version>4.0.3-preview.1</Version>
+    <Version>4.0.3</Version>
     <PackageTags>Microsoft Azure Key Vault Certificates;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 4.0.4 (Unreleased)
+## 4.0.4 (2020-07-09)
+
+### Fixed
+
+- The "get" permission is no longer required to resolve keys for `KeyResolver` ([#11574](https://github.com/Azure/azure-sdk-for-net/issues/11574))
 
 ### Minor changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Keys client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Keys client library</AssemblyTitle>
-    <Version>4.0.4-preview.1</Version>
+    <Version>4.0.4</Version>
     <PackageTags>Microsoft Azure Key Vault Keys;$(PackageCommonTags)</PackageTags>
 
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>


### PR DESCRIPTION
Only Certificates and Keys are being updated. To show these are all that changed:

```
$ git diff-tree -r --name-only Azure.Security.KeyVault.Keys_4.0.3..HEAD
sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateIssuer.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/src/ImportCertificateOptions.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/src/IssuerProperties.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/src/MergeCertificateOptions.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateIssuerTests.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatePolicyTests.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/VerifyGetIssuer.json
sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/SessionRecords/CertificateClientLiveTests/VerifyGetIssuerAsync.json
sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
sdk/keyvault/Azure.Security.KeyVault.Keys/src/CreateKeyOptions.cs
sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
sdk/keyvault/Azure.Security.KeyVault.Keys/src/JsonWebKey.cs
sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverMockTests.cs
```