### PR TITLE
[Identity] Refactor credential ctors to simplify internal calling patterns

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -177,9 +177,15 @@ namespace Azure.Identity
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
     {
         protected ManagedIdentityCredential() { }
+        public ManagedIdentityCredential(Azure.Identity.ManagedIdentityCredentialOptions options) { }
         public ManagedIdentityCredential(string clientId = null, Azure.Identity.TokenCredentialOptions options = null) { }
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class ManagedIdentityCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public ManagedIdentityCredentialOptions() { }
+        public string ClientId { get { throw null; } set { } }
     }
     public partial class SharedTokenCacheCredential : Azure.Core.TokenCredential
     {
@@ -205,12 +211,18 @@ namespace Azure.Identity
         protected UsernamePasswordCredential() { }
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId) { }
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options) { }
+        public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, Azure.Identity.UsernamePasswordCredentialOptions options) { }
         public virtual Azure.Identity.AuthenticationRecord Authenticate(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Identity.AuthenticationRecord Authenticate(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Identity.AuthenticationRecord> AuthenticateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class UsernamePasswordCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public UsernamePasswordCredentialOptions() { }
+        public bool EnablePersistentCache { get { throw null; } set { } }
     }
     public partial class VisualStudioCodeCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
@@ -13,5 +13,7 @@ namespace Azure.Identity
         /// If set to true the credential will store tokens in a cache persisted to the machine, protected to the current user, which can be shared by other credentials and processes.
         /// </summary>
         public bool EnablePersistentCache { get; set; }
+
+        internal MsalConfidentialClient Client { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
@@ -60,8 +60,8 @@ namespace Azure.Identity
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
-        public ClientSecretCredential(string tenantId, string clientId, string clientSecret, ClientSecretCredentialOptions options)
-            : this(tenantId, clientId, clientSecret, (TokenCredentialOptions)options)
+        public ClientSecretCredential(string tenantId, string clientId, string clientSecret, TokenCredentialOptions options)
+            : this(tenantId, clientId, clientSecret, new ClientSecretCredentialOptions { Pipeline = CredentialPipeline.GetInstance(options), AuthorityHost = options?.AuthorityHost })
         {
         }
 
@@ -72,40 +72,18 @@ namespace Azure.Identity
         /// <param name="clientId">The client (application) ID of the service principal</param>
         /// <param name="clientSecret">A client secret that was generated for the App Registration used to authenticate the client.</param>
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
-        public ClientSecretCredential(string tenantId, string clientId, string clientSecret, TokenCredentialOptions options)
-            : this(new MsalConfidentialClientOptions(tenantId: tenantId ?? throw new ArgumentNullException(nameof(tenantId)),
-                                                     clientId: clientId ?? throw new ArgumentNullException(nameof(clientId)),
-                                                     secret: clientSecret ?? throw new ArgumentNullException(nameof(clientSecret)),
-                                                     options: options))
+        public ClientSecretCredential(string tenantId, string clientId, string clientSecret, ClientSecretCredentialOptions options)
         {
+            TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+
+            ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+
+            ClientSecret = clientSecret ?? throw new ArgumentNullException(nameof(clientSecret));
+
+            _pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
+
+            _client = options?.Client ?? new MsalConfidentialClient(new MsalConfidentialClientOptions(tenantId, clientId, clientSecret, _pipeline));
         }
-
-        internal ClientSecretCredential(MsalConfidentialClientOptions clientOptions)
-        {
-            TenantId = clientOptions.TenantId;
-
-            ClientId = clientOptions.ClientId;
-
-            ClientSecret = clientOptions.Secret;
-
-            _pipeline = clientOptions.Pipeline;
-
-            _client = new MsalConfidentialClient(clientOptions);
-        }
-
-        internal ClientSecretCredential(string tenantId, string clientId, string secret, CredentialPipeline pipeline, MsalConfidentialClient client)
-        {
-            TenantId = tenantId;
-
-            ClientId = clientId;
-
-            ClientSecret = secret;
-
-            _pipeline = pipeline;
-
-            _client = client;
-        }
-
 
         /// <summary>
         /// Obtains a token from the Azure Active Directory service, using the specified client secret to authenticate. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/ClientSecretCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ClientSecretCredentialOptions.cs
@@ -13,5 +13,7 @@ namespace Azure.Identity
         /// If set to true the credential will store tokens in a persistent cache shared by other credentials.
         /// </summary>
         public bool EnablePersistentCache { get; set; }
+
+        internal MsalConfidentialClient Client { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/CredentialPipeline.cs
+++ b/sdk/identity/Azure.Identity/src/CredentialPipeline.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity
 
         public static CredentialPipeline GetInstance(TokenCredentialOptions options)
         {
-            return (options is null) ? s_Singleton.Value : new CredentialPipeline(options);
+            return (options is null) ? s_Singleton.Value : options.Pipeline ?? new CredentialPipeline(options);
         }
 
         public Uri AuthorityHost { get; }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -52,15 +52,10 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="options">Options that configure the management of the requests sent to Azure Active Directory services, and determine which credentials are included in the <see cref="DefaultAzureCredential"/> authentication flow.</param>
         public DefaultAzureCredential(DefaultAzureCredentialOptions options)
-            : this(new DefaultAzureCredentialFactory(CredentialPipeline.GetInstance(options)), options)
         {
-        }
+            _pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
 
-        internal DefaultAzureCredential(DefaultAzureCredentialFactory factory, DefaultAzureCredentialOptions options)
-        {
-            _pipeline = factory.Pipeline;
-
-            _sources = GetDefaultAzureCredentialChain(factory, options);
+            _sources = GetDefaultAzureCredentialChain(options?.CredentialFactory ?? new DefaultAzureCredentialFactory(_pipeline), options);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -16,22 +16,22 @@ namespace Azure.Identity
 
         public virtual TokenCredential CreateEnvironmentCredential()
         {
-            return new EnvironmentCredential(Pipeline);
+            return new EnvironmentCredential(new TokenCredentialOptions { Pipeline = Pipeline });
         }
 
         public virtual TokenCredential CreateManagedIdentityCredential(string clientId)
         {
-            return new ManagedIdentityCredential(clientId, Pipeline);
+            return new ManagedIdentityCredential(new ManagedIdentityCredentialOptions { ClientId = clientId, Pipeline = Pipeline });
         }
 
         public virtual TokenCredential CreateSharedTokenCacheCredential(string tenantId, string username)
         {
-            return new SharedTokenCacheCredential(tenantId, username, Pipeline);
+            return new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = tenantId, Username = username, Pipeline = Pipeline });
         }
 
         public virtual TokenCredential CreateInteractiveBrowserCredential(string tenantId)
         {
-            return new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, Pipeline, true);
+            return new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TenantId = tenantId, Pipeline = Pipeline, EnablePersistentCache = true });
         }
 
         public virtual TokenCredential CreateAzureCliCredential()
