### PR TITLE
Add support for using two generator versions and update Teamplate to the new one

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6223/autorest-3.0.6223.tgz</_AutoRestVersion>
-    <_AutoRestCoreVersion>3.0.6283</_AutoRestCoreVersion>
-    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200625.1/autorest-csharp-v3-3.0.0-dev.20200625.1.tgz</_AutoRestCSharpVersion>
+    <_AutoRestCoreVersion>3.0.6289</_AutoRestCoreVersion>
+    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200715.3/autorest-csharp-v3-3.0.0-dev.20200715.3.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
     <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutoRestInput Condition="'$(AutoRestInput)' == ''">$(_DefaultInputName)</AutoRestInput>
@@ -16,6 +16,12 @@
     <_AutoRestSharedCodeDirectory>$(_SharedCodeDirectory)AutoRest/</_AutoRestSharedCodeDirectory>
 
     <_GenerateCode Condition="'$(_SupportsCodeGeneration)' == 'true' AND '$(AutoRestInput)' != ''">true</_GenerateCode>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TemporaryUsePreviousGeneratorVersion)' == 'true'">
+    <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6223/autorest-3.0.6223.tgz</_AutoRestVersion>
+    <_AutoRestCoreVersion>3.0.6283</_AutoRestCoreVersion>
+    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200625.1/autorest-csharp-v3-3.0.0-dev.20200625.1.tgz</_AutoRestCSharpVersion>
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/src/Azure.ResourceManager.AppConfiguration.csproj
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/src/Azure.ResourceManager.AppConfiguration.csproj
@@ -8,5 +8,6 @@
     </Description>
     <PackageTags>azure;management;appconfiguration</PackageTags>
     <NoWarn>$(NoWarn);AZC0001;AZC0008;</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>

--- a/sdk/compute/Azure.ResourceManager.Compute/src/Azure.ResourceManager.Compute.csproj
+++ b/sdk/compute/Azure.ResourceManager.Compute/src/Azure.ResourceManager.Compute.csproj
@@ -7,6 +7,7 @@
       This is a beta preview vesion. This version uses a next-generation code generator that introduces important breaking changes, but also new features (such as intuitive authentication, custom HTTP pipeline, distributed tracing and much more).
     </Description>
     <PackageTags>azure;management;compute</PackageTags>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
     <PropertyGroup>

