### PR TITLE
Updated SasBuilder to correctly order raw string permissions

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.5.0-preview.6 (Unreleased)
 - Fixed bug where BlockBlobClient and PageBlobClient would throw NullReferenceExceptions when using Uri constructor.
 - Fixed bug where .WithSnapshot() and .WithVersion() would URL-encode the name of the new clients.
+- Updated BlobSasBuilder to correctly order raw string permissions and make the permissions lowercase.
 
 ## 12.5.0-preview.5 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -1384,7 +1384,6 @@ namespace Azure.Storage.Sas
         public void SetPermissions(Azure.Storage.Sas.BlobSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.BlobVersionSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.SnapshotSasPermissions permissions) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
         public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.BlobSasQueryParameters ToSasQueryParameters(Azure.Storage.Blobs.Models.UserDelegationKey userDelegationKey, string accountName) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -1384,7 +1384,9 @@ namespace Azure.Storage.Sas
         public void SetPermissions(Azure.Storage.Sas.BlobSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.BlobVersionSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.SnapshotSasPermissions permissions) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
+        public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.BlobSasQueryParameters ToSasQueryParameters(Azure.Storage.Blobs.Models.UserDelegationKey userDelegationKey, string accountName) { throw null; }
         public Azure.Storage.Sas.BlobSasQueryParameters ToSasQueryParameters(Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -209,8 +209,22 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
+            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                permissions: rawPermissions,
+                validPermissionsInOrder: s_validPermissionsInOrder);
         }
+
+        private static readonly List<char> s_validPermissionsInOrder = new List<char>
+        {
+            Constants.Sas.Permissions.Read,
+            Constants.Sas.Permissions.Add,
+            Constants.Sas.Permissions.Create,
+            Constants.Sas.Permissions.Write,
+            Constants.Sas.Permissions.Delete,
+            Constants.Sas.Permissions.DeleteBlobVersion,
+            Constants.Sas.Permissions.List,
+            Constants.Sas.Permissions.Tag,
+        };
 
         /// <summary>
         /// Use an account's <see cref="StorageSharedKeyCredential"/> to sign this
@@ -425,75 +439,6 @@ namespace Azure.Storage.Sas
             {
                 Version = SasQueryParameters.DefaultSasVersion;
             }
-        }
-
-        private static string ValidateAndSanitizeRawPermissions(string permissions)
-        {
-            if (permissions == null)
-            {
-                return null;
-            }
-
-            // Convert permissions string to lower case.
-            permissions = permissions.ToLowerInvariant();
-
-            HashSet<char> permissionsSet = new HashSet<char>();
-
-            foreach (char permission in permissions)
-            {
-                // Check that each permission is a real SAS permission.
-                if (!Constants.Sas.ValidPermissions.Contains(permission))
-                {
-                    throw new ArgumentException($"{permission} is not a valid SAS permission");
-                }
-
-                // Add permission to permissionsSet for re-ordering.
-                permissionsSet.Add(permission);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Read);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Add);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Create);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Write);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Delete);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.DeleteBlobVersion))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.DeleteBlobVersion);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.List);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Tag))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Tag);
-            }
-
-            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -206,12 +206,34 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
+        /// <param name="rawPermissions">
+        /// Raw permissions string for the SAS.
+        /// </param>
+        /// <param name="normalize">
+        /// If the permissions should be validated and correctly ordered.
+        /// </param>
+        public void SetPermissions(
+            string rawPermissions,
+            bool normalize = default)
+        {
+            if (normalize)
+            {
+                rawPermissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                    permissions: rawPermissions,
+                    validPermissionsInOrder: s_validPermissionsInOrder);
+            }
+
+            SetPermissions(rawPermissions);
+        }
+
+        /// <summary>
+        /// Sets the permissions for the SAS using a raw permissions string.
+        /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
-                permissions: rawPermissions,
-                validPermissionsInOrder: s_validPermissionsInOrder);
+            Permissions = rawPermissions;
         }
 
         private static readonly List<char> s_validPermissionsInOrder = new List<char>

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -224,6 +224,9 @@ namespace Azure.Storage.Sas
             Constants.Sas.Permissions.DeleteBlobVersion,
             Constants.Sas.Permissions.List,
             Constants.Sas.Permissions.Tag,
+            Constants.Sas.Permissions.Update,
+            Constants.Sas.Permissions.Process,
+            Constants.Sas.Permissions.FilterByTags,
         };
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -230,7 +230,6 @@ namespace Azure.Storage.Sas
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
             Permissions = rawPermissions;

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Cryptography;
 using System.Text;
@@ -208,7 +209,7 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = rawPermissions;
+            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
         }
 
         /// <summary>
@@ -424,6 +425,75 @@ namespace Azure.Storage.Sas
             {
                 Version = SasQueryParameters.DefaultSasVersion;
             }
+        }
+
+        private static string ValidateAndSanitizeRawPermissions(string permissions)
+        {
+            if (permissions == null)
+            {
+                return null;
+            }
+
+            // Convert permissions string to lower case.
+            permissions = permissions.ToLowerInvariant();
+
+            HashSet<char> permissionsSet = new HashSet<char>();
+
+            foreach (char permission in permissions)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!Constants.Sas.ValidPermissions.Contains(permission))
+                {
+                    throw new ArgumentException($"{permission} is not a valid SAS permission");
+                }
+
+                // Add permission to permissionsSet for re-ordering.
+                permissionsSet.Add(permission);
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Read);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Add);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Create);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Write);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Delete);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.DeleteBlobVersion))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.DeleteBlobVersion);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.List);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Tag))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Tag);
+            }
+
+            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -361,7 +361,7 @@ namespace Azure.Storage.Blobs.Test
             // Act
             TestHelper.AssertExpectedException(
                 () => blobSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("s is not a valid SAS permission"));
+                new ArgumentException("p is not a valid SAS permission"));
         }
 
         private BlobSasBuilder BuildBlobSasBuilder(bool includeBlob, bool includeSnapshot, string containerName, string blobName, TestConstants constants)

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -327,7 +327,9 @@ namespace Azure.Storage.Blobs.Test
                 BlobContainerName = test.Container.Name
             };
 
-            blobSasBuilder.SetPermissions(permissionsString);
+            blobSasBuilder.SetPermissions(
+                rawPermissions: permissionsString,
+                normalize: true);
 
             StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
 
@@ -360,7 +362,9 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             TestHelper.AssertExpectedException(
-                () => blobSasBuilder.SetPermissions("ptsdfsd"),
+                () => blobSasBuilder.SetPermissions(
+                    rawPermissions: "ptsdfsd",
+                    normalize: true),
                 new ArgumentException("s is not a valid SAS permission"));
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
@@ -257,6 +260,108 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(SasProtocol.Https, sasQueryParameters.Protocol);
             Assert.AreEqual(resource, sasQueryParameters.Resource);
             Assert.AreEqual(constants.Sas.Version, sasQueryParameters.Version);
+        }
+
+        [Test]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
+        [TestCase("FTPUCALXDWR")]
+        [TestCase("rwdxlacuptf")]
+        public async Task AccountPermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            accountSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            Uri uri = new Uri($"{test.Container.Uri}?{accountSasBuilder.ToSasQueryParameters(sharedKeyCredential)}");
+
+            BlobContainerClient sasContainerClient = new BlobContainerClient(uri, GetOptions());
+
+            // Act
+            await sasContainerClient.GetPropertiesAsync();
+        }
+
+        [Test]
+        public async Task AccountPermissionsRawPermissions_InvalidPermission()
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => accountSasBuilder.SetPermissions("werteyfg"),
+                new ArgumentException("e is not a valid SAS permission"));
+        }
+
+        [Test]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
+        [TestCase("TLXDWCAR")]
+        [TestCase("racwdxlt")]
+        public async Task ContainerPermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+
+            BlobSasBuilder blobSasBuilder = new BlobSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                BlobContainerName = test.Container.Name
+            };
+
+            blobSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            BlobUriBuilder blobUriBuilder = new BlobUriBuilder(test.Container.Uri)
+            {
+                Sas = blobSasBuilder.ToSasQueryParameters(sharedKeyCredential)
+            };
+
+            BlobContainerClient sasContainerClient = new BlobContainerClient(blobUriBuilder.ToUri(), GetOptions());
+
+            // Act
+            await foreach (BlobItem blobItem in sasContainerClient.GetBlobsAsync())
+            {
+                // Just make sure the call succeeds.
+            }
+        }
+
+        [Test]
+        public async Task ContainerPermissionsRawPermissions_Invalid()
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+
+            BlobSasBuilder blobSasBuilder = new BlobSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                BlobContainerName = test.Container.Name
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => blobSasBuilder.SetPermissions("ptsdfsd"),
+                new ArgumentException("s is not a valid SAS permission"));
         }
 
         private BlobSasBuilder BuildBlobSasBuilder(bool includeBlob, bool includeSnapshot, string containerName, string blobName, TestConstants constants)

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -361,7 +361,7 @@ namespace Azure.Storage.Blobs.Test
             // Act
             TestHelper.AssertExpectedException(
                 () => blobSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("p is not a valid SAS permission"));
+                new ArgumentException("s is not a valid SAS permission"));
         }
 
         private BlobSasBuilder BuildBlobSasBuilder(bool includeBlob, bool includeSnapshot, string containerName, string blobName, TestConstants constants)

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -446,19 +446,15 @@ namespace Azure.Storage.Test.Shared
             return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
         }
 
