### PR TITLE
Update Autorest C# - formrecognizer

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Azure.AI.FormRecognizer.csproj
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Azure.AI.FormRecognizer.csproj
@@ -6,7 +6,6 @@
     <PackageTags>Microsoft Azure Form Recognizer</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>false</GenerateAPIListing>
-    <TemporaryUsePreviousGeneratorVersion>true</TemporaryUsePreviousGeneratorVersion><!-- https://github.com/Azure/azure-sdk-for-net/issues/13506 -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BoundingBox.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BoundingBox.cs
@@ -18,16 +18,12 @@ namespace Azure.AI.FormRecognizer.Models
     {
         internal BoundingBox(IReadOnlyList<float> boundingBox)
         {
-            // TODO: improve perf here?
-            // https://github.com/Azure/azure-sdk-for-net/issues/10358
-            float[] bbPoints = boundingBox.ToArray();
-
-            int count = bbPoints.Length / 2;
+            int count = boundingBox.Count / 2;
 
             Points = new PointF[count];
             for (int i = 0; i < count; i++)
             {
-                Points[i] = new PointF(bbPoints[2 * i], bbPoints[(2 * i) + 1]);
+                Points[i] = new PointF(boundingBox[2 * i], boundingBox[(2 * i) + 1]);
             }
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BoundingBox.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BoundingBox.cs
@@ -18,6 +18,12 @@ namespace Azure.AI.FormRecognizer.Models
     {
         internal BoundingBox(IReadOnlyList<float> boundingBox)
         {
+            if (boundingBox.Count == 0)
+            {
+                Points = null;
+                return;
+            }
+
             int count = boundingBox.Count / 2;
 
             Points = new PointF[count];

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -173,7 +173,10 @@ namespace Azure.AI.FormRecognizer
         {
             Argument.AssertNotNull(formUri, nameof(formUri));
 
-            SourcePath_internal sourcePath = new SourcePath_internal(formUri.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal()
+            {
+                Source = formUri.AbsoluteUri
+            };
             Response response = ServiceClient.AnalyzeLayoutAsync(sourcePath, cancellationToken);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -193,7 +196,7 @@ namespace Azure.AI.FormRecognizer
         {
             Argument.AssertNotNull(formUri, nameof(formUri));
 
-            SourcePath_internal sourcePath = new SourcePath_internal(formUri.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal() { Source = formUri.AbsoluteUri };
             Response response = await ServiceClient.AnalyzeLayoutAsyncAsync(sourcePath, cancellationToken).ConfigureAwait(false);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -263,7 +266,7 @@ namespace Azure.AI.FormRecognizer
 
             recognizeOptions ??= new RecognizeOptions();
 
-            SourcePath_internal sourcePath = new SourcePath_internal(receiptUri.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal() { Source = receiptUri.AbsoluteUri };
             Response response = await ServiceClient.AnalyzeReceiptAsyncAsync(includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken).ConfigureAwait(false);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -285,7 +288,7 @@ namespace Azure.AI.FormRecognizer
 
             recognizeOptions ??= new RecognizeOptions();
 
-            SourcePath_internal sourcePath = new SourcePath_internal(receiptUri.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal() { Source = receiptUri.AbsoluteUri };
             Response response = ServiceClient.AnalyzeReceiptAsync(includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -341,7 +344,7 @@ namespace Azure.AI.FormRecognizer
 
             recognizeOptions ??= new RecognizeOptions();
 
-            SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal() { Source = formFileUri.AbsoluteUri };
             Response response = ServiceClient.AnalyzeWithCustomModel(guid, includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
@@ -393,7 +396,7 @@ namespace Azure.AI.FormRecognizer
 
             recognizeOptions ??= new RecognizeOptions();
 
-            SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.AbsoluteUri);
+            SourcePath_internal sourcePath = new SourcePath_internal() { Source = formFileUri.AbsoluteUri };
             Response response = await ServiceClient.AnalyzeWithCustomModelAsync(guid, includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken).ConfigureAwait(false);
             string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -123,7 +123,11 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNull(trainingFilesUri, nameof(trainingFilesUri));
 
-            var trainRequest = new TrainRequest_internal(trainingFilesUri.AbsoluteUri, trainingFileFilter, useTrainingLabels);
+            var trainRequest = new TrainRequest_internal(trainingFilesUri.AbsoluteUri)
+            {
+                SourceFilter = trainingFileFilter,
+                UseLabelFile = useTrainingLabels
+            };
 
             ResponseWithHeaders<ServiceTrainCustomModelAsyncHeaders> response = ServiceClient.TrainCustomModelAsync(trainRequest);
             return new TrainingOperation(response.Headers.Location, ServiceClient, Diagnostics);
@@ -148,7 +152,11 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNull(trainingFilesUri, nameof(trainingFilesUri));
 
-            var trainRequest = new TrainRequest_internal(trainingFilesUri.AbsoluteUri, trainingFileFilter, useTrainingLabels);
+            var trainRequest = new TrainRequest_internal(trainingFilesUri.AbsoluteUri)
+            {
+                SourceFilter = trainingFileFilter,
+                UseLabelFile = useTrainingLabels
+            };
 
             ResponseWithHeaders<ServiceTrainCustomModelAsyncHeaders> response = await ServiceClient.TrainCustomModelAsyncAsync(trainRequest).ConfigureAwait(false);
             return new TrainingOperation(response.Headers.Location, ServiceClient, Diagnostics);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeOperationResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeOperationResult_internal.Serialization.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.FormRecognizer.Models
             OperationStatus status = default;
             DateTimeOffset createdDateTime = default;
             DateTimeOffset lastUpdatedDateTime = default;
-            AnalyzeResult_internal analyzeResult = default;
+            Optional<AnalyzeResult_internal> analyzeResult = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("status"))
@@ -41,13 +41,14 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        analyzeResult = null;
                         continue;
                     }
                     analyzeResult = AnalyzeResult_internal.DeserializeAnalyzeResult_internal(property.Value);
                     continue;
                 }
             }
-            return new AnalyzeOperationResult_internal(status, createdDateTime, lastUpdatedDateTime, analyzeResult);
+            return new AnalyzeOperationResult_internal(status, createdDateTime, lastUpdatedDateTime, analyzeResult.Value);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult_internal.Serialization.cs
@@ -16,10 +16,10 @@ namespace Azure.AI.FormRecognizer.Models
         internal static AnalyzeResult_internal DeserializeAnalyzeResult_internal(JsonElement element)
         {
             string version = default;
-            IReadOnlyList<ReadResult_internal> readResults = default;
-            IReadOnlyList<PageResult_internal> pageResults = default;
-            IReadOnlyList<DocumentResult_internal> documentResults = default;
-            IReadOnlyList<FormRecognizerError> errors = default;
+            Optional<IReadOnlyList<ReadResult_internal>> readResults = default;
+            Optional<IReadOnlyList<PageResult_internal>> pageResults = default;
+            Optional<IReadOnlyList<DocumentResult_internal>> documentResults = default;
+            Optional<IReadOnlyList<FormRecognizerError>> errors = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("version"))
@@ -31,19 +31,13 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        readResults = null;
                         continue;
                     }
                     List<ReadResult_internal> array = new List<ReadResult_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(ReadResult_internal.DeserializeReadResult_internal(item));
-                        }
+                        array.Add(ReadResult_internal.DeserializeReadResult_internal(item));
                     }
                     readResults = array;
                     continue;
@@ -52,19 +46,13 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        pageResults = null;
                         continue;
                     }
                     List<PageResult_internal> array = new List<PageResult_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(PageResult_internal.DeserializePageResult_internal(item));
-                        }
+                        array.Add(PageResult_internal.DeserializePageResult_internal(item));
                     }
                     pageResults = array;
                     continue;
@@ -73,46 +61,29 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        documentResults = null;
                         continue;
                     }
                     List<DocumentResult_internal> array = new List<DocumentResult_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(DocumentResult_internal.DeserializeDocumentResult_internal(item));
