### PR TITLE
Identity update KnownAuthorityHosts to use properties

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -169,10 +169,10 @@ namespace Azure.Identity
     }
     public static partial class KnownAuthorityHosts
     {
-        public static readonly System.Uri AzureChinaCloud;
-        public static readonly System.Uri AzureCloud;
-        public static readonly System.Uri AzureGermanCloud;
-        public static readonly System.Uri AzureUSGovernment;
+        public static System.Uri AzureChinaCloud { get { throw null; } }
+        public static System.Uri AzureCloud { get { throw null; } }
+        public static System.Uri AzureGermanCloud { get { throw null; } }
+        public static System.Uri AzureUSGovernment { get { throw null; } }
     }
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/src/KnownAuthorityHosts.cs
+++ b/sdk/identity/Azure.Identity/src/KnownAuthorityHosts.cs
@@ -17,22 +17,22 @@ namespace Azure.Identity
         /// <summary>
         /// The host of the Azure Active Directory authority for tenants in the Azure Public Cloud.
         /// </summary>
-        public static readonly Uri AzureCloud = new Uri(AzureCloudHostUrl);
+        public static Uri AzureCloud { get; } = new Uri(AzureCloudHostUrl);
 
         /// <summary>
         /// The host of the Azure Active Directory authority for tenants in the Azure China Cloud.
         /// </summary>
-        public static readonly Uri AzureChinaCloud = new Uri(AzureChinaCloudHostUrl);
+        public static Uri AzureChinaCloud { get; } = new Uri(AzureChinaCloudHostUrl);
 
         /// <summary>
         /// The host of the Azure Active Directory authority for tenants in the Azure German Cloud.
         /// </summary>
-        public static readonly Uri AzureGermanCloud = new Uri(AzureGermanCloudHostUrl);
+        public static Uri AzureGermanCloud { get; } = new Uri(AzureGermanCloudHostUrl);
 
         /// <summary>
         /// The host of the Azure Active Directory authority for tenants in the Azure US Government Cloud.
         /// </summary>
-        public static readonly Uri AzureUSGovernment = new Uri(AzureUSGovernmentHostUrl);
+        public static Uri AzureUSGovernment { get; } = new Uri(AzureUSGovernmentHostUrl);
 
         internal static Uri GetDefault()
         {


### PR DESCRIPTION
Updating the static readonly fields on `KnownAuthorityHosts` to be readonly properties to align with similar types across the SDK.