-        private static string ToSasVersion(BlobClientOptions.ServiceVersion serviceVersion)
+        public static string ToSasVersion(BlobClientOptions.ServiceVersion serviceVersion)
         {
-            switch (serviceVersion)
+            return serviceVersion switch
             {
-                case BlobClientOptions.ServiceVersion.V2019_02_02:
-                    return "2019-02-02";
-                case BlobClientOptions.ServiceVersion.V2019_07_07:
-                    return "2019-07-07";
-                case BlobClientOptions.ServiceVersion.V2019_12_12:
-                    return "2019-12-12";
-                default:
-                    throw new ArgumentException("Invalid service version");
-            }
+                BlobClientOptions.ServiceVersion.V2019_02_02 => "2019-02-02",
+                BlobClientOptions.ServiceVersion.V2019_07_07 => "2019-07-07",
+                BlobClientOptions.ServiceVersion.V2019_12_12 => "2019-12-12",
+                _ => throw new ArgumentException("Invalid service version"),
+            };
         }
 
         public async Task<PageBlobClient> CreatePageBlobClientAsync(BlobContainerClient container, long size)

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%).json
@@ -1,0 +1,108 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-c7feebb5-9fa3-57b1-ae31-9617c140ba26?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8dac5404fb6ace499305bd63d6850b9d-e7320a88bc3a6b45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "327d6739-0521-ab81-09cb-3f4aa13b16ed",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:13 GMT",
+        "ETag": "\u00220x8D82793394290D7\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "327d6739-0521-ab81-09cb-3f4aa13b16ed",
+        "x-ms-request-id": "b96ef236-201e-0058-4a7c-590e71000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-c7feebb5-9fa3-57b1-ae31-9617c140ba26?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A14%3A14Z\u0026se=2020-07-14T02%3A14%3A14Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "59ddcb66-88c2-1e05-9d07-3474b09304ee",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "ETag": "\u00220x8D82793394290D7\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "59ddcb66-88c2-1e05-9d07-3474b09304ee",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "04a5a06f-f01e-003c-177c-59bed1000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-c7feebb5-9fa3-57b1-ae31-9617c140ba26?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6d1a4b2f03437b4f9e0b63da0bbfb14a-a08e7c5fa1883149-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d5e454e9-bc5d-f42b-a6b0-0fb128b71578",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d5e454e9-bc5d-f42b-a6b0-0fb128b71578",
+        "x-ms-request-id": "04a5a101-f01e-003c-1a7c-59bed1000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:14.0236326-05:00",
+    "RandomSeed": "381218147",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%)Async.json
@@ -1,0 +1,108 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-a85d2101-d553-9f79-dc7a-bbaaa463a20e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-36cee0d858e43d4da1cfe3d0a2150466-4ff0a264826a1948-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "20306dfb-8e89-b2a6-6680-b3c83e4a656d",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "ETag": "\u00220x8D827933AE60215\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "20306dfb-8e89-b2a6-6680-b3c83e4a656d",
+        "x-ms-request-id": "5d6e3038-201e-0053-337c-591605000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-a85d2101-d553-9f79-dc7a-bbaaa463a20e?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A14%3A16Z\u0026se=2020-07-14T02%3A14%3A16Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "37ae169d-8133-3685-9f37-5758ba98ca8d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "ETag": "\u00220x8D827933AE60215\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "37ae169d-8133-3685-9f37-5758ba98ca8d",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "0ee882e3-601e-0010-777c-593cec000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-a85d2101-d553-9f79-dc7a-bbaaa463a20e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a3349429c404b44aba928fdd38563602-d95e514c73351342-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "272a7904-2d9c-a03a-4484-5be1d859da27",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "272a7904-2d9c-a03a-4484-5be1d859da27",
+        "x-ms-request-id": "0ee8833b-601e-0010-457c-593cec000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:16.7596913-05:00",
+    "RandomSeed": "2033711228",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%).json
@@ -1,0 +1,108 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-80a0eb7a-1037-b52b-fc8a-3d53e473d1af?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-085a163f129576409f74bb8d50afb2c3-5bf62f3260876547-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "b195b1f9-841c-c278-b606-f81dc020842b",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "ETag": "\u00220x8D8279339B45CEE\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b195b1f9-841c-c278-b606-f81dc020842b",
+        "x-ms-request-id": "ee0326c0-c01e-003f-037c-59bdd6000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-80a0eb7a-1037-b52b-fc8a-3d53e473d1af?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A14%3A14Z\u0026se=2020-07-14T02%3A14%3A14Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3259eba7-1fdd-7d93-623f-1ded4198f523",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "ETag": "\u00220x8D8279339B45CEE\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3259eba7-1fdd-7d93-623f-1ded4198f523",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "e9c194a7-501e-003a-2a7c-5949a9000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-80a0eb7a-1037-b52b-fc8a-3d53e473d1af?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5f8a07bab114dc4fb74234eab6afbd08-00b07122e259214c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d576109e-51c6-ac4e-4e2e-9339b224ff9c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d576109e-51c6-ac4e-4e2e-9339b224ff9c",
+        "x-ms-request-id": "e9c194f4-501e-003a-6e7c-5949a9000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:14.7578375-05:00",
+    "RandomSeed": "384304156",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%)Async.json
@@ -1,0 +1,108 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-87b322e0-fee7-4891-e9c9-f3b9bc361467?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c5cbec29e2f97646bfaff014725e13e0-ed7971c04ad2b34f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "9419aa25-2a80-7599-8703-a2d7510a4f5e",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "ETag": "\u00220x8D827933B494788\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9419aa25-2a80-7599-8703-a2d7510a4f5e",
+        "x-ms-request-id": "c5a89a32-e01e-0023-0f7c-5965c1000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-87b322e0-fee7-4891-e9c9-f3b9bc361467?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A14%3A17Z\u0026se=2020-07-14T02%3A14%3A17Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "12938d66-801d-89e6-8cf1-448032818832",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "ETag": "\u00220x8D827933B494788\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "12938d66-801d-89e6-8cf1-448032818832",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "26358a50-d01e-0020-167c-5966c6000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-87b322e0-fee7-4891-e9c9-f3b9bc361467?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4cce6c8494aa1f4280c0add059e86f8c-d420fcfdea97c449-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c4706c0b-3d76-4c41-8974-855929a4d947",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c4706c0b-3d76-4c41-8974-855929a4d947",
+        "x-ms-request-id": "26358a93-d01e-0020-507c-5966c6000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:17.4103561-05:00",
+    "RandomSeed": "1447520889",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-3e30c971-fcbd-4795-cba0-205c0f6a8835?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-dfde7c168b27ce438c44d5f2e8699640-f68b8bae62c27944-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "9c00ec98-054b-5e90-629e-99703b5f8816",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:42 GMT",
+        "ETag": "\u00220x8D82792973CBE4C\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:09:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c00ec98-054b-5e90-629e-99703b5f8816",
+        "x-ms-request-id": "b94d960f-b01e-0056-257b-59e27a000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-3e30c971-fcbd-4795-cba0-205c0f6a8835?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-16e4ad977629874f8269d7ed19e21737-8d466a1347bf1042-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "23c357f1-ec6a-a0e9-78f5-1c136cccc0e8",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "23c357f1-ec6a-a0e9-78f5-1c136cccc0e8",
+        "x-ms-request-id": "b94d967f-b01e-0056-047b-59e27a000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:09:42.1942630-05:00",
+    "RandomSeed": "1985292523",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e1fe3571-7e87-1f10-2bc2-37d4ae17bf4c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d90811e8ab1ea244829ef2ea33683e44-a7b00e6b48837e4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "37caf4d3-a1e6-b3e2-dc1f-73a35aa740e5",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "ETag": "\u00220x8D8279298F5E963\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "37caf4d3-a1e6-b3e2-dc1f-73a35aa740e5",
+        "x-ms-request-id": "46ebdf9a-701e-002d-167b-5989ca000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e1fe3571-7e87-1f10-2bc2-37d4ae17bf4c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-13fb18a515ce824f8542110c45051591-d20aa8eabbcbfa46-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b900e847-874c-7c66-1535-825b503f7ab7",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b900e847-874c-7c66-1535-825b503f7ab7",
+        "x-ms-request-id": "46ebdff6-701e-002d-697b-5989ca000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:09:45.0716754-05:00",
+    "RandomSeed": "254019287",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%TLXDWCAR%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%TLXDWCAR%).json
@@ -1,0 +1,100 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-137bf8ec-e92f-072a-1de1-ffb3a248fdb7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7bc7fc73b5190749aed793e39d3738ea-32038d75da482049-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0d66681f-9c8c-337b-a1f3-e74d098096b1",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "ETag": "\u00220x8D827933A186B50\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0d66681f-9c8c-337b-a1f3-e74d098096b1",
+        "x-ms-request-id": "7234b598-601e-0032-737c-5952da000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-137bf8ec-e92f-072a-1de1-ffb3a248fdb7?sv=2019-12-12\u0026st=2020-07-14T00%3A14%3A15Z\u0026se=2020-07-14T02%3A14%3A15Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3993d208-efe1-872a-0334-e27cc43a057b",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "234",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3993d208-efe1-872a-0334-e27cc43a057b",
+        "x-ms-request-id": "a2116ce6-d01e-002b-647c-597eb2000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://seandevtest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-137bf8ec-e92f-072a-1de1-ffb3a248fdb7\u0022\u003E\u003CBlobs /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-137bf8ec-e92f-072a-1de1-ffb3a248fdb7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4be62d05bc30254eb1bd67552a2dd987-3f50bffd674c4842-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3645dcf9-5ced-75d0-55f4-56954fb97d36",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3645dcf9-5ced-75d0-55f4-56954fb97d36",
+        "x-ms-request-id": "a2116d2d-d01e-002b-257c-597eb2000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:15.4125516-05:00",
+    "RandomSeed": "2047612394",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%TLXDWCAR%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%TLXDWCAR%)Async.json
@@ -1,0 +1,100 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-294bb334-3e8e-a8a1-671d-ec69733e8ced?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-414cef98188ce043b468352c02fbdd64-479cfc6722d3d84b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a20afe65-821a-c957-0f1e-dcb5bbedccf1",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "ETag": "\u00220x8D827933BAE6E29\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a20afe65-821a-c957-0f1e-dcb5bbedccf1",
+        "x-ms-request-id": "fd612b66-701e-0004-647c-59ff88000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-294bb334-3e8e-a8a1-671d-ec69733e8ced?sv=2019-12-12\u0026st=2020-07-14T00%3A14%3A18Z\u0026se=2020-07-14T02%3A14%3A18Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "75045575-ea34-a0d2-a903-2f60084671e7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "234",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "75045575-ea34-a0d2-a903-2f60084671e7",
+        "x-ms-request-id": "d9bf027b-701e-000f-0d7c-59e7fc000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://seandevtest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-294bb334-3e8e-a8a1-671d-ec69733e8ced\u0022\u003E\u003CBlobs /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-294bb334-3e8e-a8a1-671d-ec69733e8ced?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d48ddda1ffdc484d8be09fa1de3fb431-56d0513cf1ecf44f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "66403dc9-57e9-d1bd-5861-8acf45f44671",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "66403dc9-57e9-d1bd-5861-8acf45f44671",
+        "x-ms-request-id": "d9bf02ce-701e-000f-557c-59e7fc000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:18.0736043-05:00",
+    "RandomSeed": "1805491077",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%racwdxlt%).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%racwdxlt%).json
@@ -1,0 +1,100 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e7bde5ae-9488-4feb-f0e0-a2f9d65650d1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-9e190330a8990740bfeadb5ded96d3b2-7f7997ec0b0b4544-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "25cc3ff9-0c6c-daf3-e200-d65b305db19f",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "ETag": "\u00220x8D827933A818BE0\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "25cc3ff9-0c6c-daf3-e200-d65b305db19f",
+        "x-ms-request-id": "87999267-a01e-0042-477c-59211e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e7bde5ae-9488-4feb-f0e0-a2f9d65650d1?sv=2019-12-12\u0026st=2020-07-14T00%3A14%3A16Z\u0026se=2020-07-14T02%3A14%3A16Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "97ffeb6b-2a89-1a65-27d5-a4b79e611b01",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "234",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "97ffeb6b-2a89-1a65-27d5-a4b79e611b01",
+        "x-ms-request-id": "8bc4aa6e-e01e-000a-667c-591383000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://seandevtest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-e7bde5ae-9488-4feb-f0e0-a2f9d65650d1\u0022\u003E\u003CBlobs /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e7bde5ae-9488-4feb-f0e0-a2f9d65650d1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-11210133444841438157ba87f23ee881-b2d1826a3d165f4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "44f061b3-1a5d-2215-28e8-cc408e379ac7",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "44f061b3-1a5d-2215-28e8-cc408e379ac7",
+        "x-ms-request-id": "8bc4aac3-e01e-000a-317c-591383000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:16.1020418-05:00",
+    "RandomSeed": "109361250",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%racwdxlt%)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions(%racwdxlt%)Async.json
@@ -1,0 +1,100 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e9807aae-ab7d-f45a-197e-22afad7d4a6d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-958e3eadaa890b418ed69df478f20632-19263bf6136c7e4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c0e044d5-90dd-ec25-3fab-f0336803df8c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "ETag": "\u00220x8D827933C1430FB\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:14:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c0e044d5-90dd-ec25-3fab-f0336803df8c",
+        "x-ms-request-id": "e9a2e2db-301e-002a-417c-597f4f000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e9807aae-ab7d-f45a-197e-22afad7d4a6d?sv=2019-12-12\u0026st=2020-07-14T00%3A14%3A18Z\u0026se=2020-07-14T02%3A14%3A18Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026restype=container\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "69dab6f2-8a9d-5e90-5eb3-8628b831e967",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "234",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:14:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "69dab6f2-8a9d-5e90-5eb3-8628b831e967",
+        "x-ms-request-id": "f31aeb34-001e-0022-2a7c-59643c000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://seandevtest.blob.core.windows.net/\u0022 ContainerName=\u0022test-container-e9807aae-ab7d-f45a-197e-22afad7d4a6d\u0022\u003E\u003CBlobs /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-e9807aae-ab7d-f45a-197e-22afad7d4a6d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fd77f276a741ab45abbf27c006d8db8e-4a199e07b23b1a4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b1412c73-7628-40ef-aa14-19fb2c964ce2",
+        "x-ms-date": "Tue, 14 Jul 2020 01:14:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:14:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b1412c73-7628-40ef-aa14-19fb2c964ce2",
+        "x-ms-request-id": "f31aeba0-001e-0022-0f7c-59643c000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:14:18.7409112-05:00",
+    "RandomSeed": "1409367967",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions_Invalid.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions_Invalid.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-f57b849a-18f0-9388-db75-8a9c9e254b8b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-3385107347302d49b871870266f60675-e5c16fefda25b946-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "b9348815-aa97-2372-8da1-6fe15a926382",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:43 GMT",
+        "ETag": "\u00220x8D82792977E8C81\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:09:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9348815-aa97-2372-8da1-6fe15a926382",
+        "x-ms-request-id": "361f8780-201e-0017-3b7b-59ca69000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-f57b849a-18f0-9388-db75-8a9c9e254b8b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-02a108afc2cd494ebf73d5a2b59cf26e-ce3f9e5fda8e404a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "15875d45-91f0-a6f4-c36b-da1d7bcaefe1",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:43 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "15875d45-91f0-a6f4-c36b-da1d7bcaefe1",
+        "x-ms-request-id": "361f87c3-201e-0017-747b-59ca69000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:09:42.6123715-05:00",
+    "RandomSeed": "266532820",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions_InvalidAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobSasBuilderTests/ContainerPermissionsRawPermissions_InvalidAsync.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-dd2e5dc7-d296-b7da-15fa-38fabf2ba4d0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f704ebdb036db042adfffdc6d5708499-6d5cf9c6cf6c7b40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d268c13d-69a3-0013-810d-b8460ae9e6f2",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "ETag": "\u00220x8D82792992F9FBA\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:09:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d268c13d-69a3-0013-810d-b8460ae9e6f2",
+        "x-ms-request-id": "1231338b-401e-002e-6b7b-598acd000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.blob.core.windows.net/test-container-dd2e5dc7-d296-b7da-15fa-38fabf2ba4d0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-37504a58165632488c509a70a94ffd99-8ab95cef0d335240-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "febcc377-d2c2-662c-31d0-6bcfb523293b",
+        "x-ms-date": "Tue, 14 Jul 2020 01:09:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:09:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "febcc377-d2c2-662c-31d0-6bcfb523293b",
+        "x-ms-request-id": "123133fd-401e-002e-547b-598acd000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:09:45.4512130-05:00",
+    "RandomSeed": "988758737",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text;
 
 namespace Azure.Storage.Sas
 {
@@ -92,7 +94,7 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = rawPermissions;
+            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
         }
 
         /// <summary>
@@ -150,6 +152,90 @@ namespace Azure.Storage.Sas
                 Permissions,
                 signature);
             return p;
+        }
+
+        private static string ValidateAndSanitizeRawPermissions(string permissions)
+        {
+            if (permissions == null)
+            {
+                return null;
+            }
+
+            // Convert permissions string to lower case.
+            permissions = permissions.ToLowerInvariant();
+
+            HashSet<char> permissionsSet = new HashSet<char>();
+
+            foreach (char permission in permissions)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!Constants.Sas.ValidPermissions.Contains(permission))
+                {
+                    throw new ArgumentException($"{permission} is not a valid SAS permission");
+                }
+
+                // Add permission to permissionsSet for re-ordering.
+                permissionsSet.Add(permission);
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Read);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Write);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Delete);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.DeleteBlobVersion))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.DeleteBlobVersion);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.List);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Add);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Create);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Update))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Update);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Process))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Process);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Tag))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Tag);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.FilterByTags))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.FilterByTags);
+            }
+
+            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
@@ -94,8 +94,25 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
+            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                permissions: rawPermissions,
+                validPermissionsInOrder: s_validPermissionsInOrder);
         }
