### PR TITLE
Session behavior updates

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
@@ -54,6 +54,7 @@ ServiceBusSessionProcessor processor = client.CreateSessionProcessor(queueName, 
 // this sample from terminating immediately, we can use a task completion source that
 // we complete from within the message handler.
 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+int processedMessageCount = 0;
 processor.ProcessMessageAsync += MessageHandler;
 processor.ProcessErrorAsync += ErrorHandler;
 
@@ -67,7 +68,13 @@ async Task MessageHandler(ProcessSessionMessageEventArgs args)
     // we can also set arbitrary session state using this receiver
     // the state is specific to the session, and not any particular message
     await args.SetSessionStateAsync(Encoding.Default.GetBytes("some state"));
-    tcs.SetResult(true);
+
+    // Once we've received the last message, complete the
+    // task completion source.
+    if (Interlocked.Increment(ref processedMessageCount) == 2)
+    {
+        tcs.SetResult(true);
+    }
 }
 
 Task ErrorHandler(ProcessErrorEventArgs args)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -85,8 +85,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         public override DateTimeOffset SessionLockedUntil { get; protected set; }
 
-        private Exception LinkException { get; set; }
-
         /// <summary>
         /// A map of locked messages received using the management client.
         /// </summary>
@@ -134,6 +132,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             _receiveMode = receiveMode;
             _identifier = identifier;
             _requestResponseLockedMessages = new ConcurrentExpiringSet<Guid>();
+            SessionId = sessionId;
 
             _receiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(
                 timeout =>
@@ -141,17 +140,25 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         timeout: timeout,
                         prefetchCount: prefetchCount,
                         receiveMode: receiveMode,
-                        sessionId: sessionId,
+                        sessionId: SessionId,
                         isSessionReceiver: isSessionReceiver),
                 link => CloseLink(link));
 
             _managementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(
-                timeout => _connectionScope.OpenManagementLinkAsync(
-                    _entityPath,
-                    _identifier,
-                    timeout,
-                    CancellationToken.None),
+                timeout => OpenManagementLinkAsync(timeout),
                 link => CloseLink(link));
+        }
+
+        private async Task<RequestResponseAmqpLink> OpenManagementLinkAsync(
+            TimeSpan timeout)
+        {
+            RequestResponseAmqpLink link = await _connectionScope.OpenManagementLinkAsync(
+                _entityPath,
+                _identifier,
+                timeout,
+                CancellationToken.None).ConfigureAwait(false);
+            link.Closed += OnManagementLinkClosed;
+            return link;
         }
 
         private async Task<ReceivingAmqpLink> OpenReceiverLinkAsync(
@@ -173,7 +180,18 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     sessionId: sessionId,
                     isSessionReceiver: isSessionReceiver,
                     cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                if (isSessionReceiver)
+                {
+                    // Refresh the session lock value in case we have reconnected a link.
+                    // SessionId need not be refreshed here as we do not allow reconnecting
+                    // a receiver instance to a different session.
+                    SessionLockedUntil = link.Settings.Properties.TryGetValue<long>(
+                        AmqpClientConstants.LockedUntilUtc, out var lockedUntilUtcTicks) ?
+                        new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc)
+                        : DateTime.MinValue;
+                }
                 ServiceBusEventSource.Log.CreateReceiveLinkComplete(_identifier);
+                link.Closed += OnReceiverLinkClosed;
                 return link;
             }
             catch (Exception ex)
@@ -245,14 +263,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
             var link = default(ReceivingAmqpLink);
             var amqpMessages = default(IEnumerable<AmqpMessage>);
             var receivedMessages = new List<ServiceBusReceivedMessage>();
-            if (_isSessionReceiver)
-            {
-                ThrowIfSessionLockLost();
-            }
-
             try
             {
-                link = await _receiveLink.GetOrCreateAsync(UseMinimum(_connectionScope.SessionTimeout, timeout)).ConfigureAwait(false);
+                if (!_receiveLink.TryGetOpenedObject(out link))
+                {
+                    link = await _receiveLink.GetOrCreateAsync(UseMinimum(_connectionScope.SessionTimeout, timeout)).ConfigureAwait(false);
+                }
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 var messagesReceived = await Task.Factory.FromAsync
@@ -359,11 +375,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Outcome outcome,
             TimeSpan timeout)
         {
-            if (_isSessionReceiver)
-            {
-                ThrowIfSessionLockLost();
-            }
-
             List<ArraySegment<byte>> deliveryTags = ConvertLockTokensToDeliveryTags(lockTokens);
 
             ReceivingAmqpLink receiveLink = null;
@@ -894,14 +905,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
             throw amqpResponseMessage.ToMessagingContractException();
         }
 
