### PR TITLE
Add HttpWebRequest based transport

### DIFF
--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -170,7 +170,7 @@
       Properties="TargetPackageName=$(PackageId);
                   TargetPackageVersion=$(ApiCompatVersion);
                   TargetOutputPath=$(IntermediateOutputPath);
-                  BaseIntermediateOutputPath=$(BaseIntermediateOutputPath)\ApiCompat\"
+                  BaseIntermediateOutputPath=$(IntermediateOutputPath)\ApiCompat\"
       Targets="ApiCompatVerification"
      />
   </Target>

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -133,6 +133,10 @@ jobs:
         Windows_NetFramework:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
+        Windows_NetFramework_ProjectReferences:
+          OSVmImage: "windows-2019"
+          TestTargetFramework: net461
+          ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         MacOs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1

--- a/sdk/core/Azure.Core/Azure.Core.All.sln
+++ b/sdk/core/Azure.Core/Azure.Core.All.sln
@@ -195,6 +195,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Security.KeyVault.Adm
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental.Performance", "..\Azure.Core.Experimental\tests\perf\Azure.Core.Experimental.Performance.csproj", "{83FE5FDD-D0B7-49B6-9498-6591A3A34CAD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Storage.Internal.Avro", "..\..\storage\Azure.Storage.Internal.Avro\src\Azure.Storage.Internal.Avro.csproj", "{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Storage.Blobs.ChangeFeed", "..\..\storage\Azure.Storage.Blobs.ChangeFeed\src\Azure.Storage.Blobs.ChangeFeed.csproj", "{70FE7A7E-83FF-409F-8E68-916DA106C16B}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\keyvault\Azure.Security.KeyVault.Shared\src\Azure.Security.KeyVault.Shared.projitems*{359ffa3a-4f5d-411c-8978-28e58f50eea3}*SharedItemsImports = 5
@@ -1365,6 +1369,30 @@ Global
 		{83FE5FDD-D0B7-49B6-9498-6591A3A34CAD}.Release|x64.Build.0 = Release|Any CPU
 		{83FE5FDD-D0B7-49B6-9498-6591A3A34CAD}.Release|x86.ActiveCfg = Release|Any CPU
 		{83FE5FDD-D0B7-49B6-9498-6591A3A34CAD}.Release|x86.Build.0 = Release|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Debug|x64.Build.0 = Debug|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Debug|x86.Build.0 = Debug|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Release|x64.ActiveCfg = Release|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Release|x64.Build.0 = Release|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Release|x86.ActiveCfg = Release|Any CPU
+		{C046B0E0-D304-4D3D-9FFE-ABD3C4057CDA}.Release|x86.Build.0 = Release|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Debug|x64.Build.0 = Debug|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Debug|x86.Build.0 = Debug|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Release|x64.ActiveCfg = Release|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Release|x64.Build.0 = Release|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Release|x86.ActiveCfg = Release|Any CPU
+		{70FE7A7E-83FF-409F-8E68-916DA106C16B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.4.0-preview.1 (Unreleased)
 
+### Added
+- HttpWebRequest-based transport implementation. Enabled by-default on .NET Framework. Can be disabled using `AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT` environment variable or `Azure.Core.Pipeline.DisableHttpWebRequestTransport` AppContext switch. To use the app context switch add the following snippet to your `.csproj`:
+
+```xml
+ <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Azure.Core.Pipeline.DisableHttpWebRequestTransport" Value="true" />
+  </ItemGroup>
+```
+
 ### Fixed
 - Connection leak for retried non-buffered requests on .NET Framework.
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -11,6 +11,8 @@
   </ItemGroup>
 ```
 
+When the environment variable or the switch are set the `HttpClientTransport` would be used by default instead.
+
 ### Fixed
 - Connection leak for retried non-buffered requests on .NET Framework.
 

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
   </PropertyGroup>

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
   </PropertyGroup>

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <Nullable>enable</Nullable>
     <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
-    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
   </PropertyGroup>

--- a/sdk/core/Azure.Core/src/ClientOptions.cs
+++ b/sdk/core/Azure.Core/src/ClientOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.Core
     /// </summary>
     public abstract class ClientOptions
     {
-        private HttpPipelineTransport _transport = HttpClientTransport.Shared;
+        private HttpPipelineTransport _transport = GetDefaultTransport();
 
         /// <summary>
         /// Creates a new instance of <see cref="ClientOptions"/>.
@@ -80,5 +80,33 @@ namespace Azure.Core
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+
+        private static HttpPipelineTransport GetDefaultTransport()
+        {
+#if NETFRAMEWORK
+            bool GetSwitchValue(string switchName, string envVariable)
+            {
+                if (!AppContext.TryGetSwitch(switchName, out bool ret))
+                {
+                    string? switchValue = Environment.GetEnvironmentVariable(envVariable);
+                    if (switchValue != null)
+                    {
+                        ret = string.Equals("true", switchValue, StringComparison.InvariantCultureIgnoreCase) ||
+                              switchValue.Equals("1", StringComparison.InvariantCultureIgnoreCase);
+                    }
+                }
+
+                return ret;
+            }
+
+            if (!GetSwitchValue("Azure.Core.Pipeline.DisableHttpWebRequestTransport", "AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT"))
+            {
+                return HttpWebRequestTransport.Shared;
+            }
+#endif
+            return HttpClientTransport.Shared;
+        }
+
     }
 }

--- a/sdk/core/Azure.Core/src/HttpHeader.cs
+++ b/sdk/core/Azure.Core/src/HttpHeader.cs
@@ -131,6 +131,9 @@ namespace Azure.Core
             /// Returns. <code>"If-Unmodified-Since"</code>
             /// </summary>
             public static string IfUnmodifiedSince => "If-Unmodified-Since";
+
+            internal static string Referer => "Referer";
+            internal static string Host => "Host";
         }
 
 #pragma warning disable CA1034 // Nested types should not be visible

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -38,7 +39,8 @@ namespace Azure.Core.Pipeline
             {
                 if (message.Request.Content != null)
                 {
-                    if (message.Request.Content.TryComputeLength(out var length))
+                    if (request.ContentLength == -1 &&
+                        message.Request.Content.TryComputeLength(out var length))
                     {
                         request.ContentLength = length;
                     }
@@ -62,6 +64,18 @@ namespace Azure.Core.Pipeline
             request.Proxy = _proxy;
             foreach (var messageRequestHeader in messageRequest.Headers)
             {
+                if (messageRequestHeader.Name == HttpHeader.Names.ContentLength)
+                {
+                    request.ContentLength = int.Parse(messageRequestHeader.Value, CultureInfo.InvariantCulture);
+                    continue;
+                }
+
+                if (messageRequestHeader.Name == "Host")
+                {
+                    request.Host = messageRequestHeader.Value;
+                    continue;
+                }
+
                 request.Headers.Add(messageRequestHeader.Name, messageRequestHeader.Value);
             }
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -93,49 +93,49 @@ namespace Azure.Core.Pipeline
             request.Proxy = _proxy;
             foreach (var messageRequestHeader in messageRequest.Headers)
             {
-                if (messageRequestHeader.Name == HttpHeader.Names.ContentLength)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.ContentLength, StringComparison.OrdinalIgnoreCase))
                 {
                     request.ContentLength = int.Parse(messageRequestHeader.Value, CultureInfo.InvariantCulture);
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.Host)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.Host, StringComparison.OrdinalIgnoreCase))
                 {
                     request.Host = messageRequestHeader.Value;
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.Date)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.Date, StringComparison.OrdinalIgnoreCase))
                 {
                     request.Date = DateTime.Parse(messageRequestHeader.Value, CultureInfo.InvariantCulture);
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.ContentType)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.ContentType, StringComparison.OrdinalIgnoreCase))
                 {
                     request.ContentType = messageRequestHeader.Value;
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.UserAgent)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.UserAgent, StringComparison.OrdinalIgnoreCase))
                 {
                     request.UserAgent = messageRequestHeader.Value;
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.Accept)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.Accept, StringComparison.OrdinalIgnoreCase))
                 {
                     request.Accept = messageRequestHeader.Value;
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.Referer)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.Referer, StringComparison.OrdinalIgnoreCase))
                 {
                     request.Referer = messageRequestHeader.Value;
                     continue;
                 }
 
-                if (messageRequestHeader.Name == HttpHeader.Names.Range)
+                if (string.Equals(messageRequestHeader.Name, HttpHeader.Names.Range, StringComparison.OrdinalIgnoreCase))
                 {
                     var value = RangeHeaderValue.Parse(messageRequestHeader.Value);
                     if (value.Unit != "bytes")

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -42,7 +42,7 @@ namespace Azure.Core.Pipeline
         /// <inheritdoc />
         public override async ValueTask ProcessAsync(HttpMessage message)
         {
-            await ProcessInternal(message, true);
+            await ProcessInternal(message, true).ConfigureAwait(false);
         }
 
         private async ValueTask ProcessInternal(HttpMessage message, bool async)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -1,0 +1,208 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Azure.Core.Pipeline
+{
+    /// <summary>
+    /// The <see cref="HttpWebRequest"/> based <see cref="HttpPipelineTransport"/> implementation.
+    /// </summary>
+    public class HttpWebRequestTransport : HttpPipelineTransport
+    {
+        private readonly IWebProxy? _proxy;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="HttpWebRequestTransport"/>
+        /// </summary>
+        public HttpWebRequestTransport()
+        {
+            if (HttpEnvironmentProxy.TryCreate(out IWebProxy webProxy))
+            {
+                _proxy = webProxy;
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Process(HttpMessage message)
+        {
+            var request = CreateRequest(message.Request);
+            using var registration = message.CancellationToken.Register(() => request.Abort());
+            try
+            {
+                if (message.Request.Content != null)
+                {
+                    if (message.Request.Content.TryComputeLength(out var length))
+                    {
+                        request.ContentLength = length;
+                    }
+
+                    var requestStream = request.GetRequestStream();
+                    message.Request.Content.WriteTo(requestStream, message.CancellationToken);
+                }
+
+                message.Response = new HttpWebResponseImplementation(message.Request.ClientRequestId, (HttpWebResponse) request.GetResponse());
+            }
+            catch (WebException webException)
+            {
+                throw new RequestFailedException(0, webException.Message);
+            }
+        }
+
+        private HttpWebRequest CreateRequest(Request messageRequest)
+        {
+            var request = WebRequest.CreateHttp(messageRequest.Uri.ToUri());
+            request.Method = messageRequest.Method.Method;
+            request.Proxy = _proxy;
+            foreach (var messageRequestHeader in messageRequest.Headers)
+            {
+                request.Headers.Add(messageRequestHeader.Name, messageRequestHeader.Value);
+            }
+
+            return request;
+        }
+
+        /// <inheritdoc />
+        public override ValueTask ProcessAsync(HttpMessage message)
+        {
+            Process(message);
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override Request CreateRequest()
+        {
+            return new HttpWebRequestImplementation();
+        }
+
+        private sealed class HttpWebResponseImplementation: Response
+        {
+            private readonly HttpWebResponse _webResponse;
+
+            public HttpWebResponseImplementation(string clientRequestId, HttpWebResponse webResponse)
+            {
+                _webResponse = webResponse;
+
+                ContentStream = _webResponse.GetResponseStream();
+                ClientRequestId = clientRequestId;
+            }
+
+            public override int Status => (int) _webResponse.StatusCode;
+
+            public override string ReasonPhrase => _webResponse.StatusDescription;
+
+            public override Stream? ContentStream { get; set; }
+
+            public override string ClientRequestId { get; set; }
+
+            public override void Dispose()
+            {
+                _webResponse.Dispose();
+            }
+
+            protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)
+            {
+                value = _webResponse.Headers.Get(name);
+                return value != null;
+            }
+
+            protected internal override bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values)
+            {
+                values = _webResponse.Headers.GetValues(name);
+                return values != null;
+            }
+
+            protected internal override bool ContainsHeader(string name)
+            {
+                return _webResponse.Headers.Get(name) != null;
+            }
+
+            protected internal override IEnumerable<HttpHeader> EnumerateHeaders()
+            {
+                foreach (var key in _webResponse.Headers.AllKeys)
+                {
+                    yield return new HttpHeader(key, _webResponse.Headers.Get(key));
+                }
+            }
+        }
+
+        private sealed class HttpWebRequestImplementation: Request
+        {
+            public HttpWebRequestImplementation()
+            {
+                Method = RequestMethod.Get;
+            }
+
+            private string? _clientRequestId;
+            private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            protected internal override void AddHeader(string name, string value)
+            {
+                if (!_headers.TryGetValue(name, out List<string> values))
+                {
+                    _headers[name] = values = new List<string>();
+                }
+
+                values.Add(value);
+            }
+
+            protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)
+            {
+                if (_headers.TryGetValue(name, out List<string> values))
+                {
+                    value = JoinHeaderValue(values);
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+            {
+                var result = _headers.TryGetValue(name, out List<string> valuesList);
+                values = valuesList;
+                return result;
+            }
+
+            protected internal override bool ContainsHeader(string name)
+            {
+                return TryGetHeaderValues(name, out _);
+            }
+
+            protected internal override bool RemoveHeader(string name)
+            {
+                return _headers.Remove(name);
+            }
+
+            protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
+
+            private static string JoinHeaderValue(IEnumerable<string> values)
+            {
+                return string.Join(",", values);
+            }
+            public override string ClientRequestId
+            {
+                get => _clientRequestId ??= Guid.NewGuid().ToString();
+                set
+                {
+                    Argument.AssertNotNull(value, nameof(value));
+                    _clientRequestId = value;
+                }
+            }
+
+            public override RequestContent? Content { get; set; }
+
+            public override void Dispose()
+            {
+                Content?.Dispose();
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -71,8 +71,16 @@ namespace Azure.Core.Pipeline
                     }
                 }
 
-                var webResponse = async ? await request.GetResponseAsync().ConfigureAwait(false) : request.GetResponse();
-
+                WebResponse webResponse;
+                try
+                {
+                    webResponse = async ? await request.GetResponseAsync().ConfigureAwait(false) : request.GetResponse();
+                }
+                // HttpWebRequest throws for error responses catch that
+                catch (WebException exception) when (exception.Response != null)
+                {
+                    webResponse = exception.Response;
+                }
                 message.Response = new HttpWebResponseImplementation(message.Request.ClientRequestId, (HttpWebResponse) webResponse);
             }
             // WebException is thrown in the case of .Abort() call

--- a/sdk/core/Azure.Core/tests/ClientOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientOptionsTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Pipeline;
+using Azure.Identity;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class ClientOptionsTests
+    {
+#if NETCOREAPP
+        [Test]
+        public void DefaultTransportIsHttpClientTransport()
+        {
+            var options = new TestClientOptions();
+
+            Assert.IsInstanceOf<HttpClientTransport>(options.Transport);
+        }
+#else
+        [Test]
+        public void DefaultTransportIsHttpWebRequestTransport()
+        {
+            var options = new TestClientOptions();
+
+            Assert.IsInstanceOf<HttpWebRequestTransport>(options.Transport);
+        }
+
+        [Test]
+        public void DefaultTransportIsHttpClientTransportIfEnvVarSet()
+        {
+            string oldValue = Environment.GetEnvironmentVariable("AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT", "true");
+
+                var options = new TestClientOptions();
+
+                Assert.IsInstanceOf<HttpClientTransport>(options.Transport);
+
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT", oldValue);
+            }
+        }
+
+        [Test]
+        public void DefaultTransportIsHttpClientTransportIfSwitchIsSet()
+        {
+            AppContext.TryGetSwitch("Azure.Core.Pipeline.DisableHttpWebRequestTransport", out bool oldSwitch);
+
+            try
+            {
+                AppContext.SetSwitch("Azure.Core.Pipeline.DisableHttpWebRequestTransport", true);
+
+                var options = new TestClientOptions();
+
+                Assert.IsInstanceOf<HttpClientTransport>(options.Transport);
+
+            }
+            finally
+            {
+                AppContext.SetSwitch("Azure.Core.Pipeline.DisableHttpWebRequestTransport", oldSwitch);
+            }
+        }
+
+#endif
+
+        private class TestClientOptions : ClientOptions
+        {
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
@@ -2,21 +2,24 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
+    [TestFixture(true)]
+    [TestFixture(false)]
     public class HttpClientTransportTests : PipelineTestBase
     {
+        public HttpClientTransportTests(bool isAsync) : base(isAsync)
+        {
+        }
+
         [Test]
         public async Task DoesntDisposeContentIfStreamGotReplaced()
         {
@@ -67,30 +70,6 @@ namespace Azure.Core.Tests
             Assert.AreEqual(expectedUri, requestUri);
         }
 
-        [Test]
-        public async Task CanGetAndSetContent()
-        {
-            byte[] requestBytes = null;
-            var mockHandler = new MockHttpClientHandler(
-                async httpRequestMessage =>
-                {
-                    requestBytes = await httpRequestMessage.Content.ReadAsByteArrayAsync();
-                });
-
-            var bytes = Encoding.ASCII.GetBytes("Hello world");
-            var content = RequestContent.Create(bytes);
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-            request.Content = content;
-
-            Assert.AreEqual(content, request.Content);
-
-            await ExecuteRequest(request, transport);
-
-            CollectionAssert.AreEqual(bytes, requestBytes);
-        }
 
         public static object[] HeadersWithValuesAndType =>
             new object[]
@@ -111,116 +90,6 @@ namespace Azure.Core.Tests
             };
 
         [TestCaseSource(nameof(HeadersWithValuesAndType))]
-        public async Task CanSetRequestHeaders(string headerName, string headerValue, bool contentHeader)
-        {
-            IEnumerable<string> httpHeaderValues = null;
-
-            var mockHandler = new MockHttpClientHandler(
-                httpRequestMessage =>
-                {
-                    Assert.True(
-                        httpRequestMessage.Headers.TryGetValues(headerName, out httpHeaderValues) ||
-                        httpRequestMessage.Content.Headers.TryGetValues(headerName, out httpHeaderValues));
-                });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = CreateRequest(transport);
-
-            request.Headers.Add(headerName, "Random value");
-            request.Headers.SetValue(headerName, headerValue);
-
-            Assert.True(request.Headers.TryGetValue(headerName, out var value));
-            Assert.AreEqual(headerValue, value);
-
-            Assert.True(request.Headers.TryGetValue(headerName.ToUpper(), out value));
-            Assert.AreEqual(headerValue, value);
-
-            CollectionAssert.AreEqual(new[]
-            {
-                new HttpHeader(headerName, headerValue),
-            }, request.Headers);
-
-            await ExecuteRequest(request, transport);
-
-            Assert.AreEqual(headerValue, string.Join(",", httpHeaderValues));
-        }
-
-        [TestCaseSource(nameof(HeadersWithValuesAndType))]
-        public async Task CanRemoveHeaders(string headerName, string headerValue, bool contentHeader)
-        {
-            var mockHandler = new MockHttpClientHandler(
-                httpRequestMessage =>
-                {
-                    Assert.False(
-                        httpRequestMessage.Headers.TryGetValues(headerName, out _) &&
-                        httpRequestMessage.Content.Headers.TryGetValues(headerName, out _));
-                });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = CreateRequest(transport);
-
-            request.Headers.Add(headerName, headerValue);
-            Assert.True(request.Headers.Remove(headerName));
-            Assert.False(request.Headers.Remove(headerName));
-
-            Assert.False(request.Headers.TryGetValue(headerName, out _));
-            Assert.False(request.Headers.TryGetValue(headerName.ToUpper(), out _));
-            Assert.False(request.Headers.Contains(headerName.ToUpper()));
-
-            await ExecuteRequest(request, transport);
-        }
-
-        [TestCaseSource(nameof(HeadersWithValuesAndType))]
-        public async Task CanGetAndSetResponseHeaders(string headerName, string headerValue, bool contentHeader)
-        {
-            var mockHandler = new MockHttpClientHandler(
-                httpRequestMessage =>
-                {
-                    var responseMessage = new HttpResponseMessage((HttpStatusCode)200);
-
-                    if (contentHeader)
-                    {
-                        responseMessage.Content = new StreamContent(new MemoryStream());
-                        Assert.True(responseMessage.Content.Headers.TryAddWithoutValidation(headerName, headerValue));
-                    }
-                    else
-                    {
-                        Assert.True(responseMessage.Headers.TryAddWithoutValidation(headerName, headerValue));
-                    }
-
-                    return Task.FromResult(responseMessage);
-                });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-
-            Response response = await ExecuteRequest(request, transport);
-
-            Assert.True(response.Headers.TryGetValue(headerName, out var value));
-            Assert.AreEqual(headerValue, value);
-
-            Assert.True(response.Headers.TryGetValue(headerName.ToUpper(), out value));
-            Assert.AreEqual(headerValue, value);
-
-            CollectionAssert.Contains(response.Headers, new HttpHeader(headerName, headerValue));
-        }
-
-        [TestCaseSource(nameof(HeadersWithValuesAndType))]
-        public void TryGetReturnsCorrectValuesWhenNotFound(string headerName, string headerValue, bool contentHeader)
-        {
-            var transport = new HttpClientTransport();
-            Request request = CreateRequest(transport);
-
-            Assert.False(request.Headers.TryGetValue(headerName, out string value));
-            Assert.IsNull(value);
-
-            Assert.False(request.Headers.TryGetValues(headerName, out IEnumerable<string> values));
-            Assert.IsNull(values);
-        }
-
-        [TestCaseSource(nameof(HeadersWithValuesAndType))]
         public async Task SettingContentHeaderDoesNotSetContent(string headerName, string headerValue, bool contentHeader)
         {
             HttpContent httpMessageContent = null;
@@ -235,90 +104,6 @@ namespace Azure.Core.Tests
             await ExecuteRequest(request, transport);
 
             Assert.Null(httpMessageContent);
-        }
-
-        [TestCaseSource(nameof(HeadersWithValuesAndType))]
-        public async Task CanAddMultipleValuesToRequestHeader(string headerName, string headerValue, bool contentHeader)
-        {
-            var anotherHeaderValue = headerValue + "1";
-            var joinedHeaderValues = headerValue + "," + anotherHeaderValue;
-
-            IEnumerable<string> httpHeaderValues = null;
-
-            var mockHandler = new MockHttpClientHandler(
-                httpRequestMessage =>
-                {
-                    Assert.True(
-                        httpRequestMessage.Headers.TryGetValues(headerName, out httpHeaderValues) ||
-                        httpRequestMessage.Content.Headers.TryGetValues(headerName, out httpHeaderValues));
-                });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = CreateRequest(transport);
-
-            request.Headers.Add(headerName, headerValue);
-            request.Headers.Add(headerName, anotherHeaderValue);
-
-            Assert.True(request.Headers.Contains(headerName));
-
-            Assert.True(request.Headers.TryGetValue(headerName, out var value));
-            Assert.AreEqual(joinedHeaderValues, value);
-
-            Assert.True(request.Headers.TryGetValues(headerName, out IEnumerable<string> values));
-            CollectionAssert.AreEqual(new[] { headerValue, anotherHeaderValue }, values);
-
-            CollectionAssert.AreEqual(new[]
-            {
-                new HttpHeader(headerName, joinedHeaderValues),
-            }, request.Headers);
-
-            await ExecuteRequest(request, transport);
-
-            CollectionAssert.AreEqual(new[] { headerValue, anotherHeaderValue }, httpHeaderValues);
-        }
-
-        [TestCaseSource(nameof(HeadersWithValuesAndType))]
-        public async Task CanGetAndSetMultiValueResponseHeaders(string headerName, string headerValue, bool contentHeader)
-        {
-            var anotherHeaderValue = headerValue + "1";
-            var joinedHeaderValues = headerValue + "," + anotherHeaderValue;
-
-            var mockHandler = new MockHttpClientHandler(
-                httpRequestMessage =>
-                {
-                    var responseMessage = new HttpResponseMessage((HttpStatusCode)200);
-
-                    if (contentHeader)
-                    {
-                        responseMessage.Content = new StreamContent(new MemoryStream());
-                        Assert.True(responseMessage.Content.Headers.TryAddWithoutValidation(headerName, headerValue));
-                        Assert.True(responseMessage.Content.Headers.TryAddWithoutValidation(headerName, anotherHeaderValue));
-                    }
-                    else
-                    {
-                        Assert.True(responseMessage.Headers.TryAddWithoutValidation(headerName, headerValue));
-                        Assert.True(responseMessage.Headers.TryAddWithoutValidation(headerName, anotherHeaderValue));
-                    }
-
-                    return Task.FromResult(responseMessage);
-                });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-
-            Response response = await ExecuteRequest(request, transport);
-
-            Assert.True(response.Headers.Contains(headerName));
-
-            Assert.True(response.Headers.TryGetValue(headerName, out var value));
-            Assert.AreEqual(joinedHeaderValues, value);
-
-            Assert.True(response.Headers.TryGetValues(headerName, out IEnumerable<string> values));
-            CollectionAssert.AreEqual(new[] { headerValue, anotherHeaderValue }, values);
-
-            CollectionAssert.Contains(response.Headers, new HttpHeader(headerName, joinedHeaderValues));
         }
 
         [TestCaseSource(nameof(HeadersWithValuesAndType))]
@@ -369,142 +154,6 @@ namespace Azure.Core.Tests
             request.Uri.Reset(new Uri("https://example.com:340"));
             request.Content = RequestContent.Create(bytes ?? Array.Empty<byte>());
             return request;
-        }
-
-        [Test]
-        public async Task RequestAndResponseHasRequestId()
-        {
-            var mockHandler = new MockHttpClientHandler(httpRequestMessage => { });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-            Assert.IsNotEmpty(request.ClientRequestId);
-            Assert.True(Guid.TryParse(request.ClientRequestId, out _));
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-
-            Response response = await ExecuteRequest(request, transport);
-            Assert.AreEqual(request.ClientRequestId, response.ClientRequestId);
-        }
-
-        [Test]
-        public async Task RequestIdCanBeOverriden()
-        {
-            var mockHandler = new MockHttpClientHandler(httpRequestMessage => { });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-
-            request.ClientRequestId = "123";
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-
-            Response response = await ExecuteRequest(request, transport);
-            Assert.AreEqual(request.ClientRequestId, response.ClientRequestId);
-        }
-
-        [Test]
-        public async Task ReasonPhraseIsExposed()
-        {
-            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                ReasonPhrase = "Custom ReasonPhrase"
-            };
-            var mockHandler = new MockHttpClientHandler(httpRequestMessage => Task.FromResult(httpResponseMessage));
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-
-            Response response = await ExecuteRequest(request, transport);
-
-            Assert.AreEqual("Custom ReasonPhrase", response.ReasonPhrase);
-        }
-
-        [Test]
-        public async Task StreamRequestContentCanBeSentMultipleTimes()
-        {
-            var requests = new List<HttpRequestMessage>();
-            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
-
-            var mockHandler = new MockHttpClientHandler(httpRequestMessage =>
-            {
-                requests.Add(httpRequestMessage);
-                return Task.FromResult(httpResponseMessage);
-            });
-
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-            Request request = transport.CreateRequest();
-            request.Content = RequestContent.Create(new MemoryStream(new byte[] { 1, 2, 3 }));
-            request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri("https://example.com:340"));
-
-            await ExecuteRequest(request, transport);
-            await ExecuteRequest(request, transport);
-
-            Assert.AreEqual(2, requests.Count);
-        }
-
-        [Test]
-        public async Task RequestContentIsNotDisposedOnSend()
-        {
-            var requests = new List<HttpRequestMessage>();
-            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
-
-            var mockHandler = new MockHttpClientHandler(httpRequestMessage =>
-            {
-                requests.Add(httpRequestMessage);
-                return Task.FromResult(httpResponseMessage);
-            });
-
-            DisposeTrackingContent disposeTrackingContent = new DisposeTrackingContent();
-            var transport = new HttpClientTransport(new HttpClient(mockHandler));
-
-            using (Request request = transport.CreateRequest())
-            {
-                request.Content = disposeTrackingContent;
-                request.Method = RequestMethod.Get;
-                request.Uri.Reset(new Uri("https://example.com:340"));
-
-                await ExecuteRequest(request, transport);
-                Assert.False(disposeTrackingContent.IsDisposed);
-            }
-
-            Assert.True(disposeTrackingContent.IsDisposed);
-        }
-
-        [Test]
-        public void ClientRequestIdSetterThrowsOnNull()
-        {
-            var transport = new HttpClientTransport();
-            var request = transport.CreateRequest();
-            Assert.Throws<ArgumentNullException>(() => request.ClientRequestId = null);
-        }
-
-        public class DisposeTrackingContent : RequestContent
-        {
-            public override Task WriteToAsync(Stream stream, CancellationToken cancellation)
-            {
-                return Task.CompletedTask;
-            }
-
-            public override void WriteTo(Stream stream, CancellationToken cancellation)
-            {
-            }
-
-            public override bool TryComputeLength(out long length)
-            {
-                length = 0;
-                return false;
-            }
-
-            public override void Dispose()
-            {
-                IsDisposed = true;
-            }
-
-            public bool IsDisposed { get; set; }
         }
 
         public class DisposeTrackingHttpContent : HttpContent

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -8,19 +8,23 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
-using Azure.Core.TestFramework;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-    [TestFixture(typeof(HttpClientTransport))]
-    [TestFixture(typeof(HttpWebRequestTransport))]
-    public class HttpPipelineFunctionalTests
+
+    [TestFixture(typeof(HttpClientTransport), true)]
+    [TestFixture(typeof(HttpClientTransport), false)]
+#if NETFRAMEWORK
+    [TestFixture(typeof(HttpWebRequestTransport), true)]
+    [TestFixture(typeof(HttpWebRequestTransport), false)]
+#endif
+    public class HttpPipelineFunctionalTests: PipelineTestBase
     {
         private readonly Type _transportType;
 
-        public HttpPipelineFunctionalTests(Type transportType)
+        public HttpPipelineFunctionalTests(Type transportType, bool isAsync): base(isAsync)
         {
             _transportType = transportType;
         }
@@ -53,7 +57,7 @@ namespace Azure.Core.Tests
                 using Request request = httpPipeline.CreateRequest();
                 request.Uri.Reset(testServer.Address);
 
-                using Response response = await httpPipeline.SendRequestAsync(request, CancellationToken.None);
+                using Response response = await ExecuteRequest(request, httpPipeline);
 
                 Assert.AreEqual(response.ContentStream.Length, 1000);
             }
@@ -84,7 +88,7 @@ namespace Azure.Core.Tests
                     message.Request.Uri.Reset(testServer.Address);
                     message.BufferResponse = false;
 
-                    await httpPipeline.SendAsync(message, CancellationToken.None);
+                    await ExecuteRequest(message, httpPipeline);
 
                     Assert.AreEqual(message.Response.ContentStream.CanSeek, false);
 
@@ -138,7 +142,7 @@ namespace Azure.Core.Tests
                     message.Request.Uri.Reset(testServer.Address);
                     message.BufferResponse = false;
 
-                    await httpPipeline.SendAsync(message, CancellationToken.None);
+                    await ExecuteRequest(message, httpPipeline);
 
                     Assert.AreEqual(message.Response.ContentStream.CanSeek, false);
 
@@ -178,7 +182,7 @@ namespace Azure.Core.Tests
             message.Request.Uri.Reset(testServer.Address);
             message.BufferResponse = false;
 
-            await httpPipeline.SendAsync(message, CancellationToken.None);
+            await ExecuteRequest(message, httpPipeline);
 
             Assert.AreEqual(message.Response.Status, 201);
             Assert.AreEqual(2, i);
@@ -214,7 +218,7 @@ namespace Azure.Core.Tests
             message.Request.Uri.Reset(testServer.Address);
             message.BufferResponse = false;
 
-            await httpPipeline.SendAsync(message, CancellationToken.None);
+            await ExecuteRequest(message, httpPipeline);
 
             Assert.AreEqual(message.Response.Status, 201);
             Assert.AreEqual(2, i);
@@ -243,14 +247,14 @@ namespace Azure.Core.Tests
             message.Request.Uri.Reset(testServer.Address);
             message.BufferResponse = false;
 
-            var task = httpPipeline.SendAsync(message, cts.Token);
+            var task = Task.Run(() => ExecuteRequest(message, httpPipeline, cts.Token));
 
             // Wait for server to receive a request
             await tcs.Task;
 
             cts.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await task);
             Assert.AreEqual(1, i);
 
             testDoneTcs.Cancel();
@@ -292,7 +296,7 @@ namespace Azure.Core.Tests
             message.Request.Uri.Reset(testServer.Address);
             message.BufferResponse = true;
 
-            await httpPipeline.SendAsync(message, CancellationToken.None);
+            await ExecuteRequest(message, httpPipeline);
 
             Assert.AreEqual(message.Response.Status, 201);
             Assert.AreEqual("Hello world!", await new StreamReader(message.Response.ContentStream).ReadToEndAsync());
@@ -329,7 +333,8 @@ namespace Azure.Core.Tests
             using HttpMessage message = httpPipeline.CreateMessage();
             message.Request.Uri.Reset(testServer.Address);
             message.BufferResponse = false;
-            await httpPipeline.SendAsync(message, CancellationToken.None);
+
+            await ExecuteRequest(message, httpPipeline);
 
             Assert.AreEqual(message.Response.Status, 200);
             var responseContentStream = message.Response.ContentStream;
@@ -370,7 +375,7 @@ namespace Azure.Core.Tests
 
             request.Content = content;
 
-            using Response response = await httpPipeline.SendRequestAsync(request, CancellationToken.None);
+            using Response response = await ExecuteRequest(request, httpPipeline);
             Assert.AreEqual(response.Status, 200);
             Assert.AreEqual(formCollection.Files.Count, 2);
 

--- a/sdk/core/Azure.Core/tests/PipelineTestBase.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTestBase.cs
@@ -9,7 +9,7 @@ namespace Azure.Core.Tests
 {
     public class PipelineTestBase
     {
-        protected static async Task<Response> ExecuteRequest(Request request, HttpClientTransport transport)
+        protected static async Task<Response> ExecuteRequest(Request request, HttpPipelineTransport transport)
         {
             var message = new HttpMessage(request, new ResponseClassifier());
             await transport.ProcessAsync(message);

--- a/sdk/core/Azure.Core/tests/PipelineTestBase.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTestBase.cs
@@ -9,10 +9,43 @@ namespace Azure.Core.Tests
 {
     public class PipelineTestBase
     {
-        protected static async Task<Response> ExecuteRequest(Request request, HttpPipelineTransport transport)
+        private readonly bool _isAsync;
+
+        public PipelineTestBase(bool isAsync)
+        {
+            _isAsync = isAsync;
+        }
+
+        protected async Task<Response> ExecuteRequest(Request request, HttpPipelineTransport transport)
         {
             var message = new HttpMessage(request, new ResponseClassifier());
-            await transport.ProcessAsync(message);
+            if (_isAsync)
+            {
+                await transport.ProcessAsync(message);
+            }
+            else
+            {
+                transport.Process(message);
+            }
+            return message.Response;
+        }
+
+        protected async Task<Response> ExecuteRequest(Request request, HttpPipeline pipeline, CancellationToken cancellationToken = default)
+        {
+            var message = new HttpMessage(request, new ResponseClassifier());
+            return await ExecuteRequest(message, pipeline, cancellationToken);
+        }
+
+        protected async Task<Response> ExecuteRequest(HttpMessage message, HttpPipeline pipeline, CancellationToken cancellationToken = default)
+        {
+            if (_isAsync)
+            {
+                await pipeline.SendAsync(message, cancellationToken);
+            }
+            else
+            {
+                pipeline.Send(message, cancellationToken);
+            }
             return message.Response;
         }
     }

--- a/sdk/core/Azure.Core/tests/TestServer.cs
+++ b/sdk/core/Azure.Core/tests/TestServer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -19,6 +20,10 @@ namespace Azure.Core.Tests
         private readonly IWebHost _host;
 
         public Uri Address => new Uri(_host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First());
+
+        public TestServer(Action<HttpContext> app) : this(context => { app(context); return Task.CompletedTask;})
+        {
+        }
 
         public TestServer(RequestDelegate app)
         {

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -142,6 +142,28 @@ namespace Azure.Core.Tests
             Assert.AreEqual("example.org", host.ToString());
         }
 
+        [Theory]
+        [TestCase(200)]
+        [TestCase(300)]
+        [TestCase(400)]
+        [TestCase(500)]
+        public async Task ReturnsStatusAndReasonMethod(int code)
+        {
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    context.Response.StatusCode = code;
+                });
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Uri.Reset(testServer.Address);
+
+            var response = await ExecuteRequest(request, transport);
+
+            Assert.AreEqual(code, response.Status);
+        }
+
         public static object[][] Methods => new[]
         {
             new object[] { RequestMethod.Delete, "DELETE", false },

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -212,43 +212,48 @@ namespace Azure.Core.Tests
                  new object[] { "Date", "Tue, 12 Nov 2019 08:00:00 GMT", false }
              };
 
-        [TestCaseSource(nameof(AllHeadersWithValuesAndType))]
-        public async Task CanGetAndAddRequestHeaders(string headerName, string headerValue, bool contentHeader)
-        {
-            StringValues httpHeaderValues;
+         [TestCaseSource(nameof(AllHeadersWithValuesAndType))]
+         public async Task CanGetAndAddRequestHeaders(string headerName, string headerValue, bool contentHeader)
+         {
+             StringValues httpHeaderValues;
 
-            using TestServer testServer = new TestServer(
-                context =>
-                {
-                    Assert.True(context.Request.Headers.TryGetValue(headerName, out httpHeaderValues));
-                });
+             using TestServer testServer = new TestServer(
+                 context =>
+                 {
+                     Assert.True(context.Request.Headers.TryGetValue(headerName, out httpHeaderValues));
+                 });
 
-            var transport = GetTransport();
-            Request request = CreateRequest(transport, testServer);
+             var transport = GetTransport();
+             Request request = CreateRequest(transport, testServer);
 
-            request.Headers.Add(headerName, headerValue);
+             request.Headers.Add(headerName, headerValue);
 
-            if (contentHeader)
-            {
-                request.Content = RequestContent.Create(new byte[16]);
-            }
+             if (contentHeader)
+             {
+                 request.Content = RequestContent.Create(new byte[16]);
+             }
 
-            Assert.True(request.Headers.TryGetValue(headerName, out var value));
-            Assert.AreEqual(headerValue, value);
+             Assert.True(request.Headers.TryGetValue(headerName, out var value));
+             Assert.AreEqual(headerValue, value);
 
-            Assert.True(request.Headers.TryGetValue(headerName.ToUpper(), out value));
-            Assert.AreEqual(headerValue, value);
+             Assert.True(request.Headers.TryGetValue(headerName.ToUpper(), out value));
+             Assert.AreEqual(headerValue, value);
 
-            CollectionAssert.AreEqual(new[]
-            {
-                new HttpHeader(headerName, headerValue),
-            }, request.Headers);
+             CollectionAssert.AreEqual(new[]
+             {
+                 new HttpHeader(headerName, headerValue),
+             }, request.Headers);
 
-            await ExecuteRequest(request, transport);
+             await ExecuteRequest(request, transport);
 
-            Assert.AreEqual(headerValue, string.Join(",", httpHeaderValues));
-        }
+             Assert.AreEqual(headerValue, string.Join(",", httpHeaderValues));
+         }
 
+         [TestCaseSource(nameof(AllHeadersWithValuesAndType))]
+         public async Task CanGetAndAddRequestHeadersUppercase(string headerName, string headerValue, bool contentHeader)
+         {
+             await CanGetAndAddRequestHeaders(headerName.ToUpperInvariant(), headerValue, contentHeader);
+         }
 
         [TestCaseSource(nameof(HeadersWithValuesAndType))]
         public void TryGetReturnsCorrectValuesWhenNotFound(string headerName, string headerValue, bool contentHeader)

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -2,12 +2,17 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Primitives;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -26,6 +31,203 @@ namespace Azure.Core.Tests
         private HttpPipelineTransport GetTransport()
         {
             return (HttpPipelineTransport) Activator.CreateInstance(_transportType);
+        }
+
+        public static object[] ContentWithLength =>
+            new object[]
+            {
+                new object[] { RequestContent.Create(new byte[10]), 10 },
+                new object[] { RequestContent.Create(new byte[10], 5, 5), 5 },
+                new object[] { RequestContent.Create(new ReadOnlyMemory<byte>(new byte[10])), 10 },
+                new object[] { RequestContent.Create(new ReadOnlyMemory<byte>(new byte[10]).Slice(5)), 5 },
+                new object[] { RequestContent.Create(new ReadOnlySequence<byte>(new byte[10])), 10 },
+            };
+
+        [TestCaseSource(nameof(ContentWithLength))]
+        public async Task ContentLengthIsSetForArrayContent(RequestContent content, int expectedLength)
+        {
+            long contentLength = 0;
+
+            using TestServer testServer = new TestServer(
+                context => contentLength = context.Request.ContentLength.Value);
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Post;
+            request.Uri.Reset(testServer.Address);
+            request.Content = content;
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual(expectedLength, contentLength);
+        }
+
+
+        [Test]
+        public async Task SettingHeaderOverridesDefaultContentLength()
+        {
+            long contentLength = 0;
+            using TestServer testServer = new TestServer(
+                context => contentLength = context.Request.ContentLength.Value);
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Post;
+            request.Uri.Reset(testServer.Address);
+            request.Content = RequestContent.Create(new byte[10]);
+            request.Headers.Add("Content-Length", "50");
+
+            try
+            {
+                await ExecuteRequest(request, transport);
+            }
+            catch (Exception)
+            {
+                // Sending the request would fail because of length mismatch
+            }
+
+            Assert.AreEqual(50, contentLength);
+        }
+
+
+        [Test]
+        public async Task HostHeaderSetFromUri()
+        {
+            HostString? host = null;
+            string uri = null;
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    uri = context.Request.GetDisplayUrl();
+                    host = context.Request.GetTypedHeaders().Host;
+                });
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Get;
+            request.Uri.Reset(testServer.Address);
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual(testServer.Address.ToString(), uri);
+            Assert.AreEqual(testServer.Address.Host + ":" + testServer.Address.Port, host.ToString());
+        }
+
+        [Test]
+        public async Task SettingHeaderOverridesDefaultHost()
+        {
+            HostString? host = null;
+            string uri = null;
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    uri = context.Request.GetDisplayUrl();
+                    host = context.Request.GetTypedHeaders().Host;
+                });
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Get;
+            request.Uri.Reset(testServer.Address);
+            request.Headers.Add("Host", "example.org");
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual("http://example.org/", uri);
+            Assert.AreEqual("example.org", host.ToString());
+        }
+
+        public static object[][] Methods => new[]
+        {
+            new object[] { RequestMethod.Delete, "DELETE" },
+            new object[] { RequestMethod.Get, "GET" },
+            new object[] { RequestMethod.Patch, "PATCH" },
+            new object[] { RequestMethod.Post, "POST" },
+            new object[] { RequestMethod.Put, "PUT" },
+            new object[] { RequestMethod.Head, "HEAD" },
+            new object[] { new RequestMethod("custom"), "CUSTOM" },
+        };
+
+        [Theory]
+        [TestCaseSource(nameof(Methods))]
+        public async Task CanGetAndSetMethod(RequestMethod method, string expectedMethod)
+        {
+            string httpMethod = null;
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    httpMethod = context.Request.Method.ToString();
+                });
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Method = method;
+            request.Uri.Reset(testServer.Address);
+
+            Assert.AreEqual(method, request.Method);
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual(expectedMethod, httpMethod);
+        }
+
+         public static object[] HeadersWithValuesAndType =>
+            new object[]
+            {
+                new object[] { "Allow", "adcde", true },
+                new object[] { "Content-Disposition", "adcde", true },
+                new object[] { "Content-Encoding", "adcde", true },
+                new object[] { "Content-Language", "en-US", true },
+                new object[] { "Content-Length", "16", true },
+                new object[] { "Content-Location", "adcde", true },
+                new object[] { "Content-MD5", "adcde", true },
+                new object[] { "Content-Range", "adcde", true },
+                new object[] { "Content-Type", "text/xml", true },
+                new object[] { "Expires", "11/12/19", true },
+                new object[] { "Last-Modified", "11/12/19", true },
+                new object[] { "Date", "11/12/19", false },
+                new object[] { "Custom-Header", "11/12/19", false }
+            };
+
+        [TestCaseSource(nameof(HeadersWithValuesAndType))]
+        public async Task CanGetAndAddRequestHeaders(string headerName, string headerValue, bool contentHeader)
+        {
+            StringValues httpHeaderValues;
+
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    Assert.True(context.Request.Headers.TryGetValue(headerName, out httpHeaderValues));
+                });
+
+            var transport = GetTransport();
+            Request request = CreateRequest(transport, testServer);
+
+            request.Headers.Add(headerName, headerValue);
+
+            Assert.True(request.Headers.TryGetValue(headerName, out var value));
+            Assert.AreEqual(headerValue, value);
+
+            Assert.True(request.Headers.TryGetValue(headerName.ToUpper(), out value));
+            Assert.AreEqual(headerValue, value);
+
+            CollectionAssert.AreEqual(new[]
+            {
+                new HttpHeader(headerName, headerValue),
+            }, request.Headers);
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual(headerValue, string.Join(",", httpHeaderValues));
+        }
+
+        private static Request CreateRequest(HttpPipelineTransport transport, TestServer server, byte[] bytes = null)
+        {
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Post;
+            request.Uri.Reset(server.Address);
+            request.Content = RequestContent.Create(bytes ?? Array.Empty<byte>());
+            return request;
         }
 
         [NonParallelizable]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -141,7 +141,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeContentAsync(stream, options, cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeContentAsync(stream, options, cancellationSource.Token));
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeContentFromUriAsync(fakeUri, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeContentFromUriAsync(fakeUri, cancellationToken: cancellationSource.Token));
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeReceiptsAsync(stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeReceiptsAsync(stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
         }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeReceiptsFromUriAsync(fakeUri, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeReceiptsFromUriAsync(fakeUri, cancellationToken: cancellationSource.Token));
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeCustomFormsAsync("00000000-0000-0000-0000-000000000000", stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeCustomFormsAsync("00000000-0000-0000-0000-000000000000", stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
         }
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace Azure.AI.FormRecognizer.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("00000000-0000-0000-0000-000000000000", fakeUri, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeCustomFormsFromUriAsync("00000000-0000-0000-0000-000000000000", fakeUri, cancellationToken: cancellationSource.Token));
         }
     }
 }


### PR DESCRIPTION
Adds a HttpWebRequest-based transport that's internal and enabled by default on .NET Framework.

Adds and environment variable `AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT` and AppContext switch `Azure.Core.Pipeline.DisableHttpWebRequestTransport` to be able to disable the new transport.

Fixes a few bugs with timeouts in sync methods.

Converts HttpClientTransport-test to a more functional style that run against all transport implementations and includes sync runs.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13477