+
+        private static readonly List<char> s_validPermissionsInOrder = new List<char>
+        {
+            Constants.Sas.Permissions.Read,
+            Constants.Sas.Permissions.Write,
+            Constants.Sas.Permissions.Delete,
+            Constants.Sas.Permissions.DeleteBlobVersion,
+            Constants.Sas.Permissions.List,
+            Constants.Sas.Permissions.Add,
+            Constants.Sas.Permissions.Create,
+            Constants.Sas.Permissions.Update,
+            Constants.Sas.Permissions.Process,
+            Constants.Sas.Permissions.Tag,
+            Constants.Sas.Permissions.FilterByTags,
+        };
 
         /// <summary>
         /// Use an account's <see cref="StorageSharedKeyCredential"/> to sign this
@@ -152,90 +169,6 @@ namespace Azure.Storage.Sas
                 Permissions,
                 signature);
             return p;
-        }
-
-        private static string ValidateAndSanitizeRawPermissions(string permissions)
-        {
-            if (permissions == null)
-            {
-                return null;
-            }
-
-            // Convert permissions string to lower case.
-            permissions = permissions.ToLowerInvariant();
-
-            HashSet<char> permissionsSet = new HashSet<char>();
-
-            foreach (char permission in permissions)
-            {
-                // Check that each permission is a real SAS permission.
-                if (!Constants.Sas.ValidPermissions.Contains(permission))
-                {
-                    throw new ArgumentException($"{permission} is not a valid SAS permission");
-                }
-
-                // Add permission to permissionsSet for re-ordering.
-                permissionsSet.Add(permission);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Read);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Write);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Delete);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.DeleteBlobVersion))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.DeleteBlobVersion);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.List);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Add);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Create);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Update))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Update);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Process))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Process);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Tag))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Tag);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.FilterByTags))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.FilterByTags);
-            }
-
-            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -386,21 +386,6 @@ namespace Azure.Storage
         /// </summary>
         internal static class Sas
         {
-            public static readonly HashSet<char> ValidPermissions = new HashSet<char>
-            {
-                Permissions.Read,
-                Permissions.Write,
-                Permissions.Delete,
-                Permissions.DeleteBlobVersion,
-                Permissions.List,
-                Permissions.Add,
-                Permissions.Update,
-                Permissions.Process,
-                Permissions.Create,
-                Permissions.Tag,
-                Permissions.FilterByTags
-            };
-
             internal static class Permissions
             {
                 public const char Read = 'r';

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Azure.Storage
 {
     internal static class Constants
@@ -384,6 +386,21 @@ namespace Azure.Storage
         /// </summary>
         internal static class Sas
         {
+            public static readonly HashSet<char> ValidPermissions = new HashSet<char>
+            {
+                Permissions.Read,
+                Permissions.Write,
+                Permissions.Delete,
+                Permissions.DeleteBlobVersion,
+                Permissions.List,
+                Permissions.Add,
+                Permissions.Update,
+                Permissions.Process,
+                Permissions.Create,
+                Permissions.Tag,
+                Permissions.FilterByTags
+            };
+
             internal static class Permissions
             {
                 public const char Read = 'r';

--- a/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
@@ -288,5 +288,44 @@ namespace Azure.Storage.Sas
                 stringBuilder.AppendQueryParameter(Constants.Sas.Parameters.Signature, WebUtility.UrlEncode(parameters.Signature));
             }
         }
+
+        internal static string ValidateAndSanitizeRawPermissions(string permissions,
+            List<char> validPermissionsInOrder)
+        {
+            if (permissions == null)
+            {
+                return null;
+            }
+
+            // Convert permissions string to lower case.
+            permissions = permissions.ToLowerInvariant();
+
+            HashSet<char> validPermissionsSet = new HashSet<char>(validPermissionsInOrder);
+            HashSet<char> permissionsSet = new HashSet<char>();
+
+            foreach (char permission in permissions)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!validPermissionsSet.Contains(permission))
+                {
+                    throw new ArgumentException($"{permission} is not a valid SAS permission");
+                }
+
+                // Add permission to permissionsSet for re-ordering.
+                permissionsSet.Add(permission);
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            foreach (char permission in validPermissionsInOrder)
+            {
+                if (permissionsSet.Contains(permission))
+                {
+                    stringBuilder.Append(permission);
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 12.3.0-preview.2 (Unreleased)
 - Fixed bug where DataLakeUriBuilder would return LastDirectoryOrFileName and DirectoryOrFilePath URL-encoded.
+- Updated DataLakeSasBuilder to correctly order raw string permissions and make the permissions lowercase.
 
 ## 12.3.0-preview.1 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
@@ -719,7 +719,9 @@ namespace Azure.Storage.Sas
         public void SetPermissions(Azure.Storage.Sas.DataLakeAccountSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.DataLakeFileSystemSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.DataLakeSasPermissions permissions) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
+        public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.DataLakeSasQueryParameters ToSasQueryParameters(Azure.Storage.Files.DataLake.Models.UserDelegationKey userDelegationKey, string accountName) { throw null; }
         public Azure.Storage.Sas.DataLakeSasQueryParameters ToSasQueryParameters(Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
@@ -719,7 +719,6 @@ namespace Azure.Storage.Sas
         public void SetPermissions(Azure.Storage.Sas.DataLakeAccountSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.DataLakeFileSystemSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.DataLakeSasPermissions permissions) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
         public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.DataLakeSasQueryParameters ToSasQueryParameters(Azure.Storage.Files.DataLake.Models.UserDelegationKey userDelegationKey, string accountName) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -167,12 +167,34 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
+        /// <param name="rawPermissions">
+        /// Raw permissions string for the SAS.
+        /// </param>
+        /// <param name="normalize">
+        /// If the permissions should be validated and correctly ordered.
+        /// </param>
+        public void SetPermissions(
+            string rawPermissions,
+            bool normalize = default)
+        {
+            if (normalize)
+            {
+                rawPermissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                    permissions: rawPermissions,
+                    validPermissionsInOrder: s_validPermissionsInOrder);
+            }
+
+            SetPermissions(rawPermissions);
+        }
+
+        /// <summary>
+        /// Sets the permissions for the SAS using a raw permissions string.
+        /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
-                permissions: rawPermissions,
-                validPermissionsInOrder: s_validPermissionsInOrder);
+            Permissions = rawPermissions;
         }
 
         private static readonly List<char> s_validPermissionsInOrder = new List<char>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -185,6 +185,8 @@ namespace Azure.Storage.Sas
             Constants.Sas.Permissions.DeleteBlobVersion,
             Constants.Sas.Permissions.List,
             Constants.Sas.Permissions.Tag,
+            Constants.Sas.Permissions.Update,
+            Constants.Sas.Permissions.Process
         };
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -170,8 +170,22 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
+            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                permissions: rawPermissions,
+                validPermissionsInOrder: s_validPermissionsInOrder);
         }
+
+        private static readonly List<char> s_validPermissionsInOrder = new List<char>
+        {
+            Constants.Sas.Permissions.Read,
+            Constants.Sas.Permissions.Add,
+            Constants.Sas.Permissions.Create,
+            Constants.Sas.Permissions.Write,
+            Constants.Sas.Permissions.Delete,
+            Constants.Sas.Permissions.DeleteBlobVersion,
+            Constants.Sas.Permissions.List,
+            Constants.Sas.Permissions.Tag,
+        };
 
         /// <summary>
         /// Use an account's <see cref="StorageSharedKeyCredential"/> to sign this
@@ -374,75 +388,6 @@ namespace Azure.Storage.Sas
             {
                 Version = SasQueryParameters.DefaultSasVersion;
             }
-        }
-
-        private static string ValidateAndSanitizeRawPermissions(string permissions)
-        {
-            if (permissions == null)
-            {
-                return null;
-            }
-
-            // Convert permissions string to lower case.
-            permissions = permissions.ToLowerInvariant();
-
-            HashSet<char> permissionsSet = new HashSet<char>();
-
-            foreach (char permission in permissions)
-            {
-                // Check that each permission is a real SAS permission.
-                if (!Constants.Sas.ValidPermissions.Contains(permission))
-                {
-                    throw new ArgumentException($"{permission} is not a valid SAS permission");
-                }
-
-                // Add permission to permissionsSet for re-ordering.
-                permissionsSet.Add(permission);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Read);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Add);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Create);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Write);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Delete);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.DeleteBlobVersion))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.DeleteBlobVersion);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.List);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Tag))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Tag);
-            }
-
-            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -191,7 +191,6 @@ namespace Azure.Storage.Sas
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
             Permissions = rawPermissions;

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Sas/DataLakeSasBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Cryptography;
 using System.Text;
@@ -169,7 +170,7 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = rawPermissions;
+            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
         }
 
         /// <summary>
@@ -373,6 +374,75 @@ namespace Azure.Storage.Sas
             {
                 Version = SasQueryParameters.DefaultSasVersion;
             }
+        }
+
+        private static string ValidateAndSanitizeRawPermissions(string permissions)
+        {
+            if (permissions == null)
+            {
+                return null;
+            }
+
+            // Convert permissions string to lower case.
+            permissions = permissions.ToLowerInvariant();
+
+            HashSet<char> permissionsSet = new HashSet<char>();
+
+            foreach (char permission in permissions)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!Constants.Sas.ValidPermissions.Contains(permission))
+                {
+                    throw new ArgumentException($"{permission} is not a valid SAS permission");
+                }
+
+                // Add permission to permissionsSet for re-ordering.
+                permissionsSet.Add(permission);
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Read);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Add);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Create);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Write);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Delete);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.DeleteBlobVersion))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.DeleteBlobVersion);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.List);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Tag))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Tag);
+            }
+
+            return stringBuilder.ToString();
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -104,7 +104,9 @@ namespace Azure.Storage.Files.DataLake.Tests
                 FileSystemName = test.FileSystem.Name
             };
 
-            dataLakeSasBuilder.SetPermissions(permissionsString);
+            dataLakeSasBuilder.SetPermissions(
+                rawPermissions: permissionsString,
+                normalize: true);
 
             StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
 
@@ -137,7 +139,9 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Act
             TestHelper.AssertExpectedException(
-                () => blobSasBuilder.SetPermissions("ptsdfsd"),
+                () => blobSasBuilder.SetPermissions(
+                    rawPermissions: "ptsdfsd",
+                    normalize: true),
                 new ArgumentException("s is not a valid SAS permission"));
         }
     }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -138,7 +138,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Act
             TestHelper.AssertExpectedException(
                 () => blobSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("p is not a valid SAS permission"));
+                new ArgumentException("s is not a valid SAS permission"));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -138,7 +138,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Act
             TestHelper.AssertExpectedException(
                 () => blobSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("s is not a valid SAS permission"));