@@ -41,12 +41,12 @@ namespace Azure.Identity
 
         public virtual TokenCredential CreateVisualStudioCredential(string tenantId)
         {
-            return new VisualStudioCredential(tenantId, Pipeline, default, default);
+            return new VisualStudioCredential(new VisualStudioCredentialOptions { TenantId = tenantId, Pipeline = Pipeline });
         }
 
         public virtual TokenCredential CreateVisualStudioCodeCredential(string tenantId)
         {
-            return new VisualStudioCodeCredential(tenantId, Pipeline, default, default);
+            return new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = tenantId, Pipeline = Pipeline });
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
@@ -95,5 +95,7 @@ namespace Azure.Identity
         /// Specifies whether the <see cref="VisualStudioCodeCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
         /// </summary>
         public bool ExcludeVisualStudioCodeCredential { get; set; } = false;
+
+        internal DefaultAzureCredentialFactory CredentialFactory { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
@@ -35,5 +35,7 @@ namespace Azure.Identity
         /// The <see cref="Identity.AuthenticationRecord"/> captured from a previous authentication.
         /// </summary>
         public AuthenticationRecord AuthenticationRecord { get; set; }
+
+        internal MsalPublicClient Client { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
@@ -27,7 +27,7 @@ namespace Azure.Identity
         /// Creates a new <see cref="InteractiveBrowserCredential"/> with the specified options, which will authenticate users.
         /// </summary>
         public InteractiveBrowserCredential()
-            : this(null, Constants.DeveloperSignOnClientId, CredentialPipeline.GetInstance(null), false)
+            : this((InteractiveBrowserCredentialOptions)null)
         {
 
         }
@@ -37,10 +37,16 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="options">The client options for the newly created <see cref="InteractiveBrowserCredential"/>.</param>
         public InteractiveBrowserCredential(InteractiveBrowserCredentialOptions options)
-            : this(options?.TenantId, options?.ClientId ?? Constants.DeveloperSignOnClientId, CredentialPipeline.GetInstance(options), options?.EnablePersistentCache ?? false)
         {
             _disableAutomaticAuthentication = options?.DisableAutomaticAuthentication ?? false;
+
             _record = options?.AuthenticationRecord;
+
+            _pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
+
+            var clientId = options?.ClientId ?? Constants.DeveloperSignOnClientId;
+
+            _client = options?.Client ?? new MsalPublicClient(_pipeline.HttpPipeline, _pipeline.AuthorityHost, clientId, options?.TenantId, "http://localhost", options?.EnablePersistentCache ?? false);
         }
 
         /// <summary>
@@ -48,7 +54,7 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="clientId">The client id of the application to which the users will authenticate</param>
         public InteractiveBrowserCredential(string clientId)
-            : this(null, clientId, CredentialPipeline.GetInstance(null), false)
+            : this(new InteractiveBrowserCredentialOptions { ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(null) })
         {
 
         }
@@ -61,24 +67,8 @@ namespace Azure.Identity
         /// TODO: need to link to info on how the application has to be created to authenticate users, for multiple applications
         /// <param name="options">The client options for the newly created <see cref="InteractiveBrowserCredential"/>.</param>
         public InteractiveBrowserCredential(string tenantId, string clientId, TokenCredentialOptions options = default)
-            : this(tenantId, clientId, CredentialPipeline.GetInstance(options), false)
+            : this(new InteractiveBrowserCredentialOptions { TenantId = tenantId, ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(options), AuthorityHost = options?.AuthorityHost })
         {
-        }
-
-        internal InteractiveBrowserCredential(string tenantId, string clientId, CredentialPipeline pipeline, bool attachSharedCache)
-        {
-            if (clientId is null) throw new ArgumentNullException(nameof(clientId));
-
-            _pipeline = pipeline;
-
-            _client = _pipeline.CreateMsalPublicClient(clientId, tenantId, "http://localhost", attachSharedCache);
-        }
-
-        internal InteractiveBrowserCredential(CredentialPipeline pipeline, MsalPublicClient client)
-        {
-            _pipeline = pipeline;
-
-            _client = client;
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
@@ -35,5 +35,7 @@ namespace Azure.Identity
         /// The <see cref="Identity.AuthenticationRecord"/> captured from a previous authentication.
         /// </summary>
         public AuthenticationRecord AuthenticationRecord { get; set; }
+
+        internal MsalPublicClient Client { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityCredential.cs
@@ -34,6 +34,17 @@ namespace Azure.Identity
         }
 
         /// <summary>
+        /// Creates an instance of the <see cref="ManagedIdentityCredential"/>, capable of authenticating a resource with a managed identity, with the specified options.
+        /// </summary>
+        /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
+        public ManagedIdentityCredential(ManagedIdentityCredentialOptions options)
+        {
+            _pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
+
+            _client = options?.Client ?? new ManagedIdentityClient(_pipeline, options?.ClientId);
+        }
+
+        /// <summary>
         /// Creates an instance of the ManagedIdentityCredential capable of authenticating a resource with a managed identity.
         /// </summary>
         /// <param name="clientId">
@@ -42,21 +53,8 @@ namespace Azure.Identity
         /// </param>
         /// <param name="options">Options to configure the management of the requests sent to the Azure Active Directory service.</param>
         public ManagedIdentityCredential(string clientId = null, TokenCredentialOptions options = null)
-            : this(clientId, CredentialPipeline.GetInstance(options))
+            : this(new ManagedIdentityCredentialOptions { ClientId = clientId, Pipeline = CredentialPipeline.GetInstance(options), AuthorityHost = options?.AuthorityHost })
         {
-        }
-
-        internal ManagedIdentityCredential(string clientId, CredentialPipeline pipeline)
-            : this(pipeline, new ManagedIdentityClient(pipeline, clientId))
-        {
-        }
-
-        internal ManagedIdentityCredential(CredentialPipeline pipeline, ManagedIdentityClient client)
-        {
-
-            _pipeline = pipeline;
-
-            _client = client;
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityCredentialOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Options used to configure the <see cref="ManagedIdentityCredential"/>.
+    /// </summary>
+    public class ManagedIdentityCredentialOptions : TokenCredentialOptions
+    {
+        /// <summary>
+        /// The client id of the user assigned managed identity to authenticate. If not specified the <see cref="ManagedIdentityCredential"/> will authenticate the system assigned identity.  More information on user assigned managed identities can be found here:
+        /// https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm
+        /// </summary>
+        public string ClientId { get; set; }
+
+        internal ManagedIdentityClient Client { get; set; }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -27,6 +27,8 @@ namespace Azure.Identity
         {
             tenantId ??= Constants.OrganizationsTenantId;
 
+            authorityHost ??= KnownAuthorityHosts.GetDefault();
+
             var authorityUri = new UriBuilder(authorityHost.Scheme, authorityHost.Host, authorityHost.Port, tenantId).Uri;
 
             PublicClientApplicationBuilder pubAppBuilder = PublicClientApplicationBuilder.Create(clientId).WithAuthority(authorityUri).WithHttpClientFactory(new HttpPipelineClientFactory(pipeline));

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
@@ -19,5 +19,7 @@ namespace Azure.Identity
         /// development tools, in the case multiple accounts are found in the shared token.
         /// </summary>
         public string TenantId { get; set; }
+
+        internal MsalPublicClient Client { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -20,5 +20,7 @@ namespace Azure.Identity
             get { return _authorityHost ?? KnownAuthorityHosts.GetDefault(); }
             set { _authorityHost = value; }
         }
+
+        internal CredentialPipeline Pipeline { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/UsernamePasswordCredential.cs
+++ b/sdk/identity/Azure.Identity/src/UsernamePasswordCredential.cs
@@ -44,7 +44,7 @@ namespace Azure.Identity
         /// <param name="tenantId">The Azure Active Directory tenant (directory) ID or name.</param>
         /// <param name="clientId">The client (application) ID of an App Registration in the tenant.</param>
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId)
-            : this(username, password, tenantId, clientId, (TokenCredentialOptions)null)
+            : this(username, password, tenantId, clientId, (UsernamePasswordCredentialOptions)null)
         {
 
         }
@@ -59,24 +59,28 @@ namespace Azure.Identity
         /// <param name="clientId">The client (application) ID of an App Registration in the tenant.</param>
         /// <param name="options">The client options for the newly created UsernamePasswordCredential</param>
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, TokenCredentialOptions options)
-            : this(username, password, tenantId, clientId, CredentialPipeline.GetInstance(options))
+            : this(username, password, tenantId, clientId, new UsernamePasswordCredentialOptions { Pipeline = CredentialPipeline.GetInstance(options), AuthorityHost = options?.AuthorityHost })
         {
         }
 
-        internal UsernamePasswordCredential(string username, string password, string tenantId, string clientId, CredentialPipeline pipeline)
-            : this(username, password, pipeline, pipeline.CreateMsalPublicClient(clientId, tenantId))
-        {
-        }
-
-        internal UsernamePasswordCredential(string username, string password, CredentialPipeline pipeline, MsalPublicClient client)
+        /// <summary>
+        /// Creates an instance of the <see cref="UsernamePasswordCredential"/> with the details needed to authenticate against Azure Active Directory with a simple username
+        /// and password.
+        /// </summary>
+        /// <param name="username">The user account's user name, UPN.</param>
+        /// <param name="password">The user account's password.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID or name.</param>
+        /// <param name="clientId">The client (application) ID of an App Registration in the tenant.</param>
+        /// <param name="options">The client options for the newly created UsernamePasswordCredential</param>
+        public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, UsernamePasswordCredentialOptions options)
         {
             _username = username ?? throw new ArgumentNullException(nameof(username));
 
             _password = (password != null) ? password.ToSecureString() : throw new ArgumentNullException(nameof(password));
 
-            _pipeline = pipeline;
+            _pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
 
-            _client = client;
+            _client = options?.Client ?? new MsalPublicClient(_pipeline.HttpPipeline, _pipeline.AuthorityHost, clientId, tenantId, redirectUrl: null, options?.EnablePersistentCache ?? false);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/UsernamePasswordCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/UsernamePasswordCredentialOptions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Options to configure the <see cref="UsernamePasswordCredential"/>.
+    /// </summary>
+    public class UsernamePasswordCredentialOptions : TokenCredentialOptions
+    {
+        /// <summary>
+        /// If set to true the credential will store tokens in a persistent cache shared by other user credentials.
+        /// </summary>
+        public bool EnablePersistentCache { get; set; }
+
+        internal MsalPublicClient Client { get; set; }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -36,20 +36,17 @@ namespace Azure.Identity
         /// Creates a new instance of the <see cref="VisualStudioCodeCredential"/> with the specified options.
         /// </summary>
         /// <param name="options">Options for configuring the credential.</param>
-        public VisualStudioCodeCredential(VisualStudioCodeCredentialOptions options) : this(options?.TenantId, CredentialPipeline.GetInstance(options), default, default) { }
-
-        internal VisualStudioCodeCredential(string tenantId, CredentialPipeline pipeline, IFileSystemService fileSystem, IVisualStudioCodeAdapter vscAdapter)
-            : this(tenantId, pipeline, default, fileSystem, vscAdapter)
+        public VisualStudioCodeCredential(VisualStudioCodeCredentialOptions options)
         {
-        }
+            _tenantId = options?.TenantId ?? "common";
 
-        internal VisualStudioCodeCredential(string tenantId, CredentialPipeline pipeline, MsalPublicClient client, IFileSystemService fileSystem, IVisualStudioCodeAdapter vscAdapter)
-        {
-            _tenantId = tenantId ?? "common";
-            _pipeline = pipeline;
-            _client = client ?? pipeline.CreateMsalPublicClient(ClientId);
-            _fileSystem = fileSystem ?? FileSystemService.Default;
-            _vscAdapter = vscAdapter ?? GetVscAdapter();
+            _fileSystem = options?.FileSystem ?? FileSystemService.Default;
+
+            _vscAdapter = options?.VscAdapter ?? GetVscAdapter();
+
+            _pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
+
+            _client = options?.Client ?? new MsalPublicClient(_pipeline.HttpPipeline, options?.AuthorityHost, ClientId, options?.TenantId);
         }
 
         /// <inheritdoc />

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredentialOptions.cs
@@ -16,5 +16,11 @@ namespace Azure.Identity
         /// The tenant ID the user will be authenticated to. If not specified the user will be authenticated to the tenant the user originally authenticated to via the Visual Studio Code Azure Account plugin.
         /// </summary>
         public string TenantId { get; set; }
+
+        internal IFileSystemService FileSystem { get; set; }
+
+        internal IVisualStudioCodeAdapter VscAdapter { get; set; }
+
+        internal MsalPublicClient Client { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
@@ -40,14 +40,12 @@ namespace Azure.Identity
         /// Creates a new instance of the <see cref="VisualStudioCredential"/> with the specified options.
         /// </summary>
         /// <param name="options">Options for configuring the credential.</param>
-        public VisualStudioCredential(VisualStudioCredentialOptions options) : this(options?.TenantId, CredentialPipeline.GetInstance(options), default, default) { }
-
-        internal VisualStudioCredential(string tenantId, CredentialPipeline pipeline, IFileSystemService fileSystem, IProcessService processService)
+        public VisualStudioCredential(VisualStudioCredentialOptions options)
         {
-            _tenantId = tenantId;
-            _pipeline = pipeline ?? CredentialPipeline.GetInstance(null);
-            _fileSystem = fileSystem ?? FileSystemService.Default;
-            _processService = processService ?? ProcessService.Default;
+            _tenantId = options?.TenantId;
+            _pipeline = CredentialPipeline.GetInstance(options);
+            _fileSystem = options?.FileSystem ?? FileSystemService.Default;
+            _processService = options?.ProcessService ?? ProcessService.Default;
         }
 
         /// <inheritdoc />

--- a/sdk/identity/Azure.Identity/src/VisualStudioCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCredentialOptions.cs
@@ -12,5 +12,9 @@ namespace Azure.Identity
         /// The tenant ID the user will be authenticated to. If not specified the user will be authenticated to their home tenant.
         /// </summary>
         public string TenantId { get; set; }
+
+        internal IFileSystemService FileSystem { get; set; }
+
+        internal IProcessService ProcessService { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AzureIdentityEventSourceTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureIdentityEventSourceTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Identity.Tests
         {
             var mockMsalClient = new MockMsalConfidentialClient(AuthenticationResultFactory.Create());
 
-            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new ClientSecretCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "ClientSecretCredential.GetToken";
 
@@ -66,7 +66,7 @@ namespace Azure.Identity.Tests
 
             var mockAadClient = new MockAadIdentityClient(() => new AccessToken(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow.AddMinutes(10)));
 
-            var credential = InstrumentClient(new ClientCertificateCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new X509Certificate2(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new ClientCertificateCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new X509Certificate2(), new ClientCertificateCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "ClientCertificateCredential.GetToken";
 
@@ -78,7 +78,7 @@ namespace Azure.Identity.Tests
         {
             var mockMsalClient = new MockMsalPublicClient() { DeviceCodeAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: Guid.NewGuid().ToString(), expiresOn: DateTimeOffset.UtcNow.AddMinutes(10)); } };
 
-            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, new DeviceCodeCredentialOptions { ClientId = Guid.NewGuid().ToString(), Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "DeviceCodeCredential.GetToken";
 
@@ -90,7 +90,7 @@ namespace Azure.Identity.Tests
         {
             var mockMsalClient = new MockMsalPublicClient() { InteractiveAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: Guid.NewGuid().ToString(), expiresOn: DateTimeOffset.UtcNow.AddMinutes(10)); } };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential(CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "InteractiveBrowserCredential.GetToken";
 
@@ -106,7 +106,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: Guid.NewGuid().ToString(), expiresOn: DateTimeOffset.UtcNow.AddMinutes(10)); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "SharedTokenCacheCredential.GetToken";
 
@@ -120,7 +120,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalConfidentialClient(new MockClientException(expExMessage));
 
-            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new ClientSecretCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "ClientSecretCredential.GetToken";
 
@@ -134,7 +134,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalConfidentialClient(new MockClientException(expExMessage));
 
-            var credential = InstrumentClient(new ClientCertificateCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new X509Certificate2(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new ClientCertificateCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new X509Certificate2(), new ClientCertificateCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "ClientCertificateCredential.GetToken";
 
@@ -148,7 +148,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalPublicClient() { DeviceCodeAuthFactory = (_) => throw new MockClientException(expExMessage) };
 
-            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, new DeviceCodeCredentialOptions { TenantId = Guid.NewGuid().ToString(), Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "DeviceCodeCredential.GetToken";
 
@@ -162,7 +162,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalPublicClient() { InteractiveAuthFactory = (_) => throw new MockClientException(expExMessage) };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential(CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "InteractiveBrowserCredential.GetToken";
 
@@ -180,7 +180,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => throw new MockClientException(expExMessage)
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var method = "SharedTokenCacheCredential.GetToken";
 

--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialTests.cs
@@ -110,7 +110,8 @@ namespace Azure.Identity.Tests
             var mockCert = new X509Certificate2(certificatePath);
 
             ClientCertificateCredential credential = InstrumentClient(
-                usePemFile ? new ClientCertificateCredential(expectedTenantId, expectedClientId, certificatePathPem, CredentialPipeline.GetInstance(null), mockMsalClient) : new ClientCertificateCredential(expectedTenantId, expectedClientId, mockCert, CredentialPipeline.GetInstance(null), mockMsalClient)
+                usePemFile ? new ClientCertificateCredential(expectedTenantId, expectedClientId, certificatePathPem, new ClientCertificateCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient })
+                           : new ClientCertificateCredential(expectedTenantId, expectedClientId, mockCert, new ClientCertificateCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient })
             );
 
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));

--- a/sdk/identity/Azure.Identity/tests/ClientSecretCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientSecretCredentialTests.cs
@@ -65,7 +65,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalConfidentialClient(new MockClientException(expectedInnerExMessage));
 
-            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new ClientSecretCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 

--- a/sdk/identity/Azure.Identity/tests/EnvironmentCredentialProviderTests.cs
+++ b/sdk/identity/Azure.Identity/tests/EnvironmentCredentialProviderTests.cs
@@ -102,7 +102,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalConfidentialClient(new MockClientException(expectedInnerExMessage));
 
-            ClientSecretCredential innerCred = new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(null), mockMsalClient);
+            ClientSecretCredential innerCred = new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new ClientSecretCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient });
 
             var credential = InstrumentClient(new EnvironmentCredential(CredentialPipeline.GetInstance(null), innerCred));
 

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalPublicClient() { InteractiveAuthFactory = (_) => { throw new MockClientException(expInnerExMessage); } };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential(CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -52,7 +52,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { throw new MockClientException(expInnerExMessage); }
             };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential(CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -84,7 +84,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { throw new MsalUiRequiredException("errorCode", "message"); }
             };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential(CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialImdsLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialImdsLiveTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Identity.Tests
             // if we're in playback mode we need to mock the ImdsAvailable call since we won't be able to open a connection
             var client = (Mode == RecordedTestMode.Playback) ? new MockManagedIdentityClient(pipeline, clientId) { ImdsAvailableFunc = _ => true } : new ManagedIdentityClient(pipeline, clientId);
 
-            var cred = new ManagedIdentityCredential(pipeline, client);
+            var cred = new ManagedIdentityCredential(new ManagedIdentityCredentialOptions { Pipeline = pipeline, Client = client });
 
             return cred;
         }

--- a/sdk/identity/Azure.Identity/tests/SharedTokenCacheCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/SharedTokenCacheCredentialTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -50,7 +50,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -72,7 +72,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -94,7 +94,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(tenantId, null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = tenantId, Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -115,7 +115,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(tenantId, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = tenantId, Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
@@ -137,14 +137,14 @@ namespace Azure.Identity.Tests
             };
 
             // without username
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
             Assert.AreEqual(SharedTokenCacheCredential.NoAccountsInCacheMessage, ex.Message);
 
             // with username
-            var credential2 = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential2 = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex2 = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential2.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -152,14 +152,14 @@ namespace Azure.Identity.Tests
 
 
             // with tenantId
-            var credential3 = InstrumentClient(new SharedTokenCacheCredential(Guid.NewGuid().ToString(), null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential3 = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = Guid.NewGuid().ToString(), Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex3 = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential3.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
             Assert.AreEqual(SharedTokenCacheCredential.NoAccountsInCacheMessage, ex3.Message);
 
             // with tenantId and username
-            var credential4= InstrumentClient(new SharedTokenCacheCredential(Guid.NewGuid().ToString(), "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential4 = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = Guid.NewGuid().ToString(), Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex4 = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential4.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -182,7 +182,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -206,7 +206,7 @@ namespace Azure.Identity.Tests
             };
 
             // with username
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -231,7 +231,7 @@ namespace Azure.Identity.Tests
             };
 
             // with username
-            var credential = InstrumentClient(new SharedTokenCacheCredential(tenantId, null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = tenantId, Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -256,7 +256,7 @@ namespace Azure.Identity.Tests
             };
 
             // with username
-            var credential = InstrumentClient(new SharedTokenCacheCredential(tenantId, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = tenantId, Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -280,7 +280,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -304,7 +304,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(mockuserGuestTenantId, null, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = mockuserGuestTenantId, Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -328,7 +328,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: expToken, expiresOn: expExpiresOn); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential(mockuserTenantId, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { TenantId = mockuserTenantId, Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
@@ -350,7 +350,7 @@ namespace Azure.Identity.Tests
             };
 
             // with username
-            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions { Username = "mockuser@mockdomain.com", Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 

--- a/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialTests.cs
@@ -26,8 +26,10 @@ namespace Azure.Identity.Tests
 
             var username = Guid.NewGuid().ToString();
             var password = Guid.NewGuid().ToString();
+            var clientId = Guid.NewGuid().ToString();
+            var tenantId = Guid.NewGuid().ToString();
 
-            var credential = InstrumentClient(new UsernamePasswordCredential(username, password, CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new UsernamePasswordCredential(username, password, clientId, tenantId, new UsernamePasswordCredentialOptions { Pipeline = CredentialPipeline.GetInstance(null), Client = mockMsalClient }));
 
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
@@ -41,8 +41,9 @@ namespace Azure.Identity.Tests
             var fileSystem = CreateTestFileSystemService(cloudName: cloudName);
             using IDisposable fixture = await CreateRefreshTokenFixtureAsync(tenantId, cloudName);
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystem, default));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId, FileSystem = fileSystem });
+
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
@@ -55,8 +56,8 @@ namespace Azure.Identity.Tests
             var fileSystemService = new TestFileSystemService { ReadAllHandler = s => throw new FileNotFoundException() };
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId, FileSystem = fileSystemService, VscAdapter = vscAdapter });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
@@ -69,8 +70,8 @@ namespace Azure.Identity.Tests
             var fileSystemService = new TestFileSystemService { ReadAllHandler = s => "{a,}" };
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId, FileSystem = fileSystemService, VscAdapter = vscAdapter });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
@@ -84,8 +85,8 @@ namespace Azure.Identity.Tests
             var fileSystemService = CreateTestFileSystemService();
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(default, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { FileSystem = fileSystemService, VscAdapter = vscAdapter });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -101,8 +102,8 @@ namespace Azure.Identity.Tests
             var fileSystemService = CreateTestFileSystemService(tenantId, cloudName);
             using IDisposable fixture = await CreateRefreshTokenFixtureAsync(tenantId, cloudName);
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(options), fileSystemService, default));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { FileSystem = fileSystemService });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -115,8 +116,8 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
             var fileSystem = CreateTestFileSystemService();
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystem, vscAdapter));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId, FileSystem = fileSystem, VscAdapter = vscAdapter });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
 
             Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
         }
