### PR TITLE
Merge released TA package version 5.0.0

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Release History
 
-## 1.1.0-preview.1 (Unreleased)
+## 5.1.0-preview.1 (Unreleased)
 ### Breaking changes
 - It defaults to the latest supported API version, which currently is `3.1-preview.1`.
 Note that new functionality hasn't been implemented in the client library.
+
+## 5.0.0 (2020-07-27)
+- Re-release of version `1.0.1` with updated version `5.0.0`.
 
 ## 1.0.1 (2020-06-23)
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Cognitive Services Text Analytics Service client library</Description>
     <AssemblyTitle>Microsoft Azure.AI.TextAnalytics client library</AssemblyTitle>
-    <Version>1.1.0-preview.1</Version>
-    <ApiCompatVersion>1.0.1</ApiCompatVersion>
+    <Version>5.1.0-preview.1</Version>
+    <ApiCompatVersion>5.0.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Text Analytics</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>


### PR DESCRIPTION
We had to do a release from a branch different than master where we bumped the version of the TA package to 5.0.
The intent of the PR is to bring the changes back to master.

See release tag: https://github.com/Azure/azure-sdk-for-net/releases/tag/Azure.AI.TextAnalytics_5.0.0