### PR TITLE
Storage Internals Rename

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -55,6 +55,7 @@
     <Compile Include="$(AzureStorageSharedSources)SasExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)SasQueryParametersInternals.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)SharedAccessSignatureCredentials.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureStorageSharedSources)SlicedStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageClientOptions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageConnectionString.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageCollectionEnumerator.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
@@ -66,7 +67,6 @@
     <Compile Include="$(AzureStorageSharedSources)StorageSharedKeyPipelinePolicy.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageResponseClassifier.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(AzureStorageSharedSources)StreamSlice.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UserDelegationKeyProperties.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -17,7 +17,7 @@ namespace Azure.Storage
     {
         #region Definitions
         // delegte for getting a partition from a stream based on the selected data management stragegy
-        private delegate Task<StreamSlice> GetNextStreamPartition(
+        private delegate Task<SlicedStream> GetNextStreamPartition(
             Stream stream,
             long minCount,
             long maxCount,
@@ -260,7 +260,7 @@ namespace Azure.Storage
                 // Partition the stream into individual blocks and stage them
                 if (async)
                 {
-                    await foreach (StreamSlice block in GetPartitionsAsync(
+                    await foreach (SlicedStream block in GetPartitionsAsync(
                         content,
                         contentLength,
                         partitionSize,
@@ -281,7 +281,7 @@ namespace Azure.Storage
                 }
                 else
                 {
-                    foreach (StreamSlice block in GetPartitionsAsync(
+                    foreach (SlicedStream block in GetPartitionsAsync(
                         content,
                         contentLength,
                         partitionSize,
@@ -350,7 +350,7 @@ namespace Azure.Storage
                 List<Task> runningTasks = new List<Task>();
 
                 // Partition the stream into individual blocks
-                await foreach (StreamSlice block in GetPartitionsAsync(
+                await foreach (SlicedStream block in GetPartitionsAsync(
                     content,
                     contentLength,
                     blockSize,
@@ -420,7 +420,7 @@ namespace Azure.Storage
         /// Wraps both the async method and dispose call in one task.
         /// </summary>
         private async Task StagePartitionAndDisposeInternal(
-            StreamSlice partition,
+            SlicedStream partition,
             long offset,
             TServiceSpecificArgs args,
             IProgress<long> progressHandler,
@@ -469,7 +469,7 @@ namespace Azure.Storage
         /// <summary>
         /// Partition a stream into a series of blocks buffered as needed by an array pool.
         /// </summary>
-        private static async IAsyncEnumerable<StreamSlice> GetPartitionsAsync(
+        private static async IAsyncEnumerable<SlicedStream> GetPartitionsAsync(
             Stream stream,
             long? streamLength,
             long blockSize,
@@ -502,7 +502,7 @@ namespace Azure.Storage
             long absolutePosition = 0;
             do
             {
-                StreamSlice partition = await getNextPartition(
+                SlicedStream partition = await getNextPartition(
                     stream,
                     acceptableBlockSize,
                     blockSize,
@@ -552,7 +552,7 @@ namespace Azure.Storage
         /// <returns>
         /// Task containing the buffered stream partition.
         /// </returns>
-        private async Task<StreamSlice> GetBufferedPartitionInternal(
+        private async Task<SlicedStream> GetBufferedPartitionInternal(
             Stream stream,
             long minCount,
             long maxCount,
@@ -594,14 +594,14 @@ namespace Azure.Storage
         /// <returns>
         /// Task containing the stream facade.
         /// </returns>
-        private static Task<StreamSlice> GetStreamedPartitionInternal(
+        private static Task<SlicedStream> GetStreamedPartitionInternal(
             Stream stream,
             long minCount,
             long maxCount,
             long absolutePosition,
             bool async,
             CancellationToken cancellationToken)
-            => Task.FromResult((StreamSlice)WindowStream.GetWindow(stream, maxCount, absolutePosition));
+            => Task.FromResult((SlicedStream)WindowStream.GetWindow(stream, maxCount, absolutePosition));
         #endregion
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/PooledMemoryStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PooledMemoryStream.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage.Shared
     /// Functions like a readable <see cref="MemoryStream"/> but uses an ArrayPool to supply the backing memory.
     /// This stream support buffering long sizes.
     /// </summary>
-    internal class PooledMemoryStream : StreamSlice
+    internal class PooledMemoryStream : SlicedStream
     {
         private const int DefaultMaxArrayPoolRentalSize = 128 * Constants.MB;
 

--- a/sdk/storage/Azure.Storage.Common/src/Shared/SlicedStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/SlicedStream.cs
@@ -6,7 +6,7 @@ namespace Azure.Storage.Shared
     /// <summary>
     /// Describes a stream that is a partition of another, larger stream.
     /// </summary>
-    internal abstract class StreamSlice : System.IO.Stream
+    internal abstract class SlicedStream : System.IO.Stream
     {
         /// <summary>
         /// Absolute position of the start of this stream in the larger stream it was chunked from.

--- a/sdk/storage/Azure.Storage.Common/src/Shared/WindowStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/WindowStream.cs
@@ -16,7 +16,7 @@ namespace Azure.Storage.Shared
     /// Exposes a predetermined slice of a larger stream using the same Stream interface.
     /// There should not be access to the base stream while this facade is in use.
     /// </summary>
-    internal abstract class WindowStream : StreamSlice
+    internal abstract class WindowStream : SlicedStream
     {
         private Stream InnerStream { get; }
 

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)ProgressIncrementingStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(AzureStorageSharedSources)StreamSlice.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureStorageSharedSources)SlicedStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
   </ItemGroup>
   <!-- Ensure an empty TestConfigurations.xml is always present so the build can copy it -->

--- a/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PooledMemoryStreamTests.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
 using Azure.Core.Pipeline;
 using Azure.Storage.Shared;
+using Azure.Storage.Tests.Shared;
 using NUnit.Framework;
 
 namespace Azure.Storage.Tests
@@ -18,65 +14,6 @@ namespace Azure.Storage.Tests
     public class PooledMemoryStreamTests
     {
         private readonly ArrayPool<byte> _pool = ArrayPool<byte>.Shared;
-
-        /// <summary>
-        /// Stream who's byte at position n is n % <see cref="byte.MaxValue"/>.
-        /// Note this means we have 255 possibilities, not 256, giving variation at likely buffer boundaries.
-        /// </summary>
-        private class PredictableStream : Stream
-        {
-            public override bool CanRead => true;
-
-            public override bool CanSeek => true;
-
-            public override bool CanWrite => false;
-
-            public override long Length => throw new NotSupportedException();
-
-            public override long Position { get; set; } = 0;
-
-            public override void Flush()
-            { }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    buffer[offset + i] = (byte)((Position + i) % byte.MaxValue);
-                }
-
-                Position += count;
-                return count;
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                switch (origin)
-                {
-                    case SeekOrigin.Begin:
-                        Position = offset;
-                        break;
-                    case SeekOrigin.Current:
-                        Position += offset;
-                        break;
-                    case SeekOrigin.End:
-                        Position = Length + offset;
-                        break;
-                }
-
-                return Position;
-            }
-
-            public override void SetLength(long value)
-            {
-                throw new NotSupportedException();
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                throw new NotSupportedException();
-            }
-        }
 
         /// <summary>
         /// Sanity check for our test helper stream implementation.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -51,6 +51,7 @@
     <Compile Include="$(AzureStorageSharedSources)SasExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)SasQueryParametersInternals.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)SharedAccessSignatureCredentials.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureStorageSharedSources)SlicedStream.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageClientOptions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageConnectionString.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageCollectionEnumerator.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
@@ -62,7 +63,6 @@
     <Compile Include="$(AzureStorageSharedSources)StorageSharedKeyPipelinePolicy.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageResponseClassifier.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)StorageVersionExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(AzureStorageSharedSources)StreamSlice.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureStorageSharedSources)UserDelegationKeyProperties.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />


### PR DESCRIPTION
A couple changes requested from the storage stg73 merge.

Renamed internal class StreamSlice to SlicedStream per naming guidelines.
Deleted a duplicate class from testing.