@@ -128,8 +129,8 @@ namespace Azure.Identity.Tests
             var fileSystemService = CreateTestFileSystemService();
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", "{}");
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId, FileSystem = fileSystemService, VscAdapter = vscAdapter });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
 
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
         }
@@ -141,8 +142,8 @@ namespace Azure.Identity.Tests
             var fileSystemService = CreateTestFileSystemService();
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", Guid.NewGuid().ToString());
 
-            TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
+            var options = Recording.InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId, FileSystem = fileSystemService, VscAdapter = vscAdapter });
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options));
 
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
         }

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CreateTestFileSystem();
             var (expectedToken, expectedExpiresOn, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -39,7 +39,7 @@ namespace Azure.Identity.Tests
             var (expectedToken, expectedExpiresOn, processOutput) = CreateTestToken();
             var testProcess1 = new TestProcess { Error = "Error" };
             var testProcess2 = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess1, testProcess2)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess1, testProcess2) }));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -73,7 +73,7 @@ namespace Azure.Identity.Tests
                 }
             };
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, testProcessFactory));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = testProcessFactory }));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -94,7 +94,7 @@ namespace Azure.Identity.Tests
                 return false;
             };
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), cts.Token));
         }
 
@@ -106,7 +106,7 @@ namespace Azure.Identity.Tests
             var testProcess = new TestProcess { Timeout = 10000 };
             testProcess.Started += (o, e) => cts.Cancel();
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), cts.Token));
         }
 
