### PR TITLE
Fixing see href links in storage libraries

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatch.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatch.cs
@@ -13,7 +13,8 @@ namespace Azure.Storage.Blobs.Specialized
     /// operations in a single request via <see cref="BlobBatchClient.SubmitBatch"/>.
     ///
     /// For more information, see
-    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch" />.
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch">
+    /// Blob Batch</see>.
     /// </summary>
     public class BlobBatch : IDisposable
     {
@@ -113,7 +114,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">Delete Blob</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container containing the blob to delete.
@@ -160,7 +161,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
         /// For more information, see
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">Delete Blob</see>.
         /// </summary>
         /// <param name="blobUri">
         /// The blob to delete's primary <see cref="Uri"/> endpoint.
@@ -206,8 +207,9 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// A block blob's tier determines Hot/Cool/Archive storage type.  This
         /// operation does not update the blob's ETag.  For detailed
-        /// information about block blob level tiering
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />.
+        /// information about block blob level tiering see
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container containing the blob to set the tier of.
@@ -258,7 +260,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// A block blob's tier determines Hot/Cool/Archive storage type.  This
         /// operation does not update the blob's ETag.  For detailed
         /// information about block blob level tiering
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />.
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
+        ///
         /// </summary>
         /// <param name="blobUri">
         /// The blob's primary <see cref="Uri"/> endpoint.

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/BlobChangeFeedClient.cs
@@ -37,7 +37,9 @@ namespace Azure.Storage.Blobs.ChangeFeed
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string">
+        /// Configuring Azure Storage conneciton strings</see>.
         /// </param>
         public BlobChangeFeedClient(string connectionString)
         {
@@ -53,7 +55,9 @@ namespace Azure.Storage.Blobs.ChangeFeed
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string">
+        /// Configuring Azure Storage conneciton strings</see>.
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -223,7 +223,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </summary>
         /// <param name="snapshot">The snapshot identifier.</param>
         /// <returns>A new <see cref="AppendBlobClient"/> instance.</returns>
@@ -330,7 +332,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the newly initialized append blob.  To add content to the append
         /// blob, call the <see cref="AppendBlock"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
@@ -376,7 +380,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the newly initialized append blob.  To add content to the append
         /// blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
@@ -422,7 +428,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the content of the existing append blob will remain unchanged.  To add content to
         /// the append blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="options">
         /// Optional parameters.
@@ -456,7 +464,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the content of the existing append blob will remain unchanged.  To add content to
         /// the append blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="options">
         /// Optional parameters.
@@ -490,7 +500,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the content of the existing append blob will remain unchanged.  To add content to
         /// the append blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
@@ -530,7 +542,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the content of the existing append blob will remain unchanged.  To add content to the append
         /// blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
@@ -570,7 +584,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the existing append blob will remain unchanged.  To add content to the append
         /// blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
@@ -649,7 +665,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// the newly initialized append blob.  To add content to the append
         /// blob, call the <see cref="AppendBlockAsync"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
@@ -752,7 +770,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// operation is only permitted if the blob was created as an append
         /// blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/append-block" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/append-block">
+        /// Append Block</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the block to
@@ -808,7 +828,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// operation is only permitted if the blob was created as an append
         /// blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/append-block" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/append-block">
+        /// Append Block</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the block to
@@ -864,7 +886,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// operation is only permitted if the blob was created as an append
         /// blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/append-block" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/append-block">
+        /// Append Block</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the block to
@@ -966,7 +990,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="AppendBlockFromUri"/> operation is only permitted
         /// if the blob was created as an append blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url">
+        /// Append Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1035,7 +1061,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="AppendBlockFromUriAsync"/> operation is only permitted
         /// if the blob was created as an append blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url">
+        /// Append Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1104,7 +1132,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="AppendBlockFromUriInternal"/> operation is only permitted
         /// if the blob was created as an append blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url">
+        /// Append Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -168,7 +168,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.
@@ -190,7 +192,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.
@@ -369,7 +373,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </summary>
         /// <param name="snapshot">The snapshot identifier.</param>
         /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
@@ -471,7 +477,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="Download()"/> operation downloads a blob from
         /// the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <returns>
         /// A <see cref="Response{BlobDownloadInfo}"/> describing the
@@ -489,7 +497,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="DownloadAsync()"/> operation downloads a blob from
         /// the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <returns>
         /// A <see cref="Response{BlobDownloadInfo}"/> describing the
@@ -507,7 +517,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="Download(CancellationToken)"/> operation downloads
         /// a blob from the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -533,7 +545,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// downloads a blob from the service, including its metadata and
         /// properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -560,7 +574,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// operation downloads a blob from the service, including its metadata
         /// and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="range">
         /// If provided, only download the bytes of the blob in the specified
@@ -609,7 +625,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// operation downloads a blob from the service, including its metadata
         /// and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="range">
         /// If provided, only download the bytes of the blob in the specified
@@ -657,7 +675,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="DownloadInternal"/> operation downloads a blob
         /// from the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="range">
         /// If provided, only download the bytes of the blob in the specified
@@ -1301,7 +1321,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the <see cref="GetProperties"/> to determine if the
         /// copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob">
+        /// Copy Blob</see>.
         /// </summary>
         /// <param name="source">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1364,7 +1386,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the <see cref="GetProperties"/> to determine if the
         /// copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob">
+        /// Copy Blob</see>.
         /// </summary>
         /// <param name="source">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1448,7 +1472,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the <see cref="GetPropertiesAsync"/> to determine if
         /// the copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob">
+        /// Copy Blob</see>.
         /// </summary>
         /// <param name="source">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1511,7 +1537,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the <see cref="GetPropertiesAsync"/> to determine if
         /// the copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob">
+        /// Copy Blob</see>.
         /// </summary>
         /// <param name="source">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1595,7 +1623,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the<see cref="GetPropertiesAsync"/> to determine if
         /// the copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob">
+        /// Copy Blob</see>.
         /// </summary>
         /// <param name="source">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1722,7 +1752,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="CopyFromUriOperation"/>, and leaves a this
         /// blob with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob">
+        /// Abort Copy Blob</see>.
         /// </summary>
         /// <param name="copyId">
         /// ID of the copy operation to abort.
@@ -1758,7 +1790,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="CopyFromUriOperation"/>, and leaves a this
         /// blob with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob">
+        /// Abort Copy Blob</see>.
         /// </summary>
         /// <param name="copyId">
         /// ID of the copy operation to abort.
@@ -1794,7 +1828,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="CopyFromUriOperation"/>, and leaves a this
         /// blob with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob">
+        /// Abort Copy Blob</see>.
         /// </summary>
         /// <param name="copyId">
         /// ID of the copy operation to abort.
@@ -1867,7 +1903,9 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// The size of the source blob can be a maximum length of up to 256 MB.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url">
+        /// Copy Blob From URL</see>.
         /// </summary>
         /// <param name="source">
         /// Required. Specifies the URL of the source blob. The value may be a URL of up to 2 KB in length
@@ -1916,7 +1954,9 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// The size of the source blob can be a maximum length of up to 256 MB.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url">
+        /// Copy Blob From URL</see>.
         /// </summary>
         /// <param name="source">
         /// Required. Specifies the URL of the source blob. The value may be a URL of up to 2 KB in length
@@ -1965,7 +2005,9 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// The size of the source blob can be a maximum length of up to 256 MB.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url">
+        /// Copy Blob From URL</see>.
         /// </summary>
         /// <param name="source">
         /// Required. Specifies the URL of the source blob. The value may be a URL of up to 2 KB in length
@@ -2083,7 +2125,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="snapshotsOption">
         /// Specifies options for deleting blob snapshots.
@@ -2123,7 +2167,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="snapshotsOption">
         /// Specifies options for deleting blob snapshots.
@@ -2163,7 +2209,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="snapshotsOption">
         /// Specifies options for deleting blob snapshots.
@@ -2203,7 +2251,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="snapshotsOption">
         /// Specifies options for deleting blob snapshots.
@@ -2243,7 +2293,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="snapshotsOption">
         /// Specifies options for deleting blob snapshots.
@@ -2317,7 +2369,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="snapshotsOption">
         /// Specifies options for deleting blob snapshots.
@@ -2504,7 +2558,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// and metadata of a soft deleted blob and any associated soft
         /// deleted snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob">
+        /// Undelete Blob</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2529,7 +2585,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// and metadata of a soft deleted blob and any associated soft
         /// deleted snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob">
+        /// Undelete Blob</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2554,7 +2612,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// and metadata of a soft deleted blob and any associated soft
         /// deleted snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob">
+        /// Undelete Blob</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -2609,7 +2669,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// properties for the blob. It does not return the content of the
         /// blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Blob Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -2642,7 +2704,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// properties for the blob. It does not return the content of the
         /// blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Blob Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -2675,7 +2739,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// properties for the blob. It does not return the content of the
         /// blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Blob Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -2751,10 +2817,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
-        /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
+        /// Optional. The standard HTTP header system properties to set.
+        /// If not specified, existing values will be cleared.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add conditions on
@@ -2787,7 +2856,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
@@ -2823,7 +2894,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
@@ -2911,7 +2984,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified blob as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Blob Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this blob.
@@ -2947,7 +3022,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified blob as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Blob Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this blob.
@@ -2983,7 +3060,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified blob as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Blob Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this blob.
@@ -3069,7 +3148,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="CreateSnapshot"/> operation creates a
         /// read-only snapshot of a blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob">
+        /// Snapshot Blob</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this blob snapshot.
@@ -3105,7 +3186,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="CreateSnapshotAsync"/> operation creates a
         /// read-only snapshot of a blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob">
+        /// Snapshot Blob</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this blob snapshot.
@@ -3141,7 +3224,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="CreateSnapshotInternal"/> operation creates a
         /// read-only snapshot of a blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob">
+        /// Snapshot Blob</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this blob snapshot.
@@ -3225,10 +3310,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// bandwidth of the blob.  A block blob's tier determines
         /// Hot/Cool/Archive storage type.  This operation does not update the
         /// blob's ETag.  For detailed information about block blob level
-        /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />
+        /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         ///
         /// For more information about setting the tier, see
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />.
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         /// </summary>
         /// <param name="accessTier">
         /// Indicates the tier to be set on the blob.
@@ -3275,10 +3362,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// bandwidth of the blob.  A block blob's tier determines
         /// Hot/Cool/Archive storage type.  This operation does not update the
         /// blob's ETag.  For detailed information about block blob level
-        /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />
+        /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         ///
         /// For more information about setting the tier, see
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />.
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         /// </summary>
         /// <param name="accessTier">
         /// Indicates the tier to be set on the blob.
@@ -3325,10 +3414,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// bandwidth of the blob.  A block blob's tier determines
         /// Hot/Cool/Archive storage type.  This operation does not update the
         /// blob's ETag.  For detailed information about block blob level
-        /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />
+        /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         ///
         /// For more information about setting the tier, see
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />.
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers">
+        /// Blob Storage Tiers</see>.
         /// </summary>
         /// <param name="accessTier">
         /// Indicates the tier to be set on the blob.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -43,7 +43,9 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.
@@ -65,7 +67,9 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this blob.
@@ -193,7 +197,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -219,7 +225,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -245,7 +253,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -271,7 +281,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -298,7 +310,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -334,7 +348,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -370,7 +386,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -406,7 +424,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -443,7 +463,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -484,7 +506,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -525,7 +549,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -566,7 +592,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -608,7 +636,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -650,7 +680,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -726,7 +758,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -773,7 +807,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -854,7 +890,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -896,7 +934,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -972,7 +1012,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>..
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -1019,7 +1061,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -22,19 +22,23 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The versions of Azure Blob Storage supported by this client
         /// library.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for Azure Storage Services</see>.
         /// </summary>
         public enum ServiceVersion
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// The 2019-02-02 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-02-02">
+            /// Version 2019-02-02</see>
             /// </summary>
             V2019_02_02 = 1,
 
             /// <summary>
-            /// The 2019-07-07 service version.
+            /// The 2019-07-07 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-07-07">
+            /// Version 2019-07-07</see>
             /// </summary>
             V2019_07_07 = 2,
 
@@ -48,7 +52,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for Azure Storage Services</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -165,7 +165,9 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the blob container in the storage account to reference.
@@ -184,7 +186,9 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container in the storage account to reference.
@@ -422,7 +426,9 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -473,7 +479,9 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -523,7 +531,9 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -574,7 +584,9 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -624,7 +636,9 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -675,7 +689,9 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -725,7 +741,9 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -776,7 +794,9 @@ namespace Azure.Storage.Blobs
         /// under the specified account. If the container with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -826,7 +846,9 @@ namespace Azure.Storage.Blobs
         /// operation creates a new container under the specified account.  If the container already exists, it is
         /// not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -911,7 +933,9 @@ namespace Azure.Storage.Blobs
         /// under the specified account, if it does not already exist.
         /// If the container with the same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -1000,7 +1024,9 @@ namespace Azure.Storage.Blobs
         /// container for deletion. The container and any blobs contained
         /// within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1031,7 +1057,9 @@ namespace Azure.Storage.Blobs
         /// container for deletion. The container and any blobs contained
         /// within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1062,7 +1090,9 @@ namespace Azure.Storage.Blobs
         /// container for deletion if it exists. The container and any blobs
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1094,7 +1124,9 @@ namespace Azure.Storage.Blobs
         /// container for deletion if it exists. The container and any blobs
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1126,7 +1158,9 @@ namespace Azure.Storage.Blobs
         /// container for deletion if it exists. The container and any blobs
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1192,7 +1226,9 @@ namespace Azure.Storage.Blobs
         /// container for deletion. The container and any blobs contained
         /// within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1382,7 +1418,9 @@ namespace Azure.Storage.Blobs
         /// container. The data returned does not include the container's
         /// list of blobs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties">
+        /// Get Container Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1415,7 +1453,9 @@ namespace Azure.Storage.Blobs
         /// container. The data returned does not include the container's
         /// list of blobs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties">
+        /// Get Container Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1448,7 +1488,9 @@ namespace Azure.Storage.Blobs
         /// container. The data returned does not include the container's
         /// list of blobs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties">
+        /// Get Container Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1532,7 +1574,9 @@ namespace Azure.Storage.Blobs
         /// The <see cref="SetMetadata"/> operation sets one or more
         /// user-defined name-value pairs for the specified container.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata">
+        /// Set Container Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this container.
@@ -1567,7 +1611,9 @@ namespace Azure.Storage.Blobs
         /// The <see cref="SetMetadataAsync"/> operation sets one or more
         /// user-defined name-value pairs for the specified container.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata">
+        /// Set Container Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this container.
@@ -1602,7 +1648,9 @@ namespace Azure.Storage.Blobs
         /// The <see cref="SetMetadataInternal"/> operation sets one or more
         /// user-defined name-value pairs for the specified container.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata">
+        /// Set Container Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this container.
@@ -1682,7 +1730,9 @@ namespace Azure.Storage.Blobs
         /// permissions for this container. The permissions indicate whether
         /// container data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl">
+        /// Get Container ACL</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1714,7 +1764,9 @@ namespace Azure.Storage.Blobs
         /// permissions for this container. The permissions indicate whether
         /// container data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl">
+        /// Get Container ACL</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1746,7 +1798,9 @@ namespace Azure.Storage.Blobs
         /// permissions for this container. The permissions indicate whether
         /// container data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl">
+        /// Get Container ACL</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1811,7 +1865,9 @@ namespace Azure.Storage.Blobs
         /// permissions for the specified container. The permissions indicate
         /// whether blob container data may be accessed publicly.
         ///
-        /// For more information, see <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl" />.
+        /// For more information, see
+        /// <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl">
+        /// Set Container ACL</see>.
         /// </summary>
         /// <param name="accessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -1864,7 +1920,9 @@ namespace Azure.Storage.Blobs
         /// permissions for the specified container. The permissions indicate
         /// whether blob container data may be accessed publicly.
         ///
-        /// For more information, see <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl" />.
+        /// For more information, see
+        /// <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl">
+        /// Set Container ACL</see>.
         /// </summary>
         /// <param name="accessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -1917,7 +1975,9 @@ namespace Azure.Storage.Blobs
         /// permissions for the specified container. The permissions indicate
         /// whether blob container data may be accessed publicly.
         ///
-        /// For more information, see <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl" />.
+        /// For more information, see
+        /// <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl">
+        /// Set Container ACL</see>.
         /// </summary>
         /// <param name="accessType">
         /// Optionally specifies whether data in the container may be accessed
@@ -2012,7 +2072,9 @@ namespace Azure.Storage.Blobs
         /// multiple requests to the service while fetching all the values.
         /// Blobs are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">
+        /// List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2049,7 +2111,9 @@ namespace Azure.Storage.Blobs
         /// make multiple requests to the service while fetching all the
         /// values.  Blobs are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">
+        /// List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2090,7 +2154,9 @@ namespace Azure.Storage.Blobs
         /// to continue enumerating the blobs segment by segment. Blobs are
         /// ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">
+        /// List Blobs</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -2195,7 +2261,9 @@ namespace Azure.Storage.Blobs
         /// <paramref name="delimiter"/> can be used to traverse a virtual
         /// hierarchy of blobs as though it were a file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">
+        /// List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2252,7 +2320,9 @@ namespace Azure.Storage.Blobs
         /// <paramref name="delimiter"/> can be used to traverse a virtual
         /// hierarchy of blobs as though it were a file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">
+        /// List Blobs</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blobs.
@@ -2313,7 +2383,9 @@ namespace Azure.Storage.Blobs
         /// can be used to traverse a virtual hierarchy of blobs as though
         /// it were a file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">List Blobs</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-blobs">
+        /// List Blobs</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -2429,7 +2501,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="blobName">The name of the blob to upload.</param>
         /// <param name="content">
@@ -2469,7 +2543,9 @@ namespace Azure.Storage.Blobs
         /// append blobs, please see <see cref="PageBlobClient"/> or
         /// <see cref="AppendBlobClient"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="blobName">The name of the blob to upload.</param>
         /// <param name="content">
@@ -2512,7 +2588,9 @@ namespace Azure.Storage.Blobs
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="blobName">The name of the blob to delete.</param>
         /// <param name="snapshotsOption">
@@ -2554,7 +2632,9 @@ namespace Azure.Storage.Blobs
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="blobName">The name of the blob to delete.</param>
         /// <param name="snapshotsOption">
@@ -2597,7 +2677,9 @@ namespace Azure.Storage.Blobs
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="blobName">The name of the blob to delete.</param>
         /// <param name="snapshotsOption">
@@ -2639,7 +2721,9 @@ namespace Azure.Storage.Blobs
         /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.IncludeSnapshots"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob">
+        /// Delete Blob</see>.
         /// </summary>
         /// <param name="blobName">The name of the blob to delete.</param>
         /// <param name="snapshotsOption">

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
@@ -191,7 +191,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// using the active lease ID as <see cref="LeaseId"/>, but you can
         /// specify a new <paramref name="duration"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="duration">
         /// Specifies the duration of the lease, in seconds, or specify
@@ -237,7 +239,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// using the active lease ID as <see cref="LeaseId"/>, but you can
         /// specify a new <paramref name="duration"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="duration">
         /// Specifies the duration of the lease, in seconds, or specify
@@ -355,7 +359,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// container has not been leased again since the expiration of that
         /// lease.  When you renew a lease, the lease duration clock resets.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobLeaseRequestConditions"/> to add
@@ -391,7 +397,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// container has not been leased again since the expiration of that
         /// lease.  When you renew a lease, the lease duration clock resets.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobLeaseRequestConditions"/> to add
@@ -427,7 +435,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// container has not been leased again since the expiration of that
         /// lease.  When you renew a lease, the lease duration clock resets.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobLeaseRequestConditions"/> to add
@@ -531,7 +541,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// lease allows another client to immediately acquire the lease for the
         /// container or blob as soon as the release is complete.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobLeaseRequestConditions"/> to add
@@ -567,7 +579,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// lease allows another client to immediately acquire the lease for the
         /// container or blob as soon as the release is complete.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobLeaseRequestConditions"/> to add
@@ -603,7 +617,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// lease allows another client to immediately acquire the lease for the
         /// container or blob as soon as the release is complete.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="BlobLeaseRequestConditions"/> to add
@@ -713,7 +729,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// of an active lease.  A change must include the current
         /// <see cref="LeaseId"/> and a new <paramref name="proposedId"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="proposedId">
         /// An optional proposed lease ID, in a GUID string format. A
@@ -751,7 +769,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// of an active lease.  A change must include the current
         /// <see cref="LeaseId"/> and a new <paramref name="proposedId"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="proposedId">
         /// An optional proposed lease ID, in a GUID string format. A
@@ -789,7 +809,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// of an active lease.  A change must include the current
         /// <see cref="LeaseId"/> and a new <paramref name="proposedId"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="proposedId">
         /// An optional proposed lease ID, in a GUID string format. A
@@ -913,7 +935,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// immediately acquire a blob or container lease that has been
         /// released.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="breakPeriod">
         /// Specifies the proposed duration the lease should continue before
@@ -970,7 +994,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// immediately acquire a blob or container lease that has been
         /// released.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="breakPeriod">
         /// Specifies the proposed duration the lease should continue before
@@ -1027,7 +1053,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// immediately acquire a blob or container lease that has been
         /// released.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="breakPeriod">
         /// Specifies the proposed duration the lease should continue before

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -159,7 +159,9 @@ namespace Azure.Storage.Blobs
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline
@@ -420,7 +422,9 @@ namespace Azure.Storage.Blobs
         /// blob containers may make multiple requests to the service while fetching
         /// all the values.  Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
+        /// For more information,
+        /// see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blob containers.
@@ -457,7 +461,9 @@ namespace Azure.Storage.Blobs
         /// blob containers may make multiple requests to the service while fetching
         /// all the values.  Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blob containers.
@@ -493,7 +499,9 @@ namespace Azure.Storage.Blobs
         /// blob containers may make multiple requests to the service while fetching
         /// all the values.  Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blob containers.
@@ -530,7 +538,9 @@ namespace Azure.Storage.Blobs
         /// blob containers may make multiple requests to the service while fetching
         /// all the values.  Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the blob containers.
@@ -570,7 +580,9 @@ namespace Azure.Storage.Blobs
         /// to continue enumerating the containers segment by segment.
         /// Containers are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="continuationToken">
         /// An optional string value that identifies the segment of the list
@@ -669,7 +681,9 @@ namespace Azure.Storage.Blobs
         /// The <see cref="GetAccountInfo"/> operation returns the sku
         /// name and account kind for the specified account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information">
+        /// Get Account Information</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -693,7 +707,9 @@ namespace Azure.Storage.Blobs
         /// The <see cref="GetAccountInfoAsync"/> operation returns the sku
         /// name and account kind for the specified account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information">
+        /// Get Account Information</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -717,7 +733,9 @@ namespace Azure.Storage.Blobs
         /// The <see cref="GetAccountInfoInternal"/> operation returns the sku
         /// name and account kind for the specified account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information">
+        /// Get Account Information</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -771,7 +789,9 @@ namespace Azure.Storage.Blobs
         /// of a storage account’s blob service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties">
+        /// Get Blob Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -797,7 +817,9 @@ namespace Azure.Storage.Blobs
         /// of a storage account’s blob service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties">
+        /// Get Blob Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -823,7 +845,9 @@ namespace Azure.Storage.Blobs
         /// of a storage account’s blob service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties">
+        /// Get Blob Service Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -881,7 +905,9 @@ namespace Azure.Storage.Blobs
         /// the default request version for all incoming requests to the Blob
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">Set Blob Service Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">
+        /// Set Blob Service Properties</see>.
         /// </summary>
         /// <param name="properties">The blob service properties.</param>
         /// <param name="cancellationToken">
@@ -913,7 +939,9 @@ namespace Azure.Storage.Blobs
         /// the default request version for all incoming requests to the Blob
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">Set Blob Service Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">
+        /// Set Blob Service Properties</see>.
         /// </summary>
         /// <param name="properties">The blob service properties.</param>
         /// <param name="cancellationToken">
@@ -945,7 +973,9 @@ namespace Azure.Storage.Blobs
         /// the default request version for all incoming requests to the Blob
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">Set Blob Service Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-service-properties">
+        /// Set Blob Service Properties</see>.
         /// </summary>
         /// <param name="properties">The blob service properties.</param>
         /// <param name="async">
@@ -1009,7 +1039,9 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">Get Blob Service Stats</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">
+        /// Get Blob Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1037,7 +1069,9 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">Get Blob Service Stats</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">
+        /// Get Blob Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1065,7 +1099,9 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">Get Blob Service Stats</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-service-stats">
+        /// Get Blob Service Stats</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1266,7 +1302,9 @@ namespace Azure.Storage.Blobs
         /// blob container under the specified account. If the container with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container to create.
@@ -1316,7 +1354,9 @@ namespace Azure.Storage.Blobs
         /// blob container under the specified account. If the container with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container to create.
@@ -1368,7 +1408,9 @@ namespace Azure.Storage.Blobs
         /// specified blob container for deletion. The container and any blobs
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the container to delete.
@@ -1403,7 +1445,9 @@ namespace Azure.Storage.Blobs
         /// specified container for deletion. The container and any blobs
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="blobContainerName">
         /// The name of the blob container to delete.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
@@ -14,7 +14,9 @@ namespace Azure.Storage.Blobs
     /// modify the contents of a <see cref="System.Uri"/> instance to point to
     /// different Azure Storage resources like an account, container, or blob.
     ///
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata" />.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata">
+    /// Naming and Referencing Containers, Blobs, and Metadata</see>.
     /// </summary>
     public class BlobUriBuilder
     {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -146,7 +146,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="containerName">
         /// The name of the container containing this block blob.
@@ -168,7 +170,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this block blob.
@@ -328,7 +332,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </summary>
         /// <param name="snapshot">The snapshot identifier.</param>
         /// <returns>A new <see cref="BlockBlobClient"/> instance.</returns>
@@ -398,7 +404,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block blob, use the <see cref="StageBlock"/> and
         /// <see cref="CommitBlockList(IEnumerable{string}, CommitBlockListOptions, CancellationToken)" /> operations.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -446,7 +454,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block blob, use the <see cref="StageBlock"/> and
         /// <see cref="CommitBlockListAsync(IEnumerable{string}, CommitBlockListOptions, CancellationToken)" /> operations.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -495,7 +505,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block blob, use the <see cref="StageBlock"/> and
         /// <see cref="CommitBlockList(IEnumerable{string}, BlobHttpHeaders, Metadata, BlobRequestConditions, AccessTier?, CancellationToken)" /> operations.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -563,7 +575,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block blob, use the <see cref="StageBlockAsync"/> and
         /// <see cref="CommitBlockListAsync(IEnumerable{string}, BlobHttpHeaders, Metadata, BlobRequestConditions, AccessTier?, CancellationToken)" /> operations.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -631,7 +645,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block blob, use the <see cref="StageBlockInternal"/> and
         /// <see cref="CommitBlockListInternal" /> operations.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-blob">
+        /// Put Blob</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -749,7 +765,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// part of a block blob's "staging area" to be eventually committed
         /// via the <see cref="CommitBlockList(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block">
+        /// Put Block</see>.
         /// </summary>
         /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
@@ -814,7 +832,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// part of a block blob's "staging area" to be eventually committed
         /// via the <see cref="CommitBlockListAsync(IEnumerable{string}, CommitBlockListOptions, CancellationToken)"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block">
+        /// Put Block</see>.
         /// </summary>
         /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
@@ -879,7 +899,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// as part of a block blob's "staging area" to be eventually committed
         /// via the <see cref="CommitBlockListInternal"/> operation.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block">
+        /// Put Block</see>.
         /// </summary>
         /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
@@ -982,7 +1004,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block to be committed as part of a blob where the contents are
         /// read from the <paramref name="sourceUri" />.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">Put Block From URL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">
+        /// Put Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1059,7 +1083,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block to be committed as part of a blob where the contents are
         /// read from the <paramref name="sourceUri" />.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">Put Block From URL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">
+        /// Put Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1136,7 +1162,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// block to be committed as part of a blob where the contents are
         /// read from the <paramref name="sourceUri" />.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">Put Block From URL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-from-url">
+        /// Put Block From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -1265,7 +1293,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">
+        /// Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1318,7 +1348,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">Put Block List</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">
+        /// Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1387,7 +1419,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">
+        /// Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1440,7 +1474,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">Put Block List</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">
+        /// Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1509,7 +1545,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         ///
-        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">Put Block List</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list">
+        /// Put Block List</see>.
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1636,7 +1674,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve the block list
         /// from. For more information on working with blob snapshots, see
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1686,7 +1725,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve the block list
         /// from. For more information on working with blob snapshots, see
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add
@@ -1736,7 +1776,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve the block list
         /// from. For more information on working with blob snapshots, see
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="BlobRequestConditions"/> to add

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobHttpHeaders.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobHttpHeaders.cs
@@ -12,7 +12,9 @@ namespace Azure.Storage.Blobs.Models
     /// names, as specified in the Header Field Definitions section 14 of the
     /// HTTP/1.1 protocol specification.
     ///
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources" />.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources">
+    /// Setting and retrieving properties and metadata for Blob service resources</see>.
     /// </summary>
     public class BlobHttpHeaders
     {

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -62,7 +62,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this page blob.
@@ -84,7 +86,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="blobContainerName">
         /// The name of the container containing this page blob.
@@ -219,7 +223,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// class with an identical <see cref="Uri"/> source but the specified
         /// snapshot timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </summary>
         /// <param name="snapshot">The snapshot identifier.</param>
         /// <returns>A new <see cref="PageBlobClient"/> instance.</returns>
@@ -871,7 +877,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <paramref name="content"/> to a range of pages in a page blob,
         /// starting at <paramref name="offset"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-page">
+        /// Put Page</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the pages to
@@ -932,7 +940,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <paramref name="content"/> to a range of pages in a page blob,
         /// starting at <paramref name="offset"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-page">
+        /// Put Page</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the pages to
@@ -993,7 +1003,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <paramref name="content"/> to a range of pages in a page blob,
         /// starting at <paramref name="offset"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-page">
+        /// Put Page</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the pages to
@@ -1102,7 +1114,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="ClearPages"/> operation clears one or more
         /// pages from the page blob, as specificed by the <paramref name="range"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-page">
+        /// Put Page</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and
@@ -1144,7 +1158,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="ClearPagesAsync"/> operation clears one or more
         /// pages from the page blob, as specificed by the <paramref name="range"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-page">
+        /// Put Page</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and
@@ -1186,7 +1202,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="ClearPagesInternal"/> operation clears one or more
         /// pages from the page blob, as specificed by the <paramref name="range"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-page">
+        /// Put Page</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and
@@ -1273,7 +1291,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="GetPageRanges"/> operation returns the list of
         /// valid page ranges for a page blob or snapshot of a page blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1282,7 +1302,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="PageBlobRequestConditions"/> to add
@@ -1317,7 +1338,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="GetPageRangesAsync"/> operation returns the list of
         /// valid page ranges for a page blob or snapshot of a page blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1326,7 +1349,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="PageBlobRequestConditions"/> to add
@@ -1361,7 +1385,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="GetPageRangesInternal"/> operation returns the list
         /// of valid page ranges for a page blob or snapshot of a page blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1370,7 +1396,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="PageBlobRequestConditions"/> to add
@@ -1451,7 +1478,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <paramref name="previousSnapshot"/> and this page blob. Changed pages
         /// include both updated and cleared pages.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1460,7 +1489,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshot">
         /// Specifies that the response will contain only pages that were
@@ -1508,7 +1538,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <paramref name="previousSnapshot"/> and this page blob. Changed pages
         /// include both updated and cleared pages.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1517,7 +1549,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshot">
         /// Specifies that the response will contain only pages that were
@@ -1565,7 +1598,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <paramref name="previousSnapshot"/> and this page blob. Changed pages
         /// include both updated and cleared pages.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1574,7 +1609,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshot">
         /// Specifies that the response will contain only pages that were
@@ -1681,7 +1717,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// include both updated and cleared pages.  This API only works with
         /// managed disk storage accounts.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1690,7 +1728,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshotUri">
         /// This parameter only works with managed disk storage accounts.
@@ -1740,7 +1779,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// include both updated and cleared pages.  This API only works with
         /// managed disk storage accounts.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges">
+        /// Get Page Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optionally specifies the range of bytes over which to list ranges,
@@ -1749,7 +1790,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="snapshot">
         /// Optionally specifies the blob snapshot to retrieve page ranges
         /// information from. For more information on working with blob snapshots,
-        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">Create a snapshot of a blob</see>.
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/creating-a-snapshot-of-a-blob">
+        /// Create a snapshot of a blob</see>.
         /// </param>
         /// <param name="previousSnapshotUri">
         /// This parameter only works with managed disk storage accounts.
@@ -1801,7 +1843,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// specified value is less than the current size of the blob, then
         /// all pages above the specified value are cleared.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="size">
         /// Specifies the maximum size for the page blob, up to 8 TB.  The
@@ -1842,7 +1886,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// specified value is less than the current size of the blob, then
         /// all pages above the specified value are cleared.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="size">
         /// Specifies the maximum size for the page blob, up to 8 TB.  The
@@ -1883,7 +1929,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// specified value is less than the current size of the blob, then
         /// all pages above the specified value are cleared.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="size">
         /// Specifies the maximum size for the page blob, up to 8 TB.  The
@@ -1965,7 +2013,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// sequence number <paramref name="action"/> and <paramref name="sequenceNumber"/>
         /// for this page blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="action">
         /// Specifies how the service should modify the blob's sequence number.
@@ -2022,7 +2072,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// sequence number <paramref name="action"/> and <paramref name="sequenceNumber"/>
         /// for this page blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="action">
         /// Specifies how the service should modify the blob's sequence number.
@@ -2079,7 +2131,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// sequence number <paramref name="action"/> and <paramref name="sequenceNumber"/>
         /// for this page blob.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="action">
         /// Specifies how the service should modify the blob's sequence number.
@@ -2181,8 +2235,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the <see cref="BlobBaseClient.GetProperties"/> to
         /// determine if the copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
-        /// and <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">Back up Azure unmanaged VM disks with incremental snapshots</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob">
+        /// Incremental Copy Blob</see> and
+        /// <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">
+        /// Back up Azure unmanaged VM disks with incremental snapshots</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the to the source page blob as a <see cref="Uri"/> up to
@@ -2287,8 +2344,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// returned from the <see cref="BlobBaseClient.GetPropertiesAsync"/>
         /// to determine if thecopy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
-        /// and <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">Back up Azure unmanaged VM disks with incremental snapshots</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob">
+        /// Incremental Copy Blob</see> and
+        /// <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">
+        /// Back up Azure unmanaged VM disks with incremental snapshots</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the to the source page blob as a <see cref="Uri"/> up to
@@ -2394,8 +2454,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="BlobBaseClient.GetPropertiesAsync"/> to determine if the
         /// copy has completed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
-        /// and <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">Back up Azure unmanaged VM disks with incremental snapshots</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob">
+        /// Incremental Copy Blob</see> and
+        /// <see href="https://docs.microsoft.com/azure/virtual-machines/windows/incremental-snapshots">
+        /// Back up Azure unmanaged VM disks with incremental snapshots</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the to the source page blob as a <see cref="Uri"/> up to
@@ -2533,7 +2596,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// of pages to a page blob where the contents are read from
         /// sourceUri.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url">
+        /// Put Page From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -2608,7 +2673,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// of pages to a page blob where the contents are read from
         /// sourceUri.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url">
+        /// Put Page From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
@@ -2683,7 +2750,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// range of pages to a page blob where the contents are read from
         /// sourceUri.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url">
+        /// Put Page From URL</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -13,7 +13,9 @@ namespace Azure.Storage.Sas
     /// <summary>
     /// <see cref="BlobSasBuilder"/> is used to generate a Shared Access
     /// Signature (SAS) for an Azure Storage container or blob.
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas" />.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas">
+    /// Create a service SAS</see>.
     /// </summary>
     public class BlobSasBuilder
     {

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
@@ -13,7 +13,9 @@ namespace Azure.Storage.Sas
     /// parameters.  You can construct a new instance using
     /// <see cref="BlobSasBuilder"/>.
     ///
-    /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/create-service-sas">Create a service SAS</see>.
+    /// For more information,
+    /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-service-sas">
+    /// Create a service SAS</see>.
     /// </summary>
     public sealed class BlobSasQueryParameters : SasQueryParameters
     {

--- a/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
@@ -10,7 +10,8 @@ namespace Azure.Storage.Sas
     /// <see cref="AccountSasBuilder"/> is used to generate an account level
     /// Shared Access Signature (SAS) for Azure Storage services.
     /// For more information, see
-    /// <see href="https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas" />.
+    /// <see href="https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas">
+    /// Create an account SAS</see>.
     /// </summary>
     public class AccountSasBuilder
     {

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
@@ -16,7 +16,9 @@ namespace Azure.Storage.Sas
     /// parameters.  It includes components used by all Azure Storage resources
     /// (Blob Containers, Blobs, Files, and Queues).  You can construct a new instance
     /// using the service specific SAS builder types.
-    /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/create-service-sas">Create a service SAS</see>.
+    /// For more information,
+    /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-service-sas">
+    /// Create a service SAS</see>.
     /// </summary>
     public partial class SasQueryParameters
     {

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeClientOptions.cs
@@ -22,19 +22,23 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The versions of Azure Data Lake Sevice supported by this client
         /// library.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for the Azure Storage services</see>.
         /// </summary>
         public enum ServiceVersion
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// The 2019-02-02 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-02-02">
+            /// Version 2019-02-02</see>
             /// </summary>
             V2019_02_02 = 1,
 
             /// <summary>
-            /// The 2019-07-07 service version.
+            /// The 2019-07-07 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-07-07">
+            /// Version 2019-07-07</see>
             /// </summary>
             V2019_07_07 = 2,
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -551,7 +551,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -599,7 +601,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -650,7 +654,9 @@ namespace Azure.Storage.Files.DataLake
         /// for deletion, if the directory exists. The directory is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -698,7 +704,9 @@ namespace Azure.Storage.Files.DataLake
         /// for deletion, if the directory exists. The directory is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -885,7 +893,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControl"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -942,7 +952,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControlAsync"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -1002,7 +1014,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlList"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -1064,7 +1078,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlListAsync"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -1129,7 +1145,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissions"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -1192,7 +1210,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissionsAsync"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -1259,7 +1279,9 @@ namespace Azure.Storage.Files.DataLake
         /// properties for the path. It does not return the content of the
         /// path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -1311,7 +1333,9 @@ namespace Azure.Storage.Files.DataLake
         /// properties for the path. It does not return the content of the
         /// path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -1361,10 +1385,13 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
-        /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
+        /// Optional. The standard HTTP header system properties to set.
+        /// If not specified, existing values will be cleared.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -1413,10 +1440,13 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the PATH.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
-        /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
+        /// Optional. The standard HTTP header system properties to set.
+        /// If not specified, existing values will be cleared.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -1468,7 +1498,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified path as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this path.
@@ -1520,7 +1552,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified path as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this path.
@@ -1754,7 +1788,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteFile"/> operation deletes a file
         /// in this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="fileName">
         /// The name of the file to delete.
@@ -1804,7 +1840,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteFileAsync"/> operation deletes a file
         /// in this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="fileName">
         /// The name of the file to delete.
@@ -2033,7 +2071,9 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteSubDirectory"/> deletes a sub directory in this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="path">
         /// The path to the directory to delete.
@@ -2090,7 +2130,9 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteSubDirectoryAsync"/> deletes a sub directory in this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="path">
         /// The path to the directory to delete.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -528,7 +528,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -576,7 +578,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -627,7 +631,9 @@ namespace Azure.Storage.Files.DataLake
         /// for deletion, if the file exists. The file is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -675,7 +681,9 @@ namespace Azure.Storage.Files.DataLake
         /// for deletion, if the file exists. The file is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -862,7 +870,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControl"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -919,7 +929,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControlAsync"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -979,7 +991,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlList"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -1041,7 +1055,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlListAsync"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -1106,7 +1122,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissions"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -1169,7 +1187,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissionsAsync"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -1236,7 +1256,9 @@ namespace Azure.Storage.Files.DataLake
         /// properties for the path. It does not return the content of the
         /// path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -1288,7 +1310,9 @@ namespace Azure.Storage.Files.DataLake
         /// properties for the path. It does not return the content of the
         /// path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -1338,10 +1362,13 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
-        /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
+        /// Optional. The standard HTTP header system properties to set.
+        /// If not specified, existing values will be cleared.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -1390,10 +1417,13 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the PATH.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Blob Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
-        /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
+        /// Optional. The standard HTTP header system properties to set.
+        /// If not specified, existing values will be cleared.
         /// </param>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add conditions on
@@ -1445,7 +1475,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified path as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this path.
@@ -1497,7 +1529,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified path as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this path.
@@ -1549,11 +1583,14 @@ namespace Azure.Storage.Files.DataLake
 
         #region Append Data
         /// <summary>
-        /// The <see cref="Append"/> operation uploads data to be appended to a file.  Data can only be appended to a file.
+        /// The <see cref="Append"/> operation uploads data to be appended to a file.
+        /// Data can only be appended to a file.
         /// To apply perviously uploaded data to a file, call Flush Data.
         /// Append is currently limited to 4000 MB per request.  To upload large files all at once, consider using <see cref="Upload(Stream)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -1630,7 +1667,9 @@ namespace Azure.Storage.Files.DataLake
         /// To apply perviously uploaded data to a file, call Flush Data.
         /// Append is currently limited to 4000 MB per request.  To upload large files all at once, consider using <see cref="UploadAsync(Stream)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -1706,7 +1745,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="AppendInternal"/> operation uploads data to be appended to a file.  Data can only be appended to a file.
         /// To apply perviously uploaded data to a file, call Flush Data.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2078,7 +2119,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Read()"/> operation downloads a file from
         /// the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <returns>
         /// A <see cref="Response{FileDownloadInfo}"/> describing the
@@ -2118,7 +2161,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="ReadAsync()"/> operation downloads a file from
         /// the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <returns>
         /// A <see cref="Response{FileDownloadInfo}"/> describing the
@@ -2159,7 +2204,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Read(CancellationToken)"/> operation downloads a file from
         /// the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2204,7 +2251,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="ReadAsync(CancellationToken)"/> operation downloads a file from
         /// the service, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2251,7 +2300,9 @@ namespace Azure.Storage.Files.DataLake
         /// operation downloads a file from the service, including its metadata
         /// and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="range">
         /// If provided, only donwload the bytes of the file in the specified
@@ -2320,7 +2371,9 @@ namespace Azure.Storage.Files.DataLake
         /// operation downloads a file from the service, including its metadata
         /// and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob">
+        /// Get Blob</see>.
         /// </summary>
         /// <param name="range">
         /// If provided, only donwload the bytes of the file in the specified
@@ -2637,7 +2690,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeFileUploadOptions.Conditions"/> or alternatively use
         /// <see cref="Upload(Stream)"/>, <see cref="Upload(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2728,7 +2783,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Upload(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2753,7 +2810,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Upload(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2790,7 +2849,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeFileUploadOptions.Conditions"/> or alternatively use
         /// <see cref="UploadAsync(Stream)"/>, <see cref="UploadAsync(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2827,7 +2888,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeRequestConditions"/> or alternatively use
         /// <see cref="UploadAsync(Stream)"/>, <see cref="UploadAsync(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2882,7 +2945,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="UploadAsync(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2908,7 +2973,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="UploadAsync(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -2945,7 +3012,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeFileUploadOptions.Conditions"/> or alternatively use
         /// <see cref="Upload(Stream)"/>, <see cref="Upload(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -2983,7 +3052,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeRequestConditions"/> or alternatively use
         /// <see cref="Upload(Stream)"/>, <see cref="Upload(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -3045,7 +3116,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Upload(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -3071,7 +3144,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Upload(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -3108,7 +3183,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeFileUploadOptions.Conditions"/> or alternatively use
         /// <see cref="UploadAsync(Stream)"/>, <see cref="UploadAsync(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -3151,7 +3228,9 @@ namespace Azure.Storage.Files.DataLake
         /// unless otherwise specified in the <see cref="DataLakeRequestConditions"/> or alternatively use
         /// <see cref="Upload(Stream)"/>, <see cref="Upload(Stream, bool, CancellationToken)"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -3206,7 +3285,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="UploadAsync(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.
@@ -3232,7 +3313,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="UploadAsync(Stream, bool, CancellationToken)"/>
         /// operation creates and uploads content to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" >
+        /// Update Path</see>.
         /// </summary>
         /// <param name="path">
         /// A file path containing the content to upload.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -389,7 +389,9 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -459,7 +461,9 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -532,7 +536,9 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -605,7 +611,9 @@ namespace Azure.Storage.Files.DataLake
         /// under the specified account. If the file system with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="publicAccessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -680,7 +688,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system for deletion. The file system and any paths contained
         /// within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -728,7 +738,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system for deletion. The file system and any paths contained
         /// within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -778,7 +790,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system for deletion if it exists. The file system and any files
         /// and directories contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -826,7 +840,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system for deletion if it exists. The file system and any files
         /// and directories contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -963,7 +979,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system. The data returned does not include the file system's
         /// list of paths.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties">
+        /// Get Container Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -1016,7 +1034,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system. The data returned does not include the file system's
         /// list of paths.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties">
+        /// Get Container Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -1070,7 +1090,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadata"/> operation sets one or more
         /// user-defined name-value pairs for the specified file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata">
+        /// Set Container Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file system.
@@ -1129,7 +1151,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadataAsync"/> operation sets one or more
         /// user-defined name-value pairs for the specified file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata">
+        /// Set Container Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file system.
@@ -1192,7 +1216,9 @@ namespace Azure.Storage.Files.DataLake
         /// of paths in this file system.  Enumerating the paths may make
         /// multiple requests to the service while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">Path - List</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">
+        /// List Path(s)</see>.
         /// </summary>
         /// <param name="path">
         /// Filters results to paths within the specified directory.
@@ -1237,7 +1263,9 @@ namespace Azure.Storage.Files.DataLake
         /// make multiple requests to the service while fetching all the
         /// values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">Path - List</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">
+        /// List Path(s)</see>.
         /// </summary>
         /// <param name="path">
         /// Filters results to paths within the specified directory.
@@ -1285,7 +1313,9 @@ namespace Azure.Storage.Files.DataLake
         /// to continue enumerating the paths segment by segment. Paths are
         /// ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">Path - List</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/path/list">
+        /// List Path(s)</see>.
         /// </summary>
         /// <param name="path">
         /// Filters results to paths within the specified directory.
@@ -1575,7 +1605,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="path">
         /// The path to the directory to delete.
@@ -1626,7 +1658,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteDirectoryAsync"/> deletes a directory in this file system.
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="path">
         /// The path to the directory to delete.
@@ -1858,7 +1892,9 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteFile"/> deletes a file in this file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="path">
         /// The path to the file to delete.
@@ -1907,7 +1943,9 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteFileAsync"/> deletes a file in this file system.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="path">
         /// The path to the file to delete.
@@ -1961,7 +1999,9 @@ namespace Azure.Storage.Files.DataLake
         /// permissions for this file system. The permissions indicate whether
         /// file system data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl">
+        /// Get Container ACL</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -2013,7 +2053,9 @@ namespace Azure.Storage.Files.DataLake
         /// permissions for this file system. The permissions indicate whether
         /// file system data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl">
+        /// Get Container ACL</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -2068,7 +2110,9 @@ namespace Azure.Storage.Files.DataLake
         /// permissions for the specified file system. The permissions indicate
         /// whether file system data may be accessed publicly.
         ///
-        /// For more information, see <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-acl">
+        /// Set Container ACL</see>.
         /// </summary>
         /// <param name="accessType">
         /// Optionally specifies whether data in the file system may be accessed
@@ -2145,7 +2189,9 @@ namespace Azure.Storage.Files.DataLake
         /// permissions for the specified file system. The permissions indicate
         /// whether the file system data may be accessed publicly.
         ///
-        /// For more information, see <see href=" https://docs.microsoft.com/rest/api/storageservices/set-container-acl" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-acl">
+        /// Set Container ACL</see>.
         /// </summary>
         /// <param name="accessType">
         /// Optionally specifies whether data in the file system may be accessed

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeLeaseClient.cs
@@ -106,7 +106,9 @@ namespace Azure.Storage.Files.DataLake
         /// using the active lease ID as <see cref="LeaseId"/>, but you can
         /// specify a new <paramref name="duration"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="duration">
         /// Specifies the duration of the lease, in seconds, or specify
@@ -171,7 +173,9 @@ namespace Azure.Storage.Files.DataLake
         /// using the active lease ID as <see cref="LeaseId"/>, but you can
         /// specify a new <paramref name="duration"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="duration">
         /// Specifies the duration of the lease, in seconds, or specify
@@ -238,7 +242,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system has not been leased again since the expiration of that
         /// lease.  When you renew a lease, the lease duration clock resets.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="RequestConditions"/> to add
@@ -294,7 +300,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system has not been leased again since the expiration of that
         /// lease.  When you renew a lease, the lease duration clock resets.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="RequestConditions"/> to add
@@ -351,7 +359,9 @@ namespace Azure.Storage.Files.DataLake
         /// lease allows another client to immediately acquire the lease for the
         /// file system or path as soon as the release is complete.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="RequestConditions"/> to add
@@ -407,7 +417,9 @@ namespace Azure.Storage.Files.DataLake
         /// lease allows another client to immediately acquire the lease for the
         /// file system or path as soon as the release is complete.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="RequestConditions"/> to add
@@ -462,7 +474,9 @@ namespace Azure.Storage.Files.DataLake
         /// of an active lease.  A change must include the current
         /// <see cref="LeaseId"/> and a new <paramref name="proposedId"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="proposedId">
         /// An optional proposed lease ID, in a GUID string format. A
@@ -520,7 +534,9 @@ namespace Azure.Storage.Files.DataLake
         /// of an active lease.  A change must include the current
         /// <see cref="LeaseId"/> and a new <paramref name="proposedId"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="proposedId">
         /// An optional proposed lease ID, in a GUID string format. A
@@ -594,7 +610,9 @@ namespace Azure.Storage.Files.DataLake
         /// immediately acquire a path or file system lease that has been
         /// released.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="breakPeriod">
         /// Specifies the proposed duration the lease should continue before
@@ -670,7 +688,9 @@ namespace Azure.Storage.Files.DataLake
         /// immediately acquire a path or file system lease that has been
         /// released.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container">
+        /// Lease Container</see>.
         /// </summary>
         /// <param name="breakPeriod">
         /// Specifies the proposed duration the lease should continue before

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -1083,7 +1083,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="recursive">
         /// Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
@@ -1138,7 +1140,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="recursive">
         /// Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
@@ -1193,7 +1197,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="recursive">
         /// Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
@@ -1269,7 +1275,9 @@ namespace Azure.Storage.Files.DataLake
         /// for deletion, if the path exists. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="recursive">
         /// Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
@@ -1306,7 +1314,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion, if the path exists. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="recursive">
         /// Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
@@ -1343,7 +1353,9 @@ namespace Azure.Storage.Files.DataLake
         /// deletion, if the path exists. The path is later deleted during
         /// garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
+        /// Delete Path</see>.
         /// </summary>
         /// <param name="recursive">
         /// Required and valid only when the resource is a directory. If "true", all paths beneath the directory will be deleted.
@@ -1665,7 +1677,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControl"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -1724,7 +1738,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControlAsync"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -1783,7 +1799,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="GetAccessControlInternal"/> operation returns the
         /// access control data for a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/getproperties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="userPrincipalName">
         /// Optional.Valid only when Hierarchical Namespace is enabled for the account.If "true",
@@ -1870,7 +1888,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlList"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -1934,7 +1954,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlListAsync"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -1998,7 +2020,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetAccessControlListInternal"/> operation sets the
         /// Access Control on a path
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="accessControlList">
         /// The POSIX access control list for the file or directory.
@@ -2092,7 +2116,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissions"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -2157,7 +2183,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissionsAsync"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -2221,7 +2249,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetPermissionsInternal"/> operation sets the
         /// file permissions on a path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/update">
+        /// Update Path</see>.
         /// </summary>
         /// <param name="permissions">
         ///  The POSIX access permissions for the file owner, the file owning group, and others.
@@ -2317,7 +2347,9 @@ namespace Azure.Storage.Files.DataLake
         /// properties for the path. It does not return the content of the
         /// path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -2370,7 +2402,9 @@ namespace Azure.Storage.Files.DataLake
         /// properties for the path. It does not return the content of the
         /// path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties">
+        /// Get Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="DataLakeRequestConditions"/> to add
@@ -2424,7 +2458,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the path.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
@@ -2480,7 +2516,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the PATH.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties">
+        /// Set Properties</see>.
         /// </summary>
         /// <param name="httpHeaders">
         /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
@@ -2539,7 +2577,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified path as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this path.
@@ -2594,7 +2634,9 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified path as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
+        ///For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata">
+        /// Set Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this path.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -420,7 +420,9 @@ namespace Azure.Storage.Files.DataLake
         /// file systems may make multiple requests to the service while fetching
         /// all the values.  File systems are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the file systems.
@@ -453,7 +455,9 @@ namespace Azure.Storage.Files.DataLake
         /// files systems may make multiple requests to the service while fetching
         /// all the values.  File systems are ordered lexicographically by name.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">List Containers</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2">
+        /// List Containers</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies trait options for shaping the file systems.
@@ -487,7 +491,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system under the specified account. If the file systen with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="fileSystemName">
         /// The name of the file system to create.
@@ -552,7 +558,9 @@ namespace Azure.Storage.Files.DataLake
         /// file system under the specified account. If the file system with the
         /// same name already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">Create Container</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-container">
+        /// Create Container</see>.
         /// </summary>
         /// <param name="fileSystemName">
         /// The name of the file system to create.
@@ -619,7 +627,9 @@ namespace Azure.Storage.Files.DataLake
         /// specified file system for deletion. The file system and any paths
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="fileSystemName">
         /// The name of the file system to delete.
@@ -671,7 +681,9 @@ namespace Azure.Storage.Files.DataLake
         /// specified file system for deletion. The file system and any paths
         /// contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
+        /// Delete Container</see>.
         /// </summary>
         /// <param name="fileSystemName">
         /// The name of the file system to delete.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Models/FileDownloadDetails.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Models/FileDownloadDetails.cs
@@ -75,7 +75,7 @@ namespace Azure.Storage.Files.DataLake.Models
         public string CopyStatusDescription { get; internal set; }
 
         /// <summary>
-        /// String identifier for this copy operation. Use with Get Blob Properties to check the status of this copy
+        /// String identifier for this copy operation. Use with Get Properties to check the status of this copy
         /// operation, or pass to Abort Copy Blob to abort a pending copy.
         /// </summary>
         public string CopyId { get; internal set; }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Models/PathHttpHeaders.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Models/PathHttpHeaders.cs
@@ -11,7 +11,9 @@ namespace Azure.Storage.Files.DataLake.Models
     /// names, as specified in the Header Field Definitions section 14 of the
     /// HTTP/1.1 protocol specification.
     ///
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources" />.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources">
+    /// Setting and retrieving properties and metadata for service resources</see>.
     /// </summary>
     public class PathHttpHeaders
     {

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -13,7 +13,10 @@ namespace Azure.Storage.Sas
     /// <summary>
     /// <see cref="DataLakeSasBuilder"/> is used to generate a Shared Access
     /// Signature (SAS) for a Data Lake file system or path
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas" />.
+    ///
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas">
+    /// Constructing a Service SAS</see>.
     /// </summary>
     public class DataLakeSasBuilder
     {

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasQueryParameters.cs
@@ -13,7 +13,9 @@ namespace Azure.Storage.Sas
     /// parameters.  You can construct a new instance using
     /// <see cref="DataLakeSasBuilder"/>.
     ///
-    /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/create-service-sas">Create a service SAS</see>.
+    /// For more information,
+    /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-service-sas">
+    /// Create a service SAS</see>.
     /// </summary>
     public sealed class DataLakeSasQueryParameters : SasQueryParameters
     {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileHttpHeaders.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileHttpHeaders.cs
@@ -14,7 +14,9 @@ namespace Azure.Storage.Files.Shares.Models
     /// names, as specified in the Header Field Definitions section 14 of the
     /// HTTP/1.1 protocol specification.
     ///
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources" />.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-and-retrieving-properties-and-metadata-for-blob-resources">
+    /// Setting and retrieving properties and metadata for service resources</see>.
     /// </summary>
     public class ShareFileHttpHeaders
     {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -10,7 +10,10 @@ namespace Azure.Storage.Sas
     /// <summary>
     /// <see cref="ShareSasBuilder"/> is used to generate a Shared Access
     /// Signature (SAS) for an Azure Storage share, directory, or file.
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas" />.
+    ///
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas">
+    /// Creating a Service SAS</see>.
     /// </summary>
     public class ShareSasBuilder
     {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -117,7 +117,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -136,7 +138,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -253,7 +257,9 @@ namespace Azure.Storage.Files.Shares
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">
+        /// Snapshot Share</see>.
         /// </summary>
         /// <remarks>
         /// Pass null or empty string to remove the snapshot returning a URL to the base share.
@@ -320,7 +326,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -356,7 +364,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -392,7 +402,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -465,7 +477,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -500,7 +514,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -535,7 +551,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -712,7 +730,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -740,7 +760,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -768,7 +790,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -831,7 +855,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a read-only snapshot of a share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">
+        /// Snapshot Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -860,7 +886,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a read-only snapshot of a share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">
+        /// Snapshot Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -889,7 +917,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a read-only snapshot of a share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">
+        /// Snapshot Share</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -950,7 +980,9 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -980,7 +1012,9 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -1010,7 +1044,9 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="includeSnapshots">
         /// A value indicating whether to delete a share's snapshots in addition
@@ -1077,7 +1113,9 @@ namespace Azure.Storage.Files.Shares
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">Get Share Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">
+        /// Get Share Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1103,7 +1141,9 @@ namespace Azure.Storage.Files.Shares
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">Get Share Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">
+        /// Get Share Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1129,7 +1169,9 @@ namespace Azure.Storage.Files.Shares
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">Get Share Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-properties">
+        /// Get Share Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1185,9 +1227,14 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">Set Share Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">
+        /// Set Share Properties</see>.
         /// </summary>
-        /// <param name="quotaInGB">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
+        /// <param name="quotaInGB">
+        /// Optional. The maximum size of the share.
+        /// If unspecified, use the service's default value.
+        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
@@ -1212,9 +1259,14 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">Set Share Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">
+        /// Set Share Properties</see>.
         /// </summary>
-        /// <param name="quotaInGB">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
+        /// <param name="quotaInGB">
+        /// Optional. The maximum size of the share.
+        /// If unspecified, use the service's default value.
+        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
@@ -1239,9 +1291,14 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">Set Share Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-properties">
+        /// Set Share Properties</see>.
         /// </summary>
-        /// <param name="quotaInGB">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
+        /// <param name="quotaInGB">
+        /// Optional. The maximum size of the share.
+        /// If unspecified, use the service's default value.
+        /// </param>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
         /// </param>
@@ -1300,7 +1357,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified share as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">Set Share Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">
+        /// Set Share Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -1330,7 +1389,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified share as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">Set Share Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">
+        /// Set Share Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -1360,7 +1421,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified share as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">Set Share Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata">
+        /// Set Share Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -1422,7 +1485,9 @@ namespace Azure.Storage.Files.Shares
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">Get Share ACL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">
+        /// Get Share ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1448,7 +1513,9 @@ namespace Azure.Storage.Files.Shares
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">Get Share ACL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">
+        /// Get Share ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1474,7 +1541,9 @@ namespace Azure.Storage.Files.Shares
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">Get Share ACL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl">
+        /// Get Share ACL</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1531,7 +1600,9 @@ namespace Azure.Storage.Files.Shares
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">Set Share ACL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">
+        /// Set Share ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1563,7 +1634,9 @@ namespace Azure.Storage.Files.Shares
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">Set Share ACL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">
+        /// Set Share ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1595,7 +1668,9 @@ namespace Azure.Storage.Files.Shares
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">Set Share ACL</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl">
+        /// Set Share ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1656,7 +1731,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Retrieves statistics related to the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">Get Share Stats</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">
+        /// Get Share Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1680,7 +1757,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Retrieves statistics related to the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">Get Share Stats</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">
+        /// Get Share Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1704,7 +1783,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Retrieves statistics related to the share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats">Get Share Stats</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-stats"
+        /// >Get Share Stats</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1965,7 +2046,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateDirectory"/> operation creates a new
         /// directory in this share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to create.
@@ -2014,7 +2097,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateDirectoryAsync"/> operation creates a new
         /// directory in this share.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to create.
@@ -2065,7 +2150,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteDirectory"/> operation removes the specified empty
         /// directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to delete.
@@ -2093,7 +2180,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteDirectoryAsync"/> operation removes the specified empty
         /// directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to delete.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClientOptions.cs
@@ -19,19 +19,23 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The versions of Azure File Storage supported by this client
         /// library.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for the Azure Storage services</see>.
         /// </summary>
         public enum ServiceVersion
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// The 2019-02-02 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-02-02">
+            /// Version 2019-02-02</see>
             /// </summary>
             V2019_02_02 = 1,
 
             /// <summary>
-            /// The 2019-07-07 service version.
+            /// The 2019-07-07 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-07-07">
+            /// Version 2019-07-07</see>
             /// </summary>
             V2019_07_07 = 2,
 
@@ -45,7 +49,8 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for the Azure Storage services</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -148,7 +148,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -169,7 +171,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -298,7 +302,9 @@ namespace Azure.Storage.Files.Shares
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">
+        /// Snapshot Share</see>.
         /// </summary>
         /// <remarks>
         /// Pass null or empty string to remove the snapshot returning a URL to the base directory.
@@ -373,7 +379,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Create"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -413,7 +421,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateAsync"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -453,7 +463,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateInternal"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -542,7 +554,9 @@ namespace Azure.Storage.Files.Shares
         /// if it does not already exists.  If the directory already exists, it is not
         /// modified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -582,7 +596,9 @@ namespace Azure.Storage.Files.Shares
         /// if it does not already exists.  If the directory already exists, it is not
         /// modified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -622,7 +638,9 @@ namespace Azure.Storage.Files.Shares
         /// if it does not already exists.  If the directory already exists, it is not
         /// modified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -803,7 +821,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExists"/> operation removes the specified
         /// empty directory, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -825,7 +845,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExistsAsync"/> operation removes the specified
         /// empty directory, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -847,7 +869,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExistsInternal"/> operation removes the specified
         /// empty directory, if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -906,7 +930,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="Delete"/> operation removes the specified empty directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -928,7 +954,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation removes the specified empty directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -951,7 +979,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteInternal"/> operation removes the specified
         /// empty directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1011,7 +1041,9 @@ namespace Azure.Storage.Files.Shares
         /// directory. The data returned does not include the directory's
         /// list of subdirectories or files.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">Get Directory Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">
+        /// Get Directory Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1038,7 +1070,9 @@ namespace Azure.Storage.Files.Shares
         /// directory. The data returned does not include the directory's
         /// list of subdirectories or files.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">Get Directory Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">
+        /// Get Directory Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1065,7 +1099,9 @@ namespace Azure.Storage.Files.Shares
         /// directory. The data returned does not include the directory's
         /// list of subdirectories or files.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">Get Directory Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-directory-properties">
+        /// Get Directory Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1131,7 +1167,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">Set Directory Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">
+        /// Set Directory Properties</see>.
         /// </summary>
         /// <param name="smbProperties">
         /// Optional SMB properties to set for the directory.
@@ -1201,7 +1239,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">Set Directory Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-properties">
+        /// Set Directory Properties</see>.
         /// </summary>
         /// <param name="smbProperties">
         /// Optional SMB properties to set for the directory.
@@ -1281,7 +1321,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">Set Directory Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">
+        /// Set Directory Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -1310,7 +1352,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataAsync"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">Set Directory Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">
+        /// Set Directory Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -1339,7 +1383,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataInternal"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">Set Directory Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata">
+        /// Set Directory Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -1403,7 +1449,9 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the files and directories may make multiple requests
         /// to the service while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">List Directories and Files</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">
+        /// List Directories and Files</see>.
         /// </summary>
         /// <param name="prefix">
         /// Optional string that filters the results to return only
@@ -1432,7 +1480,9 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the files and directories may make multiple requests
         /// to the service while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">List Directories and Files</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">
+        /// List Directories and Files</see>.
         /// </summary>
         /// <param name="prefix">
         /// Optional string that filters the results to return only
@@ -1460,7 +1510,9 @@ namespace Azure.Storage.Files.Shares
         /// single segment of files and subdirectories in this directory, starting
         /// from the specified <paramref name="marker"/>.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">List Directories and Files</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-directories-and-files">
+        /// List Directories and Files</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -1544,7 +1596,9 @@ namespace Azure.Storage.Files.Shares
         /// handles may make multiple requests to the service while fetching
         /// all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">
+        /// List Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1572,7 +1626,9 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the handles may make multiple requests to the service
         /// while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">
+        /// List Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1598,7 +1654,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="GetHandlesAsync"/> operation returns a list of open
         /// handles on a directory or a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">
+        /// List Handles</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -1685,7 +1743,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -1730,7 +1790,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -1776,7 +1838,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1813,7 +1877,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// FFor more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1850,7 +1916,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="recursive">
         /// Optional. A boolean value that specifies if the operation should also apply to the files and subdirectories of the directory specified.
@@ -1913,7 +1981,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -1998,7 +2068,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateSubdirectory"/> operation creates a new
         /// subdirectory under this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="metadata">
@@ -2043,7 +2115,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="CreateSubdirectoryAsync"/> operation creates a new
         /// subdirectory under this directory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">Create Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory">
+        /// Create Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="metadata">
@@ -2091,7 +2165,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteSubdirectory"/> operation removes the
         /// specified empty subdirectory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="cancellationToken">
@@ -2114,7 +2190,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteSubdirectoryAsync"/> operation removes the
         /// specified empty subdirectory.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">Delete Directory</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory">
+        /// Delete Directory</see>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="cancellationToken">
@@ -2140,7 +2218,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2203,7 +2283,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2264,7 +2346,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2327,7 +2411,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -2391,7 +2477,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFile(string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="conditions">
@@ -2422,7 +2510,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFile(string, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="cancellationToken">
@@ -2451,7 +2541,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFile(string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="conditions">
@@ -2484,7 +2576,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteFileAsync(string, CancellationToken)"/>
         /// operation immediately removesthe file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="cancellationToken">

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -162,7 +162,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -183,7 +185,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
@@ -308,7 +312,9 @@ namespace Azure.Storage.Files.Shares
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="shareSnapshot"/> timestamp.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">Snapshot Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-share">
+        /// Snapshot Share</see>.
         /// </summary>
         /// <remarks>
         /// Pass null or empty string to remove the snapshot returning a URL to the base file.
@@ -344,7 +350,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -403,7 +411,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -460,7 +470,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -519,7 +531,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -576,7 +590,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">Create File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-file">
+        /// Create File</see>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -801,7 +817,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExists"/> operation immediately removes the file from the storage account,
         /// if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -831,7 +849,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExists"/> operation immediately removes the file from the storage account,
         /// if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -861,7 +881,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteIfExistsInternal"/> operation immediately removes the file from the storage account,
         /// if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -924,7 +946,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">
+        /// Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -994,7 +1018,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">
+        /// Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1037,7 +1063,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">
+        /// Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1107,7 +1135,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">
+        /// Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1150,7 +1180,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file">
+        /// Copy File</see>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -1258,7 +1290,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">
+        /// Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1292,7 +1326,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">
+        /// Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1324,7 +1360,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">
+        /// Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1358,7 +1396,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">
+        /// Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1390,7 +1430,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">Abort Copy File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file">
+        /// Abort Copy File</see>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -1458,7 +1500,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Download(HttpRange, bool, ShareFileRequestConditions, CancellationToken)"/>
         /// operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">
+        /// Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1506,7 +1550,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Download(HttpRange, bool, CancellationToken)"/> operation reads
         /// or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">
+        /// Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1552,7 +1598,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DownloadAsync(HttpRange, bool, ShareFileRequestConditions, CancellationToken)"/>
         /// operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">
+        /// Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1600,7 +1648,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DownloadAsync(HttpRange, bool, CancellationToken)"/> operation reads
         /// or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">
+        /// Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1645,7 +1695,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="DownloadInternal"/> operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">
+        /// Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1751,7 +1803,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="StartDownloadAsync"/> operation starts to read or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">Get File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file">
+        /// Get File</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -1821,7 +1875,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Delete(ShareFileRequestConditions, CancellationToken)"/>
         /// operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -1851,7 +1907,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Delete(CancellationToken)"/> operation immediately
         /// removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1879,7 +1937,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteAsync(ShareFileRequestConditions, CancellationToken)"/> operation
         /// immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -1909,7 +1969,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="DeleteAsync(CancellationToken)"/> operation
         /// immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1936,7 +1998,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// The <see cref="DeleteInternal"/> operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">Delete File</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-file2">
+        /// Delete File</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2003,7 +2067,9 @@ namespace Azure.Storage.Files.Shares
         /// and system properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">
+        /// Get File Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2036,7 +2102,9 @@ namespace Azure.Storage.Files.Shares
         /// and system properties for the file. It does not return the
         /// content of the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">
+        /// Get File Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2066,7 +2134,9 @@ namespace Azure.Storage.Files.Shares
         /// operation returns all user-defined metadata, standard HTTP properties, and system
         /// properties for the file. It does not return the content of the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">
+        /// Get File Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2099,7 +2169,9 @@ namespace Azure.Storage.Files.Shares
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">
+        /// Get File Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -2130,7 +2202,9 @@ namespace Azure.Storage.Files.Shares
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">Get File Properties</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties">
+        /// Get File Properties</see>.
         /// </summary>
         /// <param name="conditions">
         /// Optional <see cref="ShareFileRequestConditions"/> to add conditions
@@ -2202,7 +2276,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeaders(long?, ShareFileHttpHeaders, FileSmbProperties, string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation sets system properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">
+        /// Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2257,7 +2333,9 @@ namespace Azure.Storage.Files.Shares
         /// operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">
+        /// Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2309,7 +2387,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersAsync(long?, ShareFileHttpHeaders, FileSmbProperties, string, ShareFileRequestConditions, CancellationToken)"/>
         /// operation sets system properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">
+        /// Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2363,7 +2443,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersAsync(long?, ShareFileHttpHeaders, FileSmbProperties, string, CancellationToken)"/>
         /// operation sets system properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">
+        /// Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2415,7 +2497,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">Set File Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties">
+        /// Set File Properties</see>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -2521,7 +2605,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata(Metadata, ShareFileRequestConditions, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">
+        /// Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2557,7 +2643,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata(Metadata, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">
+        /// Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2591,7 +2679,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataAsync(Metadata, ShareFileRequestConditions, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">
+        /// Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2627,7 +2717,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadata(Metadata, CancellationToken)"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">
+        /// Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2661,7 +2753,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">Set File Metadata</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata">
+        /// Set File Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -2730,7 +2824,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClearRange"/>
         /// operation clears the <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and end of the range must be specified.
@@ -2767,7 +2863,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClearRangeAsync"/>
         /// operation clears the <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be cleared. Both the start and end of the range must be specified.
@@ -2803,9 +2901,10 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRangeInternal"/> operation clears the
         /// <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
-
         /// <param name="range">
         /// Specifies the range of bytes to be cleated. Both the start and end of the range must be specified.
         /// </param>
@@ -2878,7 +2977,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRange(HttpRange, Stream, byte[], IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be written. Both the start and end of the range must be specified.
@@ -2936,7 +3037,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRangeAsync(HttpRange, Stream, byte[], IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="range">
         /// Specifies the range of bytes to be written. Both the start and end of the range must be specified.
@@ -2994,7 +3097,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRange(ShareFileRangeWriteType, HttpRange, Stream, byte[], IProgress{long}, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -3051,7 +3156,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRange(ShareFileRangeWriteType, HttpRange, Stream, byte[], IProgress{long}, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -3108,9 +3215,10 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadRangeInternal"/> operation writes
         /// <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
-
         /// <param name="range">
         /// Specifies the range of bytes to be written. Both the start and end of the range must be specified.
         /// </param>
@@ -3472,7 +3580,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Upload(Stream, IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3516,7 +3626,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="Upload(Stream, IProgress{long}, ShareFileRequestConditions, CancellationToken)"/>
         /// operation writes <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3558,7 +3670,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadAsync(Stream, IProgress{long}, ShareFileRequestConditions, CancellationToken)"/> operation writes
         /// <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3602,7 +3716,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadAsync(Stream, IProgress{long}, CancellationToken)"/> operation writes
         /// <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content of the file to upload.
@@ -3644,7 +3760,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="UploadInternal"/> operation writes
         /// <paramref name="content"/> to a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">Put Range</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-range">
+        /// Put Range</see>.
         /// </summary>
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
@@ -3770,7 +3888,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">
+        /// List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3806,7 +3926,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">
+        /// List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3840,7 +3962,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">
+        /// List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3876,7 +4000,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">
+        /// List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3910,7 +4036,9 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">List Ranges</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-ranges">
+        /// List Ranges</see>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively.
@@ -3982,7 +4110,9 @@ namespace Azure.Storage.Files.Shares
         /// handles may make multiple requests to the service while fetching
         /// all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">
+        /// List Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4006,7 +4136,9 @@ namespace Azure.Storage.Files.Shares
         /// Enumerating the handles may make multiple requests to the service
         /// while fetching all the values.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">
+        /// List Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4028,7 +4160,9 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="GetHandlesInternal"/> operation returns a list of open
         /// handles on the file.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">List Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-handles">
+        /// List Handles</see>.
         /// </summary>
         /// <remarks>
         /// </remarks>
@@ -4110,7 +4244,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -4154,7 +4290,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Specifies the handle ID to be closed.
@@ -4198,7 +4336,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4229,7 +4369,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -4260,7 +4402,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -4312,7 +4456,9 @@ namespace Azure.Storage.Files.Shares
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">Force Close Handles</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/force-close-handles">
+        /// Force Close Handles</see>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -101,7 +101,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         public ShareServiceClient(string connectionString)
             : this(connectionString, null)
@@ -117,7 +119,9 @@ namespace Azure.Storage.Files.Shares
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information,
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline
@@ -218,7 +222,9 @@ namespace Azure.Storage.Files.Shares
         /// make multiple requests to the service while fetching all the
         /// values.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">List Shares</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">
+        /// List Shares</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies traits to include in the <see cref="ShareItem"/>s.
@@ -255,7 +261,9 @@ namespace Azure.Storage.Files.Shares
         /// make multiple requests to the service while fetching all the
         /// values.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">List Shares</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">
+        /// List Shares</see>.
         /// </summary>
         /// <param name="traits">
         /// Specifies traits to include in the <see cref="ShareItem"/>s.
@@ -295,7 +303,9 @@ namespace Azure.Storage.Files.Shares
         /// empty to make subsequent calls to <see cref="GetSharesAsync"/>
         /// to continue enumerating the shares segment by segment.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">List Shares</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-shares">
+        /// List Shares</see>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -394,7 +404,9 @@ namespace Azure.Storage.Files.Shares
         /// of a storage account’s file service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties">
+        /// Get File Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -420,7 +432,9 @@ namespace Azure.Storage.Files.Shares
         /// of a storage account’s file service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties">
+        /// Get File Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -446,7 +460,9 @@ namespace Azure.Storage.Files.Shares
         /// of a storage account’s file service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-service-properties">
+        /// Get File Service Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -506,7 +522,9 @@ namespace Azure.Storage.Files.Shares
         /// the default request version for all incoming requests to the File
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">Set File Service Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">
+        /// Set File Service Properties</see>.
         /// </summary>
         /// <param name="properties">The file service properties.</param>
         /// <param name="cancellationToken">
@@ -537,7 +555,9 @@ namespace Azure.Storage.Files.Shares
         /// the default request version for all incoming requests to the File
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">Set File Service Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">
+        /// Set File Service Properties</see>.
         /// </summary>
         /// <param name="properties">The file service properties.</param>
         /// <param name="cancellationToken">
@@ -568,7 +588,9 @@ namespace Azure.Storage.Files.Shares
         /// the default request version for all incoming requests to the File
         /// service that do not have a version specified.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">Set File Service Properties</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-service-properties">
+        /// Set File Service Properties</see>.
         /// </summary>
         /// <param name="properties">The file service properties.</param>
         /// <param name="async">
@@ -627,7 +649,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to create.
@@ -674,7 +698,9 @@ namespace Azure.Storage.Files.Shares
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">Create Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-share">
+        /// Create Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to create.
@@ -722,9 +748,12 @@ namespace Azure.Storage.Files.Shares
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         ///
-        /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
+        /// Currently, this method will always delete snapshots.
+        /// There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to delete.
@@ -761,7 +790,9 @@ namespace Azure.Storage.Files.Shares
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">Delete Share</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
+        /// Delete Share</see>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to delete.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
@@ -16,7 +16,9 @@ namespace Azure.Storage.Files.Shares
     /// modify the contents of a <see cref="System.Uri"/> instance to point to
     /// different Azure Storage resources like an account, share, or file.
     ///
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata" />.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata">
+    /// Naming and Referencing Shares, Directories, Files, and Metadata</see>.
     /// </summary>
     public class ShareUriBuilder
     {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -150,7 +150,9 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         /// <param name="queueName">
         /// The name of the queue in the storage account to reference.
@@ -169,7 +171,9 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         /// <param name="queueName">
         /// The name of the queue in the storage account to reference.
@@ -343,7 +347,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional <see cref="Metadata"/>.
@@ -366,7 +372,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional <see cref="Metadata"/>.
@@ -389,7 +397,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional <see cref="Metadata"/>.
@@ -446,10 +456,12 @@ namespace Azure.Storage.Queues
         #region CreateIfNotExists
         /// <summary>
         /// The <see cref="CreateIfNotExists"/>
-        /// operation creates a new queue under the specified account.  If the queue already exists, it is
-        /// not changed.
+        /// operation creates a new queue under the specified account.
+        /// If the queue already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this queue.
@@ -476,10 +488,12 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// The <see cref="CreateIfNotExistsAsync"/>
-        /// operation creates a new queue under the specified account.  If the queue already exists, it is
-        /// not changed.
+        /// operation creates a new queue under the specified account.
+        /// If the queue already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this queue.
@@ -506,10 +520,12 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// The <see cref="CreateIfNotExistsInternal"/>
-        /// operation creates a new queue under the specified account.  If the queue already exists, it is
-        /// not changed.
+        /// operation creates a new queue under the specified account.
+        /// If the queue already exists, it is not changed.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this queue.
@@ -683,7 +699,9 @@ namespace Azure.Storage.Queues
         /// The <see cref="DeleteIfExists"/> operation deletes the specified
         /// queue if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -707,7 +725,9 @@ namespace Azure.Storage.Queues
         /// The <see cref="DeleteIfExistsAsync"/> operation deletes the specified
         /// queue if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -731,7 +751,9 @@ namespace Azure.Storage.Queues
         /// The <see cref="DeleteIfExistsInternal"/> operation deletes the specified
         /// queue if it exists.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -788,7 +810,10 @@ namespace Azure.Storage.Queues
         #region Delete
         /// <summary>
         /// Deletes a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -805,7 +830,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -822,7 +850,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -875,7 +906,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">Get Queue Metadata</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">
+        /// Get Queue Metadata</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -893,7 +927,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">Get Queue Metadata</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">
+        /// Get Queue Metadata</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -911,7 +948,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">Get Queue Metadata</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-metadata">
+        /// Get Queue Metadata</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -963,7 +1003,10 @@ namespace Azure.Storage.Queues
         #region SetMetadata
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">Set Queue Metadata</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">
+        /// Set Queue Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// <see cref="Metadata"/>
@@ -985,7 +1028,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">Set Queue Metadata</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">
+        /// Set Queue Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// <see cref="Metadata"/>
@@ -1007,7 +1053,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">Set Queue Metadata</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-metadata">
+        /// Set Queue Metadata</see>.
         /// </summary>
         /// <param name="metadata">
         /// <see cref="Metadata"/>
@@ -1060,7 +1109,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">Get Queue ACL</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">
+        /// Get Queue ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -1078,7 +1130,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">Get Queue ACL</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">
+        /// Get Queue ACL</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -1096,7 +1151,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">Get Queue ACL</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-acl">
+        /// Get Queue ACL</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1143,7 +1201,10 @@ namespace Azure.Storage.Queues
         #region SetAccessPolicy
         /// <summary>
         /// SetAccessPolicyAsync sets stored access policies for the queue that may be used with Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">Set Queue ACL</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">
+        /// Set Queue ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// IEnumerable of <see cref="QueueSignedIdentifier"/>
@@ -1165,7 +1226,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// SetAccessPolicyAsync sets stored access policies for the queue that may be used with Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">Set Queue ACL</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">
+        /// Set Queue ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// IEnumerable of <see cref="QueueSignedIdentifier"/>
@@ -1187,7 +1251,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// SetAccessPolicyInternal sets stored access policies for the queue that may be used with Shared Access Signatures.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">Set Queue ACL</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-acl">
+        /// Set Queue ACL</see>.
         /// </summary>
         /// <param name="permissions">
         /// IEnumerable of <see cref="QueueSignedIdentifier"/>
@@ -1239,7 +1306,10 @@ namespace Azure.Storage.Queues
         #region ClearMessages
         /// <summary>
         /// Deletes all messages from a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">Clear Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">
+        /// Clear Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>.
@@ -1256,7 +1326,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes all messages from a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">Clear Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">
+        /// Clear Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>.
@@ -1273,7 +1346,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Deletes all messages from a queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">Clear Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/clear-messages">
+        /// Clear Messages</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1322,7 +1398,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1338,7 +1417,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1355,7 +1437,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1375,7 +1460,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1395,7 +1483,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1428,7 +1519,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1461,7 +1555,10 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">Put Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/put-message">
+        /// Put Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -1536,7 +1633,10 @@ namespace Azure.Storage.Queues
         #region ReceiveMessages
         /// <summary>
         /// Receives one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <returns>
         /// <see cref="Response{T}"/> where T is an array of <see cref="QueueMessage"/>
@@ -1545,7 +1645,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <returns>
         /// <see cref="Response{T}"/> where T is an array of <see cref="QueueMessage"/>
@@ -1556,7 +1659,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Receives one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/>
@@ -1571,7 +1677,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/>
@@ -1587,7 +1696,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Receives one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32.
@@ -1615,7 +1727,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32.
@@ -1643,7 +1758,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">Get Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-messages">
+        /// Get Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32.
@@ -1722,7 +1840,10 @@ namespace Azure.Storage.Queues
         #region PeekMessages
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">Peek Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">
+        /// Peek Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to peek from the queue, up to a maximum of 32.
@@ -1745,7 +1866,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">Peek Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">
+        /// Peek Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to peek from the queue, up to a maximum of 32.
@@ -1768,7 +1892,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">Peek Messages</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/peek-messages">
+        /// Peek Messages</see>.
         /// </summary>
         /// <param name="maxMessages">
         /// Optional. A nonzero integer value that specifies the number of messages to peek from the queue, up to a maximum of 32.
@@ -1849,7 +1976,10 @@ namespace Azure.Storage.Queues
         #region DeleteMessage
         /// <summary>
         /// Permanently removes the specified message from its queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">Delete Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">
+        /// Delete Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to delete.</param>
         /// <param name="popReceipt">
@@ -1874,7 +2004,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Permanently removes the specified message from its queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">Delete Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">
+        /// Delete Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to delete.</param>
         /// <param name="popReceipt">
@@ -1899,7 +2032,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Permanently removes the specified message from its queue.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">Delete Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-message2">
+        /// Delete Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to delete.</param>
         /// <param name="popReceipt">
@@ -1957,7 +2093,10 @@ namespace Azure.Storage.Queues
         #region UpdateMessage
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">Update Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">
+        /// Update Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to update.</param>
         /// <param name="popReceipt">
@@ -1994,7 +2133,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">Update Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">
+        /// Update Message</see>.
         /// </summary>
         /// <param name="messageId">ID of the message to update.</param>
         /// <param name="popReceipt">
@@ -2031,7 +2173,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">Update Message</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/update-message">
+        /// Update Message</see>.
         /// </summary>
         /// <param name="messageText">
         /// Updated message text.

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -21,20 +21,26 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// The versions of Azure Queue Storage supported by this client
-        /// library.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// library.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for the Azure Storage services</see>.
         /// </summary>
         public enum ServiceVersion
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// The 2019-02-02 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-02-02">
+            /// Version 2019-02-02</see>.
             /// </summary>
             V2019_02_02 = 1,
 
             /// <summary>
-            /// The 2019-07-07 service version.
+            /// The 2019-07-07 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2019-07-07">
+            /// Version 2019-07-07</see>.
             /// </summary>
             V2019_07_07 = 2,
 
@@ -48,7 +54,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Gets the <see cref="ServiceVersion"/> of the service API used when
         /// making requests.  For more, see
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services" />.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services">
+        /// Versioning for the Azure Storage services</see>.
         /// </summary>
         public ServiceVersion Version { get; }
 

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -109,7 +109,9 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         public QueueServiceClient(string connectionString)
             : this(connectionString, null)
@@ -125,7 +127,9 @@ namespace Azure.Storage.Queues
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
         ///
-        /// For more information, <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">Configure Azure Storage connection strings</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/azure/storage/common/storage-configure-connection-string">
+        /// Configure Azure Storage connection strings</see>.
         /// </param>
         /// <param name="options">
         /// Optional client options that define the transport pipeline
@@ -253,7 +257,9 @@ namespace Azure.Storage.Queues
         /// queues may make multiple requests to the service while fetching
         /// all the values.  Queue names are returned in lexicographic order.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">List Queues</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">
+        /// List Queues</see>.
         /// </summary>
         /// <param name="traits">
         /// Optional trait options for shaping the queues.
@@ -280,7 +286,9 @@ namespace Azure.Storage.Queues
         /// queues may make multiple requests to the service while fetching
         /// all the values.  Queue names are returned in lexicographic order.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">List Queues</see>
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">
+        /// List Queues</see>.
         /// </summary>
         /// <param name="traits">
         /// Optional trait options for shaping the queues.
@@ -307,7 +315,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Returns a single segment of containers starting from the specified marker.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">List Queues</see>
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/list-queues1">
+        /// List Queues</see>.
         /// </summary>
         /// <param name="marker">
         /// Marker from the previous request.
@@ -393,7 +404,10 @@ namespace Azure.Storage.Queues
         #region GetProperties
         /// <summary>
         /// Gets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">Get Queue Service Properties</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">
+        /// Get Queue Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -410,7 +424,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Gets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">Get Queue Service Properties</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">
+        /// Get Queue Service Properties</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -427,7 +444,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Gets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">Get Queue Service Properties</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-properties">
+        /// Get Queue Service Properties</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -474,7 +494,10 @@ namespace Azure.Storage.Queues
         #region SetProperties
         /// <summary>
         /// Sets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">Set Queue Service Properties</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">
+        /// Set Queue Service Properties</see>.
         /// </summary>
         /// <param name="properties">
         /// <see cref="QueueServiceProperties"/>
@@ -496,7 +519,9 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">Set Queue Service Properties</see>.
+        ///
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">
+        /// Set Queue Service Properties</see>.
         /// </summary>
         /// <param name="properties">
         /// <see cref="QueueServiceProperties"/>
@@ -518,7 +543,10 @@ namespace Azure.Storage.Queues
 
         /// <summary>
         /// Sets the properties of the queue service.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">Set Queue Service Properties</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/set-queue-service-properties">
+        /// Set Queue Service Properties</see>.
         /// </summary>
         /// <param name="properties">
         /// <see cref="QueueServiceProperties"/>
@@ -574,7 +602,10 @@ namespace Azure.Storage.Queues
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication is enabled for the storage account.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">Get Queue Service Stats</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">
+        /// Get Queue Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -593,7 +624,10 @@ namespace Azure.Storage.Queues
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication is enabled for the storage account.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">Get Queue Service Stats</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">
+        /// Get Queue Service Stats</see>.
         /// </summary>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -612,7 +646,10 @@ namespace Azure.Storage.Queues
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication is enabled for the storage account.
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">Get Queue Service Stats</see>.
+        ///
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/get-queue-service-stats">
+        /// Get Queue Service Stats</see>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -660,7 +697,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to create.
@@ -688,7 +727,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Creates a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">Create Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/create-queue4">
+        /// Create Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to create.
@@ -718,7 +759,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Deletes a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to delete.
@@ -738,7 +781,9 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Deletes a queue.
         ///
-        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">Delete Queue</see>.
+        /// For more information, see
+        /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-queue3">
+        /// Delete Queue</see>.
         /// </summary>
         /// <param name="queueName">
         /// The name of the queue to delete.

--- a/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
@@ -14,7 +14,9 @@ namespace Azure.Storage.Queues
     /// modify the contents of a <see cref="System.Uri"/> instance to point to
     /// different Azure Storage resources like an account, queue, or message.
     ///
-    /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/addressing-queue-service-resources">Addressing Queue Service Resources</see>.
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/rest/api/storageservices/addressing-queue-service-resources">
+    /// Addressing Queue Service Resources</see>.
     /// </summary>
     public class QueueUriBuilder
     {

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -10,7 +10,10 @@ namespace Azure.Storage.Sas
     /// <summary>
     /// <see cref="QueueSasBuilder"/> is used to generate a Shared Access
     /// Signature (SAS) for an Azure Storage queue.
-    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas" />.
+    ///
+    /// For more information, see
+    /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas">
+    /// Create  a Service SAS</see>.
     /// </summary>
     public class QueueSasBuilder
     {


### PR DESCRIPTION
There's a doc bug where all our `<see href="http://doc...."/>` does not show up in our docs.

For reference https://docs.microsoft.com/en-us/dotnet/api/azure.storage.blobs?view=azure-dotnet
![image](https://user-images.githubusercontent.com/48961492/87100380-1f0e2d00-c201-11ea-8549-309fee5c36e0.png)

