### PR TITLE
Adding new path-based rule for the Compute API

### DIFF
--- a/.github/sla.yml
+++ b/.github/sla.yml
@@ -1,0 +1,14 @@
+- scheduleTask:	
+    action: sendEmail	
+    scope: pull_request	
+    name: "send email given path change is in the CPlat SDK path"	
+    trigger:	
+      - path	
+    args:	
+      message: '<p>You have just completed the second step towards onboarding your API change to the Compute Management library.</p><p>You&#39;ve just opened a PR making changes in the Compute Management Library&#39;s path of the Azure .NET SDK repository.</p><p>What&#39;s next?</p><ol type="1"><li value="1">Your PR will be reviewed by a member of the OneSDK team and a member from our team</li><li>[If applicable] If you haven&#39;t already, you should get started on the design doc for your api&#39;s Azure PowerShell cmdlet.</li><ol type="a"><li value="1">All you need to do is send a design doc of any change/new Azure PowerShell cmdlet related to your api by creating an issue with your design <a href="https://github.com/Azure/azure-powershell-cmdlet-review-pr/issues">here</a>.<br>Then, send an email to <a href="mailto:azdevxpsdr@microsoft.com">azdevxpsdr@microsoft.com</a> with the issue number and cc our dl (<a href="mailto:cplatsdkdev@microsoft.com">cplatsdkdev@microsoft.com</a>) on the email, so we can leave comments on your design doc as well.</li><li>Once your PowerShell cmdlet design has been approved, send an email to&nbsp;<a href="mailto:cplatsdkdev@microsoft.com?subject=PowerShell%20Design%20Review%20Approved">our team</a><br /> We will implement and test the PowerShell cmdlet following the approved design. We will then make a pull request to the appropriate repository</li></ol><li>[If applicable] You can also get started on any Azure CLI module or extension for your API change. Find more information about next steps on that process <a href="https://github.com/Azure/azure-cli/blob/dev/doc/onboarding_guide.md">here</a>.</li></ol><hr><ul type="disc"><li>To view the full CPlat SDK PowerShell API onboarding wiki, please visit <a href="https://aka.ms/cplatsdk">aka.ms/cplatsdk</a></li></ul><p>This email was automatically sent. Please send an email to&nbsp;<a href="mailto:cplatsdkdev@microsoft.com">cplatsdkdev@microsoft.com</a>&nbsp;if you have any questions.</p>'	
+      targetPaths:	
+        - "sdk/compute/**"	
+      subject: "[Action Required] CPlat .NET SDK Pull Request opened: Next steps"	
+      to: ${AUTHOR}
+      cc:
+        - cplatsdkdev@microsoft.com


### PR DESCRIPTION
This is a new yml configuration file for the OpenAPI's SLA bot. Once the bot is enabled on the repo, this rule in the file specifies a configuration helpful to the cplat (Compute Platform) sdk team. This configuration rule mainly specifies a path, here the Compute Management library's sdk path, and an email that will be sent by the bot whenever a PR is opened and the PR changes are in the Compute Management library's path.