### PR TITLE
Updating Management Track 2 project template

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -85,6 +85,7 @@
     <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;net461</RequiredTargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" Condition="'$(IsMgmtClientLibrary)' == 'true'"/>
   <Import Project="TestFramework.props" Condition="'$(IsTestProject)' == 'true'"/>
 
   <PropertyGroup>

--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -61,6 +61,7 @@
       $(NoWarn);
       CA1812;  <!-- Avoid uninstantiated internal classes. (Result from below including the Azure.Core source) -->
       AZC0012; <!-- Single word class names -->
+      AZC0008;
     </NoWarn>
   </PropertyGroup>
 

--- a/eng/templates/Azure.ResourceManager.Template/.template.config/template.json
+++ b/eng/templates/Azure.ResourceManager.Template/.template.config/template.json
@@ -9,7 +9,7 @@
     "language": "C#",
     "type": "project"
   },
-  "sourceName": "Azure.Management.Template",
+  "sourceName": "Azure.ResourceManager.Template",
   "preferNameDirectory": true,
   "guids": [
     "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC",

--- a/eng/templates/Azure.ResourceManager.Template/Azure.ResourceManager.Template.sln
+++ b/eng/templates/Azure.ResourceManager.Template/Azure.ResourceManager.Template.sln
@@ -8,41 +8,41 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.ResourceManager.Template.Tests", "tests\Azure.ResourceManager.Template.Tests.csproj", "{3E25C0E3-A852-4DCB-B406-66E5565551DC}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x64.Build.0 = Debug|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x86.Build.0 = Debug|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x64.ActiveCfg = Release|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x64.Build.0 = Release|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x86.ActiveCfg = Release|Any CPU
-		{F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x86.Build.0 = Release|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x64.Build.0 = Debug|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x86.Build.0 = Debug|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x64.ActiveCfg = Release|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x64.Build.0 = Release|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x86.ActiveCfg = Release|Any CPU
-		{3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+  GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Any CPU = Debug|Any CPU
+    Debug|x64 = Debug|x64
+    Debug|x86 = Debug|x86
+    Release|Any CPU = Release|Any CPU
+    Release|x64 = Release|x64
+    Release|x86 = Release|x86
+  EndGlobalSection
+  GlobalSection(SolutionProperties) = preSolution
+    HideSolutionNode = FALSE
+  EndGlobalSection
+  GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x64.Build.0 = Debug|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Debug|x86.Build.0 = Debug|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|Any CPU.Build.0 = Release|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x64.ActiveCfg = Release|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x64.Build.0 = Release|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x86.ActiveCfg = Release|Any CPU
+    {F58E71A4-DED3-4714-B107-4E0E899BECEF}.Release|x86.Build.0 = Release|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x64.Build.0 = Debug|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Debug|x86.Build.0 = Debug|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|Any CPU.Build.0 = Release|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x64.ActiveCfg = Release|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x64.Build.0 = Release|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x86.ActiveCfg = Release|Any CPU
+    {3E25C0E3-A852-4DCB-B406-66E5565551DC}.Release|x86.Build.0 = Release|Any CPU
+  EndGlobalSection
 EndGlobal

--- a/eng/templates/Azure.ResourceManager.Template/src/Azure.ResourceManager.Template.csproj
+++ b/eng/templates/Azure.ResourceManager.Template/src/Azure.ResourceManager.Template.csproj
@@ -5,4 +5,9 @@
     <Description>Azure management client SDK for Azure resource provider ProviderFullName</Description>
     <PackageTags>azure;management;ProviderNameLowercase</PackageTags>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- TODO: Temp workaround. Should be fixed prior to release  -->
+    <NoWarn>$(NoWarn);AZC0001;AZC0008</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/eng/templates/Azure.ResourceManager.Template/src/Azure.ResourceManager.Template.csproj
+++ b/eng/templates/Azure.ResourceManager.Template/src/Azure.ResourceManager.Template.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <Version>1.0.0-preview.1</Version>
     <PackageId>Azure.ResourceManager.Template</PackageId>
-    <Description>Azure management client SDK for Azure resource provider ProviderFullName</Description>
-    <PackageTags>azure;management;ProviderNameLowercase</PackageTags>
+    <Description>Azure Resource Manager client SDK for Azure resource provider ProviderFullName</Description>
+    <PackageTags>azure;management;arm;resource manager;ProviderNameLowercase</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- TODO: Temp workaround. Should be fixed prior to release  -->
-    <NoWarn>$(NoWarn);AZC0001;AZC0008</NoWarn>
+    <!-- TODO: As part of release process, this PropertyGroup can be removed once RP is approved for namespace -->
+    <NoWarn>$(NoWarn);AZC0001</NoWarn>
   </PropertyGroup>
 </Project>

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/Directory.Build.props
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/compute/Azure.ResourceManager.Compute/Directory.Build.props
+++ b/sdk/compute/Azure.ResourceManager.Compute/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/digitaltwins/Azure.ResourceManager.DigitalTwins/Directory.Build.props
+++ b/sdk/digitaltwins/Azure.ResourceManager.DigitalTwins/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/Directory.Build.props
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/Directory.Build.props
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/network/Azure.ResourceManager.Network/Directory.Build.props
+++ b/sdk/network/Azure.ResourceManager.Network/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/resources/Azure.ResourceManager.Resources/Directory.Build.props
+++ b/sdk/resources/Azure.ResourceManager.Resources/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -30,7 +30,7 @@
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <Import Condition="'$(IsClientLibrary)' == 'true'" Project="$(MSBuildThisFileDirectory)..\core\Azure.Core\src\Azure.Core.props" />
+  <Import Condition="'$(IsClientLibrary)' == 'true' AND '$(IsMgmtClientLibrary)' != 'true'" Project="$(MSBuildThisFileDirectory)..\core\Azure.Core\src\Azure.Core.props" />
 
   <!-- Add references for CLIENT LIBRARY projects -->
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsClientLibrary)' == 'true'">

--- a/sdk/testcommon/Azure.Management.Compute.2019_12/Directory.Build.props
+++ b/sdk/testcommon/Azure.Management.Compute.2019_12/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/testcommon/Azure.Management.Network.2020_04/Directory.Build.props
+++ b/sdk/testcommon/Azure.Management.Network.2020_04/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/testcommon/Azure.Management.Resources.2017_05/Directory.Build.props
+++ b/sdk/testcommon/Azure.Management.Resources.2017_05/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>

--- a/sdk/testcommon/Azure.Management.Storage.2019_06/Directory.Build.props
+++ b/sdk/testcommon/Azure.Management.Storage.2019_06/Directory.Build.props
@@ -3,5 +3,4 @@
     Add any shared properties you want for the projects under this package directory that need to be set before the auto imported Directory.Build.props
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-  <Import Condition="'$(IsMgmtClientLibrary)' == 'true'" Project="$(RepoRoot)/sdk/core/Azure.Core/src/Azure.Core.props" />
 </Project>


### PR DESCRIPTION
The dotnet template for Track 2 management SDK was out of date due to namespace change. Fixed:
1. correct token replacement
2. moved Azure.Core reference to shared Directory.Build.Data.Props from each RP folder's Directory.Build.Props
3.  fixed tab to space in .sln file
4. Added default warning override in the csproj

[AB#3983](https://dev.azure.com/azure-mgmt-ex/4b92ce2a-39c0-4c42-816c-214829fe2a54/_workitems/edit/3983)