### PR TITLE
Don't enable statistics for Bing searches

### DIFF
--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -105,9 +105,7 @@
             },
             "kind": "CognitiveServices",
             "properties": {
-                "apiProperties": {
-                    "statisticsEnabled": false
-                },
+                "apiProperties": {},
                 "publicNetworkAccess": "Enabled"
             }
         }


### PR DESCRIPTION
Fixes #13383. Some cloud environments do not support it, and we don't
need it anyway.