### PR TITLE
[FormRecognizer] Move aka.ms links to new azsdk scheme

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -197,7 +197,7 @@ using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
     RecognizedFormCollection receipts = await client.StartRecognizeReceiptsAsync(stream).WaitForCompletionAsync();
 
     // To see the list of the supported fields returned by service and its corresponding types, consult:
-    // https://aka.ms/azsdk/python/formrecognizer/receiptfields
+    // https://aka.ms/formrecognizer/receiptfields
 
     foreach (RecognizedForm receipt in receipts)
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -481,7 +481,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 <!-- LINKS -->
 [formreco_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/formrecognizer/Azure.AI.FormRecognizer/src
 [formreco_docs]: https://docs.microsoft.com/azure/cognitive-services/form-recognizer/
-[formreco_refdocs]: https://aka.ms/azsdk-net-formrecognizer-ref-docs
+[formreco_refdocs]: https://aka.ms/azsdk/net/docs/ref/formrecognizer
 [formreco_nuget_package]: https://www.nuget.org/packages/Azure.AI.FormRecognizer
 [formreco_samples]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
 [formreco_rest_api]: https://westus2.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-preview

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeReceipts.md
@@ -25,7 +25,7 @@ To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method
 RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
 // To see the list of the supported fields returned by service and its corresponding types, consult:
-// https://aka.ms/azsdk/python/formrecognizer/receiptfields
+// https://aka.ms/formrecognizer/receiptfields
 
 foreach (RecognizedForm receipt in receipts)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample4_StronglyTypingARecognizedForm.md
@@ -34,7 +34,7 @@ The `Receipt` class is composed of multiple `FormField<T>` properties. `FormFiel
 public Receipt(RecognizedForm recognizedForm)
 {
     // To see the list of the supported fields returned by service and its corresponding types, consult:
-    // https://aka.ms/azsdk/python/formrecognizer/receiptfields
+    // https://aka.ms/formrecognizer/receiptfields
 
     ReceiptType = ConvertStringField("ReceiptType", recognizedForm.Fields);
     MerchantAddress = ConvertStringField("MerchantAddress", recognizedForm.Fields);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Receipt.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Receipt.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.Samples
         public Receipt(RecognizedForm recognizedForm)
         {
             // To see the list of the supported fields returned by service and its corresponding types, consult:
-            // https://aka.ms/azsdk/python/formrecognizer/receiptfields
+            // https://aka.ms/formrecognizer/receiptfields
 
             ReceiptType = ConvertStringField("ReceiptType", recognizedForm.Fields);
             MerchantAddress = ConvertStringField("MerchantAddress", recognizedForm.Fields);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/ReceiptItem.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/ReceiptItem.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.Samples
         public ReceiptItem(FormField<string> name, FormField<float> quantity, FormField<float> price, FormField<float> totalPrice)
         {
             // To see the list of the supported fields returned by service and its corresponding types, consult:
-            // https://aka.ms/azsdk/python/formrecognizer/receiptfields
+            // https://aka.ms/formrecognizer/receiptfields
 
             Name = name;
             Quantity = quantity;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromFile.cs
@@ -32,7 +32,7 @@ namespace Azure.AI.FormRecognizer.Samples
                 RecognizedFormCollection receipts = await client.StartRecognizeReceiptsAsync(stream).WaitForCompletionAsync();
 
                 // To see the list of the supported fields returned by service and its corresponding types, consult:
-                // https://aka.ms/azsdk/python/formrecognizer/receiptfields
+                // https://aka.ms/formrecognizer/receiptfields
 
                 foreach (RecognizedForm receipt in receipts)
                 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeReceiptsFromUri.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.Samples
             RecognizedFormCollection receipts = await client.StartRecognizeReceiptsFromUriAsync(receiptUri).WaitForCompletionAsync();
 
             // To see the list of the supported fields returned by service and its corresponding types, consult:
-            // https://aka.ms/azsdk/python/formrecognizer/receiptfields
+            // https://aka.ms/formrecognizer/receiptfields
 
             foreach (RecognizedForm receipt in receipts)
             {


### PR DESCRIPTION
Updating our current aka.ms links to the new azsdk scheme (azsdk/{lang}/docs/ref/{service}). We're also updating `https://aka.ms/azsdk/python/formrecognizer/receiptfields` to remove `azsdk` and `python` mentions, since the docs are not language nor azsdk-specific.

Fixes #11516.