### PR TITLE
Cache PropertyInfos in .ToTableEntityList and .ToTableEntity

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -129,7 +129,7 @@
     <PackageReference Update="System.Text.Json" Version="4.6.0" />
 
     <!-- Build time packages -->
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20200602.2" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20200721.2" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" />
 

--- a/sdk/tables/Azure.Data.Tables/Azure.Data.Tables.sln
+++ b/sdk/tables/Azure.Data.Tables/Azure.Data.Tables.sln
@@ -7,7 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.Tables", "src\Az
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.Tables.Tests", "tests\Azure.Data.Tables.Tests.csproj", "{DE6D1CE8-3B67-4651-B401-A868A72398D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{70C6A56F-209B-470E-8E39-05AE3B4CE5F4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{70C6A56F-209B-470E-8E39-05AE3B4CE5F4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.Tables.Performance", "tests\perf\Azure.Data.Tables.Performance.csproj", "{3EA53995-C462-43F2-9413-72E29BE04DD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{70C6A56F-209B-470E-8E39-05AE3B4CE5F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70C6A56F-209B-470E-8E39-05AE3B4CE5F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70C6A56F-209B-470E-8E39-05AE3B4CE5F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/tables/Azure.Data.Tables/src/AssemblyInfo.cs
+++ b/sdk/tables/Azure.Data.Tables/src/AssemblyInfo.cs
@@ -10,6 +10,13 @@ using System.Runtime.CompilerServices;
     "e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593d" +
     "aa7b11b4")]
 
+[assembly: InternalsVisibleTo("Azure.Data.Tables.Performance, PublicKey=" +
+    "0024000004800000940000000602000000240000525341310004000001000100d15ddcb2968829" +
+    "5338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc" +
+    "012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265" +
+    "e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593d" +
+    "aa7b11b4")]
+
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=" +
     "0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99" +
     "c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654" +

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/DictionaryTableExtensions.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/DictionaryTableExtensions.cs
@@ -115,8 +115,12 @@ namespace Azure.Data.Tables
         /// </summary>
         internal static List<T> ToTableEntityList<T>(this IReadOnlyList<IDictionary<string, object>> entityList) where T : TableEntity, new()
         {
-            PropertyInfo[] properties = s_propertyInfoCache.GetOrAdd(typeof(T), typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public));
-            var result = new List<T>();
+            PropertyInfo[] properties = s_propertyInfoCache.GetOrAdd(typeof(T), (type) =>
+            {
+                return type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+            });
+
+            var result = new List<T>(entityList.Count);
 
             foreach (var entity in entityList)
             {
@@ -133,7 +137,11 @@ namespace Azure.Data.Tables
         /// </summary>
         internal static T ToTableEntity<T>(this IDictionary<string, object> entity, PropertyInfo[]? properties = null) where T : TableEntity, new()
         {
-            properties ??= s_propertyInfoCache.GetOrAdd(typeof(T), typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public));
+            properties ??= s_propertyInfoCache.GetOrAdd(typeof(T), (type) =>
+            {
+                return type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+            });
+
             var result = new T();
 
             // Iterate through each property of the entity and set them as the correct type.

--- a/sdk/tables/Azure.Data.Tables/tests/Azure.Data.Tables.Tests.csproj
+++ b/sdk/tables/Azure.Data.Tables/tests/Azure.Data.Tables.Tests.csproj
@@ -2,6 +2,11 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="perf\**" />
+    <EmbeddedResource Remove="perf\**" />
+    <None Remove="perf\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />

--- a/sdk/tables/Azure.Data.Tables/tests/perf/Azure.Data.Tables.Performance.csproj
+++ b/sdk/tables/Azure.Data.Tables/tests/perf/Azure.Data.Tables.Performance.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Azure.Data.Tables.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/sdk/tables/Azure.Data.Tables/tests/perf/GenericTableEntityCreationBenchmark.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/perf/GenericTableEntityCreationBenchmark.cs
@@ -11,7 +11,7 @@ namespace Azure.Data.Tables.Performance
     [MemoryDiagnoser]
     public class GenericTableEntityCreationBenchmark
     {
-        public const int ItemCount = 1000;
+        public const int ItemCount = 10000;
         private readonly List<Dictionary<string, object>> _items = new List<Dictionary<string, object>>(ItemCount);
 
         [GlobalSetup]

--- a/sdk/tables/Azure.Data.Tables/tests/perf/GenericTableEntityCreationBenchmark.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/perf/GenericTableEntityCreationBenchmark.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Data.Tables;
+using BenchmarkDotNet.Attributes;
+
+namespace Azure.Data.Tables.Performance
+{
+    [MemoryDiagnoser]
+    public class GenericTableEntityCreationBenchmark
+    {
+        public const int ItemCount = 1000;
+        private readonly List<Dictionary<string, object>> _items = new List<Dictionary<string, object>>(ItemCount);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            for (int i = 0; i < ItemCount; i++)
+            {
+                _items.Add(new Dictionary<string, object>
+                    {
+                        {"PartitionKey", "partition"},
+                        {"RowKey", i.ToString("D2")},
+                        {"SomeGuid", Guid.NewGuid().ToString()},
+                        {"SomeString", $"This is table entity number {i:D2}"},
+                        {"SomeInt", i},
+                        {"SomeDateTime", new DateTime(2020, 1,1,1,1,0,DateTimeKind.Utc).AddMinutes(i).ToString("o") },
+                        {"SomeBinary", Convert.ToBase64String(new byte[]{ 0x01, 0x02, 0x03, 0x04, 0x05 })},
+                    });
+            }
+        }
+
+        [Benchmark]
+        public void ToTableEntity()
+        {
+            for (int i = 0; i < _items.Count; i++)
+            {
+                _items[i].ToTableEntity<BenchmarkEntity>();
+            }
+        }
+
+        [Benchmark]
+        public void ToTableEntityList()
+        {
+            _items.ToTableEntityList<BenchmarkEntity>();
+        }
+
+        public class BenchmarkEntity : TableEntity
+        {
+            public BenchmarkEntity()
+            {
+            }
+
+            public BenchmarkEntity(string partitionKey, string rowKey) : base(partitionKey, rowKey)
+            {
+            }
+
+            public Guid SomeGuid { get; set; }
+            public string SomeString { get; set; }
+            public int SomeInt { get; set; }
+            public DateTime SomeDateTime { get; set; }
+            public byte[] SomeBinary { get; set; }
+        }
+    }
+}

--- a/sdk/tables/Azure.Data.Tables/tests/perf/Program.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/perf/Program.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using BenchmarkDotNet.Running;
+
+namespace Azure.Data.Tables.Performance
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}


### PR DESCRIPTION
fixes #12204

Before
|            Method |     Mean |     Error |   StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------ |---------:|----------:|---------:|----------:|---------:|---------:|----------:|
|     ToTableEntity | 30.05 ms | 0.6008 ms | 1.540 ms | 1750.0000 |        - |        - |   7.25 MB |
| ToTableEntityList | 33.33 ms | 0.6619 ms | 1.291 ms | 1200.0000 | 533.3333 | 133.3333 |   6.58 MB |

After
|            Method |     Mean |     Error |    StdDev |     Gen 0 |    Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|----------:|---------:|------:|----------:|
|     ToTableEntity | 26.58 ms | 0.2027 ms | 0.1797 ms | 1531.2500 |        - |     - |   6.33 MB |
| ToTableEntityList | 29.02 ms | 0.1824 ms | 0.1617 ms | 1062.5000 | 468.7500 |     - |   6.41 MB |