### PR TITLE
Update Autorest C# - eventgrid

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Azure.Messaging.EventGrid.csproj
@@ -6,7 +6,6 @@
     <PackageTags>Microsoft Azure EventGrid;Event Grid;Event Grid Publishing;</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>
-    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridClient.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridClient.cs
@@ -179,16 +179,18 @@ namespace Azure.Messaging.EventGrid
                             new CloudEvent(
                                 cloudEvent.Id,
                                 cloudEvent.Source,
-                                new EventGridSerializer(
+                                cloudEvent.Type,
+                                cloudEvent.Specversion)
+                            {
+                                Data = new EventGridSerializer(
                                     cloudEvent.Data,
                                     _serializer,
                                     cancellationToken),
-                                cloudEvent.Type,
-                                cloudEvent.Time,
-                                cloudEvent.Specversion,
-                                cloudEvent.Dataschema,
-                                cloudEvent.Datacontenttype,
-                                cloudEvent.Subject));
+                                Time = cloudEvent.Time,
+                                Datacontenttype = cloudEvent.Datacontenttype,
+                                Dataschema = cloudEvent.Dataschema,
+                                Subject = cloudEvent.Subject
+                            });
                     }
                     else
                     {

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEvent.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEvent.Serialization.cs
@@ -19,31 +19,31 @@ namespace Azure.Messaging.EventGrid.Models
             writer.WriteStringValue(Id);
             writer.WritePropertyName("source");
             writer.WriteStringValue(Source);
-            if (Data != null)
+            if (Optional.IsDefined(Data))
             {
                 writer.WritePropertyName("data");
                 writer.WriteObjectValue(Data);
             }
             writer.WritePropertyName("type");
             writer.WriteStringValue(Type);
-            if (Time != null)
+            if (Optional.IsDefined(Time))
             {
                 writer.WritePropertyName("time");
                 writer.WriteStringValue(Time.Value, "O");
             }
             writer.WritePropertyName("specversion");
             writer.WriteStringValue(Specversion);
-            if (Dataschema != null)
+            if (Optional.IsDefined(Dataschema))
             {
                 writer.WritePropertyName("dataschema");
                 writer.WriteStringValue(Dataschema);
             }
-            if (Datacontenttype != null)
+            if (Optional.IsDefined(Datacontenttype))
             {
                 writer.WritePropertyName("datacontenttype");
                 writer.WriteStringValue(Datacontenttype);
             }
-            if (Subject != null)
+            if (Optional.IsDefined(Subject))
             {
                 writer.WritePropertyName("subject");
                 writer.WriteStringValue(Subject);

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/CloudEvent.cs
@@ -42,29 +42,6 @@ namespace Azure.Messaging.EventGrid.Models
             Specversion = specversion;
         }
 
-        /// <summary> Initializes a new instance of CloudEvent. </summary>
-        /// <param name="id"> An identifier for the event. The combination of id and source must be unique for each distinct event. </param>
-        /// <param name="source"> Identifies the context in which an event happened. The combination of id and source must be unique for each distinct event. </param>
-        /// <param name="data"> Event data specific to the event type. </param>
-        /// <param name="type"> Type of event related to the originating occurrence. </param>
-        /// <param name="time"> The time (in UTC) the event was generated, in RFC3339 format. </param>
-        /// <param name="specversion"> The version of the CloudEvents specification which the event uses. </param>
-        /// <param name="dataschema"> Identifies the schema that data adheres to. </param>
-        /// <param name="datacontenttype"> Content type of data value. </param>
-        /// <param name="subject"> This describes the subject of the event in the context of the event producer (identified by source). </param>
-        internal CloudEvent(string id, string source, object data, string type, DateTimeOffset? time, string specversion, string dataschema, string datacontenttype, string subject)
-        {
-            Id = id;
-            Source = source;
-            Data = data;
-            Type = type;
-            Time = time;
-            Specversion = specversion;
-            Dataschema = dataschema;
-            Datacontenttype = datacontenttype;
-            Subject = subject;
-        }
-
         /// <summary> An identifier for the event. The combination of id and source must be unique for each distinct event. </summary>
         public string Id { get; }
         /// <summary> Identifies the context in which an event happened. The combination of id and source must be unique for each distinct event. </summary>

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/EventGridEvent.Serialization.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/EventGridEvent.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.Messaging.EventGrid.Models
             writer.WriteStartObject();
             writer.WritePropertyName("id");
             writer.WriteStringValue(Id);
-            if (Topic != null)
+            if (Optional.IsDefined(Topic))
             {
                 writer.WritePropertyName("topic");
                 writer.WriteStringValue(Topic);
@@ -30,11 +30,6 @@ namespace Azure.Messaging.EventGrid.Models
             writer.WriteStringValue(EventType);
             writer.WritePropertyName("eventTime");
             writer.WriteStringValue(EventTime, "O");
-            if (MetadataVersion != null)
-            {
-                writer.WritePropertyName("metadataVersion");
-                writer.WriteStringValue(MetadataVersion);
-            }
             writer.WritePropertyName("dataVersion");
             writer.WriteStringValue(DataVersion);
             writer.WriteEndObject();

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/EventGridEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Generated/Models/EventGridEvent.cs
@@ -50,27 +50,6 @@ namespace Azure.Messaging.EventGrid.Models
             DataVersion = dataVersion;
         }
 
-        /// <summary> Initializes a new instance of EventGridEvent. </summary>
-        /// <param name="id"> An unique identifier for the event. </param>
-        /// <param name="topic"> The resource path of the event source. </param>
-        /// <param name="subject"> A resource path relative to the topic path. </param>
-        /// <param name="data"> Event data specific to the event type. </param>
-        /// <param name="eventType"> The type of the event that occurred. </param>
-        /// <param name="eventTime"> The time (in UTC) the event was generated. </param>
-        /// <param name="metadataVersion"> The schema version of the event metadata. </param>
-        /// <param name="dataVersion"> The schema version of the data object. </param>
-        internal EventGridEvent(string id, string topic, string subject, object data, string eventType, DateTimeOffset eventTime, string metadataVersion, string dataVersion)
-        {
-            Id = id;
-            Topic = topic;
-            Subject = subject;
-            Data = data;
-            EventType = eventType;
-            EventTime = eventTime;
-            MetadataVersion = metadataVersion;
-            DataVersion = dataVersion;
-        }
-
         /// <summary> An unique identifier for the event. </summary>
         public string Id { get; }
         /// <summary> The resource path of the event source. </summary>


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/13511

Major features

1. Collections are now always initialized and collection properties are readonly by default
2. Internal deserialization ctors are removed for input-only models
3. Improved nullability support - fewer extra null checks, correct nullable types generated. Might require adding missing annotations to the swagger spec.
4. Improved header support - descriptions and `x-ms-client-name` honored.
5. Single value, `modelAsString` enums are generated as types, they were string constants before.
6. Readonly properties are not serialized - affects recordings.

What you might need to do:
1. If you copied and overrode the serialization code you might want to update it to be in sync with new generator patterns.
2. **Please follow up on updating the centralized swagger file if there were workarounds applied to autorest.md**