-                        }
+                        array.Add(DocumentResult_internal.DeserializeDocumentResult_internal(item));
                     }
                     documentResults = array;
                     continue;
                 }
                 if (property.NameEquals("errors"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
-                        }
+                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
                     }
                     errors = array;
                     continue;
                 }
             }
-            return new AnalyzeResult_internal(version, readResults, pageResults, documentResults, errors);
+            return new AnalyzeResult_internal(version, Optional.ToList(readResults), Optional.ToList(pageResults), Optional.ToList(documentResults), Optional.ToList(errors));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult_internal.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -23,6 +24,10 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             Version = version;
+            ReadResults = new ChangeTrackingList<ReadResult_internal>();
+            PageResults = new ChangeTrackingList<PageResult_internal>();
+            DocumentResults = new ChangeTrackingList<DocumentResult_internal>();
+            Errors = new ChangeTrackingList<FormRecognizerError>();
         }
 
         /// <summary> Initializes a new instance of AnalyzeResult_internal. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyOperationResult.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyOperationResult.Serialization.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.FormRecognizer.Training
             OperationStatus status = default;
             DateTimeOffset createdDateTime = default;
             DateTimeOffset lastUpdatedDateTime = default;
-            CopyResult copyResult = default;
+            Optional<CopyResult> copyResult = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("status"))
@@ -39,15 +39,11 @@ namespace Azure.AI.FormRecognizer.Training
                 }
                 if (property.NameEquals("copyResult"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     copyResult = CopyResult.DeserializeCopyResult(property.Value);
                     continue;
                 }
             }
-            return new CopyOperationResult(status, createdDateTime, lastUpdatedDateTime, copyResult);
+            return new CopyOperationResult(status, createdDateTime, lastUpdatedDateTime, copyResult.Value);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyResult.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyResult.Serialization.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.FormRecognizer.Training
         internal static CopyResult DeserializeCopyResult(JsonElement element)
         {
             Guid modelId = default;
-            IReadOnlyList<FormRecognizerError> errors = default;
+            Optional<IReadOnlyList<FormRecognizerError>> errors = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("modelId"))
@@ -28,27 +28,16 @@ namespace Azure.AI.FormRecognizer.Training
                 }
                 if (property.NameEquals("errors"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
-                        }
+                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
                     }
                     errors = array;
                     continue;
                 }
             }
-            return new CopyResult(modelId, errors);
+            return new CopyResult(modelId, Optional.ToList(errors));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyResult.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CopyResult.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using Azure.AI.FormRecognizer.Models;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Training
 {
@@ -19,6 +20,7 @@ namespace Azure.AI.FormRecognizer.Training
         internal CopyResult(Guid modelId)
         {
             ModelId = modelId;
+            Errors = new ChangeTrackingList<FormRecognizerError>();
         }
 
         /// <summary> Initializes a new instance of CopyResult. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CustomFormModelField.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/CustomFormModelField.Serialization.cs
@@ -27,6 +27,7 @@ namespace Azure.AI.FormRecognizer.Training
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        accuracy = null;
                         continue;
                     }
                     accuracy = property.Value.GetSingle();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTableCell_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTableCell_internal.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -34,8 +35,9 @@ namespace Azure.AI.FormRecognizer.Models
             RowIndex = rowIndex;
             ColumnIndex = columnIndex;
             Text = text;