-        private void ThrowIfSessionLockLost()
-        {
-            if (LinkException != null)
-            {
-                throw LinkException;
-            }
-        }
-
         /// <summary>
         /// Renews the lock on the message. The lock will be renewed based on the setting specified on the queue.
         /// </summary>
@@ -971,10 +974,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         private async Task<AmqpResponseMessage> ExecuteRequest(TimeSpan timeout, AmqpRequestMessage amqpRequestMessage)
         {
-            if (_isSessionReceiver)
-            {
-                ThrowIfSessionLockLost();
-            }
             AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
                 _connectionScope,
                 _managementLink,
@@ -1242,26 +1241,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         }
 
-        private void OnSessionReceiverLinkClosed(object receiver, EventArgs e)
-        {
-            var receivingAmqpLink = (ReceivingAmqpLink)receiver;
-            if (receivingAmqpLink != null)
-            {
-                Exception exception = receivingAmqpLink.GetInnerException();
-                if (((exception is ServiceBusException sbException) && sbException.Reason != ServiceBusException.FailureReason.SessionLockLost) || !(exception is ServiceBusException))
-                {
-                    exception = new ServiceBusException(
-                        Resources.SessionLockExpiredOnMessageSession, ServiceBusException.FailureReason.SessionLockLost,
-                        innerException: exception);
-                }
+        private void OnReceiverLinkClosed(object receiver, EventArgs e) =>
+            ServiceBusEventSource.Log.ReceiveLinkClosed(
+                _identifier,
+                SessionId,
+                receiver);
 
-                LinkException = exception;
-                ServiceBusEventSource.Log.SessionReceiverLinkClosed(
-                    _identifier,
-                    SessionId,
-                    LinkException.ToString());
-            }
-        }
+        private void OnManagementLinkClosed(object managementLink, EventArgs e) =>
+            ServiceBusEventSource.Log.ManagementLinkClosed(
+                _identifier,
+                managementLink);
 
         /// <summary>
         /// Uses the minimum value of the two specified <see cref="TimeSpan" /> instances.
@@ -1307,11 +1296,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     throw new ServiceBusException(true, Resources.AmqpFieldSessionId);
                 }
                 SessionId = tempSessionId;
-                SessionLockedUntil = link.Settings.Properties.TryGetValue<long>(AmqpClientConstants.LockedUntilUtc, out var lockedUntilUtcTicks)
-                ? new DateTime(lockedUntilUtcTicks, DateTimeKind.Utc)
-                : DateTime.MinValue;
-                link.Closed += OnSessionReceiverLinkClosed;
-
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -7,7 +7,9 @@ using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Core.Diagnostics;
+using Azure.Messaging.ServiceBus.Amqp;
 using Azure.Messaging.ServiceBus.Primitives;
+using Microsoft.Azure.Amqp;
 
 namespace Azure.Messaging.ServiceBus.Diagnostics
 {
@@ -95,7 +97,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int ReceiveDeferredMessageExceptionEvent = 36;
 
         internal const int LinkStateLostEvent = 37;
-        internal const int SessionReceiverLinkClosedEvent = 38;
+        internal const int ReceiveLinkClosedEvent = 38;
         internal const int AmqpLinkRefreshStartEvent = 39;
         internal const int AmqpLinkRefreshCompleteEvent = 40;
         internal const int AmqpLinkRefreshExceptionEvent = 41;
@@ -177,6 +179,8 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int PluginExceptionEvent = 98;
 
         internal const int MaxMessagesExceedsPrefetchEvent = 99;
+        internal const int SendLinkClosedEvent = 100;
+        internal const int ManagementLinkClosedEvent = 101;
 
         #endregion
         // add new event numbers here incrementing from previous
@@ -834,12 +838,32 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(SessionReceiverLinkClosedEvent, Level = EventLevel.Informational, Message = "SessionReceiver Link Closed. identifier: {0}, SessionId: {1}, linkException: {2}.")]
-        public virtual void SessionReceiverLinkClosed(string identifier, string sessionId, string linkException)
+        [NonEvent]
+        public virtual void ReceiveLinkClosed(
+            string identifier,
+            string sessionId,
+            object receiver)
         {
             if (IsEnabled())
             {
-                WriteEvent(SessionReceiverLinkClosedEvent, identifier, sessionId, linkException);
+                var link = (ReceivingAmqpLink)receiver;
+                if (link != null)
+                {
+                    Exception exception = link.GetInnerException();
+                    ReceiveLinkClosedCore(
+                        identifier,
+                        sessionId,
+                        exception?.ToString());
+                }
+            }
+        }
+
+        [Event(ReceiveLinkClosedEvent, Level = EventLevel.Informational, Message = "Receive Link Closed. Identifier: {0}, SessionId: {1}, linkException: {2}.")]
+        public virtual void ReceiveLinkClosedCore(string identifier, string sessionId, string linkException)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ReceiveLinkClosedEvent, identifier, sessionId, linkException);
             }
         }
 