+                new ArgumentException("p is not a valid SAS permission"));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -2,14 +2,22 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
-    public class DataLakeSasBuilderTests
+    public class DataLakeSasBuilderTests : DataLakeTestBase
     {
+        public DataLakeSasBuilderTests(bool async, DataLakeClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
+        {
+        }
+
         private readonly DataLakeSasPermissions _sasPermissions = DataLakeSasPermissions.All;
 
         [Test]
@@ -28,6 +36,109 @@ namespace Azure.Storage.Files.DataLake.Tests
             TestHelper.AssertExpectedException(
                 () => sasBuilder.EnsureState(),
                 new InvalidOperationException("SAS is missing required parameter: ExpiresOn"));
+        }
+
+        [Test]
+        [TestCase("TLXDWCAR")]
+        [TestCase("racwdxlt")]
+        public async Task AccountPermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            await test.FileSystem.GetPropertiesAsync();
+
+            accountSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
+
+            Uri uri = new Uri($"{test.FileSystem.Uri}?{accountSasBuilder.ToSasQueryParameters(sharedKeyCredential)}");
+
+            DataLakeFileSystemClient sasFileSystemClient = new DataLakeFileSystemClient(uri, GetOptions());
+
+            // Act
+            await sasFileSystemClient.GetPropertiesAsync();
+        }
+
+        [Test]
+        public async Task AccountPermissionsRawPermissions_InvalidPermission()
+        {
+            // Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => accountSasBuilder.SetPermissions("werteyfg"),
+                new ArgumentException("e is not a valid SAS permission"));
+        }
+
+        [Test]
+        [ServiceVersion(Min = DataLakeClientOptions.ServiceVersion.V2019_12_12)]
+        [TestCase("TLXDWCAR")]
+        [TestCase("racwdxlt")]
+        public async Task FileSystemPermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            DataLakeSasBuilder dataLakeSasBuilder = new DataLakeSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                FileSystemName = test.FileSystem.Name
+            };
+
+            dataLakeSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
+
+            DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(test.FileSystem.Uri)
+            {
+                Sas = dataLakeSasBuilder.ToSasQueryParameters(sharedKeyCredential)
+            };
+
+            DataLakeFileSystemClient sasFileSystemClient = new DataLakeFileSystemClient(dataLakeUriBuilder.ToUri(), GetOptions());
+
+            // Act
+            await foreach (PathItem pathItem in sasFileSystemClient.GetPathsAsync())
+            {
+                // Just make sure the call succeeds.
+            }
+        }
+
+        [Test]
+        public async Task FileSystemPermissionsRawPermissions_Invalid()
+        {
+            // Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+
+            BlobSasBuilder blobSasBuilder = new BlobSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                BlobContainerName = test.FileSystem.Name
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => blobSasBuilder.SetPermissions("ptsdfsd"),
+                new ArgumentException("s is not a valid SAS permission"));
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%TLXDWCAR%).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%TLXDWCAR%).json
@@ -1,0 +1,147 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-516ec232-6d13-b266-c96c-ebc555c91471?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4918bab12647824883e921ff52de3a67-bb8612be6e8ab84c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0b299546-3da7-e1b0-0437-554468cbdabc",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "ETag": "\u00220x8D82793AAEB4842\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0b299546-3da7-e1b0-0437-554468cbdabc",
+        "x-ms-request-id": "1f541b82-201e-0080-097c-596e84000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-516ec232-6d13-b266-c96c-ebc555c91471?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-689eeb954cec694cb6e6d4b65f56df8f-aa177c2c10254f49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c07e21b8-099f-cbca-348c-6243c40153d9",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "ETag": "\u00220x8D82793AAEB4842\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c07e21b8-099f-cbca-348c-6243c40153d9",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1f541b98-201e-0080-197c-596e84000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-516ec232-6d13-b266-c96c-ebc555c91471?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A17%3A24Z\u0026se=2020-07-14T02%3A17%3A24Z\u0026sp=rwdxlact\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "478b795a-194c-c61c-fc82-224403c3557b",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "ETag": "\u00220x8D82793AAEB4842\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "478b795a-194c-c61c-fc82-224403c3557b",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "02f95222-b01e-002b-2e7c-59114e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-516ec232-6d13-b266-c96c-ebc555c91471?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ba3564fdcd3fc240850d5af4133d5515-f089540987b8fc4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4ae93b5e-0b75-718d-e0f2-111e3ab5deca",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4ae93b5e-0b75-718d-e0f2-111e3ab5deca",
+        "x-ms-request-id": "02f95229-b01e-002b-337c-59114e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:24.7008905-05:00",
+    "RandomSeed": "1236645278",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%TLXDWCAR%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%TLXDWCAR%)Async.json
@@ -1,0 +1,147 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-e5fca0e9-3342-6563-96d9-a1c95861c85d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e008940aa67c1498db1c06d8abb4042-e1426024ceffc44b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "9f3ce74f-dc3a-210e-8024-89c147b3a25e",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "ETag": "\u00220x8D82793ACA41DF0\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9f3ce74f-dc3a-210e-8024-89c147b3a25e",
+        "x-ms-request-id": "59984220-c01e-0053-2f7c-59b2b6000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-e5fca0e9-3342-6563-96d9-a1c95861c85d?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4f127765656f2f46a8cd314012d517ba-92cdc03dba192342-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "707a0cfd-2824-4a23-0306-cc52775a2bc1",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "ETag": "\u00220x8D82793ACA41DF0\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "707a0cfd-2824-4a23-0306-cc52775a2bc1",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "5998424b-c01e-0053-537c-59b2b6000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-e5fca0e9-3342-6563-96d9-a1c95861c85d?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A17%3A27Z\u0026se=2020-07-14T02%3A17%3A27Z\u0026sp=rwdxlact\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3ac4be97-3138-7439-97e0-65bb79c17129",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "ETag": "\u00220x8D82793ACA41DF0\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3ac4be97-3138-7439-97e0-65bb79c17129",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1548e4b3-101e-008b-2a7c-5995ef000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-e5fca0e9-3342-6563-96d9-a1c95861c85d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e2f54034274f04eb823059190366f28-adc00294ca369945-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b9bb8ff0-f096-3288-8e0e-86c00d178f11",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9bb8ff0-f096-3288-8e0e-86c00d178f11",
+        "x-ms-request-id": "1548e4c3-101e-008b-347c-5995ef000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:27.6294157-05:00",
+    "RandomSeed": "1229445007",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%racwdxlt%).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%racwdxlt%).json
@@ -1,0 +1,147 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-9cb647dd-f74b-784f-51e0-e58d53943125?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-701f122e497537438d1ce685ceb3fa9f-749660745a65cd47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a2d11194-d6bc-a093-15d0-082d65d699c6",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "ETag": "\u00220x8D82793AB3E3F45\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a2d11194-d6bc-a093-15d0-082d65d699c6",
+        "x-ms-request-id": "1b1562b8-b01e-003b-527c-59d426000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-9cb647dd-f74b-784f-51e0-e58d53943125?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-cd3e8f3273c33c478636c7992161338a-830f342393e89e41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "41f8e213-8fc2-0668-f5bd-501fa4ffce7a",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "ETag": "\u00220x8D82793AB3E3F45\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "41f8e213-8fc2-0668-f5bd-501fa4ffce7a",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "1b1562ca-b01e-003b-5f7c-59d426000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-9cb647dd-f74b-784f-51e0-e58d53943125?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A17%3A25Z\u0026se=2020-07-14T02%3A17%3A25Z\u0026sp=rwdxlact\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "8319713c-57dd-9604-c3ba-121c28f18c1b",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "ETag": "\u00220x8D82793AB3E3F45\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8319713c-57dd-9604-c3ba-121c28f18c1b",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "80a78b02-101e-009b-1e7c-595087000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-9cb647dd-f74b-784f-51e0-e58d53943125?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0167caab19c0be449e1d4f3a8de98d29-ca743e6f46552b4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "32e3a49b-4be5-269d-ad2a-f53fb30cf10e",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "32e3a49b-4be5-269d-ad2a-f53fb30cf10e",
+        "x-ms-request-id": "80a78b1c-101e-009b-317c-595087000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:25.2642603-05:00",
+    "RandomSeed": "1816168727",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%racwdxlt%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions(%racwdxlt%)Async.json
@@ -1,0 +1,147 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-8d6e60b1-a554-ecc3-b886-53e9e1f6d7f2?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5126a99abfbd694ba5e4888541f4fdf4-fd10cbb4b5e9a646-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "72225afc-23c4-e86f-5bcb-f509798442c1",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "ETag": "\u00220x8D82793ACF9C7E1\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "72225afc-23c4-e86f-5bcb-f509798442c1",
+        "x-ms-request-id": "a40b5827-501e-0023-077c-590b41000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-8d6e60b1-a554-ecc3-b886-53e9e1f6d7f2?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-17ee71cbb5723c48b51b759de19ba77e-7ef5d06e4ea5ff42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "87ed98b5-65d3-012d-a9ee-5ac904b1543c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "ETag": "\u00220x8D82793ACF9C7E1\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "87ed98b5-65d3-012d-a9ee-5ac904b1543c",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "a40b583f-501e-0023-1b7c-590b41000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-8d6e60b1-a554-ecc3-b886-53e9e1f6d7f2?sv=2019-12-12\u0026ss=b\u0026srt=sco\u0026st=2020-07-14T00%3A17%3A28Z\u0026se=2020-07-14T02%3A17%3A28Z\u0026sp=rwdxlact\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "e0547a0e-ba96-71ed-a194-1626abe2b3f3",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "ETag": "\u00220x8D82793ACF9C7E1\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e0547a0e-ba96-71ed-a194-1626abe2b3f3",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "0fb198b8-301e-000a-477c-593535000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-8d6e60b1-a554-ecc3-b886-53e9e1f6d7f2?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d650b9a1f4037a43a8827cd30f7090ce-e5b3cd6796e0644f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "8abb1bf2-745d-67a5-0a5e-be12f97e4acb",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8abb1bf2-745d-67a5-0a5e-be12f97e4acb",
+        "x-ms-request-id": "0fb198da-301e-000a-637c-593535000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:28.1657636-05:00",
+    "RandomSeed": "1025531946",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-81bf4822-bf9c-053e-6966-4739b3a54c20?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-424adb09bd8a3f48b1ffa48916af495d-733e3b7f81711244-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a89d631f-ce3a-7d40-0d81-b8758235f532",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "ETag": "\u00220x8D82793AA843762\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a89d631f-ce3a-7d40-0d81-b8758235f532",
+        "x-ms-request-id": "73a6d9ff-701e-0024-187c-596722000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-81bf4822-bf9c-053e-6966-4739b3a54c20?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fcf8ecea27cc7c4b8dfe8ca21437fd13-10c02125a99e464a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4f19403f-a308-f7e6-4fb4-b461ec741f8a",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4f19403f-a308-f7e6-4fb4-b461ec741f8a",
+        "x-ms-request-id": "73a6da26-701e-0024-377c-596722000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:24.0501525-05:00",
+    "RandomSeed": "974145577",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-54020c53-58c8-c04f-40c9-ab627ae34211?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2e02e12035bc47479f22c1a6b5d97f15-1ae229d0c671fe49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "a248b3e0-7143-0ffc-9564-5d5fa4a8d027",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "ETag": "\u00220x8D82793AC3D153C\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a248b3e0-7143-0ffc-9564-5d5fa4a8d027",
+        "x-ms-request-id": "4b3b1281-801e-0099-7d7c-59ee3f000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-54020c53-58c8-c04f-40c9-ab627ae34211?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8a1e5e6e2a7f1146a474d8ccea35eada-66e09da484a63d40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c68176b0-a09b-4acd-61ac-e65e4491e0d3",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c68176b0-a09b-4acd-61ac-e65e4491e0d3",
+        "x-ms-request-id": "4b3b12af-801e-0099-207c-59ee3f000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:26.9189925-05:00",
+    "RandomSeed": "378417342",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/EnsureStateTests.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/EnsureStateTests.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/EnsureStateTestsAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/EnsureStateTestsAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%TLXDWCAR%).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%TLXDWCAR%).json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-db9a188a-4598-61bb-eb0d-6db1e31dba2c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4a1521a0bd631449f8bdb33b2149db2-00fd67a430a72e47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cc710b3d-afed-6966-0049-918ab1c599e6",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "ETag": "\u00220x8D82793AB8B45ED\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc710b3d-afed-6966-0049-918ab1c599e6",
+        "x-ms-request-id": "58eecdcc-701e-0046-287c-59a505000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.dfs.core.windows.net/test-filesystem-db9a188a-4598-61bb-eb0d-6db1e31dba2c?sv=2019-12-12\u0026st=2020-07-14T00%3A17%3A25Z\u0026se=2020-07-14T02%3A17%3A25Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026resource=filesystem\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d774ba8a-eeab-683e-6251-4f3fe8e216df",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "13",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d774ba8a-eeab-683e-6251-4f3fe8e216df",
+        "x-ms-request-id": "a92e6d99-201f-0016-3c7c-596755000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[]}\n"
+      ]
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-db9a188a-4598-61bb-eb0d-6db1e31dba2c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-58c155ca34d9804c843df8b89709e52c-e55c6805c098a240-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "f7003d55-c150-b93b-4f6d-f473be0729c9",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f7003d55-c150-b93b-4f6d-f473be0729c9",
+        "x-ms-request-id": "58eece2a-701e-0046-757c-59a505000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:25.7459699-05:00",
+    "RandomSeed": "734007062",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%TLXDWCAR%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%TLXDWCAR%)Async.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-447db243-5dca-5ae4-944c-b97c2506836c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-bec003cef6ab774fa5401b46a8635259-2fe768272da36c41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d7e5f74f-257b-6188-e830-b67d10f3b6e3",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "ETag": "\u00220x8D82793AD4A2383\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d7e5f74f-257b-6188-e830-b67d10f3b6e3",
+        "x-ms-request-id": "0dd8a883-501e-007e-6f7c-5901c5000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.dfs.core.windows.net/test-filesystem-447db243-5dca-5ae4-944c-b97c2506836c?sv=2019-12-12\u0026st=2020-07-14T00%3A17%3A28Z\u0026se=2020-07-14T02%3A17%3A28Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026resource=filesystem\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "2d2d9f4a-ab21-0ff1-fc21-e6a9294db503",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "13",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2d2d9f4a-ab21-0ff1-fc21-e6a9294db503",
+        "x-ms-request-id": "4ea0d543-901f-0013-287c-59b58e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[]}\n"
+      ]
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-447db243-5dca-5ae4-944c-b97c2506836c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-10257e7f8c20a64a9aba86a53edd74fc-2a2c896071522941-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "70323eb7-88c6-8ac1-937d-15ffe6383a99",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "70323eb7-88c6-8ac1-937d-15ffe6383a99",
+        "x-ms-request-id": "0dd8a919-501e-007e-737c-5901c5000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:28.6868366-05:00",
+    "RandomSeed": "1512881190",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%racwdxlt%).json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%racwdxlt%).json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-a902be83-1e50-3516-3633-e7e2698cc9dc?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-80c6393d6054ee4595b713dcab163926-605238b5b22e9f46-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5be040de-b122-5eaf-6e4b-130c880e07ac",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "ETag": "\u00220x8D82793ABF9CB52\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5be040de-b122-5eaf-6e4b-130c880e07ac",
+        "x-ms-request-id": "271b7575-701e-008d-367c-59a650000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.dfs.core.windows.net/test-filesystem-a902be83-1e50-3516-3633-e7e2698cc9dc?sv=2019-12-12\u0026st=2020-07-14T00%3A17%3A26Z\u0026se=2020-07-14T02%3A17%3A26Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026resource=filesystem\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "2803e832-6dab-15b9-1d40-0b3129501b5a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "13",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2803e832-6dab-15b9-1d40-0b3129501b5a",
+        "x-ms-request-id": "9cec7a22-a01f-009e-1c7c-59825c000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[]}\n"
+      ]
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-a902be83-1e50-3516-3633-e7e2698cc9dc?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-bca795011d382f42aa5fbda7940f914b-e8e90f142a9ef048-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "9fd9ee08-de0b-4000-eee2-07413fe81d10",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9fd9ee08-de0b-4000-eee2-07413fe81d10",
+        "x-ms-request-id": "271b7644-701e-008d-787c-59a650000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:26.4726006-05:00",
+    "RandomSeed": "845872763",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%racwdxlt%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions(%racwdxlt%)Async.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-754eeb33-da93-74e1-1688-0fabd441fbca?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1ba2c9d9f2035c47b883526b1d6d1582-ce901d993da30e49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "b5887f7a-48f9-ff54-a147-a7bfc84af5d4",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:28 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "ETag": "\u00220x8D82793AD9723CC\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b5887f7a-48f9-ff54-a147-a7bfc84af5d4",
+        "x-ms-request-id": "e4f0eacf-301e-0025-0f7c-5938fe000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.dfs.core.windows.net/test-filesystem-754eeb33-da93-74e1-1688-0fabd441fbca?sv=2019-12-12\u0026st=2020-07-14T00%3A17%3A29Z\u0026se=2020-07-14T02%3A17%3A29Z\u0026sr=c\u0026sp=racwdxlt\u0026sig=Sanitized\u0026resource=filesystem\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "5431997d-46b9-f0d0-6440-71a1c7eba808",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "13",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5431997d-46b9-f0d0-6440-71a1c7eba808",
+        "x-ms-request-id": "4f646e40-201f-004b-2e7c-596dd1000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[]}\n"
+      ]
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-754eeb33-da93-74e1-1688-0fabd441fbca?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b9bbb10300a0054b81b2d193da399d4a-c5ddaa4dacbbf24e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "2f41a3d6-a018-891b-d705-b9a60f8dfb54",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:29 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2f41a3d6-a018-891b-d705-b9a60f8dfb54",
+        "x-ms-request-id": "e4f0eb23-301e-0025-547c-5938fe000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:29.1792867-05:00",
+    "RandomSeed": "474515527",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions_Invalid.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions_Invalid.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-d640eb81-09d5-e114-325f-43934d402f44?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c0a6f6ca8e30594eb1ebd33ea0602ac0-2283b161ef5eff44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "36957b49-29fd-8d76-a7ec-c0aedbb399ba",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "ETag": "\u00220x8D82793AABF5393\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "36957b49-29fd-8d76-a7ec-c0aedbb399ba",
+        "x-ms-request-id": "4c8b8fa1-b01e-0049-0a7c-59d369000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-d640eb81-09d5-e114-325f-43934d402f44?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-bd619f6334bb2a498608765d737c4dad-bf855a983f5ed44a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d149ee4c-f9ab-eb47-e468-24ad51d2243b",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:24 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d149ee4c-f9ab-eb47-e468-24ad51d2243b",
+        "x-ms-request-id": "4c8b8ff5-b01e-0049-547c-59d369000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:24.4298973-05:00",
+    "RandomSeed": "708571244",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions_InvalidAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeSasBuilderTests/FileSystemPermissionsRawPermissions_InvalidAsync.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-aabb1db1-1bf6-0883-1c9c-1e491bc98a34?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e15e01550472fd40b7023cb570d8c08b-892860998957d14e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f61fd1d6-643d-0786-7170-67e41c09073d",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "ETag": "\u00220x8D82793AC6BB8B5\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f61fd1d6-643d-0786-7170-67e41c09073d",
+        "x-ms-request-id": "8ce5f462-501e-001c-427c-59c3e2000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seanmccdfsca2.blob.core.windows.net/test-filesystem-aabb1db1-1bf6-0883-1c9c-1e491bc98a34?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a25cb9cf9b3b414faa7a32b23f58d9f9-ccfcd8c39494024b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4972ac37-94a9-9bf7-0a31-9465497c797c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:17:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4972ac37-94a9-9bf7-0a31-9465497c797c",
+        "x-ms-request-id": "8ce5f475-501e-001c-527c-59c3e2000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:17:27.2329008-05:00",
+    "RandomSeed": "2094005866",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmccdfsca2\nU2FuaXRpemVk\nhttps://seanmccdfsca2.blob.core.windows.net\nhttps://seanmccdfsca2.file.core.windows.net\nhttps://seanmccdfsca2.queue.core.windows.net\nhttps://seanmccdfsca2.table.core.windows.net\n\n\n\n\nhttps://seanmccdfsca2-secondary.blob.core.windows.net\nhttps://seanmccdfsca2-secondary.file.core.windows.net\nhttps://seanmccdfsca2-secondary.queue.core.windows.net\nhttps://seanmccdfsca2-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://seanmccdfsca2.blob.core.windows.net/;QueueEndpoint=https://seanmccdfsca2.queue.core.windows.net/;FileEndpoint=https://seanmccdfsca2.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmccdfsca2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmccdfsca2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmccdfsca2-secondary.file.core.windows.net/;AccountName=seanmccdfsca2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 12.3.0-preview.2 (Unreleased)
 - Fixed bug where ShareUriBuilder would return LastDirectoryOrFileName and DirectoryOrFilePath URL-encoded.
