### PR TITLE
Remove exception Lease catch in FileClient.Upload

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed bug where ShareUriBuilder would return LastDirectoryOrFileName and DirectoryOrFilePath URL-encoded.
 - Updated ShareSasBuilder to correctly order raw string permissions and make the permissions lowercase.
 - Added ShareFileClient.OpenRead().
+- Fixed bug where in Upload, all exceptions except for LeaseNotPresentWithFileOperation were not being thrown.
 
 ## 12.3.0-preview.1 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed bug where ShareUriBuilder would return LastDirectoryOrFileName and DirectoryOrFilePath URL-encoded.
 - Updated ShareSasBuilder to correctly order raw string permissions and make the permissions lowercase.
 - Added ShareFileClient.OpenRead().
-- Fixed bug where in Upload, all exceptions except for LeaseNotPresentWithFileOperation were not being thrown.
+- Fixed bug where in ShareFileClient.Upload(), all exceptions except for LeaseNotPresentWithFileOperation were not being thrown.
 
 ## 12.3.0-preview.1 (2020-07-03)
 - Added support for service version 2019-12-12.

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -4035,30 +4035,18 @@ namespace Azure.Storage.Files.Shares
         {
             // Try to upload the file as a single range
             Debug.Assert(singleRangeThreshold <= Constants.File.MaxFileUpdateRange);
-            try
+            var length = content.Length;
+            if (length <= singleRangeThreshold)
             {
-                var length = content.Length;
-                if (length <= singleRangeThreshold)
-                {
-                    return await UploadRangeInternal(
-                        new HttpRange(0, length),
-                        content,
-                        null,
-                        progressHandler,
-                        conditions,
-                        async,
-                        cancellationToken)
-                        .ConfigureAwait(false);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (ex is RequestFailedException
-                    && ((RequestFailedException)ex).ErrorCode.Equals(
-                        Constants.File.Errors.LeaseNotPresentWithFileOperation, StringComparison.InvariantCulture))
-                {
-                    throw;
-                }
+                return await UploadRangeInternal(
+                    new HttpRange(0, length),
+                    content,
+                    null,
+                    progressHandler,
+                    conditions,
+                    async,
+                    cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             // Otherwise naively split the file into ranges and upload them individually

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/UploadAsync_ReadOnlyError.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/UploadAsync_ReadOnlyError.json
@@ -1,0 +1,117 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d6595b31-66a7-e869-2c84-bf6d3b6d2b32?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-da4cb137fa99804dadcac30068f7c564-e989aed44dd7be4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200715.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "079dddac-8cc9-b666-1842-2bed69bd4864",
+        "x-ms-date": "Wed, 15 Jul 2020 23:28:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 15 Jul 2020 23:28:10 GMT",
+        "ETag": "\u00220x8D82916BD1CF97B\u0022",
+        "Last-Modified": "Wed, 15 Jul 2020 23:28:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "079dddac-8cc9-b666-1842-2bed69bd4864",
+        "x-ms-request-id": "55c36a9e-101a-010d-4dff-5a3b42000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d6595b31-66a7-e869-2c84-bf6d3b6d2b32/test-file-237a0646-8915-d701-3eff-6c42ea33ed72",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ddd3e9ce05a1b84dacd9f1b305617008-a960116f0bc7764e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200715.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f4ef161c-6e3e-235b-dcc6-c8c91f24cce4",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Wed, 15 Jul 2020 23:28:11 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 15 Jul 2020 23:28:10 GMT",
+        "ETag": "\u00220x8D82916BD349A64\u0022",
+        "Last-Modified": "Wed, 15 Jul 2020 23:28:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f4ef161c-6e3e-235b-dcc6-c8c91f24cce4",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-07-15T23:28:11.3285732Z",
+        "x-ms-file-creation-time": "2020-07-15T23:28:11.3285732Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-07-15T23:28:11.3285732Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "55c36aa1-101a-010d-4eff-5a3b42000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-d6595b31-66a7-e869-2c84-bf6d3b6d2b32?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-9370188008d0ef44838b70f5feec0791-6e59e907e86a8b44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200715.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d325c00f-f944-8333-f29d-810a5b9f0285",
+        "x-ms-date": "Wed, 15 Jul 2020 23:28:11 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 15 Jul 2020 23:28:11 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d325c00f-f944-8333-f29d-810a5b9f0285",
+        "x-ms-request-id": "ee42be23-001a-00b7-32ff-5a9d1e000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "799802997",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Kg==;\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/UploadAsync_ReadOnlyErrorAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/UploadAsync_ReadOnlyErrorAsync.json
@@ -1,0 +1,117 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b8fc8e6b-5e8d-95cd-01f9-64a9fcb375c8?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-dc3a842b67ac0442b0a7ecbbc589208e-235533fb49b9984d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200715.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0bc79eee-ab0a-2bf7-231e-11fe19a35ee7",
+        "x-ms-date": "Wed, 15 Jul 2020 23:28:11 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "ETag": "\u00220x8D82916BDACFCC5\u0022",
+        "Last-Modified": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0bc79eee-ab0a-2bf7-231e-11fe19a35ee7",
+        "x-ms-request-id": "ca1c53d4-d01a-00be-38ff-5a8790000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b8fc8e6b-5e8d-95cd-01f9-64a9fcb375c8/test-file-dbf326b9-7ab6-4139-ca32-994273d0a54f",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-9097b88f16e3374aa241374bfc93fb3e-2956ab7f76c3b94a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200715.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ca4203eb-1fbd-73e7-6486-40d712b5b753",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "ETag": "\u00220x8D82916BDBDE054\u0022",
+        "Last-Modified": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ca4203eb-1fbd-73e7-6486-40d712b5b753",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-07-15T23:28:12.2282068Z",
+        "x-ms-file-creation-time": "2020-07-15T23:28:12.2282068Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-07-15T23:28:12.2282068Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "ca1c53d8-d01a-00be-39ff-5a8790000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandadev2.file.core.windows.net/test-share-b8fc8e6b-5e8d-95cd-01f9-64a9fcb375c8?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1236d6596904bc4db7a68597a3daa922-a49c98f99e367c4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200715.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "70561d81-da8d-df92-e047-f8652ae76d8f",
+        "x-ms-date": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-12-12"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 15 Jul 2020 23:28:12 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "70561d81-da8d-df92-e047-f8652ae76d8f",
+        "x-ms-request-id": "ca1c53da-d01a-00be-3bff-5a8790000000",
+        "x-ms-version": "2019-12-12"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2118868519",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttps://amandadev2.blob.core.windows.net\nhttps://amandadev2.file.core.windows.net\nhttps://amandadev2.queue.core.windows.net\nhttps://amandadev2.table.core.windows.net\n\n\n\n\nhttps://amandadev2-secondary.blob.core.windows.net\nhttps://amandadev2-secondary.file.core.windows.net\nhttps://amandadev2-secondary.queue.core.windows.net\nhttps://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://amandadev2.blob.core.windows.net/;QueueEndpoint=https://amandadev2.queue.core.windows.net/;FileEndpoint=https://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=https://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Kg==;\n"
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/13060

Open to the history on why we were catching this exception here. I checked with Java and Python and we don't do any catch there.