### PR TITLE
[FormRecognizer] Move receipt documentation links to aka.ms

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -197,7 +197,7 @@ using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
     RecognizedFormCollection receipts = await client.StartRecognizeReceiptsAsync(stream).WaitForCompletionAsync();
 
     // To see the list of the supported fields returned by service and its corresponding types, consult:
-    // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+    // https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
     foreach (RecognizedForm receipt in receipts)
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
@@ -25,7 +25,7 @@ To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method
 RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
 // To see the list of the supported fields returned by service and its corresponding types, consult:
-// https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+// https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
 foreach (RecognizedForm receipt in receipts)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
@@ -34,7 +34,7 @@ The `Receipt` class is composed of multiple `FormField<T>` properties. `FormFiel
 public Receipt(RecognizedForm recognizedForm)
 {
     // To see the list of the supported fields returned by service and its corresponding types, consult:
-    // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+    // https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
     ReceiptType = ConvertStringField("ReceiptType", recognizedForm.Fields);
     MerchantAddress = ConvertStringField("MerchantAddress", recognizedForm.Fields);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Receipt.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Receipt.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.Samples
         public Receipt(RecognizedForm recognizedForm)
         {
             // To see the list of the supported fields returned by service and its corresponding types, consult:
-            // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+            // https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
             ReceiptType = ConvertStringField("ReceiptType", recognizedForm.Fields);
             MerchantAddress = ConvertStringField("MerchantAddress", recognizedForm.Fields);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/ReceiptItem.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/ReceiptItem.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.Samples
         public ReceiptItem(FormField<string> name, FormField<float> quantity, FormField<float> price, FormField<float> totalPrice)
         {
             // To see the list of the supported fields returned by service and its corresponding types, consult:
-            // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+            // https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
             Name = name;
             Quantity = quantity;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
@@ -32,7 +32,7 @@ namespace Azure.AI.FormRecognizer.Samples
                 RecognizedFormCollection receipts = await client.StartRecognizeReceiptsAsync(stream).WaitForCompletionAsync();
 
                 // To see the list of the supported fields returned by service and its corresponding types, consult:
-                // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+                // https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
                 foreach (RecognizedForm receipt in receipts)
                 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.Samples
             RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
             // To see the list of the supported fields returned by service and its corresponding types, consult:
-            // https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult
+            // https://aka.ms/azsdk/python/formrecognizer/receiptfields
 
             foreach (RecognizedForm receipt in receipts)
             {


### PR DESCRIPTION
Replacing occurrences of `https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview/operations/GetAnalyzeReceiptResult` with an aka.ms link: `https://aka.ms/azsdk/python/formrecognizer/receiptfields`.

Python's link is being reused since we're trying to keep the number of aka.ms links to a minimum.

Fixes #12968.