### PR TITLE
Dispose response content on retry for unbuffered streams

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.4.0-preview.1 (Unreleased)
 
+### Fixed
+- Connection leak for retried non-buffered requests on .NET Framework.
 
 ## 1.3.0 (2020-07-02)
 

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
@@ -127,6 +127,9 @@ namespace Azure.Core.Pipeline
                     }
                 }
 
+                // Dispose the content stream to free up a connection if the request has any
+                message.Response.ContentStream?.Dispose();
+
                 AzureCoreEventSource.Singleton.RequestRetrying(message.Request.ClientRequestId, attempt, elapsed);
             }
         }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
@@ -127,8 +127,11 @@ namespace Azure.Core.Pipeline
                     }
                 }
 
-                // Dispose the content stream to free up a connection if the request has any
-                message.Response.ContentStream?.Dispose();
+                if (message.HasResponse)
+                {
+                    // Dispose the content stream to free up a connection if the request has any
+                    message.Response.ContentStream?.Dispose();
+                }
 
                 AzureCoreEventSource.Singleton.RequestRetrying(message.Request.ClientRequestId, attempt, elapsed);
             }

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 
@@ -79,6 +80,63 @@ namespace Azure.Core.Tests
                 Assert.AreEqual(memoryStream.Length, 1000);
                 extractedStream.Dispose();
             }
+        }
+
+
+        [Test]
+        public async Task NonBufferedFailedResponsesAreDisposedOf()
+        {
+            byte[] buffer = { 0 };
+
+            HttpPipeline httpPipeline = HttpPipelineBuilder.Build(new TestOptions()
+            {
+                Retry =
+                {
+                    Delay = TimeSpan.FromMilliseconds(2),
+                    NetworkTimeout = TimeSpan.FromSeconds(5)
+                },
+            });
+
+            int reqNum = 0;
+
+            using TestServer testServer = new TestServer(
+                async context =>
+                {
+                    if (Interlocked.Increment(ref reqNum) % 2 == 0)
+                    {
+                        // Respond with 503 to every other request to force a retry
+                        context.Response.StatusCode = 503;
+                    }
+
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        await context.Response.Body.WriteAsync(buffer, 0, 1);
+                    }
+                });
+
+            // Make sure we dispose things correctly and not exhaust the connection pool
+            for (int i = 0; i < 100; i++)
+            {
+                Stream extractedStream;
+                using (HttpMessage message = httpPipeline.CreateMessage())
+                {
+                    message.Request.Uri.Reset(testServer.Address);
+                    message.BufferResponse = false;
+
+                    await httpPipeline.SendAsync(message, CancellationToken.None);
+
+                    Assert.AreEqual(message.Response.ContentStream.CanSeek, false);
+
+                    extractedStream = message.ExtractResponseContent();
+                }
+
+                var memoryStream = new MemoryStream();
+                await extractedStream.CopyToAsync(memoryStream);
+                Assert.AreEqual(memoryStream.Length, 1000);
+                extractedStream.Dispose();
+            }
+
+            Assert.Greater(reqNum, 100);
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -97,6 +97,7 @@ namespace Azure.Core.Tests
                 },
             });
 
+            int bodySize = 1000;
             int reqNum = 0;
 
             using TestServer testServer = new TestServer(
@@ -108,14 +109,15 @@ namespace Azure.Core.Tests
                         context.Response.StatusCode = 503;
                     }
 
-                    for (int i = 0; i < 1000; i++)
+                    for (int i = 0; i < bodySize; i++)
                     {
                         await context.Response.Body.WriteAsync(buffer, 0, 1);
                     }
                 });
 
             // Make sure we dispose things correctly and not exhaust the connection pool
-            for (int i = 0; i < 100; i++)
+            var requestCount = 100;
+            for (int i = 0; i < requestCount; i++)
             {
                 Stream extractedStream;
                 using (HttpMessage message = httpPipeline.CreateMessage())
@@ -132,11 +134,11 @@ namespace Azure.Core.Tests
 
                 var memoryStream = new MemoryStream();
                 await extractedStream.CopyToAsync(memoryStream);
-                Assert.AreEqual(memoryStream.Length, 1000);
+                Assert.AreEqual(memoryStream.Length, bodySize);
                 extractedStream.Dispose();
             }
 
-            Assert.Greater(reqNum, 100);
+            Assert.Greater(reqNum, requestCount);
         }
 
         [Test]


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13546