-            BoundingBox = boundingBox.ToArray();
+            BoundingBox = boundingBox.ToList();
             Confidence = confidence;
+            Elements = new ChangeTrackingList<string>();
         }
 
         /// <summary> Initializes a new instance of DataTableCell_internal. </summary>
@@ -56,7 +58,7 @@ namespace Azure.AI.FormRecognizer.Models
             RowSpan = rowSpan;
             ColumnSpan = columnSpan;
             Text = text;
-            BoundingBox = boundingBox ?? new List<float>();
+            BoundingBox = boundingBox;
             Confidence = confidence;
             Elements = elements;
             IsHeader = isHeader;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTable_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTable_internal.Serialization.cs
@@ -35,14 +35,7 @@ namespace Azure.AI.FormRecognizer.Models
                     List<DataTableCell_internal> array = new List<DataTableCell_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(DataTableCell_internal.DeserializeDataTableCell_internal(item));
-                        }
+                        array.Add(DataTableCell_internal.DeserializeDataTableCell_internal(item));
                     }
                     cells = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTable_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTable_internal.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.Models
 
             Rows = rows;
             Columns = columns;
-            Cells = cells.ToArray();
+            Cells = cells.ToList();
         }
 
         /// <summary> Initializes a new instance of DataTable_internal. </summary>
@@ -38,7 +38,7 @@ namespace Azure.AI.FormRecognizer.Models
         {
             Rows = rows;
             Columns = columns;
-            Cells = cells ?? new List<DataTableCell_internal>();
+            Cells = cells;
         }
 
         /// <summary> Number of rows. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentResult_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentResult_internal.cs
@@ -34,7 +34,7 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             DocType = docType;
-            PageRange = pageRange.ToArray();
+            PageRange = pageRange.ToList();
             Fields = fields;
         }
 
@@ -45,8 +45,8 @@ namespace Azure.AI.FormRecognizer.Models
         internal DocumentResult_internal(string docType, IReadOnlyList<int> pageRange, IReadOnlyDictionary<string, FieldValue_internal> fields)
         {
             DocType = docType;
-            PageRange = pageRange ?? new List<int>();
-            Fields = fields ?? new Dictionary<string, FieldValue_internal>();
+            PageRange = pageRange;
+            Fields = fields;
         }
 
         /// <summary> Document type. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FieldValue_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FieldValue_internal.Serialization.cs
@@ -17,19 +17,19 @@ namespace Azure.AI.FormRecognizer.Models
         internal static FieldValue_internal DeserializeFieldValue_internal(JsonElement element)
         {
             FieldValueType type = default;
-            string valueString = default;
-            DateTimeOffset? valueDate = default;
-            TimeSpan? valueTime = default;
-            string valuePhoneNumber = default;
-            float? valueNumber = default;
-            long? valueInteger = default;
-            IReadOnlyList<FieldValue_internal> valueArray = default;
-            IReadOnlyDictionary<string, FieldValue_internal> valueObject = default;
-            string text = default;
-            IReadOnlyList<float> boundingBox = default;
-            float? confidence = default;
-            IReadOnlyList<string> elements = default;
-            int? page = default;
+            Optional<string> valueString = default;
+            Optional<DateTimeOffset> valueDate = default;
+            Optional<TimeSpan> valueTime = default;
+            Optional<string> valuePhoneNumber = default;
+            Optional<float> valueNumber = default;
+            Optional<long> valueInteger = default;
+            Optional<IReadOnlyList<FieldValue_internal>> valueArray = default;
+            Optional<IReadOnlyDictionary<string, FieldValue_internal>> valueObject = default;
+            Optional<string> text = default;
+            Optional<IReadOnlyList<float>> boundingBox = default;
+            Optional<float> confidence = default;
+            Optional<IReadOnlyList<string>> elements = default;
+            Optional<int> page = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("type"))
@@ -39,115 +39,61 @@ namespace Azure.AI.FormRecognizer.Models
                 }
                 if (property.NameEquals("valueString"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     valueString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("valueDate"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     valueDate = property.Value.GetDateTimeOffset("D");
                     continue;
                 }
                 if (property.NameEquals("valueTime"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     valueTime = property.Value.GetTimeSpan("T");
                     continue;
                 }
                 if (property.NameEquals("valuePhoneNumber"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     valuePhoneNumber = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("valueNumber"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     valueNumber = property.Value.GetSingle();
                     continue;
                 }
                 if (property.NameEquals("valueInteger"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     valueInteger = property.Value.GetInt64();
                     continue;
                 }
                 if (property.NameEquals("valueArray"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<FieldValue_internal> array = new List<FieldValue_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(DeserializeFieldValue_internal(item));
-                        }
+                        array.Add(DeserializeFieldValue_internal(item));
                     }
                     valueArray = array;
                     continue;
                 }
                 if (property.NameEquals("valueObject"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     Dictionary<string, FieldValue_internal> dictionary = new Dictionary<string, FieldValue_internal>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        if (property0.Value.ValueKind == JsonValueKind.Null)
-                        {
-                            dictionary.Add(property0.Name, null);
-                        }
-                        else
-                        {
-                            dictionary.Add(property0.Name, DeserializeFieldValue_internal(property0.Value));
-                        }
+                        dictionary.Add(property0.Name, DeserializeFieldValue_internal(property0.Value));
                     }
                     valueObject = dictionary;
                     continue;
                 }
                 if (property.NameEquals("text"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     text = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("boundingBox"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<float> array = new List<float>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
@@ -158,45 +104,26 @@ namespace Azure.AI.FormRecognizer.Models
                 }
                 if (property.NameEquals("confidence"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     confidence = property.Value.GetSingle();
                     continue;
                 }
                 if (property.NameEquals("elements"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(item.GetString());
-                        }
+                        array.Add(item.GetString());
                     }
                     elements = array;
                     continue;
                 }
                 if (property.NameEquals("page"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     page = property.Value.GetInt32();
                     continue;
                 }
             }
-            return new FieldValue_internal(type, valueString, valueDate, valueTime, valuePhoneNumber, valueNumber, valueInteger, valueArray, valueObject, text, boundingBox, confidence, elements, page);
+            return new FieldValue_internal(type, valueString.Value, Optional.ToNullable(valueDate), Optional.ToNullable(valueTime), valuePhoneNumber.Value, Optional.ToNullable(valueNumber), Optional.ToNullable(valueInteger), Optional.ToList(valueArray), Optional.ToDictionary(valueObject), text.Value, Optional.ToList(boundingBox), Optional.ToNullable(confidence), Optional.ToList(elements), Optional.ToNullable(page));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FieldValue_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FieldValue_internal.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -18,6 +19,10 @@ namespace Azure.AI.FormRecognizer.Models
         internal FieldValue_internal(FieldValueType type)
         {
             Type = type;
+            ValueArray = new ChangeTrackingList<FieldValue_internal>();
+            ValueObject = new ChangeTrackingDictionary<string, FieldValue_internal>();
+            BoundingBox = new ChangeTrackingList<float>();
+            Elements = new ChangeTrackingList<string>();
         }
 
         /// <summary> Initializes a new instance of FieldValue_internal. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement_internal.Serialization.cs
@@ -16,8 +16,8 @@ namespace Azure.AI.FormRecognizer.Models
         internal static KeyValueElement_internal DeserializeKeyValueElement_internal(JsonElement element)
         {
             string text = default;
-            IReadOnlyList<float> boundingBox = default;
-            IReadOnlyList<string> elements = default;
+            Optional<IReadOnlyList<float>> boundingBox = default;
+            Optional<IReadOnlyList<string>> elements = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("text"))
@@ -29,6 +29,7 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        boundingBox = null;
                         continue;
                     }
                     List<float> array = new List<float>();
@@ -43,25 +44,19 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        elements = null;
                         continue;
                     }
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(item.GetString());
-                        }
+                        array.Add(item.GetString());
                     }
                     elements = array;
                     continue;
                 }
             }
-            return new KeyValueElement_internal(text, boundingBox, elements);
+            return new KeyValueElement_internal(text, Optional.ToList(boundingBox), Optional.ToList(elements));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement_internal.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -23,6 +24,8 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             Text = text;
+            BoundingBox = new ChangeTrackingList<float>();
+            Elements = new ChangeTrackingList<string>();
         }
 
         /// <summary> Initializes a new instance of KeyValueElement_internal. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValuePair_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValuePair_internal.Serialization.cs