@@ -930,6 +954,35 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
+        [NonEvent]
+        public virtual void SendLinkClosed(
+            string identifier,
+            object sender)
+        {
+            if (IsEnabled())
+            {
+                var link = (SendingAmqpLink)sender;
+                if (link != null)
+                {
+                    Exception exception = link.GetInnerException();
+                    SendLinkClosedCore(
+                        identifier,
+                        exception?.ToString());
+                }
+            }
+        }
+
+        [Event(SendLinkClosedEvent, Level = EventLevel.Informational, Message = "Send Link Closed. Identifier: {0}, linkException: {1}.")]
+        public virtual void SendLinkClosedCore(
+            string identifier,
+            string linkException)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(SendLinkClosedEvent, identifier, linkException);
+            }
+        }
+
         [Event(CreateReceiveLinkStartEvent, Level = EventLevel.Informational, Message = "Creating receive link for Identifier: {0}.")]
         public virtual void CreateReceiveLinkStart(string identifier)
         {
@@ -981,6 +1034,35 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(CreateManagementLinkExceptionEvent, identifier, exception);
+            }
+        }
+
+        [NonEvent]
+        public virtual void ManagementLinkClosed(
+            string identifier,
+            object managementLink)
+        {
+            if (IsEnabled())
+            {
+                var link = (RequestResponseAmqpLink)managementLink;
+                if (link != null)
+                {
+                    Exception exception = link.GetInnerException();
+                    ManagementLinkClosedCore(
+                        identifier,
+                        exception?.ToString());
+                }
+            }
+        }
+
+        [Event(ManagementLinkClosedEvent, Level = EventLevel.Informational, Message = "Management Link Closed. Identifier: {0}, linkException: {1}.")]
+        public virtual void ManagementLinkClosedCore(
+            string identifier,
+            string linkException)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ManagementLinkClosedEvent, identifier, linkException);
             }
         }
         #endregion

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Management/TopicRuntimeProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Management/TopicRuntimeProperties.cs
@@ -6,7 +6,7 @@ using System;
 namespace Azure.Messaging.ServiceBus.Management
 {
     /// <summary>
-    /// This provides runtime information of the topic.
+    /// This provides runtime properties of the topic.
     /// </summary>
     public class TopicRuntimeProperties
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -69,8 +69,7 @@ namespace Azure.Messaging.ServiceBus
         }
 
         public virtual async Task CloseReceiverIfNeeded(
-            CancellationToken cancellationToken,
-            bool forceClose = false)
+            CancellationToken cancellationToken)
         {
             try
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -187,9 +187,12 @@ namespace Azure.Messaging.ServiceBus
             MaxConcurrentCalls = _options.MaxConcurrentCalls;
             MaxConcurrentSessions = maxConcurrentSessions;
             MaxConcurrentCallsPerSession = maxConcurrentCallsPerSession;
+            _sessionIds = sessionIds ?? Array.Empty<string>();
 
             int maxCalls = isSessionEntity ?
-                MaxConcurrentSessions * MaxConcurrentCallsPerSession :
+                (_sessionIds.Length > 0 ?
+                    Math.Min(_sessionIds.Length, MaxConcurrentSessions) :
+                    MaxConcurrentSessions) * MaxConcurrentCallsPerSession :
                 MaxConcurrentCalls;
 
             MessageHandlerSemaphore = new SemaphoreSlim(
@@ -205,7 +208,6 @@ namespace Azure.Messaging.ServiceBus
 
             EntityPath = entityPath;
             IsSessionProcessor = isSessionEntity;
-            _sessionIds = sessionIds ?? Array.Empty<string>();
             _scopeFactory = new EntityScopeFactory(EntityPath, FullyQualifiedNamespace);
             _plugins = plugins;
         }
@@ -479,6 +481,13 @@ namespace Azure.Messaging.ServiceBus
                 for (int i = 0; i < numReceivers; i++)
                 {
                     var sessionId = _sessionIds.Length > 0 ? _sessionIds[i] : null;
+                    // If the user has listed named sessions, and they
+                    // have MaxConcurrentSessions greater or equal to the number
+                    // of sessions, we can leave the sessions open at all times
+                    // instead of cycling through them as receive calls time out.
+                    bool keepOpenOnReceiveTimeout = _sessionIds.Length > 0 &&
+                        MaxConcurrentSessions >= _sessionIds.Length;
+
                     _receiverManagers.Add(
                         new SessionReceiverManager(
                             _connection,
@@ -494,7 +503,8 @@ namespace Azure.Messaging.ServiceBus
                             MaxConcurrentAcceptSessionsSemaphore,
                             _scopeFactory,
                             _plugins,
-                            MaxConcurrentCallsPerSession));
+                            MaxConcurrentCallsPerSession,
+                            keepOpenOnReceiveTimeout));
                 }
             }
             else