@@ -118,7 +118,7 @@ namespace Azure.Identity.Tests
 
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -127,7 +127,7 @@ namespace Azure.Identity.Tests
         {
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, new TestFileSystemService(), new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = new TestFileSystemService(), ProcessService = new TestProcessService(testProcess) }));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -137,7 +137,7 @@ namespace Azure.Identity.Tests
             var (_, _, processOutput) = CreateTestToken();
             var fileSystem = new TestFileSystemService { ReadAllHandler = s => throw new DirectoryNotFoundException() };
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -147,7 +147,7 @@ namespace Azure.Identity.Tests
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
             var fileSystem = new TestFileSystemService { ReadAllHandler = p => "{\"Some\": false}" };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -156,7 +156,7 @@ namespace Azure.Identity.Tests
         {
             var testProcess = new TestProcess { Error = "Some error" };
             var fileSystem = CreateTestFileSystem();
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -165,7 +165,7 @@ namespace Azure.Identity.Tests
         {
             var testProcess = new TestProcess { Output = "Not Json" };
             var fileSystem = CreateTestFileSystem();
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(new VisualStudioCredentialOptions { FileSystem = fileSystem, ProcessService = new TestProcessService(testProcess) }));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 


### PR DESCRIPTION
This PR removes most of the internal constructors which were previously used for internal construction of credentials, and for testing credentials. The large number of internal constructors added a lot of complexity to construction as it was not always obvious which public constructors called into which internal constructors. Also in several cases these internal constructors had separate implementations which lead to inconsistency depending on which constructor was called, and tests which missed issues because they constructed credentials directly via an internal constructor.

In order to eliminate the need for the internal constructors on credentials we have moved this internal configuration to the options which are specified when constructing the credentials. These internal configurations are exposed as internal properties on the options classes. For instance on the base `TokenCredentialOptions` we have added the internal property `Pipeline' which allows internal callers to configure the `CredentialPipeline` which the credential should use. This is used in cases where we have many credentials which are intended to share a pipeline such as in the case of the `DefaultAzureCredential` or `EnvironmentCredential`. Also specific credential options classes add internal configuration properties which are specific to their credentials. A more specific example demonstrating this is the `VisualStudioCodeCredential` adds the internal properties `FileSystem`, `VscAdapter` and `Client` which allow the internal configuration of the file system abstraction, the Visual Studio Code abstraction and the MSAL public client which is used.