@@ -14,7 +14,7 @@ namespace Azure.AI.FormRecognizer.Models
     {
         internal static KeyValuePair_internal DeserializeKeyValuePair_internal(JsonElement element)
         {
-            string label = default;
+            Optional<string> label = default;
             KeyValueElement_internal key = default;
             KeyValueElement_internal value = default;
             float confidence = default;
@@ -22,10 +22,6 @@ namespace Azure.AI.FormRecognizer.Models
             {
                 if (property.NameEquals("label"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     label = property.Value.GetString();
                     continue;
                 }
@@ -45,7 +41,7 @@ namespace Azure.AI.FormRecognizer.Models
                     continue;
                 }
             }
-            return new KeyValuePair_internal(label, key, value, confidence);
+            return new KeyValuePair_internal(label.Value, key, value, confidence);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeysResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeysResult_internal.Serialization.cs
@@ -23,26 +23,12 @@ namespace Azure.AI.FormRecognizer
                     Dictionary<string, IList<string>> dictionary = new Dictionary<string, IList<string>>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        List<string> array = new List<string>();
+                        foreach (var item in property0.Value.EnumerateArray())
                         {
-                            dictionary.Add(property0.Name, null);
+                            array.Add(item.GetString());
                         }
-                        else
-                        {
-                            List<string> array = new List<string>();
-                            foreach (var item in property0.Value.EnumerateArray())
-                            {
-                                if (item.ValueKind == JsonValueKind.Null)
-                                {
-                                    array.Add(null);
-                                }
-                                else
-                                {
-                                    array.Add(item.GetString());
-                                }
-                            }
-                            dictionary.Add(property0.Name, array);
-                        }
+                        dictionary.Add(property0.Name, array);
                     }
                     clusters = dictionary;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Model_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Model_internal.Serialization.cs
@@ -17,8 +17,8 @@ namespace Azure.AI.FormRecognizer.Training
         internal static Model_internal DeserializeModel_internal(JsonElement element)
         {
             ModelInfo_internal modelInfo = default;
-            KeysResult_internal keys = default;
-            TrainResult_internal trainResult = default;
+            Optional<KeysResult_internal> keys = default;
+            Optional<TrainResult_internal> trainResult = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("modelInfo"))
@@ -28,24 +28,16 @@ namespace Azure.AI.FormRecognizer.Training
                 }
                 if (property.NameEquals("keys"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     keys = KeysResult_internal.DeserializeKeysResult_internal(property.Value);
                     continue;
                 }
                 if (property.NameEquals("trainResult"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     trainResult = TrainResult_internal.DeserializeTrainResult_internal(property.Value);
                     continue;
                 }
             }
-            return new Model_internal(modelInfo, keys, trainResult);
+            return new Model_internal(modelInfo, keys.Value, trainResult.Value);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Models_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Models_internal.Serialization.cs
@@ -15,52 +15,33 @@ namespace Azure.AI.FormRecognizer.Training
     {
         internal static Models_internal DeserializeModels_internal(JsonElement element)
         {
-            ModelsSummary_internal summary = default;
-            IReadOnlyList<ModelInfo_internal> modelList = default;
-            string nextLink = default;
+            Optional<ModelsSummary_internal> summary = default;
+            Optional<IReadOnlyList<ModelInfo_internal>> modelList = default;
+            Optional<string> nextLink = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("summary"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     summary = ModelsSummary_internal.DeserializeModelsSummary_internal(property.Value);
                     continue;
                 }
                 if (property.NameEquals("modelList"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<ModelInfo_internal> array = new List<ModelInfo_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(ModelInfo_internal.DeserializeModelInfo_internal(item));
-                        }
+                        array.Add(ModelInfo_internal.DeserializeModelInfo_internal(item));
                     }
                     modelList = array;
                     continue;
                 }
                 if (property.NameEquals("nextLink"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     nextLink = property.Value.GetString();
                     continue;
                 }
             }
-            return new Models_internal(summary, modelList, nextLink);
+            return new Models_internal(summary.Value, Optional.ToList(modelList), nextLink.Value);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Models_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Models_internal.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Training
 {
@@ -15,6 +16,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// <summary> Initializes a new instance of Models_internal. </summary>
         internal Models_internal()
         {
+            ModelList = new ChangeTrackingList<ModelInfo_internal>();
         }
 
         /// <summary> Initializes a new instance of Models_internal. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/PageResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/PageResult_internal.Serialization.cs
@@ -16,9 +16,9 @@ namespace Azure.AI.FormRecognizer.Models
         internal static PageResult_internal DeserializePageResult_internal(JsonElement element)
         {
             int page = default;
-            int? clusterId = default;
-            IReadOnlyList<KeyValuePair_internal> keyValuePairs = default;
-            IReadOnlyList<DataTable_internal> tables = default;
+            Optional<int?> clusterId = default;
+            Optional<IReadOnlyList<KeyValuePair_internal>> keyValuePairs = default;
+            Optional<IReadOnlyList<DataTable_internal>> tables = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("page"))
@@ -30,6 +30,7 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
+                        clusterId = null;
                         continue;
                     }
                     clusterId = property.Value.GetInt32();
@@ -37,48 +38,26 @@ namespace Azure.AI.FormRecognizer.Models
                 }
                 if (property.NameEquals("keyValuePairs"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<KeyValuePair_internal> array = new List<KeyValuePair_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(KeyValuePair_internal.DeserializeKeyValuePair_internal(item));
-                        }
+                        array.Add(KeyValuePair_internal.DeserializeKeyValuePair_internal(item));
                     }
                     keyValuePairs = array;
                     continue;
                 }
                 if (property.NameEquals("tables"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<DataTable_internal> array = new List<DataTable_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(DataTable_internal.DeserializeDataTable_internal(item));
-                        }
+                        array.Add(DataTable_internal.DeserializeDataTable_internal(item));
                     }
                     tables = array;
                     continue;
                 }
             }