@@ -576,14 +586,6 @@ namespace Azure.Messaging.ServiceBus
 
                     ActiveReceiveTask.Dispose();
                     ActiveReceiveTask = null;
-
-                    foreach (ReceiverManager receiverManager in _receiverManagers)
-                    {
-                        await receiverManager.CloseReceiverIfNeeded(
-                            cancellationToken,
-                            forceClose: true)
-                            .ConfigureAwait(false);
-                    }
                 }
             }
             catch (Exception exception)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -586,6 +586,13 @@ namespace Azure.Messaging.ServiceBus
 
                     ActiveReceiveTask.Dispose();
                     ActiveReceiveTask = null;
+
+                    foreach (ReceiverManager receiverManager in _receiverManagers)
+                    {
+                        await receiverManager.CloseReceiverIfNeeded(
+                            cancellationToken)
+                            .ConfigureAwait(false);
+                    }
                 }
             }
             catch (Exception exception)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -31,9 +31,11 @@ namespace Azure.Messaging.ServiceBus
         private readonly SemaphoreSlim _concurrentAcceptSessionsSemaphore;
         private readonly int _maxCallsPerSession;
         private readonly ServiceBusSessionReceiverOptions _sessionReceiverOptions;
+        private readonly bool _keepOpenOnReceiveTimeout;
         private ServiceBusSessionReceiver _receiver;
         private CancellationTokenSource _sessionLockRenewalCancellationSource;
         private Task _sessionLockRenewalTask;
+        private CancellationTokenSource _sessionCancellationSource = new CancellationTokenSource();
         protected override ServiceBusReceiver Receiver => _receiver;
 
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
@@ -52,7 +54,8 @@ namespace Azure.Messaging.ServiceBus
             SemaphoreSlim concurrentAcceptSessionsSemaphore,
             EntityScopeFactory scopeFactory,
             IList<ServiceBusPlugin> plugins,
-            int maxCallsPerSession)
+            int maxCallsPerSession,
+            bool keepOpenOnReceiveTimeout)
             : base(connection, fullyQualifiedNamespace, entityPath, identifier, processorOptions, default, errorHandler,
                   scopeFactory, plugins)
         {
@@ -67,6 +70,7 @@ namespace Azure.Messaging.ServiceBus
                 PrefetchCount = _processorOptions.PrefetchCount,
                 SessionId = sessionId
             };
+            _keepOpenOnReceiveTimeout = keepOpenOnReceiveTimeout;
         }
 
         private async Task<bool> EnsureCanProcess(CancellationToken cancellationToken)
@@ -111,28 +115,29 @@ namespace Azure.Messaging.ServiceBus
         }
 
         private async Task CreateAndInitializeSessionReceiver(
-            CancellationToken cancellationToken)
+            CancellationToken processorCancellationToken)
         {
-            await CreateReceiver(cancellationToken).ConfigureAwait(false);
+            await CreateReceiver(processorCancellationToken).ConfigureAwait(false);
+            _sessionCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(processorCancellationToken);
 
             if (AutoRenewLock)
             {
-                _sessionLockRenewalTask = RenewSessionLock(cancellationToken);
+                _sessionLockRenewalTask = RenewSessionLock();
             }
 
             if (_sessionInitHandler != null)
             {
-                var args = new ProcessSessionEventArgs(_receiver, cancellationToken);
+                var args = new ProcessSessionEventArgs(_receiver, processorCancellationToken);
                 await _sessionInitHandler(args).ConfigureAwait(false);
             }
         }
 
