### PR TITLE
[Azure Messaging Clients] Open Link Failure Cleanup

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// </summary>
         ///
         /// <param name="serviceEndpoint">Endpoint for the Event Hubs service to which the scope is associated.</param>
-        /// <param name="eventHubName"> The name of the Event Hub to which the scope is associated</param>
+        /// <param name="eventHubName"> The name of the Event Hub to which the scope is associated.</param>
         /// <param name="credential">The credential to use for authorization with the Event Hubs service.</param>
         /// <param name="transport">The transport to use for communication.</param>
         /// <param name="proxy">The proxy, if any, to use for communication.</param>
@@ -800,15 +800,39 @@ namespace Azure.Messaging.EventHubs.Amqp
         }
 
         /// <summary>
-        ///   Performs the actions needed to open a generic AMQP object, such
+        ///   Performs the actions needed to open an AMQP object, such
         ///   as a session or link for use.
         /// </summary>
         ///
         /// <param name="target">The target AMQP object to open.</param>
         /// <param name="timeout">The timeout to apply when opening the link.</param>
         ///
-        protected virtual Task OpenAmqpObjectAsync(AmqpObject target,
-                                                   TimeSpan timeout) => target.OpenAsync(timeout);
+        protected virtual async Task OpenAmqpObjectAsync(AmqpObject target,
+                                                         TimeSpan timeout)
+        {
+            try
+            {
+                await target.OpenAsync(timeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                switch (target)
+                {
+                    case AmqpLink linkTarget:
+                        linkTarget.Session?.SafeClose();
+                        break;
+                    case RequestResponseAmqpLink linkTarget:
+                        linkTarget.Session?.SafeClose();
+                        break;
+
+                    default:
+                        break;
+                }
+
+                target.SafeClose();
+                throw;
+            }
+        }
 
         /// <summary>
         ///   Requests authorization for a connection or link using a connection via the CBS mechanism.


### PR DESCRIPTION
# Summary

The focus of these changes is to ensure that any AMQP object that triggers an error path when being opened is fully cleaned-up.  Previously, it was
believed that the `FaultTolerantAmqpObject` responsible for creating/opening the object owned cleanup responsibility, but that has proven incorrect.

# Last Upstream Rebase

Friday, July 24, 10:56am (EDT)

# References and Related Issues 

- [[BUG] Azure.Messaging.ServiceBus Session processor exceptions while receiving multiple 1kb messages from sessions](https://github.com/Azure/azure-sdk-for-net/issues/13686) (#13686)