### PR TITLE
[Event Hubs Client] Load Balancer Recovery of Owned Partitions

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/InMemoryStorageManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/InMemoryStorageManager.cs
@@ -48,6 +48,14 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Initializes a new instance of the <see cref="MockCheckPointStorage"/> class.
         /// </summary>
         ///
+        public InMemoryStorageManager() : this(null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MockCheckPointStorage"/> class.
+        /// </summary>
+        ///
         /// <param name="logger">Logs activities performed by this storage manager.</param>
         ///
         public InMemoryStorageManager(Action<string> logger = null)


### PR DESCRIPTION
# Summary

The focus of these changes is to allow the load balancer to recognize partitions which its associated processor has ownership of but is not aware of.  This is
a case that presents most often when recovering from a crash or other scenario that causes the processor to be recreated.

# Last Upstream Rebase

Friday, July 17, 5:452pm (EDT)

# References and Related Issues 

- [Load Balancer: Detect and Handle Reclaiming Ownership on Restart](https://github.com/Azure/azure-sdk-for-net/issues/13191) (#13191)