-        private async Task CreateReceiver(CancellationToken cancellationToken)
+        private async Task CreateReceiver(CancellationToken processorCancellationToken)
         {
             bool releaseSemaphore = false;
             try
             {
-                await _concurrentAcceptSessionsSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _concurrentAcceptSessionsSemaphore.WaitAsync(processorCancellationToken).ConfigureAwait(false);
                 // only attempt to release semaphore if WaitAsync is successful,
                 // otherwise SemaphoreFullException can occur.
                 releaseSemaphore = true;
@@ -141,7 +146,7 @@ namespace Azure.Messaging.ServiceBus
                     connection: _connection,
                     plugins: _plugins,
                     options: _sessionReceiverOptions,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken: processorCancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -158,22 +163,29 @@ namespace Azure.Messaging.ServiceBus
         }
 
         public override async Task CloseReceiverIfNeeded(
-            CancellationToken cancellationToken,
+            CancellationToken processorCancellationToken,
             bool forceClose = false)
         {
             bool releaseSemaphore = false;
             try
             {
-                await WaitSemaphore(cancellationToken).ConfigureAwait(false);
+                // Intentionally not including processor cancellation token as
+                // we need to ensure that we at least attempt to close the receiver if needed.
+                await WaitSemaphore(CancellationToken.None).ConfigureAwait(false);
                 releaseSemaphore = true;
                 if (_receiver == null)
                 {
                     return;
                 }
                 _threadCount--;
-                if (_threadCount == 0 || forceClose)
+                if (_threadCount == 0)
                 {
-                    await CloseReceiver(cancellationToken).ConfigureAwait(false);
+                    if (!_keepOpenOnReceiveTimeout ||
+                        !AutoRenewLock ||
+                        _sessionLockRenewalCancellationSource.IsCancellationRequested)
+                    {
+                        await CloseReceiver(processorCancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
             finally
@@ -220,7 +232,7 @@ namespace Azure.Messaging.ServiceBus
             }
         }
 
-        public override async Task ReceiveAndProcessMessagesAsync(CancellationToken cancellationToken)
+        public override async Task ReceiveAndProcessMessagesAsync(CancellationToken processorCancellationToken)
         {
             ServiceBusErrorSource errorSource = ServiceBusErrorSource.AcceptMessageSession;
             bool canProcess = false;
@@ -228,7 +240,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 try
                 {
-                    canProcess = await EnsureCanProcess(cancellationToken).ConfigureAwait(false);
+                    canProcess = await EnsureCanProcess(processorCancellationToken).ConfigureAwait(false);
                     if (!canProcess)
                     {
                         return;
@@ -241,14 +253,13 @@ namespace Azure.Messaging.ServiceBus
                     // so simply return and allow this to be tried again on next thread
                     return;
                 }
-
                 // loop within the context of this thread
-                while (!cancellationToken.IsCancellationRequested)
+                while (!_sessionCancellationSource.Token.IsCancellationRequested)
                 {
                     errorSource = ServiceBusErrorSource.Receive;
                     ServiceBusReceivedMessage message = await _receiver.ReceiveMessageAsync(
                         _maxReceiveWaitTime,
-                        cancellationToken).ConfigureAwait(false);
+                        _sessionCancellationSource.Token).ConfigureAwait(false);
                     if (message == null)
                     {
                         // Break out of the loop to allow a new session to
@@ -258,14 +269,28 @@ namespace Azure.Messaging.ServiceBus
                     await ProcessOneMessageWithinScopeAsync(
                         message,
                         DiagnosticProperty.ProcessSessionMessageActivityName,
-                        cancellationToken).ConfigureAwait(false);
+                        _sessionCancellationSource.Token).ConfigureAwait(false);
                 }
             }
-            catch (Exception ex) when (!(ex is TaskCanceledException))
+            catch (Exception ex)
+            when (!_sessionCancellationSource.IsCancellationRequested &&
+            // Even though the _sessionCancellationSource is linked to processorCancellationToken,
+            // we need to check both here in case the processor token gets cancelled before the
+            // session token is linked.
+            !processorCancellationToken.IsCancellationRequested)
             {
                 if (ex is ServiceBusException sbException && sbException.ProcessorErrorSource.HasValue)
                 {
                     errorSource = sbException.ProcessorErrorSource.Value;
+
+                    // Signal cancellation so user event handlers can stop whatever processing they are doing
+                    // as soon as we know the session lock has been lost. Note, we don't have analogous handling
+                    // for message locks in ReceiverManager, because there is only ever one thread processing a
+                    // single message at one time, so cancelling the token there would serve no purpose.
+                    if (sbException.Reason == ServiceBusException.FailureReason.SessionLockLost)
+                    {
+                        _sessionCancellationSource.Cancel();
+                    }
                 }
                 await RaiseExceptionReceived(
                     new ProcessErrorEventArgs(
@@ -279,7 +304,8 @@ namespace Azure.Messaging.ServiceBus
             {
                 if (canProcess)
                 {
-                    await CloseReceiverIfNeeded(cancellationToken).ConfigureAwait(false);
+                    await CloseReceiverIfNeeded(
+                        processorCancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -287,11 +313,11 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///
         /// </summary>
-        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private async Task RenewSessionLock(CancellationToken cancellationToken)
+        private async Task RenewSessionLock()
         {
-            _sessionLockRenewalCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _sessionLockRenewalCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(
+                _sessionCancellationSource.Token);
             _sessionLockRenewalCancellationSource.CancelAfter(_processorOptions.MaxAutoLockRenewalDuration);
             CancellationToken sessionLockRenewalCancellationToken = _sessionLockRenewalCancellationSource.Token;
             while (!sessionLockRenewalCancellationToken.IsCancellationRequested)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -351,12 +351,12 @@ namespace Azure.Messaging.ServiceBus
 
         protected override async Task OnMessageHandler(
             ServiceBusReceivedMessage message,
-            CancellationToken processorCancellationToken)
+            CancellationToken cancellationToken)
         {
             var args = new ProcessSessionMessageEventArgs(
                 message,
                 _receiver,
-                processorCancellationToken);
+                cancellationToken);
             await _messageHandler(args).ConfigureAwait(false);
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -163,8 +163,7 @@ namespace Azure.Messaging.ServiceBus
         }
 
         public override async Task CloseReceiverIfNeeded(
-            CancellationToken processorCancellationToken,
-            bool forceClose = false)
+            CancellationToken processorCancellationToken)
         {
             bool releaseSemaphore = false;
             try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -84,11 +84,11 @@ namespace Azure.Messaging.ServiceBus
                 {
                     return false;
                 }
-                _threadCount++;
                 if (_receiver == null)
                 {
                     await CreateAndInitializeSessionReceiver(cancellationToken).ConfigureAwait(false);
                 }
+                _threadCount++;
                 return true;
             }
             finally
@@ -272,11 +272,12 @@ namespace Azure.Messaging.ServiceBus
                 }
             }
             catch (Exception ex)
-            when (!_sessionCancellationSource.IsCancellationRequested &&
+            when (!(ex is TaskCanceledException) ||
+            (!_sessionCancellationSource.IsCancellationRequested &&
             // Even though the _sessionCancellationSource is linked to processorCancellationToken,
             // we need to check both here in case the processor token gets cancelled before the
             // session token is linked.
-            !processorCancellationToken.IsCancellationRequested)
+            !processorCancellationToken.IsCancellationRequested))
             {
                 if (ex is ServiceBusException sbException && sbException.ProcessorErrorSource.HasValue)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -105,8 +105,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 await receiver.DisposeAsync();
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeStartEvent, e => e.Payload.Contains(nameof(ServiceBusReceiver)) && e.Payload.Contains(receiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeCompleteEvent, e => e.Payload.Contains(nameof(ServiceBusReceiver)) && e.Payload.Contains(receiver.Identifier));
-                // link closed event is fired asynchronously, so add a small
-                // delay
+                // link closed event is fired asynchronously, so add a small delay
                 await Task.Delay(TimeSpan.FromSeconds(5));
                 _listener.SingleEventById(ServiceBusEventSource.ReceiveLinkClosedEvent, e => e.Payload.Contains(receiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.ManagementLinkClosedEvent, e => e.Payload.Contains(receiver.Identifier));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -105,6 +105,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 await receiver.DisposeAsync();
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeStartEvent, e => e.Payload.Contains(nameof(ServiceBusReceiver)) && e.Payload.Contains(receiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeCompleteEvent, e => e.Payload.Contains(nameof(ServiceBusReceiver)) && e.Payload.Contains(receiver.Identifier));
+                // link closed event is fired asynchronously, so add a small
+                // delay
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                _listener.SingleEventById(ServiceBusEventSource.ReceiveLinkClosedEvent, e => e.Payload.Contains(receiver.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.ManagementLinkClosedEvent, e => e.Payload.Contains(receiver.Identifier));
 
                 Assert.IsFalse(_listener.EventsById(ServiceBusEventSource.MaxMessagesExceedsPrefetchEvent).Any());
                 receiver = client.CreateReceiver(scope.QueueName, new ServiceBusReceiverOptions { PrefetchCount = 10 });
@@ -178,6 +183,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 await sessionReceiver.DisposeAsync();
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeStartEvent, e => e.Payload.Contains(nameof(ServiceBusSessionReceiver)) && e.Payload.Contains(sessionReceiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeCompleteEvent, e => e.Payload.Contains(nameof(ServiceBusSessionReceiver)) && e.Payload.Contains(sessionReceiver.Identifier));
+                await Task.Delay(TimeSpan.FromSeconds(2));
+                _listener.SingleEventById(ServiceBusEventSource.ReceiveLinkClosedEvent, e => e.Payload.Contains(sessionReceiver.Identifier) &&
+                  e.Payload.Contains(sessionReceiver.SessionId));
 
                 await sender.DisposeAsync();
                 _listener.SingleEventById(ServiceBusEventSource.ClientDisposeStartEvent, e => e.Payload.Contains(nameof(ServiceBusSender)) && e.Payload.Contains(sender.Identifier));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -236,7 +236,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     }
                     else
                     {
-                       await args.CompleteMessageAsync(args.Message);
+                        await args.CompleteMessageAsync(args.Message);
                     }
                     if (args.Message.MessageId == "9")
                     {
@@ -1363,9 +1363,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                                 await client.CreateSessionReceiverAsync(
                                     scope.QueueName,
                                     new ServiceBusSessionReceiverOptions
-                                {
-                                    SessionId = args.SessionId
-                                });
+                                    {
+                                        SessionId = args.SessionId
+                                    },
+                                    args.CancellationToken);
                                 break;
                             case ServiceBusErrorSource.UserCallback:
                                 await Task.Delay(delayDuration);
@@ -1513,12 +1514,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 processor.ProcessMessageAsync += ProcessMessage;
                 processor.ProcessErrorAsync += args =>
                 {
-                        // If the connection drops due to network flakiness
-                        // after the message is received but before we
-                        // complete it, we will get a session lock
-                        // lost exception. We are still able to verify
-                        // that the message will be completed eventually.
-                        var exception = (ServiceBusException)args.Exception;
+                    // If the connection drops due to network flakiness
+                    // after the message is received but before we
+                    // complete it, we will get a session lock
+                    // lost exception. We are still able to verify
+                    // that the message will be completed eventually.
+                    var exception = (ServiceBusException)args.Exception;
                     if (!(args.Exception is ServiceBusException sbEx) ||
                     sbEx.Reason != ServiceBusException.FailureReason.SessionLockLost)
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -230,9 +230,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     if (args.Message.MessageId == "5" && !receivedDelayMsg)
                     {
                         receivedDelayMsg = true;
-                        // simulate the situation where we need to
-                        // delay processing on subsequent messages until
-                        // this message can be handled
+                        // Simulate the situation where we need to delay processing on
+                        // subsequent messages until this message can be handled.
                         await Task.Delay(lockDuration.Add(lockDuration));
                     }
                     else

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -643,64 +643,67 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public async Task ReceiverThrowsAfterSessionLockLost(bool isSessionSpecified)
+        public async Task ReceiverCanReconnectToSameSession(bool isSessionSpecified)
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: true, lockDuration: TimeSpan.FromSeconds(5)))
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                var sessionId1 = "sessionId1";
 
-                await sender.SendMessageAsync(GetMessage(sessionId1));
+                await sender.SendMessagesAsync(GetMessages(3, "sessionId1"));
                 // send another session message before the one we are interested in to make sure that when isSessionSpecified=true, it is being respected
-                await sender.SendMessageAsync(GetMessage("sessionId2"));
+                await sender.SendMessagesAsync(GetMessages(3, "sessionId2"));
 
                 ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
                     scope.QueueName,
                     new ServiceBusSessionReceiverOptions
                     {
-                        SessionId = isSessionSpecified ? sessionId1 : null
+                        SessionId = isSessionSpecified ? "sessionId1" : null
                     });
                 if (isSessionSpecified)
                 {
-                    Assert.AreEqual(sessionId1, receiver.SessionId);
+                    Assert.AreEqual("sessionId1", receiver.SessionId);
                 }
 
-                var message = await receiver.ReceiveMessageAsync();
-
+                var firstMessage = await receiver.ReceiveMessageAsync();
+                Assert.AreEqual(receiver.SessionId, firstMessage.SessionId);
+                var sessionId = receiver.SessionId;
                 await Task.Delay((receiver.SessionLockedUntil - DateTime.UtcNow) + TimeSpan.FromSeconds(5));
 
-                Assert.That(async () => await receiver.ReceiveMessageAsync(),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
+                var secondMessage = await receiver.ReceiveMessageAsync();
+                Assert.AreEqual(sessionId, receiver.SessionId);
+                Assert.AreEqual(receiver.SessionId, secondMessage.SessionId);
 
-                Assert.That(async () => await receiver.SetSessionStateAsync(null),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
+                // Even though the receiver has re-established the session link, since the first message was
+                // received before we reconnected, the message won't be able to be settled. This is analogous
+                // to the case of reconnecting a regular non-session link and getting a MessageLockLost error.
+                Assert.That(
+                    async() => await receiver.CompleteMessageAsync(firstMessage),
+                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.SessionLockLost));
+                await Task.Delay((receiver.SessionLockedUntil - DateTime.UtcNow) + TimeSpan.FromSeconds(5));
 
-                Assert.That(async () => await receiver.GetSessionStateAsync(),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
+                // If another receiver accepts the session after the lock is lost, we expect a SessionCannotBeLocked error,
+                // when we try to receive again with our initial receiver.
+                ServiceBusSessionReceiver secondReceiver = await client.CreateSessionReceiverAsync(
+                    scope.QueueName,
+                    new ServiceBusSessionReceiverOptions
+                    {
+                        SessionId = sessionId
+                    });
 
-                Assert.That(async () => await receiver.CompleteMessageAsync(message),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
-
-                Assert.That(async () => await receiver.CompleteMessageAsync(message),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
-
-                Assert.That(async () => await receiver.DeadLetterMessageAsync(message),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
-
-                Assert.That(async () => await receiver.DeferMessageAsync(message),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
-
-                Assert.That(async () => await receiver.AbandonMessageAsync(message),
-                    Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason))
-                    .EqualTo(ServiceBusException.FailureReason.SessionLockLost));
+                try
+                {
+                    await receiver.ReceiveMessageAsync();
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusException.FailureReason.SessionCannotBeLocked)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Expected exception not thrown: {ex}");
+                }
+                Assert.Fail("No exception thrown!");
             }
         }
 


### PR DESCRIPTION
In Track 1, when using sessions, if a transient error occurred that caused the session link to close, we would not attempt to re-establish the link and would instead throw a `SessionLockLost` exception. This means that we pretty much don't have retries when using sessions. The stated reason for this was that we wouldn't want to reconnect to any session, but only to the specific session that the user was previously receiving from. However, we know the session that the user was receiving from - in Track 2 this is immutably set on the `SessionId` property on the `ServiceBusSessionReceiver` at the time the receiver is created. As such, we can attempt to reconnect to the same session. The one potentially confusing aspect to this change is that if another receiver has since locked the session, the user might be confused to get a `SessionCannotBeLocked` exception. My hunch is that this scenario will be much more rare than the common scenario where the session link can be re-established. The other piece to this is that messages received before the session link dropped and reconnected, still will not be able to be settled. This is a service limitation currently, and the same is true for settling messages on non-session links.

Apart from this change, also updating some of the behavior for the session processor
- If a user specifies a list of named sessions, and `MaxConcurrentSessions` that is greater or equal to the number of sessions, we won't automatically close the session when a receive call times out. Closing the session and moving on to other sessions is useful when the user hasn't listed sessions, or they have listed sessions but don't want to process all of them concurrently, as it provides a mechanism to ensure that all sessions can be processed. This mechanism isn't needed when we know we have enough concurrency for the listed sessions.
- If the session lock is lost, we will now cancel the cancellation token that gets passed to the user message handler event args. This will allow them to stop processing early if their processing depends on being able to ultimately settle the message (which they won't be able to do, if they haven't already). We don't do the same for message locks, as a message will only be processed by one callback at a time, and we generally won't know that the message lock was lost until after the callback has returned. The session lock lost cancellation will only be applicable if the user has `MaxConcurrentCallsPerSession > 1` (otherwise we have the analogous situation as with non-session).
- Also added events for send/management link closed, and expanded the session link closed event to also apply to non-sessions.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/13760