-            return new PageResult_internal(page, clusterId, keyValuePairs, tables);
+            return new PageResult_internal(page, Optional.ToNullable(clusterId), Optional.ToList(keyValuePairs), Optional.ToList(tables));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/PageResult_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/PageResult_internal.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -17,6 +18,8 @@ namespace Azure.AI.FormRecognizer.Models
         internal PageResult_internal(int page)
         {
             Page = page;
+            KeyValuePairs = new ChangeTrackingList<KeyValuePair_internal>();
+            Tables = new ChangeTrackingList<DataTable_internal>();
         }
 
         /// <summary> Initializes a new instance of PageResult_internal. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult_internal.Serialization.cs
@@ -20,8 +20,8 @@ namespace Azure.AI.FormRecognizer.Models
             float width = default;
             float height = default;
             LengthUnit unit = default;
-            Language_internal? language = default;
-            IReadOnlyList<TextLine_internal> lines = default;
+            Optional<Language_internal> language = default;
+            Optional<IReadOnlyList<TextLine_internal>> lines = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("page"))
@@ -51,36 +51,21 @@ namespace Azure.AI.FormRecognizer.Models
                 }
                 if (property.NameEquals("language"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     language = new Language_internal(property.Value.GetString());
                     continue;
                 }
                 if (property.NameEquals("lines"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<TextLine_internal> array = new List<TextLine_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(TextLine_internal.DeserializeTextLine_internal(item));
-                        }
+                        array.Add(TextLine_internal.DeserializeTextLine_internal(item));
                     }
                     lines = array;
                     continue;
                 }
             }
-            return new ReadResult_internal(page, angle, width, height, unit, language, lines);
+            return new ReadResult_internal(page, angle, width, height, unit, Optional.ToNullable(language), Optional.ToList(lines));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult_internal.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -25,6 +26,7 @@ namespace Azure.AI.FormRecognizer.Models
             Width = width;
             Height = height;
             Unit = unit;
+            Lines = new ChangeTrackingList<TextLine_internal>();
         }
 
         /// <summary> Initializes a new instance of ReadResult_internal. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/SourcePath_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/SourcePath_internal.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.FormRecognizer.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Source != null)