+- Updated ShareSasBuilder to correctly order raw string permissions and make the permissions lowercase.
 
 ## 12.3.0-preview.1 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
@@ -793,7 +793,6 @@ namespace Azure.Storage.Sas
         public void SetPermissions(Azure.Storage.Sas.ShareAccountSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.ShareFileSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.ShareSasPermissions permissions) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
         public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.SasQueryParameters ToSasQueryParameters(Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
@@ -793,7 +793,9 @@ namespace Azure.Storage.Sas
         public void SetPermissions(Azure.Storage.Sas.ShareAccountSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.ShareFileSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.ShareSasPermissions permissions) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
+        public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.SasQueryParameters ToSasQueryParameters(Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -158,12 +158,34 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
+        /// <param name="rawPermissions">
+        /// Raw permissions string for the SAS.
+        /// </param>
+        /// <param name="normalize">
+        /// If the permissions should be validated and correctly ordered.
+        /// </param>
+        public void SetPermissions(
+            string rawPermissions,
+            bool normalize = default)
+        {
+            if (normalize)
+            {
+                rawPermissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                    permissions: rawPermissions,
+                    validPermissionsInOrder: s_validPermissionsInOrder);
+            }
+
+            SetPermissions(rawPermissions);
+        }
+
+        /// <summary>
+        /// Sets the permissions for the SAS using a raw permissions string.
+        /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
-                permissions: rawPermissions,
-                validPermissionsInOrder: s_validPermissionsInOrder);
+            Permissions = rawPermissions;
         }
 
         private static readonly List<char> s_validPermissionsInOrder = new List<char>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text;
 using Azure.Storage.Files.Shares;
 
 namespace Azure.Storage.Sas
@@ -159,7 +161,7 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = rawPermissions;
+            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
         }
 
         /// <summary>
@@ -234,6 +236,60 @@ namespace Azure.Storage.Sas
             => !string.IsNullOrEmpty(filePath)
                ? $"/file/{account}/{shareName}/{filePath.Replace("\\", "/")}"
                : $"/file/{account}/{shareName}";
+
+        private static string ValidateAndSanitizeRawPermissions(string permissions)
+        {
+            if (permissions == null)
+            {
+                return null;
+            }
+
+            // Convert permissions string to lower case.
+            permissions = permissions.ToLowerInvariant();
+
+            HashSet<char> permissionsSet = new HashSet<char>();
+
+            foreach (char permission in permissions)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!Constants.Sas.ValidPermissions.Contains(permission))
+                {
+                    throw new ArgumentException($"{permission} is not a valid SAS permission");
+                }
+
+                // Add permission to permissionsSet for re-ordering.
+                permissionsSet.Add(permission);
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Read);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Create);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Write);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Delete);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.List);
+            }
+
+            return stringBuilder.ToString();
+        }
 
         /// <summary>
         /// Returns a string that represents the current object.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -169,10 +169,16 @@ namespace Azure.Storage.Sas
         private static readonly List<char> s_validPermissionsInOrder = new List<char>
         {
             Constants.Sas.Permissions.Read,
+            Constants.Sas.Permissions.Add,
             Constants.Sas.Permissions.Create,
             Constants.Sas.Permissions.Write,
             Constants.Sas.Permissions.Delete,
-            Constants.Sas.Permissions.List
+            Constants.Sas.Permissions.DeleteBlobVersion,
+            Constants.Sas.Permissions.List,
+            Constants.Sas.Permissions.Tag,
+            Constants.Sas.Permissions.Update,
+            Constants.Sas.Permissions.Process,
+            Constants.Sas.Permissions.FilterByTags,
         };
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -161,8 +161,19 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
+            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                permissions: rawPermissions,
+                validPermissionsInOrder: s_validPermissionsInOrder);
         }
+
+        private static readonly List<char> s_validPermissionsInOrder = new List<char>
+        {
+            Constants.Sas.Permissions.Read,
+            Constants.Sas.Permissions.Create,
+            Constants.Sas.Permissions.Write,
+            Constants.Sas.Permissions.Delete,
+            Constants.Sas.Permissions.List
+        };
 
         /// <summary>
         /// Use an account's <see cref="StorageSharedKeyCredential"/> to sign this
@@ -236,60 +247,6 @@ namespace Azure.Storage.Sas
             => !string.IsNullOrEmpty(filePath)
                ? $"/file/{account}/{shareName}/{filePath.Replace("\\", "/")}"
                : $"/file/{account}/{shareName}";
-
-        private static string ValidateAndSanitizeRawPermissions(string permissions)
-        {
-            if (permissions == null)
-            {
-                return null;
-            }
-
-            // Convert permissions string to lower case.
-            permissions = permissions.ToLowerInvariant();
-
-            HashSet<char> permissionsSet = new HashSet<char>();
-
-            foreach (char permission in permissions)
-            {
-                // Check that each permission is a real SAS permission.
-                if (!Constants.Sas.ValidPermissions.Contains(permission))
-                {
-                    throw new ArgumentException($"{permission} is not a valid SAS permission");
-                }
-
-                // Add permission to permissionsSet for re-ordering.
-                permissionsSet.Add(permission);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Read);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Create);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Write);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Delete);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.List);
-            }
-
-            return stringBuilder.ToString();
-        }
 
         /// <summary>
         /// Returns a string that represents the current object.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Sas/ShareSasBuilder.cs
@@ -182,7 +182,6 @@ namespace Azure.Storage.Sas
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
             Permissions = rawPermissions;

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -208,7 +208,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Act
             TestHelper.AssertExpectedException(
                 () => blobSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("s is not a valid SAS permission"));
+                new ArgumentException("p is not a valid SAS permission"));
         }
 
         private ShareSasBuilder BuildFileSasBuilder(bool includeVersion, bool includeFilePath, TestConstants constants, string shareName, string filePath)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Sas;
+using Azure.Storage.Test;
 using NUnit.Framework;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
@@ -111,6 +113,102 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.AreEqual(resource, sasQueryParameters.Resource);
             Assert.AreEqual(SasProtocol.Https, sasQueryParameters.Protocol);
             Assert.AreEqual(constants.Sas.Version, sasQueryParameters.Version);
+        }
+
+        [Test]
+        [TestCase("FTPUCALXDWR")]
+        [TestCase("rwdxlacuptf")]
+        public async Task AccountPermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Files,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            accountSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            Uri uri = new Uri($"{test.Share.Uri}?{accountSasBuilder.ToSasQueryParameters(sharedKeyCredential)}");
+
+            ShareClient sasShareClient = new ShareClient(uri, GetOptions());
+
+            // Act
+            await sasShareClient.GetPropertiesAsync();
+        }
+
+        [Test]
+        public async Task AccountPermissionsRawPermissions_InvalidPermission()
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => accountSasBuilder.SetPermissions("werteyfg"),
+                new ArgumentException("e is not a valid SAS permission"));
+        }
+
+        [Test]
+        [TestCase("LDWCR")]
+        [TestCase("rcwdl")]
+        public async Task SharePermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+
+            ShareSasBuilder blobSasBuilder = new ShareSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                ShareName = test.Share.Name
+            };
+
+            blobSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            ShareUriBuilder blobUriBuilder = new ShareUriBuilder(test.Share.Uri)
+            {
+                Sas = blobSasBuilder.ToSasQueryParameters(sharedKeyCredential)
+            };
+
+            ShareClient sasShareClient = new ShareClient(blobUriBuilder.ToUri(), GetOptions());
+
+            // Act
+            await sasShareClient.GetRootDirectoryClient().GetPropertiesAsync();
+        }
+
+        [Test]
+        public async Task SharePermissionsRawPermissions_Invalid()
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+            ShareSasBuilder blobSasBuilder = new ShareSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                ShareName = test.Share.Name
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => blobSasBuilder.SetPermissions("ptsdfsd"),
+                new ArgumentException("s is not a valid SAS permission"));
         }
 
         private ShareSasBuilder BuildFileSasBuilder(bool includeVersion, bool includeFilePath, TestConstants constants, string shareName, string filePath)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -208,7 +208,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Act
             TestHelper.AssertExpectedException(
                 () => blobSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("p is not a valid SAS permission"));
+                new ArgumentException("s is not a valid SAS permission"));
         }
 
         private ShareSasBuilder BuildFileSasBuilder(bool includeVersion, bool includeFilePath, TestConstants constants, string shareName, string filePath)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -178,7 +178,9 @@ namespace Azure.Storage.Files.Shares.Test
                 ShareName = test.Share.Name
             };
 
-            blobSasBuilder.SetPermissions(permissionsString);
+            blobSasBuilder.SetPermissions(
+                rawPermissions: permissionsString,
+                normalize: true);
 
             StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
 
