### PR TITLE
[Central Package Versions] Bumping the AMQP Library Version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -30,7 +30,7 @@
     <PackageReference Update="Castle.Core" Version="4.4.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.4" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.5" />
     <PackageReference Update="Microsoft.Azure.Batch" Version="11.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="[1.29.0-preview-004]" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="[1.27.0-preview-004]" />


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the central version for the `Microsoft.Azure.Amqp` library to v2.4.5, which now contains a target for `netstandard2.0` and makes more efficient use of resources by eagerly disposing timers rather than waiting for the finalizer.

# Last Upstream Rebase

Saturday, July 18, 11:10am (EDT)