+            if (Optional.IsDefined(Source))
             {
                 writer.WritePropertyName("source");
                 writer.WriteStringValue(Source);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/SourcePath_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/SourcePath_internal.cs
@@ -15,13 +15,6 @@ namespace Azure.AI.FormRecognizer.Models
         {
         }
 
-        /// <summary> Initializes a new instance of SourcePath_internal. </summary>
-        /// <param name="source"> File source path. </param>
-        internal SourcePath_internal(string source)
-        {
-            Source = source;
-        }
-
         /// <summary> File source path. </summary>
         public string Source { get; set; }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextLine_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextLine_internal.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.FormRecognizer.Models
         {
             string text = default;
             IReadOnlyList<float> boundingBox = default;
-            Language_internal? language = default;
+            Optional<Language_internal> language = default;
             IReadOnlyList<TextWord_internal> words = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -38,10 +38,6 @@ namespace Azure.AI.FormRecognizer.Models
                 }
                 if (property.NameEquals("language"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     language = new Language_internal(property.Value.GetString());
                     continue;
                 }
@@ -50,20 +46,13 @@ namespace Azure.AI.FormRecognizer.Models
                     List<TextWord_internal> array = new List<TextWord_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(TextWord_internal.DeserializeTextWord_internal(item));
-                        }
+                        array.Add(TextWord_internal.DeserializeTextWord_internal(item));
                     }
                     words = array;
                     continue;
                 }
             }
-            return new TextLine_internal(text, boundingBox, language, words);
+            return new TextLine_internal(text, boundingBox, Optional.ToNullable(language), words);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextLine_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextLine_internal.cs
@@ -34,8 +34,8 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             Text = text;
-            BoundingBox = boundingBox.ToArray();
-            Words = words.ToArray();
+            BoundingBox = boundingBox.ToList();
+            Words = words.ToList();
         }
 
         /// <summary> Initializes a new instance of TextLine_internal. </summary>
@@ -46,9 +46,9 @@ namespace Azure.AI.FormRecognizer.Models
         internal TextLine_internal(string text, IReadOnlyList<float> boundingBox, Language_internal? language, IReadOnlyList<TextWord_internal> words)
         {
             Text = text;
-            BoundingBox = boundingBox ?? new List<float>();
+            BoundingBox = boundingBox;
             Language = language;
-            Words = words ?? new List<TextWord_internal>();
+            Words = words;
         }
 
         /// <summary> The text content of the line. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextWord_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextWord_internal.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.FormRecognizer.Models
         {
             string text = default;
             IReadOnlyList<float> boundingBox = default;
-            float? confidence = default;
+            Optional<float> confidence = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("text"))
@@ -37,15 +37,11 @@ namespace Azure.AI.FormRecognizer.Models
                 }
                 if (property.NameEquals("confidence"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     confidence = property.Value.GetSingle();
                     continue;
                 }
             }
-            return new TextWord_internal(text, boundingBox, confidence);
+            return new TextWord_internal(text, boundingBox, Optional.ToNullable(confidence));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextWord_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextWord_internal.cs
@@ -29,7 +29,7 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             Text = text;
-            BoundingBox = boundingBox.ToArray();
+            BoundingBox = boundingBox.ToList();
         }
 
         /// <summary> Initializes a new instance of TextWord_internal. </summary>
@@ -39,7 +39,7 @@ namespace Azure.AI.FormRecognizer.Models
         internal TextWord_internal(string text, IReadOnlyList<float> boundingBox, float? confidence)
         {
             Text = text;
-            BoundingBox = boundingBox ?? new List<float>();
+            BoundingBox = boundingBox;
             Confidence = confidence;
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainRequest_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainRequest_internal.Serialization.cs
@@ -17,12 +17,12 @@ namespace Azure.AI.FormRecognizer.Models
             writer.WriteStartObject();
             writer.WritePropertyName("source");
             writer.WriteStringValue(Source);
-            if (SourceFilter != null)
+            if (Optional.IsDefined(SourceFilter))
             {
                 writer.WritePropertyName("sourceFilter");
                 writer.WriteObjectValue(SourceFilter);
             }
-            if (UseLabelFile != null)
+            if (Optional.IsDefined(UseLabelFile))
             {
                 writer.WritePropertyName("useLabelFile");
                 writer.WriteBooleanValue(UseLabelFile.Value);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainRequest_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainRequest_internal.cs
@@ -25,17 +25,6 @@ namespace Azure.AI.FormRecognizer.Models
             Source = source;
         }
 
-        /// <summary> Initializes a new instance of TrainRequest_internal. </summary>
-        /// <param name="source"> Source path containing the training documents. </param>
-        /// <param name="sourceFilter"> Filter to apply to the documents in the source path for training. </param>
-        /// <param name="useLabelFile"> Use label file for training a model. </param>
-        internal TrainRequest_internal(string source, TrainingFileFilter sourceFilter, bool? useLabelFile)
-        {
-            Source = source;
-            SourceFilter = sourceFilter;
-            UseLabelFile = useLabelFile;
-        }
-
         /// <summary> Source path containing the training documents. </summary>
         public string Source { get; }
         /// <summary> Filter to apply to the documents in the source path for training. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainResult_internal.Serialization.cs
@@ -17,9 +17,9 @@ namespace Azure.AI.FormRecognizer.Models
         internal static TrainResult_internal DeserializeTrainResult_internal(JsonElement element)
         {
             IReadOnlyList<TrainingDocumentInfo> trainingDocuments = default;
-            IReadOnlyList<CustomFormModelField> fields = default;
-            float? averageModelAccuracy = default;
-            IReadOnlyList<FormRecognizerError> errors = default;
+            Optional<IReadOnlyList<CustomFormModelField>> fields = default;
+            Optional<float> averageModelAccuracy = default;
+            Optional<IReadOnlyList<FormRecognizerError>> errors = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("trainingDocuments"))
@@ -27,71 +27,38 @@ namespace Azure.AI.FormRecognizer.Models
                     List<TrainingDocumentInfo> array = new List<TrainingDocumentInfo>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(TrainingDocumentInfo.DeserializeTrainingDocumentInfo(item));
-                        }
+                        array.Add(TrainingDocumentInfo.DeserializeTrainingDocumentInfo(item));
                     }
                     trainingDocuments = array;
                     continue;
                 }
                 if (property.NameEquals("fields"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<CustomFormModelField> array = new List<CustomFormModelField>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(CustomFormModelField.DeserializeCustomFormModelField(item));
-                        }
+                        array.Add(CustomFormModelField.DeserializeCustomFormModelField(item));
                     }
                     fields = array;
                     continue;
                 }
                 if (property.NameEquals("averageModelAccuracy"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     averageModelAccuracy = property.Value.GetSingle();
                     continue;
                 }
                 if (property.NameEquals("errors"))
                 {
-                    if (property.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
-                        }
+                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
                     }
                     errors = array;
                     continue;
                 }
             }