@@ -207,7 +209,9 @@ namespace Azure.Storage.Files.Shares.Test
 
             // Act
             TestHelper.AssertExpectedException(
-                () => blobSasBuilder.SetPermissions("ptsdfsd"),
+                () => blobSasBuilder.SetPermissions(
+                    rawPermissions: "ptsdfsd",
+                    normalize: true),
                 new ArgumentException("s is not a valid SAS permission"));
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public static Uri s_invalidUri = new Uri("https://error.file.core.windows.net");
 
         public FileTestBase(bool async, ShareClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
-            : base(async, RecordedTestMode.Record)
+            : base(async, mode)
         {
             _serviceVersion = serviceVersion;
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public static Uri s_invalidUri = new Uri("https://error.file.core.windows.net");
 
         public FileTestBase(bool async, ShareClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
-            : base(async, mode)
+            : base(async, RecordedTestMode.Record)
         {
             _serviceVersion = serviceVersion;
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%).json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-99b38c0e-a22d-bdaa-e3cc-04c87ac944a8?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d71f852460c8b54b84d2762337e8d82d-e306d593e3679042-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ec4b7500-4ea5-67dd-0b74-ddb7d473dd99",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:12 GMT",
+        "ETag": "\u00220x8D8279456AA3858\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ec4b7500-4ea5-67dd-0b74-ddb7d473dd99",
+        "x-ms-request-id": "fd0441cb-001a-0000-4e7d-590a0a000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-99b38c0e-a22d-bdaa-e3cc-04c87ac944a8?sv=2019-12-12\u0026ss=f\u0026srt=sco\u0026st=2020-07-14T00%3A22%3A12Z\u0026se=2020-07-14T02%3A22%3A12Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=share",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "04c8c436-587d-c302-4e90-1b2040c4a285",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "ETag": "\u00220x8D8279456AA3858\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "TransactionOptimized",
+        "x-ms-access-tier-change-time": "7/14/2020 1:22:13 AM",
+        "x-ms-client-request-id": "04c8c436-587d-c302-4e90-1b2040c4a285",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-request-id": "8ee8438c-701a-0069-4b7d-5955a6000000",
+        "x-ms-share-quota": "5120",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-99b38c0e-a22d-bdaa-e3cc-04c87ac944a8?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-eea46931d872e8448196060813ea01f5-3a355c5b92b89d44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "108145fa-d8ab-261b-8b4f-a2bf9953b14c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "108145fa-d8ab-261b-8b4f-a2bf9953b14c",
+        "x-ms-request-id": "8ee8438f-701a-0069-4c7d-5955a6000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:12.9051036-05:00",
+    "RandomSeed": "1389145455",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%)Async.json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fe7d4a47-d429-1701-928a-27cbb9c89af9?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-cdde07747e95f44db2b27da7625b9daf-8834e8379581314a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "a6926b5f-15a5-fe96-8369-db13aeea769f",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "ETag": "\u00220x8D8279458833034\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6926b5f-15a5-fe96-8369-db13aeea769f",
+        "x-ms-request-id": "9dbe8e32-601a-0032-4f7d-5952da000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fe7d4a47-d429-1701-928a-27cbb9c89af9?sv=2019-12-12\u0026ss=f\u0026srt=sco\u0026st=2020-07-14T00%3A22%3A15Z\u0026se=2020-07-14T02%3A22%3A15Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=share",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4d6b9361-f435-cd53-3421-2498e1c76905",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "ETag": "\u00220x8D8279458833034\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "TransactionOptimized",
+        "x-ms-access-tier-change-time": "7/14/2020 1:22:16 AM",
+        "x-ms-client-request-id": "4d6b9361-f435-cd53-3421-2498e1c76905",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-request-id": "283f85e8-301a-0065-1d7d-59bb57000000",
+        "x-ms-share-quota": "5120",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fe7d4a47-d429-1701-928a-27cbb9c89af9?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-218a11dc0159a44f95c82a8007995d5e-f1fa5b35484ee441-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "1bb1be10-287e-226a-7e3b-9258a2d2a8a8",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1bb1be10-287e-226a-7e3b-9258a2d2a8a8",
+        "x-ms-request-id": "283f85eb-301a-0065-1e7d-59bb57000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:15.9477575-05:00",
+    "RandomSeed": "126463024",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%).json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-19843a9d-925d-d8dc-ed6b-baff506e32a7?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1d02c9e58534e3488ee042997aa54f34-bebe17d10c09cb4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "bd73821f-27b8-cc7d-7437-9c2b8cee1ca9",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "ETag": "\u00220x8D827945726BBBE\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bd73821f-27b8-cc7d-7437-9c2b8cee1ca9",
+        "x-ms-request-id": "818707f6-101a-0072-117d-597b34000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-19843a9d-925d-d8dc-ed6b-baff506e32a7?sv=2019-12-12\u0026ss=f\u0026srt=sco\u0026st=2020-07-14T00%3A22%3A13Z\u0026se=2020-07-14T02%3A22%3A13Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=share",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "cedfab09-74fa-ceef-5b01-2d1865909097",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "ETag": "\u00220x8D827945726BBBE\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "TransactionOptimized",
+        "x-ms-access-tier-change-time": "7/14/2020 1:22:14 AM",
+        "x-ms-client-request-id": "cedfab09-74fa-ceef-5b01-2d1865909097",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-request-id": "77728331-501a-0031-6b7d-5951dd000000",
+        "x-ms-share-quota": "5120",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-19843a9d-925d-d8dc-ed6b-baff506e32a7?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ba610547db942d4cbd4162b005785150-8222cefbf6739b4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "e021e60c-4e0f-f2ae-c26e-73c0932f35ee",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:13 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e021e60c-4e0f-f2ae-c26e-73c0932f35ee",
+        "x-ms-request-id": "77728334-501a-0031-6c7d-5951dd000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:13.6648316-05:00",
+    "RandomSeed": "2018611526",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%)Async.json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-6be075ff-8d3f-465f-ad8b-1097e796fa1d?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-913125a2920d2649b747a9055eaabb30-2022d9693c78934b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "307ac505-249e-c32c-f2cf-b28d95e3b42e",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "ETag": "\u00220x8D82794590366DD\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "307ac505-249e-c32c-f2cf-b28d95e3b42e",
+        "x-ms-request-id": "ab6aef31-d01a-004d-167d-59cce8000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-6be075ff-8d3f-465f-ad8b-1097e796fa1d?sv=2019-12-12\u0026ss=f\u0026srt=sco\u0026st=2020-07-14T00%3A22%3A16Z\u0026se=2020-07-14T02%3A22%3A16Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026restype=share",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "21914785-ca1c-357f-2eca-9ef082c316cc",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "ETag": "\u00220x8D82794590366DD\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-access-tier": "TransactionOptimized",
+        "x-ms-access-tier-change-time": "7/14/2020 1:22:17 AM",
+        "x-ms-client-request-id": "21914785-ca1c-357f-2eca-9ef082c316cc",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-request-id": "118d52ee-b01a-0019-1e7d-592662000000",
+        "x-ms-share-quota": "5120",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-6be075ff-8d3f-465f-ad8b-1097e796fa1d?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5bfc76ee7810e943954a7cf36db474f8-88ad77511e211642-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4d071650-9252-9d12-906d-faaaff164660",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4d071650-9252-9d12-906d-faaaff164660",
+        "x-ms-request-id": "118d52f6-b01a-0019-247d-592662000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:16.7905660-05:00",
+    "RandomSeed": "884246892",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-1b19408a-630d-c1ee-790e-827ffc785c30?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e30d354f8969e44799ac7ad1977697f8-3b15bb9f39378744-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "bf1ef470-3bb9-3371-5550-027617b7d69b",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:15 GMT",
+        "ETag": "\u00220x8D8279410A6DB40\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:20:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bf1ef470-3bb9-3371-5550-027617b7d69b",
+        "x-ms-request-id": "53d77e4f-a01a-0049-3b7c-59396a000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-1b19408a-630d-c1ee-790e-827ffc785c30?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-df1f13ba83abcc49b6985ce839ee1db8-09d93f9680f93a49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "080fb0cd-9d59-0e76-78f8-319193cde23c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:15 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "080fb0cd-9d59-0e76-78f8-319193cde23c",
+        "x-ms-request-id": "53d77e53-a01a-0049-3c7c-59396a000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:20:15.4024847-05:00",
+    "RandomSeed": "1707773307",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-0d6a9bdc-6770-3c55-fe92-640d10f9821c?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5431edc44cabe14dac5407881ccae064-4025870ff606ec42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4af95f68-9fc0-125c-47da-2e495e7bc0fa",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "ETag": "\u00220x8D82794127DD1D3\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:20:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4af95f68-9fc0-125c-47da-2e495e7bc0fa",
+        "x-ms-request-id": "355f4717-b01a-0030-737c-595020000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-0d6a9bdc-6770-3c55-fe92-640d10f9821c?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d2fbab9dc351ce4386a8ef0825d74fa6-50822aa543ed2245-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b1a50416-38ff-be5c-9943-43ea6bfe3829",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b1a50416-38ff-be5c-9943-43ea6bfe3829",
+        "x-ms-request-id": "355f471a-b01a-0030-747c-595020000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:20:18.4747421-05:00",
+    "RandomSeed": "651817703",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%LDWCR%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%LDWCR%).json
@@ -1,0 +1,109 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-160f3758-3b30-2307-182d-285168a01e74?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0fa7b72261535e44a828c78586d2756f-e189f7b7baf2864e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c395a9e7-35a6-6c36-fa44-3c050a75e737",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "ETag": "\u00220x8D8279457A381AB\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c395a9e7-35a6-6c36-fa44-3c050a75e737",
+        "x-ms-request-id": "0c518d27-501a-005c-037d-59fbf3000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-160f3758-3b30-2307-182d-285168a01e74?sv=2019-12-12\u0026st=2020-07-14T00%3A22%3A14Z\u0026se=2020-07-14T02%3A22%3A14Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "be6a407d-5a0b-9fcd-3629-332d5d551a8f",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "ETag": "\u00220x8D8279457DAD182\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "be6a407d-5a0b-9fcd-3629-332d5d551a8f",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-07-14T01:22:15.5526530Z",
+        "x-ms-file-creation-time": "2020-07-14T01:22:15.5526530Z",
+        "x-ms-file-id": "0",
+        "x-ms-file-last-write-time": "2020-07-14T01:22:15.5526530Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-request-id": "b86b8f1f-301a-0003-037d-59090d000000",
+        "x-ms-server-encrypted": "false",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-160f3758-3b30-2307-182d-285168a01e74?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a47a6b65fcf57b449a105ed735d5a0ae-a5d869c9642ded41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c9880115-280b-d32c-f634-ad6dc6106186",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c9880115-280b-d32c-f634-ad6dc6106186",
+        "x-ms-request-id": "b86b8f28-301a-0003-0a7d-59090d000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:14.5318629-05:00",
+    "RandomSeed": "1821768506",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%LDWCR%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%LDWCR%)Async.json
@@ -1,0 +1,109 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-4f723a0b-d1ef-425d-8627-0e71dffb8fa2?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-16bfd85bd0cfc442a5e6245d61dd2a1e-86d8dbaa4ba62f44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "905b7b4a-d43e-0926-aeec-d289a682fdb2",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "ETag": "\u00220x8D82794596D68E3\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "905b7b4a-d43e-0926-aeec-d289a682fdb2",
+        "x-ms-request-id": "dadcb701-d01a-006f-077d-59a2de000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-4f723a0b-d1ef-425d-8627-0e71dffb8fa2?sv=2019-12-12\u0026st=2020-07-14T00%3A22%3A17Z\u0026se=2020-07-14T02%3A22%3A17Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6427d9f7-fea0-8763-f82d-26be1ddb9078",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "ETag": "\u00220x8D82794599AFB7C\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6427d9f7-fea0-8763-f82d-26be1ddb9078",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-07-14T01:22:18.4897404Z",
+        "x-ms-file-creation-time": "2020-07-14T01:22:18.4897404Z",
+        "x-ms-file-id": "0",
+        "x-ms-file-last-write-time": "2020-07-14T01:22:18.4897404Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-request-id": "5ee1f886-901a-002c-3a7d-598837000000",
+        "x-ms-server-encrypted": "false",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-4f723a0b-d1ef-425d-8627-0e71dffb8fa2?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-564dbc9b06816f428b50ab0e479b6ea2-095090953656b94b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "cc9162a1-995a-8412-eb7d-d22adee2fff9",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc9162a1-995a-8412-eb7d-d22adee2fff9",
+        "x-ms-request-id": "5ee1f88a-901a-002c-3c7d-598837000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:17.4835285-05:00",
+    "RandomSeed": "282353188",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%rcwdl%).json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%rcwdl%).json
@@ -1,0 +1,109 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-2f24d23e-a0c9-8f18-1412-3dc266420bb8?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-16ac80da2298e34eb682a52a07a4f3f2-9040bbaa356a1644-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "7b2cdc9c-19f4-e44e-bd9d-98866e2f513d",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "ETag": "\u00220x8D827945816CEC8\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7b2cdc9c-19f4-e44e-bd9d-98866e2f513d",
+        "x-ms-request-id": "317b37f5-601a-001b-5d7d-592498000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-2f24d23e-a0c9-8f18-1412-3dc266420bb8?sv=2019-12-12\u0026st=2020-07-14T00%3A22%3A15Z\u0026se=2020-07-14T02%3A22%3A15Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "8925afe8-9016-67c3-e065-418d3174f817",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "ETag": "\u00220x8D82794584406A0\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8925afe8-9016-67c3-e065-418d3174f817",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-07-14T01:22:16.2421408Z",
+        "x-ms-file-creation-time": "2020-07-14T01:22:16.2421408Z",
+        "x-ms-file-id": "0",
+        "x-ms-file-last-write-time": "2020-07-14T01:22:16.2421408Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-request-id": "ea3f072d-f01a-0037-2d7d-59a6a5000000",
+        "x-ms-server-encrypted": "false",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-2f24d23e-a0c9-8f18-1412-3dc266420bb8?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-da55c8c551a5cf4fb3b350abceeb7da4-7604c8dbddd1194e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "be9d505f-c709-6326-8fd2-3f496cca4262",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:15 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "be9d505f-c709-6326-8fd2-3f496cca4262",
+        "x-ms-request-id": "ea3f073c-f01a-0037-3a7d-59a6a5000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:15.2374513-05:00",
+    "RandomSeed": "45397265",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%rcwdl%)Async.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions(%rcwdl%)Async.json
@@ -1,0 +1,109 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fa6b428b-407b-858e-cfc1-927b14660812?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8d1c0d2b62033944bfa08775460b4bb4-370f3af540959f4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4d24132e-bc7b-d84e-9412-9eca0e60e4e6",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "ETag": "\u00220x8D8279459D87B39\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4d24132e-bc7b-d84e-9412-9eca0e60e4e6",
+        "x-ms-request-id": "66448c11-401a-002e-397d-598acd000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fa6b428b-407b-858e-cfc1-927b14660812?sv=2019-12-12\u0026st=2020-07-14T00%3A22%3A18Z\u0026se=2020-07-14T02%3A22%3A18Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "004ddb1c-bb42-c897-04ee-4e86488e9085",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "ETag": "\u00220x8D827945A076594\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:22:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "004ddb1c-bb42-c897-04ee-4e86488e9085",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-07-14T01:22:19.2002452Z",
+        "x-ms-file-creation-time": "2020-07-14T01:22:19.2002452Z",
+        "x-ms-file-id": "0",
+        "x-ms-file-last-write-time": "2020-07-14T01:22:19.2002452Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-request-id": "b8b9c3fd-901a-0063-487d-594c2f000000",
+        "x-ms-server-encrypted": "false",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fa6b428b-407b-858e-cfc1-927b14660812?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a41c4e9fd3fa8241a16959caab520f00-9d12f325dcb40640-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "32ae9623-e413-28a3-bc02-8a2519195b5a",
+        "x-ms-date": "Tue, 14 Jul 2020 01:22:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:22:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "32ae9623-e413-28a3-bc02-8a2519195b5a",
+        "x-ms-request-id": "b8b9c401-901a-0063-497d-594c2f000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:22:18.1847557-05:00",
+    "RandomSeed": "1346119638",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions_Invalid.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions_Invalid.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-70c26e78-3761-9d5a-6a9e-3534861ec203?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-03e4d023ca02e64a8deb69173d2d1cad-a51fd305c704e64d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3a197aec-41bb-4ba8-e791-50ff6b8af0d7",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:15 GMT",
+        "ETag": "\u00220x8D8279410EC5CAD\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:20:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3a197aec-41bb-4ba8-e791-50ff6b8af0d7",
+        "x-ms-request-id": "53e65781-001a-000b-597c-59127e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-70c26e78-3761-9d5a-6a9e-3534861ec203?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-772f18cf0c80214da89af07bcf3419a4-8d32021ae9987b4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "0b479baa-8805-ec47-7d72-c6bde228c26f",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:15 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:16 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0b479baa-8805-ec47-7d72-c6bde228c26f",
+        "x-ms-request-id": "53e65785-001a-000b-5b7c-59127e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:20:15.8407630-05:00",
+    "RandomSeed": "1575550834",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions_InvalidAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileSasBuilderTests/SharePermissionsRawPermissions_InvalidAsync.json
@@ -1,0 +1,72 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-c5114614-49f7-4593-dcdb-22e4e1366dad?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-86b45f86fd8e4a469d677b1513b27c3d-993abe9ac69a4544-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "92e78f49-4d4d-7457-b54a-c79b7ad8498d",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "ETag": "\u00220x8D8279412BA6BAE\u0022",
+        "Last-Modified": "Tue, 14 Jul 2020 01:20:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "92e78f49-4d4d-7457-b54a-c79b7ad8498d",
+        "x-ms-request-id": "d76778a4-c01a-0034-757c-59a5a2000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-c5114614-49f7-4593-dcdb-22e4e1366dad?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-dc51bd4dcf0cb74f80546bc4d876164b-59d5b07da21ec44c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "529a6ab3-db4e-6c5f-f7fb-645ab4e282a2",
+        "x-ms-date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:20:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "529a6ab3-db4e-6c5f-f7fb-645ab4e282a2",
+        "x-ms-request-id": "d76778b3-c01a-0034-027c-59a5a2000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:20:18.8768188-05:00",
+    "RandomSeed": "1660605727",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.4.0-preview.6 (Unreleased)
-
+- Updated QueueSasBuilder to correctly order raw string permissions and make the permissions lowercase.
 
 ## 12.4.0-preview.5 (2020-07-03)
 - Fixed a bug in queue client-side encryption deserialization.

