### PR TITLE
[Event Hubs Client] Tweak for LoadBalancer.IsBalanced

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ConnectionStringPropertiesTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ConnectionStringPropertiesTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ValidateDetectsMultipleEventNames()
+        public void ValidateDetectsMultipleEventHubNames()
         {
             var eventHubName = "myHub";
             var fakeConnection = $"Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=[unique_fake]";

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -223,7 +223,7 @@ try
 {
     // Read events using the consumer client
 }
-catch (EventHubsException ex) where 
+catch (EventHubsException ex) when 
     (ex.Reason == EventHubsException.FailureReason.ConsumerDisconnected)
 {
     // Take action based on a consumer being disconnected


### PR DESCRIPTION
# Summary

The focus of these changes is to adjust the way that the load balancer determines whether or not it is currently in a balanced state.  The new
approach will consider the load balanced if the minimum share of partitions is owned and no attempt was made to claim another partition during the current cycle.

# Last Upstream Rebase

Monday, July 13, 1:42pm (EDT)

# References and Related Issues 

- [Load Balancer: Detect and Handle Reclaiming Ownership on Restart](https://github.com/Azure/azure-sdk-for-net/issues/13191) (#13191)