-            return new TrainResult_internal(trainingDocuments, fields, averageModelAccuracy, errors);
+            return new TrainResult_internal(trainingDocuments, Optional.ToList(fields), Optional.ToNullable(averageModelAccuracy), Optional.ToList(errors));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainResult_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainResult_internal.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Azure.AI.FormRecognizer.Training;
+using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -24,7 +25,9 @@ namespace Azure.AI.FormRecognizer.Models
                 throw new ArgumentNullException(nameof(trainingDocuments));
             }
 
-            TrainingDocuments = trainingDocuments.ToArray();
+            TrainingDocuments = trainingDocuments.ToList();
+            Fields = new ChangeTrackingList<CustomFormModelField>();
+            Errors = new ChangeTrackingList<FormRecognizerError>();
         }
 
         /// <summary> Initializes a new instance of TrainResult_internal. </summary>
@@ -34,7 +37,7 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="errors"> Errors returned during the training operation. </param>
         internal TrainResult_internal(IReadOnlyList<TrainingDocumentInfo> trainingDocuments, IReadOnlyList<CustomFormModelField> fields, float? averageModelAccuracy, IReadOnlyList<FormRecognizerError> errors)
         {
-            TrainingDocuments = trainingDocuments ?? new List<TrainingDocumentInfo>();
+            TrainingDocuments = trainingDocuments;
             Fields = fields;
             AverageModelAccuracy = averageModelAccuracy;
             Errors = errors;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingDocumentInfo.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingDocumentInfo.Serialization.cs
@@ -37,14 +37,7 @@ namespace Azure.AI.FormRecognizer.Training
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        if (item.ValueKind == JsonValueKind.Null)
-                        {
-                            array.Add(null);
-                        }
-                        else
-                        {
-                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
-                        }
+                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
                     }
                     errors = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingDocumentInfo.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingDocumentInfo.cs
@@ -33,7 +33,7 @@ namespace Azure.AI.FormRecognizer.Training
 
             DocumentName = documentName;
             PageCount = pageCount;
-            Errors = errors.ToArray();
+            Errors = errors.ToList();
             Status = status;
         }
 
@@ -46,7 +46,7 @@ namespace Azure.AI.FormRecognizer.Training
         {
             DocumentName = documentName;
             PageCount = pageCount;
-            Errors = errors ?? new List<FormRecognizerError>();
+            Errors = errors;
             Status = status;
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingFileFilter.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingFileFilter.Serialization.cs
@@ -15,13 +15,16 @@ namespace Azure.AI.FormRecognizer.Training
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Prefix != null)
+            if (Optional.IsDefined(Prefix))
             {
                 writer.WritePropertyName("prefix");
                 writer.WriteStringValue(Prefix);
             }