--- a/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
@@ -369,7 +369,6 @@ namespace Azure.Storage.Sas
         public override int GetHashCode() { throw null; }
         public void SetPermissions(Azure.Storage.Sas.QueueAccountSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.QueueSasPermissions permissions) { }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
         public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.SasQueryParameters ToSasQueryParameters(Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { throw null; }

--- a/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
@@ -369,7 +369,9 @@ namespace Azure.Storage.Sas
         public override int GetHashCode() { throw null; }
         public void SetPermissions(Azure.Storage.Sas.QueueAccountSasPermissions permissions) { }
         public void SetPermissions(Azure.Storage.Sas.QueueSasPermissions permissions) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions) { }
+        public void SetPermissions(string rawPermissions, bool normalize = false) { }
         public Azure.Storage.Sas.SasQueryParameters ToSasQueryParameters(Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -116,11 +116,14 @@ namespace Azure.Storage.Sas
             Constants.Sas.Permissions.Read,
             Constants.Sas.Permissions.Write,
             Constants.Sas.Permissions.Delete,
+            Constants.Sas.Permissions.DeleteBlobVersion,
             Constants.Sas.Permissions.List,
             Constants.Sas.Permissions.Add,
             Constants.Sas.Permissions.Create,
             Constants.Sas.Permissions.Update,
-            Constants.Sas.Permissions.Process
+            Constants.Sas.Permissions.Process,
+            Constants.Sas.Permissions.Tag,
+            Constants.Sas.Permissions.FilterByTags,
         };
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text;
 using Azure.Storage.Queues;
 
 namespace Azure.Storage.Sas
@@ -104,7 +106,7 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = rawPermissions;
+            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
         }
 
         /// <summary>
@@ -214,6 +216,75 @@ namespace Azure.Storage.Sas
             {
                 Version = SasQueryParameters.DefaultSasVersion;
             }
+        }
+
+        private static string ValidateAndSanitizeRawPermissions(string permissions)
+        {
+            if (permissions == null)
+            {
+                return null;
+            }
+
+            // Convert permissions string to lower case.
+            permissions = permissions.ToLowerInvariant();
+
+            HashSet<char> permissionsSet = new HashSet<char>();
+
+            foreach (char permission in permissions)
+            {
+                // Check that each permission is a real SAS permission.
+                if (!Constants.Sas.ValidPermissions.Contains(permission))
+                {
+                    throw new ArgumentException($"{permission} is not a valid SAS permission");
+                }
+
+                // Add permission to permissionsSet for re-ordering.
+                permissionsSet.Add(permission);
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Read);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Write);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Delete);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.List);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Add);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Create);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Update))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Update);
+            }
+
+            if (permissionsSet.Contains(Constants.Sas.Permissions.Process))
+            {
+                stringBuilder.Append(Constants.Sas.Permissions.Process);
+            }
+
+            return stringBuilder.ToString();
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -103,12 +103,34 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
+        /// <param name="rawPermissions">
+        /// Raw permissions string for the SAS.
+        /// </param>
+        /// <param name="normalize">
+        /// If the permissions should be validated and correctly ordered.
+        /// </param>
+        public void SetPermissions(
+            string rawPermissions,
+            bool normalize = default)
+        {
+            if (normalize)
+            {
+                rawPermissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                    permissions: rawPermissions,
+                    validPermissionsInOrder: s_validPermissionsInOrder);
+            }
+
+            SetPermissions(rawPermissions);
+        }
+
+        /// <summary>
+        /// Sets the permissions for the SAS using a raw permissions string.
+        /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
-                permissions: rawPermissions,
-                validPermissionsInOrder: s_validPermissionsInOrder);
+            Permissions = rawPermissions;
         }
 
         private static readonly List<char> s_validPermissionsInOrder = new List<char>

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -127,7 +127,6 @@ namespace Azure.Storage.Sas
         /// Sets the permissions for the SAS using a raw permissions string.
         /// </summary>
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPermissions(string rawPermissions)
         {
             Permissions = rawPermissions;

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -106,8 +106,22 @@ namespace Azure.Storage.Sas
         /// <param name="rawPermissions">Raw permissions string for the SAS.</param>
         public void SetPermissions(string rawPermissions)
         {
-            Permissions = ValidateAndSanitizeRawPermissions(rawPermissions);
+            Permissions = SasExtensions.ValidateAndSanitizeRawPermissions(
+                permissions: rawPermissions,
+                validPermissionsInOrder: s_validPermissionsInOrder);
         }
+
+        private static readonly List<char> s_validPermissionsInOrder = new List<char>
+        {
+            Constants.Sas.Permissions.Read,
+            Constants.Sas.Permissions.Write,
+            Constants.Sas.Permissions.Delete,
+            Constants.Sas.Permissions.List,
+            Constants.Sas.Permissions.Add,
+            Constants.Sas.Permissions.Create,
+            Constants.Sas.Permissions.Update,
+            Constants.Sas.Permissions.Process
+        };
 
         /// <summary>
         /// Use an account's <see cref="StorageSharedKeyCredential"/> to sign this
@@ -216,75 +230,6 @@ namespace Azure.Storage.Sas
             {
                 Version = SasQueryParameters.DefaultSasVersion;
             }
-        }
-
-        private static string ValidateAndSanitizeRawPermissions(string permissions)
-        {
-            if (permissions == null)
-            {
-                return null;
-            }
-
-            // Convert permissions string to lower case.
-            permissions = permissions.ToLowerInvariant();
-
-            HashSet<char> permissionsSet = new HashSet<char>();
-
-            foreach (char permission in permissions)
-            {
-                // Check that each permission is a real SAS permission.
-                if (!Constants.Sas.ValidPermissions.Contains(permission))
-                {
-                    throw new ArgumentException($"{permission} is not a valid SAS permission");
-                }
-
-                // Add permission to permissionsSet for re-ordering.
-                permissionsSet.Add(permission);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Read))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Read);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Write))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Write);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Delete))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Delete);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.List))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.List);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Add))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Add);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Create))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Create);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Update))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Update);
-            }
-
-            if (permissionsSet.Contains(Constants.Sas.Permissions.Process))
-            {
-                stringBuilder.Append(Constants.Sas.Permissions.Process);
-            }
-
-            return stringBuilder.ToString();
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -203,7 +203,7 @@ namespace Azure.Storage.Queues.Test
             // Act
             TestHelper.AssertExpectedException(
                 () => queueSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("s is not a valid SAS permission"));
+                new ArgumentException("t is not a valid SAS permission"));
         }
 
         private QueueSasBuilder BuildQueueSasBuilder(TestConstants constants, string queueName, bool includeVersion)

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -203,7 +203,7 @@ namespace Azure.Storage.Queues.Test
             // Act
             TestHelper.AssertExpectedException(
                 () => queueSasBuilder.SetPermissions("ptsdfsd"),
-                new ArgumentException("t is not a valid SAS permission"));
+                new ArgumentException("s is not a valid SAS permission"));
         }
 
         private QueueSasBuilder BuildQueueSasBuilder(TestConstants constants, string queueName, bool includeVersion)

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -172,7 +172,9 @@ namespace Azure.Storage.Queues.Test
                 QueueName = test.Queue.Name
             };
 
-            queueSasBuilder.SetPermissions(permissionsString);
+            queueSasBuilder.SetPermissions(
+                rawPermissions: permissionsString,
+                normalize: true);
 
             StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
 
@@ -202,7 +204,9 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             TestHelper.AssertExpectedException(
-                () => queueSasBuilder.SetPermissions("ptsdfsd"),
+                () => queueSasBuilder.SetPermissions(
+                    rawPermissions: "ptsdfsd",
+                    normalize: true),
                 new ArgumentException("s is not a valid SAS permission"));
         }
 

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
 using Azure.Storage.Queues.Tests;
 using Azure.Storage.Sas;
+using Azure.Storage.Test;
 using NUnit.Framework;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
@@ -104,6 +107,103 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(constants.Sas.Identifier, sasQueryParameters.Identifier);
             Assert.AreEqual(SasProtocol.Https, sasQueryParameters.Protocol);
             Assert.AreEqual(constants.Sas.Version, sasQueryParameters.Version);
