### PR TITLE
[Azure.Core] Test Environment Variables

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -101,6 +101,21 @@ namespace Azure.Core.TestFramework
         public string TenantId => GetRecordedVariable("TENANT_ID");
 
         /// <summary>
+        ///   The URL of the Azure Resource Manager to be used for management plane operations. Recorded.
+        /// </summary>
+        public string ResourceManagerUrl => GetRecordedOptionalVariable("RESOURCE_MANAGER_URL");
+
+        /// <summary>
+        ///   The URL of the Azure Service Management endpoint to be used for management plane authentication. Recorded.
+        /// </summary>
+        public string ServiceManagementUrl => GetRecordedOptionalVariable("SERVICE_MANAGEMENT_URL");
+
+        /// <summary>
+        ///   The URL of the Azure Authority host to be used for authentication. Recorded.
+        /// </summary>
+        public string AuthorityHostUrl => GetRecordedOptionalVariable("AZURE_AUTHORITY_HOST");
+
+        /// <summary>
         ///   The client id of the Azure Active Directory service principal to use during Live tests. Recorded.
         /// </summary>
         public string ClientId => GetRecordedVariable("CLIENT_ID");


### PR DESCRIPTION
# Summary

The focus of these changes is to include additional environment variables in the `TestEnvironment` to allow for cross-cloud management plane operations,
such as those used by the Azure Messaging client libraries.  This is the first step in enabling cross-cloud support for Live testing in the Event Hubs and Service Bus client libraries, both T1 and T2.

The test resource creation script has been updated to populate these additional variables using the current Azure environment context.   Orthogonal, but included are some tweaks to allow local runs of the `TestResources.ps1` script using the `-WhatIf` flag, which was failing for me before changes were made. 
 _(see: [#822](https://github.com/Azure/azure-sdk-tools/pull/822))_

# Last Upstream Rebase

Monday, July 27, 4:48pm (EDT)

# References and Related Issues 

- [Test Resources: Add Environment Variables](https://github.com/Azure/azure-sdk-tools/pull/822) (#822)
- [New-TestResources.ps1 should set AZURE_AUTHORITY_HOST environment variable](https://github.com/Azure/azure-sdk-tools/issues/757) (#757)
- [Event Hubs: AAD Auth failure when testing against other clouds](https://github.com/Azure/azure-sdk-for-net/issues/12964) (#12964)
- [Event Hub Live Test Change](https://github.com/Azure/azure-sdk-for-net/issues/13217) (#13217)