-            writer.WritePropertyName("includeSubFolders");
-            writer.WriteBooleanValue(IncludeSubFolders);
+            if (Optional.IsDefined(IncludeSubFolders))
+            {
+                writer.WritePropertyName("includeSubFolders");
+                writer.WriteBooleanValue(IncludeSubFolders);
+            }
             writer.WriteEndObject();
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingFileFilter.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingFileFilter.cs
@@ -10,14 +10,5 @@ namespace Azure.AI.FormRecognizer.Training
     /// <summary> Filter to apply to the documents in the source path for training. </summary>
     public partial class TrainingFileFilter
     {
-
-        /// <summary> Initializes a new instance of TrainingFileFilter. </summary>
-        /// <param name="prefix"> A case-sensitive prefix string to filter documents in the source path for training. For example, when using a Azure storage blob Uri, use the prefix to restrict sub folders for training. </param>
-        /// <param name="includeSubFolders"> A flag to indicate if sub folders within the set of prefix folders will also need to be included when searching for content to be preprocessed. </param>
-        internal TrainingFileFilter(string prefix, bool includeSubFolders)
-        {
-            Prefix = prefix;
-            IncludeSubFolders = includeSubFolders;
-        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceAnalyzeLayoutAsyncHeaders.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceAnalyzeLayoutAsyncHeaders.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer
         {
             _response = response;
         }
+        /// <summary> URL containing the resultId used to track the progress and obtain the result of the analyze operation. </summary>
         public string OperationLocation => _response.Headers.TryGetValue("Operation-Location", out string value) ? value : null;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceAnalyzeReceiptAsyncHeaders.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceAnalyzeReceiptAsyncHeaders.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer
         {
             _response = response;
         }
+        /// <summary> URL containing the resultId used to track the progress and obtain the result of the analyze operation. </summary>
         public string OperationLocation => _response.Headers.TryGetValue("Operation-Location", out string value) ? value : null;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceAnalyzeWithCustomModelHeaders.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceAnalyzeWithCustomModelHeaders.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer
         {
             _response = response;
         }
+        /// <summary> URL containing the resultId used to track the progress and obtain the result of the analyze operation. </summary>
         public string OperationLocation => _response.Headers.TryGetValue("Operation-Location", out string value) ? value : null;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceCopyCustomModelHeaders.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceCopyCustomModelHeaders.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer
         {
             _response = response;
         }
+        /// <summary> URL containing the resultId used to track the progress and obtain the result of the copy operation. </summary>
         public string OperationLocation => _response.Headers.TryGetValue("Operation-Location", out string value) ? value : null;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceGenerateModelCopyAuthorizationHeaders.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceGenerateModelCopyAuthorizationHeaders.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer
         {
             _response = response;
         }
+        /// <summary> Location and ID of the model being copied. The status of model copy is specified in the status property at the model location. </summary>
         public string Location => _response.Headers.TryGetValue("Location", out string value) ? value : null;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceRestClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceRestClient.cs
@@ -134,14 +134,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Model_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Model_internal.DeserializeModel_internal(document.RootElement);
-                        }
+                        value = Model_internal.DeserializeModel_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -163,14 +156,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Model_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Model_internal.DeserializeModel_internal(document.RootElement);
-                        }
+                        value = Model_internal.DeserializeModel_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -389,14 +375,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         AnalyzeOperationResult_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
-                        }
+                        value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -418,14 +397,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         AnalyzeOperationResult_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
-                        }
+                        value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -528,14 +500,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         CopyOperationResult value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = CopyOperationResult.DeserializeCopyOperationResult(document.RootElement);
-                        }
+                        value = CopyOperationResult.DeserializeCopyOperationResult(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -557,14 +522,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         CopyOperationResult value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = CopyOperationResult.DeserializeCopyOperationResult(document.RootElement);
-                        }
+                        value = CopyOperationResult.DeserializeCopyOperationResult(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -598,14 +556,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         CopyAuthorizationResult value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = CopyAuthorizationResult.DeserializeCopyAuthorizationResult(document.RootElement);
-                        }
+                        value = CopyAuthorizationResult.DeserializeCopyAuthorizationResult(document.RootElement);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -626,14 +577,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         CopyAuthorizationResult value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = CopyAuthorizationResult.DeserializeCopyAuthorizationResult(document.RootElement);
-                        }
+                        value = CopyAuthorizationResult.DeserializeCopyAuthorizationResult(document.RootElement);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -795,14 +739,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         AnalyzeOperationResult_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
-                        }
+                        value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -823,14 +760,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         AnalyzeOperationResult_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
-                        }
+                        value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -980,14 +910,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         AnalyzeOperationResult_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
-                        }
+                        value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1008,14 +931,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         AnalyzeOperationResult_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
-                        }
+                        value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1049,14 +965,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Models_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
-                        }
+                        value = Models_internal.DeserializeModels_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1076,14 +985,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Models_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
-                        }
+                        value = Models_internal.DeserializeModels_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1117,14 +1019,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Models_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
-                        }
+                        value = Models_internal.DeserializeModels_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1144,14 +1039,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Models_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
-                        }
+                        value = Models_internal.DeserializeModels_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1190,14 +1078,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Models_internal value = default;
                         using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
-                        }
+                        value = Models_internal.DeserializeModels_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:
@@ -1223,14 +1104,7 @@ namespace Azure.AI.FormRecognizer
                     {
                         Models_internal value = default;
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        if (document.RootElement.ValueKind == JsonValueKind.Null)
-                        {
-                            value = null;
-                        }
-                        else
-                        {
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
-                        }
+                        value = Models_internal.DeserializeModels_internal(document.RootElement);
                         return Response.FromValue(value, message.Response);
                     }
                 default:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceTrainCustomModelAsyncHeaders.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/ServiceTrainCustomModelAsyncHeaders.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.FormRecognizer
         {
             _response = response;
         }
+        /// <summary> Location and ID of the model being trained. The status of model training is specified in the status property at the model location. </summary>
         public string Location => _response.Headers.TryGetValue("Location", out string value) ? value : null;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedForm.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -108,7 +109,7 @@ namespace Azure.AI.FormRecognizer.Models
 
                 if (pageNumber >= PageRange.FirstPageNumber && pageNumber <= PageRange.LastPageNumber)
                 {
-                    pages.Add(new FormPage(pageResults != null ? pageResults[i] : null, readResults, i));
+                    pages.Add(new FormPage(pageResults.Any() ? pageResults[i] : null, readResults, i));
                 }
             }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
@@ -21,3 +21,48 @@ directive:
   where: $.definitions.AnalyzeResult
   transform: $.required = ["version"];
 ```
+
+### Add nullable annotations
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AnalyzeResult
+  transform: >
+    $.properties.readResults["x-nullable"] = true;
+    $.properties.pageResults["x-nullable"] = true;
+    $.properties.documentResults["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AnalyzeOperationResult
+  transform: >
+    $.properties.analyzeResult["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.KeyValueElement
+  transform: >
+    $.properties.boundingBox["x-nullable"] = true;
+    $.properties.elements["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.PageResult
+  transform: >
+    $.properties.clusterId["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.DocumentResult
+  transform: >
+    $.properties.fields.additionalProperties["x-nullable"] = true;
+```


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/13511

Major features

1. Collections are now always initialized and collection properties are readonly by default
2. Internal deserialization ctors are removed for input-only models
3. Improved nullability support - fewer extra null checks, correct nullable types generated. Might require adding missing annotations to the swagger spec.
4. Improved header support - descriptions and `x-ms-client-name` honored.
5. Single value, `modelAsString` enums are generated as types, they were string constants before.
6. Readonly properties are not serialized - affects recordings.

What you might need to do:
1. If you copied and overrode the serialization code you might want to update it to be in sync with new generator patterns.
2. **Please follow up on updating the centralized swagger file if there were workarounds applied to autorest.md**