+        }
+
+        [Test]
+        [ServiceVersion(Min = QueueClientOptions.ServiceVersion.V2019_12_12)]
+        [TestCase("FTPUCALXDWR")]
+        [TestCase("rwdxlacuptf")]
+        public async Task AccountPermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Queues,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            accountSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            Uri uri = new Uri($"{test.Queue.Uri}?{accountSasBuilder.ToSasQueryParameters(sharedKeyCredential)}");
+
+            QueueClient queueClient = new QueueClient(uri, GetOptions());
+
+            // Act
+            await queueClient.GetPropertiesAsync();
+        }
+
+        [Test]
+        public async Task AccountPermissionsRawPermissions_InvalidPermission()
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+
+            AccountSasBuilder accountSasBuilder = new AccountSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                Services = AccountSasServices.Queues,
+                ResourceTypes = AccountSasResourceTypes.All
+            };
+
+            TestHelper.AssertExpectedException(
+                () => accountSasBuilder.SetPermissions("werteyfg"),
+                new ArgumentException("e is not a valid SAS permission"));
+        }
+
+        [Test]
+        [TestCase("PUAR")]
+        [TestCase("raup")]
+        public async Task QueuePermissionsRawPermissions(string permissionsString)
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+
+            QueueSasBuilder queueSasBuilder = new QueueSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                QueueName = test.Queue.Name
+            };
+
+            queueSasBuilder.SetPermissions(permissionsString);
+
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+
+            QueueUriBuilder queueUriBuilder = new QueueUriBuilder(test.Queue.Uri)
+            {
+                Sas = queueSasBuilder.ToSasQueryParameters(sharedKeyCredential)
+            };
+
+            QueueClient sasQueueClient = new QueueClient(queueUriBuilder.ToUri(), GetOptions());
+
+            // Act
+            await sasQueueClient.PeekMessagesAsync();
+        }
+
+        [Test]
+        public async Task QueuePermissionsRawPermissions_Invalid()
+        {
+            // Arrange
+            await using DisposingQueue test = await GetTestQueueAsync();
+
+            QueueSasBuilder queueSasBuilder = new QueueSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                QueueName = test.Queue.Name
+            };
+
+            // Act
+            TestHelper.AssertExpectedException(
+                () => queueSasBuilder.SetPermissions("ptsdfsd"),
+                new ArgumentException("s is not a valid SAS permission"));
         }
 
         private QueueSasBuilder BuildQueueSasBuilder(TestConstants constants, string queueName, bool includeVersion)

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%).json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-71351bbe-0cdb-d3d6-f68d-2e147b8f45f9",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-55b43c6d68917f4094af9447b49c3e44-3a6f1d15a0eb754b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "735fce30-85a7-b34d-7e02-c26952472bf3",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:03 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "0357a52b-3003-0003-307d-59090d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-71351bbe-0cdb-d3d6-f68d-2e147b8f45f9?sv=2019-12-12\u0026ss=q\u0026srt=sco\u0026st=2020-07-14T00%3A26%3A02Z\u0026se=2020-07-14T02%3A26%3A02Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ace45afa-d130-0652-079a-de3fc5124356",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:03 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "0889377a-1003-005b-3b7d-590d76000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-71351bbe-0cdb-d3d6-f68d-2e147b8f45f9",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-4bdddba59335374daa4127b7c96e8b73-bc9dd67396271143-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "f86e5366-7e63-95c2-51cb-cc5395a9708d",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:03 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "08893788-1003-005b-457d-590d76000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:02.9512178-05:00",
+    "RandomSeed": "671321386",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%FTPUCALXDWR%)Async.json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-6872ad62-8a48-5b09-d13d-1614335d17d8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-06e74ab08d66294a80ebdfadcf9be772-4f64c7386670b943-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "2e95c65d-c1b7-7343-8c1f-78366c764317",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:08 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "2c71f75a-1003-001f-657d-59d11a000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-6872ad62-8a48-5b09-d13d-1614335d17d8?sv=2019-12-12\u0026ss=q\u0026srt=sco\u0026st=2020-07-14T00%3A26%3A07Z\u0026se=2020-07-14T02%3A26%3A07Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6cb713b4-e9c7-9e20-c1a9-ee661d1916a7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "8a506ca3-f003-0037-357d-59a6a5000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-6872ad62-8a48-5b09-d13d-1614335d17d8",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-de750e0e2e933e4aaa6d3d7789017e35-23e62be85dffe943-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "58816977-d7bf-1850-37b8-53e0e48aae44",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "8a506cb5-f003-0037-457d-59a6a5000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:07.4118724-05:00",
+    "RandomSeed": "849927001",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%).json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7862269e-d9bd-c8fa-f5b3-a910a4d31fe5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c6eb83a14c7ac946830632d573ba289c-252a6a556290274b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "2122dda9-98a0-c406-1d25-18a4a51f01e2",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "9afe542f-a003-002f-617d-598b30000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7862269e-d9bd-c8fa-f5b3-a910a4d31fe5?sv=2019-12-12\u0026ss=q\u0026srt=sco\u0026st=2020-07-14T00%3A26%3A04Z\u0026se=2020-07-14T02%3A26%3A04Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c76694e9-feb0-4f44-4e9d-c392270414fe",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "ebe45d11-1003-0050-637d-591502000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7862269e-d9bd-c8fa-f5b3-a910a4d31fe5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0d9d2ec159cca94e8e667f9faba0dc35-347beaf372b3ee44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "11bbfc25-3ab8-2631-2076-51255ddd3778",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:04 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "ebe45d17-1003-0050-677d-591502000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:04.6301264-05:00",
+    "RandomSeed": "644072145",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions(%rwdxlacuptf%)Async.json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7bbe9db5-a8ef-7543-e64a-2d0bf8512ff1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c6d52fa154276847a17871bfc0f76eb2-5970c0c313b2454c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "1fa60608-2e80-5a69-66c1-e9f4ce7c7d8e",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:08 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e17d33e0-f003-001e-717d-59d0e7000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7bbe9db5-a8ef-7543-e64a-2d0bf8512ff1?sv=2019-12-12\u0026ss=q\u0026srt=sco\u0026st=2020-07-14T00%3A26%3A08Z\u0026se=2020-07-14T02%3A26%3A08Z\u0026sp=rwdxlacuptf\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "f2030651-10aa-8671-0c53-087f69c09b9a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:08 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "40221555-0003-0066-2e7d-59b850000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7bbe9db5-a8ef-7543-e64a-2d0bf8512ff1",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f149dcc3be033f45b5869eae541529fb-39efc1302344f345-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c8a23d37-8b79-7ae4-0ae5-2fa12420f928",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:08 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "40221594-0003-0066-677d-59b850000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:08.0824292-05:00",
+    "RandomSeed": "930054314",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermission.json
@@ -1,0 +1,67 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-a5e93c99-b1ca-a9ab-6b47-c9bebe19d3a8",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-58ff752dd7348743bfdf697ffdffb1c7-b83668bda6637a45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4557f91f-47b3-5257-0bd5-363a9cc4631c",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "b4d41070-3003-0008-6d7d-591179000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-a5e93c99-b1ca-a9ab-6b47-c9bebe19d3a8",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-29e6757721e666469b3bd08a5064c7b9-f6a8222c1f790b41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c49fbba0-8ec1-96f4-8451-5fe2dddd43c5",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "b4d41087-3003-0008-017d-591179000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:02.0677432-05:00",
+    "RandomSeed": "1807209960",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/AccountPermissionsRawPermissions_InvalidPermissionAsync.json
@@ -1,0 +1,67 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-87406672-b8a9-19a4-149e-7a825bf9804a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fae4bf06ad887e409b5d29a0f601a866-8382aa168befff44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "43c3a227-2606-eadd-98ef-629bf667c6e4",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "7635a18e-c003-0052-3a7d-5917f8000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-87406672-b8a9-19a4-149e-7a825bf9804a",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2883ba8a6a4a24479beb90428eda41e6-8f69cb9489ef9d4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b95a5be4-3c35-fd43-ab4b-2eb84cd0f770",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "7635a1ae-c003-0052-537d-5917f8000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:06.6769352-05:00",
+    "RandomSeed": "1419572244",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%PUAR%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%PUAR%).json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-4d82873e-a0dc-2b52-4bb7-4a34ed9e4400",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-59413fcfaae05a4392cc3d9b561c864a-bed8c341dcb8c043-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c36b1ae3-1492-7735-5cef-ca6b1a84d672",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:04 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e5b7c4da-d003-006f-7b7d-59a2de000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-4d82873e-a0dc-2b52-4bb7-4a34ed9e4400/messages?sv=2019-12-12\u0026st=2020-07-14T00%3A26%3A05Z\u0026se=2020-07-14T02%3A26%3A05Z\u0026sp=raup\u0026sig=Sanitized\u0026peekonly=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d350e60f-8132-196e-f497-8ad042835739",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "62",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:26:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-request-id": "ca4d35c7-1003-0036-017d-59a758000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CQueueMessagesList /\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-4d82873e-a0dc-2b52-4bb7-4a34ed9e4400",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-361398e48ef7b04d8aaca9238dd23d27-ae0cdef192050d4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "335c35fe-0333-b840-b843-b6ee0197ef15",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:05 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "ca4d35cc-1003-0036-037d-59a758000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:05.2867317-05:00",
+    "RandomSeed": "266217059",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%PUAR%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%PUAR%)Async.json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-9abd424f-afcc-6303-86da-b7fac2fa6dcb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1e40c1aa2f17e14983d379408cd81230-bf177eca73ee114b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d17161e2-3f8a-1912-4915-af0229b053b9",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "41e7d167-5003-0018-3f7d-59279f000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-9abd424f-afcc-6303-86da-b7fac2fa6dcb/messages?sv=2019-12-12\u0026st=2020-07-14T00%3A26%3A08Z\u0026se=2020-07-14T02%3A26%3A08Z\u0026sp=raup\u0026sig=Sanitized\u0026peekonly=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6018c914-9b88-7b41-7b99-42c8d400091c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "62",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-request-id": "ca65d2c4-7003-0062-567d-594dd2000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CQueueMessagesList /\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-9abd424f-afcc-6303-86da-b7fac2fa6dcb",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-de582b923166d94690167dee5b627205-8b1e5d483618fe4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "5fedb8b3-f297-f731-b0b2-40c53171f73f",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "ca65d2de-7003-0062-6c7d-594dd2000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:08.8209289-05:00",
+    "RandomSeed": "1375117650",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%raup%).json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%raup%).json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-561ea30d-6a69-bdec-4a3d-213c92b3de49",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-56ef1fc2d0a00c4c866dc770f1fc7d23-b3ec20edfde5ee4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "63a59b9a-b5ba-4c5e-ae02-6bd4c9af2257",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "e247e8e4-a003-0006-567d-59fd72000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-561ea30d-6a69-bdec-4a3d-213c92b3de49/messages?sv=2019-12-12\u0026st=2020-07-14T00%3A26%3A06Z\u0026se=2020-07-14T02%3A26%3A06Z\u0026sp=raup\u0026sig=Sanitized\u0026peekonly=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "f6a2c389-7a0d-4e8f-eb76-f8d33440d0ee",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "62",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-request-id": "6a73c6f4-7003-0026-4d7d-5991be000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CQueueMessagesList /\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-561ea30d-6a69-bdec-4a3d-213c92b3de49",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5ca9c151b6143344ac213bf47b9dc1b1-b347f0b09b1a0e4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "054a24a2-2b0d-574a-c7dc-132ca27e394f",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "6a73c702-7003-0026-587d-5991be000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:06.0012168-05:00",
+    "RandomSeed": "692413830",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%raup%)Async.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions(%raup%)Async.json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-da22f75f-187f-f680-0043-64633b281afc",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e35a7916d8402146ac568c7e774f1af0-5917a63126188747-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "382634ef-1bd9-5e32-235c-ab431d58f142",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "1229e2d3-5003-0013-4a7d-593feb000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-da22f75f-187f-f680-0043-64633b281afc/messages?sv=2019-12-12\u0026st=2020-07-14T00%3A26%3A09Z\u0026se=2020-07-14T02%3A26%3A09Z\u0026sp=raup\u0026sig=Sanitized\u0026peekonly=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "077371fc-e202-2023-2266-cca147c6e7b7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "62",
+        "Content-Type": "application/xml",
+        "Date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-request-id": "7053fc5b-c003-0034-297d-59a5a2000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CQueueMessagesList /\u003E"
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-da22f75f-187f-f680-0043-64633b281afc",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-bde0ff18e4835d4ab3129ac8c379cd05-eceaba44a57cd448-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ab472656-eae5-5a40-22b4-4eed15802425",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "7053fc61-c003-0034-2d7d-59a5a2000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:09.4763025-05:00",
+    "RandomSeed": "1083408854",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions_Invalid.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions_Invalid.json
@@ -1,0 +1,67 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-59b00801-49d3-463d-a271-c623b54373cf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-43606a528e0bc642bf7970ad53dd3e0c-1af89bb65fbc354d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "78777f3b-d11e-de37-289d-79bd28b8c9b7",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "7acdc3ac-9003-0063-037d-594c2f000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-59b00801-49d3-463d-a271-c623b54373cf",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-81ad6cfb28d8f24c9e668440973a3e77-ee1209a43a15dd42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "35e8f4c1-fbcb-02b0-5b89-47685a96982f",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:02 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "7acdc3b3-9003-0063-087d-594c2f000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:02.5752570-05:00",
+    "RandomSeed": "29944713",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions_InvalidAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueSasBuilderTests/QueuePermissionsRawPermissions_InvalidAsync.json
@@ -1,0 +1,67 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7d5fbf16-ece3-42b9-c720-9d073965d9bf",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-663753a8f0e7454ea1b08b37e7ec3485-4ed9ff2fdf1e764a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4d4ee428-e619-72da-0d95-f3e4d2181a12",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "49c2b320-c003-003f-3c7d-59bdd6000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://seandevtest.queue.core.windows.net/test-queue-7d5fbf16-ece3-42b9-c720-9d073965d9bf",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a6342fd587ce46408844de23e1268170-6d6954ff0f0b9b4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues/12.4.0-dev.20200713.1",
+          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "55de87ed-8c17-76a5-3994-498e38437597",
+        "x-ms-date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 14 Jul 2020 01:26:07 GMT",
+        "Server": [
+          "Windows-Azure-Queue/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": "49c2b323-c003-003f-3d7d-59bdd6000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-07-13T20:26:07.0478128-05:00",
+    "RandomSeed": "849478636",
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
+  }
+}


### PR DESCRIPTION
I updated `BlobSasBuilder`, `ShareSasBuilder`, `DataLakeSasBuilder`, and `QueueSasBuilder` to validate and re-order raw string permissions when the `SetPermissions()` method is called with a string.