### PR TITLE
Flush the request stream in HttpWebRequest transport

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -59,7 +59,7 @@ namespace Azure.Core.Pipeline
                         request.ContentLength = length;
                     }
 
-                    var requestStream = async ? await request.GetRequestStreamAsync().ConfigureAwait(false) : request.GetRequestStream();
+                    using var requestStream = async ? await request.GetRequestStreamAsync().ConfigureAwait(false) : request.GetRequestStream();
 
                     if (async)
                     {


### PR DESCRIPTION
Fixes issue seen in https://github.com/Azure/azure-sdk-for-net/pull/13746 where transport throws "System.Net.ProtocolViolationException : You must write ContentLength bytes to the request stream before calling [Begin]GetResponse" exception.