### PR TITLE
Fix changelog to include date per release check

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-preview.3 (Unreleased)
+## 1.0.0-preview.3 (2020-07-13)
 
 ### Breaking changes
 


### PR DESCRIPTION
Looks like there is a new requirement for changelogs, that was caught during [release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=456221&view=logs&j=bdf8e406-dc8e-5cc2-0f0d-9533782394b8&t=57570c59-45d0-5174-72cc-97385a28d796).