--- a/sdk/core/Azure.Core/src/Shared/AutoRest/ChangeTrackingDictionary.cs
+++ b/sdk/core/Azure.Core/src/Shared/AutoRest/ChangeTrackingDictionary.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Azure.Core
+{
+    internal class ChangeTrackingDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue> where TKey: notnull
+    {
+        private IDictionary<TKey, TValue>? _innerDictionary;
+
+        public ChangeTrackingDictionary()
+        {
+        }
+
+        public ChangeTrackingDictionary(Optional<IReadOnlyDictionary<TKey, TValue>> optionalDictionary) : this(optionalDictionary.Value)
+        {
+        }
+
+        public ChangeTrackingDictionary(Optional<IDictionary<TKey, TValue>> optionalDictionary) : this(optionalDictionary.Value)
+        {
+        }
+
+        private ChangeTrackingDictionary(IDictionary<TKey, TValue> dictionary)
+        {
+            if (dictionary == null) return;
+
+            _innerDictionary = new Dictionary<TKey, TValue>(dictionary);
+        }
+
+        private ChangeTrackingDictionary(IReadOnlyDictionary<TKey, TValue> dictionary)
+        {
+            if (dictionary == null) return;
+
+            _innerDictionary = new Dictionary<TKey, TValue>();
+            foreach (KeyValuePair<TKey, TValue> pair in dictionary)
+            {
+                _innerDictionary.Add(pair);
+            }
+        }
+
+        public bool IsUndefined => _innerDictionary == null;
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            if (IsUndefined)
+            {
+                IEnumerator<KeyValuePair<TKey, TValue>> GetEmptyEnumerator()
+                {
+                    yield break;
+                }
+                return GetEmptyEnumerator();
+            }
+            return EnsureDictionary().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            EnsureDictionary().Add(item);
+        }
+
+        public void Clear()
+        {
+            EnsureDictionary().Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            if (IsUndefined)
+            {
+                return false;
+            }
+
+            return EnsureDictionary().Contains(item);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            if (IsUndefined)
+            {
+                return;
+            }
+
+            EnsureDictionary().CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            if (IsUndefined)
+            {
+                return false;
+            }
+
+            return EnsureDictionary().Remove(item);
+        }
+
+        public int Count
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    return 0;
+                }
+
+                return EnsureDictionary().Count;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    return false;
+                }
+                return EnsureDictionary().IsReadOnly;
+            }
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            EnsureDictionary().Add(key, value);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            if (IsUndefined)
+            {
+                return false;
+            }
+
+            return EnsureDictionary().ContainsKey(key);
+        }
+
+        public bool Remove(TKey key)
+        {
+            if (IsUndefined)
+            {
+                return false;
+            }
+
+            return EnsureDictionary().Remove(key);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            if (IsUndefined)
+            {
+                value = default!;
+                return false;
+            }
+            return EnsureDictionary().TryGetValue(key, out value);
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    throw new KeyNotFoundException(nameof(key));
+                }
+
+                return EnsureDictionary()[key];
+            }
+            set => EnsureDictionary()[key] = value;
+        }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    return Array.Empty<TKey>();
+                }
+
+                return EnsureDictionary().Keys;
+            }
+        }
+
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    return Array.Empty<TValue>();
+                }
+
+                return EnsureDictionary().Values;
+            }
+        }
+
+        private IDictionary<TKey, TValue> EnsureDictionary()
+        {
+            return _innerDictionary ??= new Dictionary<TKey, TValue>();
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/AutoRest/ChangeTrackingList.cs
+++ b/sdk/core/Azure.Core/src/Shared/AutoRest/ChangeTrackingList.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace Azure.Core
+{
+    internal class ChangeTrackingList<T>: IList<T>, IReadOnlyList<T>
+    {
+        private IList<T>? _innerList;
+
+        public ChangeTrackingList()
+        {
+        }
+
+        public ChangeTrackingList(Optional<IList<T>> optionalList) : this(optionalList.Value)
+        {
+        }
+
+        public ChangeTrackingList(Optional<IReadOnlyList<T>> optionalList) : this(optionalList.Value)
+        {
+        }
+
+        private ChangeTrackingList(IEnumerable<T> innerList)
+        {
+            if (innerList == null)
+            {
+                return;
+            }
+
+            _innerList = innerList.ToList();
+        }
+
+        private ChangeTrackingList(IList<T> innerList)
+        {
+            if (innerList == null)
+            {
+                return;
+            }
+
+            _innerList = innerList;
+        }
+
+        public bool IsUndefined => _innerList == null;
+
+        public void Reset()
+        {
+            _innerList = null;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (IsUndefined)
+            {
+                IEnumerator<T> EnumerateEmpty()
+                {
+                    yield break;
+                }
+
+                return EnumerateEmpty();
+            }
+            return EnsureList().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Add(T item)
+        {
+            EnsureList().Add(item);
+        }
+
+        public void Clear()
+        {
+            EnsureList().Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            if (IsUndefined)
+            {
+                return false;
+            }
+
+            return EnsureList().Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            if (IsUndefined)
+            {
+                return;
+            }
+
+            EnsureList().CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(T item)
+        {
+            if (IsUndefined)
+            {
+                return false;
+            }
+
+            return EnsureList().Remove(item);
+        }
+
+        public int Count
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    return 0;
+                }
+                return EnsureList().Count;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    return false;
+                }
+
+                return EnsureList().IsReadOnly;
+            }
+        }
+
+        public int IndexOf(T item)
+        {
+            if (IsUndefined)
+            {
+                return -1;
+            }
+
+            return EnsureList().IndexOf(item);
+        }
+
+        public void Insert(int index, T item)
+        {
+            EnsureList().Insert(index, item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            if (IsUndefined)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            EnsureList().RemoveAt(index);
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                if (IsUndefined)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return EnsureList()[index];
+            }
+            set
+            {
+                if (IsUndefined)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                EnsureList()[index] = value;
+            }
+        }
+
+        private IList<T> EnsureList()
+        {
+            return _innerList ??= new List<T>();
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/AutoRest/Optional.cs
+++ b/sdk/core/Azure.Core/src/Shared/AutoRest/Optional.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.Core
+{
+    internal static class Optional
+    {
+        public static bool IsCollectionDefined<T>(IEnumerable<T> collection)
+        {
+            return !(collection is ChangeTrackingList<T> changeTrackingList && changeTrackingList.IsUndefined);
+        }
+
+        public static bool IsCollectionDefined<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> collection)
+        {
+            return !(collection is ChangeTrackingDictionary<TKey, TValue> changeTrackingList && changeTrackingList.IsUndefined);
+        }
+
+        public static bool IsCollectionDefined<TKey, TValue>(IDictionary<TKey, TValue> collection)
+        {
+            return !(collection is ChangeTrackingDictionary<TKey, TValue> changeTrackingList && changeTrackingList.IsUndefined);
+        }
+
+        public static bool IsDefined<T>(T? value) where T: struct
+        {
+            return value.HasValue;
+        }
+        public static bool IsDefined(object value)
+        {
+            return value != null;
+        }
+        public static bool IsDefined(string value)
+        {
+            return value != null;
+        }
+
+        public static IReadOnlyDictionary<TKey, TValue> ToDictionary<TKey, TValue>(Optional<IReadOnlyDictionary<TKey, TValue>> optional)
+        {
+            if (optional.HasValue)
+            {
+                return optional.Value;
+            }
+            return new ChangeTrackingDictionary<TKey, TValue>(optional);
+        }
+
+        public static IDictionary<TKey, TValue> ToDictionary<TKey, TValue>(Optional<IDictionary<TKey, TValue>> optional)
+        {
+            if (optional.HasValue)
+            {
+                return optional.Value;
+            }
+            return new ChangeTrackingDictionary<TKey, TValue>(optional);
+        }
+        public static IReadOnlyList<T> ToList<T>(Optional<IReadOnlyList<T>> optional)
+        {
+            if (optional.HasValue)
+            {
+                return optional.Value;
+            }
+            return new ChangeTrackingList<T>(optional);
+        }
+
+        public static IList<T> ToList<T>(Optional<IList<T>> optional)
+        {
+            if (optional.HasValue)
+            {
+                return optional.Value;
+            }
+            return new ChangeTrackingList<T>(optional);
+        }
+
+        public static T? ToNullable<T>(Optional<T> optional) where T: struct
+        {
+            if (optional.HasValue)
+            {
+                return optional.Value;
+            }
+            return default;
+        }
+
+        public static T? ToNullable<T>(Optional<T?> optional) where T: struct
+        {
+            return optional.Value;
+        }
+    }
+
+    internal readonly partial struct Optional<T>
+    {
+        public Optional(T value) : this()
+        {
+            Value = value;
+            HasValue = true;
+        }
+
+        public T Value { get; }
+        public bool HasValue { get; }
+
+        public static implicit operator Optional<T>(T value) => new Optional<T>(value);
+        public static implicit operator T(Optional<T> optional) => optional.Value;
+    }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
@@ -7,6 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <NoWarn>$(NoWarn);CA1812</NoWarn>
+    
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <!-- Nuget properties -->

--- a/sdk/digitaltwins/Azure.ResourceManager.DigitalTwins/src/Azure.ResourceManager.DigitalTwins.csproj
+++ b/sdk/digitaltwins/Azure.ResourceManager.DigitalTwins/src/Azure.ResourceManager.DigitalTwins.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0-preview.1</Version>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Microsoft Azure EventGrid;Event Grid;Event Grid Publishing;</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/src/Azure.ResourceManager.EventHubs.csproj
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/src/Azure.ResourceManager.EventHubs.csproj
@@ -8,5 +8,6 @@
     </Description>
     <PackageTags>azure;management;eventhub</PackageTags>
     <NoWarn>$(NoWarn);AZC0001;AZC0008</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Azure.AI.FormRecognizer.csproj
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Azure.AI.FormRecognizer.csproj
@@ -6,6 +6,7 @@
     <PackageTags>Microsoft Azure Form Recognizer</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>false</GenerateAPIListing>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Azure.Iot.Hub.Service.csproj
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Azure.Iot.Hub.Service.csproj
@@ -5,6 +5,7 @@
     <EnableApiCompat>false</EnableApiCompat>
     <!-- These supressions should be removed in a production library -->
     <NoWarn>$(NoWarn);CA1812;1591</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <!-- Nuget properties -->

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/src/Azure.ResourceManager.KeyVault.csproj
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/src/Azure.ResourceManager.KeyVault.csproj
@@ -9,6 +9,7 @@
     <PackageTags>azure;management;keyvault</PackageTags>
     <!-- TODO: Temp workaround. Should be fixed prio release  -->
     <NoWarn>$(NoWarn);AZC0001;AZC0008;</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/Azure.Security.KeyVault.Administration.csproj
@@ -7,6 +7,7 @@
     <PackageTags>Microsoft Azure Key Vault Administration;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021;CA1812</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj
+++ b/sdk/network/Azure.ResourceManager.Network/src/Azure.ResourceManager.Network.csproj
@@ -7,6 +7,7 @@
       This is a beta preview vesion.  This version uses a next-generation code generator that introduces important breaking changes, but also new features (such as intuitive authentication, custom HTTP pipeline, distributed tracing and much more).
     </Description>
     <PackageTags>azure;management;network</PackageTags>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/resources/Azure.ResourceManager.Resources/src/Azure.ResourceManager.Resources.csproj
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/Azure.ResourceManager.Resources.csproj
@@ -8,5 +8,6 @@
     </Description>
     <PackageTags>azure;management;resource</PackageTags>
     <NoWarn>$(NoWarn);AZC0008;AZC0001</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>

--- a/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
+++ b/sdk/search/Azure.Search.Documents/src/Azure.Search.Documents.csproj
@@ -14,6 +14,7 @@
 
     <!-- These are still firing but not valid -->
     <NoWarn>$(NoWarn);AZC0007;AZC0004;AZC0001</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <!-- Pull in Shared Source from Azure.Core -->

--- a/sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj
@@ -8,5 +8,6 @@
     </Description>
     <PackageTags>azure;management;storage</PackageTags>
     <NoWarn>$(NoWarn);AZC0001;AZC0008</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/Azure.Analytics.Synapse.AccessControl.csproj
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/Azure.Analytics.Synapse.AccessControl.csproj
@@ -13,6 +13,7 @@
       <!-- Missing XML comment for publicly visible type or member  -->
       CS1591;
     </NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <Import Project="..\..\Azure.Analytics.Synapse.Shared\src\Azure.Analytics.Synapse.Shared.projitems" Label="Shared" />

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Azure.Analytics.Synapse.Artifacts.csproj
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Azure.Analytics.Synapse.Artifacts.csproj
@@ -13,6 +13,7 @@
       <!-- Missing XML comment for publicly visible type or member  -->
       CS1591;
     </NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <Import Project="..\..\Azure.Analytics.Synapse.Shared\src\Azure.Analytics.Synapse.Shared.projitems" Label="Shared" />

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Azure.Analytics.Synapse.Spark.csproj
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Azure.Analytics.Synapse.Spark.csproj
@@ -15,6 +15,7 @@
     </NoWarn>
 
     <AssemblyName>Azure.Analytics.Synapse.Spark</AssemblyName>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <Import Project="..\..\Azure.Analytics.Synapse.Shared\src\Azure.Analytics.Synapse.Shared.projitems" Label="Shared" />

--- a/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
+++ b/sdk/tables/Azure.Data.Tables/src/Azure.Data.Tables.csproj
@@ -8,6 +8,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- These supressions should be removed in a production library -->
     <NoWarn>$(NoWarn);CA1812;CS1591</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />

--- a/sdk/template/Azure.Template/src/Generated/Models/SecretBundle.Serialization.cs
+++ b/sdk/template/Azure.Template/src/Generated/Models/SecretBundle.Serialization.cs
@@ -15,82 +15,51 @@ namespace Azure.Template.Models
     {
         internal static SecretBundle DeserializeSecretBundle(JsonElement element)
         {
-            string value = default;
-            string id = default;
-            string contentType = default;
-            IReadOnlyDictionary<string, string> tags = default;
-            string kid = default;
-            bool? managed = default;
+            Optional<string> value = default;
+            Optional<string> id = default;
+            Optional<string> contentType = default;
+            Optional<IReadOnlyDictionary<string, string>> tags = default;
+            Optional<string> kid = default;
+            Optional<bool> managed = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("value"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     value = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("id"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     id = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("contentType"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     contentType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("tags"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     Dictionary<string, string> dictionary = new Dictionary<string, string>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        if (property0.Value.ValueKind == JsonValueKind.Null)
-                        {
-                            dictionary.Add(property0.Name, null);
-                        }
-                        else
-                        {
-                            dictionary.Add(property0.Name, property0.Value.GetString());
-                        }
+                        dictionary.Add(property0.Name, property0.Value.GetString());
                     }
                     tags = dictionary;
                     continue;
                 }
                 if (property.NameEquals("kid"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     kid = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("managed"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     managed = property.Value.GetBoolean();
                     continue;
                 }
             }
-            return new SecretBundle(value, id, contentType, tags, kid, managed);
+            return new SecretBundle(value.Value, id.Value, contentType.Value, Optional.ToDictionary(tags), kid.Value, Optional.ToNullable(managed));
         }
     }
 }

--- a/sdk/template/Azure.Template/src/Generated/Models/SecretBundle.cs
+++ b/sdk/template/Azure.Template/src/Generated/Models/SecretBundle.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.Template.Models
 {
@@ -15,6 +16,7 @@ namespace Azure.Template.Models
         /// <summary> Initializes a new instance of SecretBundle. </summary>
         internal SecretBundle()
         {
+            Tags = new ChangeTrackingDictionary<string, string>();
         }
 
         /// <summary> Initializes a new instance of SecretBundle. </summary>

--- a/sdk/template/Azure.Template/src/Generated/ServiceRestClient.cs
+++ b/sdk/template/Azure.Template/src/Generated/ServiceRestClient.cs
@@ -78,14 +78,7 @@ namespace Azure.Template
                     {
                         SecretBundle value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = SecretBundle.DeserializeSecretBundle(document.RootElement);
-                        }
+                        value = SecretBundle.DeserializeSecretBundle(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -111,14 +104,7 @@ namespace Azure.Template
                     {
                         SecretBundle value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = SecretBundle.DeserializeSecretBundle(document.RootElement);
-                        }
+                        value = SecretBundle.DeserializeSecretBundle(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:

--- a/sdk/testcommon/Azure.Graph.Rbac/src/Azure.Graph.Rbac.csproj
+++ b/sdk/testcommon/Azure.Graph.Rbac/src/Azure.Graph.Rbac.csproj
@@ -8,5 +8,6 @@
     as this project doesn't start with Azure.Management-->
     <IsMgmtClientLibrary>true</IsMgmtClientLibrary>
     <NoWarn>$(NoWarn);AZC0001;AZC0008;AZC0012;CS1591</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>

--- a/sdk/testcommon/Azure.Management.Compute.2019_12/src/Azure.Management.Compute.csproj
+++ b/sdk/testcommon/Azure.Management.Compute.2019_12/src/Azure.Management.Compute.csproj
@@ -4,6 +4,7 @@
     <PackageId>Azure.Management.Compute</PackageId>
     <Description>Azure management client SDK for Azure resource provider Microsoft.Compute</Description>
     <PackageTags>azure;management;compute</PackageTags>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
     <PropertyGroup>

--- a/sdk/testcommon/Azure.Management.Network.2020_04/src/Azure.Management.Network.csproj
+++ b/sdk/testcommon/Azure.Management.Network.2020_04/src/Azure.Management.Network.csproj
@@ -4,6 +4,7 @@
     <PackageId>Azure.Management.Network</PackageId>
     <Description>Azure management client SDK for Azure resource provider Microsoft.Network</Description>
     <PackageTags>azure;management;network</PackageTags>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/testcommon/Azure.Management.Resources.2017_05/src/Azure.Management.Resources.csproj
+++ b/sdk/testcommon/Azure.Management.Resources.2017_05/src/Azure.Management.Resources.csproj
@@ -5,5 +5,6 @@
     <Description>Azure management client SDK for Azure resource provider Microsoft.Resources</Description>
     <PackageTags>azure;management;resources</PackageTags>
     <NoWarn>$(NoWarn);AZC0008</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>

--- a/sdk/testcommon/Azure.Management.Storage.2019_06/src/Azure.Management.Storage.csproj
+++ b/sdk/testcommon/Azure.Management.Storage.2019_06/src/Azure.Management.Storage.csproj
@@ -5,5 +5,6 @@
     <Description>Azure management client SDK for Azure resource provider Microsoft.Storage</Description>
     <PackageTags>azure;management;storage</PackageTags>
     <NoWarn>$(NoWarn);AZC0008</NoWarn>
+    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR enables us to use 2 generator versions in the repo to allow migration of separate projects individually and easier reviews.

Next step would be removing this flag from projects and opening individual PRs.