### PR TITLE
[FR] Extend ExtractFailureContent to improve error information

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
@@ -52,24 +52,14 @@ namespace Azure.AI.FormRecognizer
         {
             string errorCode = default;
 
-            if (string.IsNullOrEmpty(errorMessage))
+            if (errors.Count > 0)
             {
-                if (errors.Count > 0)
-                {
-                    var firstError = errors[0];
-
-                    errorMessage = firstError.Message;
-                    errorCode = firstError.ErrorCode;
-                }
-                else
-                {
-                    errorMessage = "Operation failed.";
-                }
+                errorCode = errors[0].ErrorCode;
+                errorMessage ??= errors[0].Message;
             }
 
             var errorInfo = new Dictionary<string, string>();
             int index = 0;
-
             foreach (var error in errors)
             {
                 errorInfo.Add($"error-{index}", $"{error.ErrorCode}: {error.Message}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientDiagnostics.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientDiagnostics.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Azure.AI.FormRecognizer.Models;
+
+#nullable enable
+
+namespace Azure.Core.Pipeline
+{
+    /// <summary>
+    /// Extend ClientDiagnostics to customize the exceptions thrown by the
+    /// generated code.
+    /// </summary>
+    internal sealed partial class ClientDiagnostics
+    {
+        /// <summary>
+        /// Customize the exception messages we throw from the protocol layer by
+        /// attempting to parse them as <see cref="FormRecognizerError"/>s.
+        /// </summary>
+        /// <param name="content">The error content.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="errorCode">The error code.</param>
+        /// <param name="additionalInfo">Additional error details.</param>
+        partial void ExtractFailureContent(
+            string? content,
+            ref string? message,
+            ref string? errorCode,
+#pragma warning disable CA1801 // Remove unused parameter
+            ref IDictionary<string, string>? additionalInfo)
+#pragma warning restore CA1801 // Remove unused parameter
+        {
+            if (!string.IsNullOrEmpty(content))
+            {
+                try
+                {
+                    // Try to parse the failure content and use that as the
+                    // default value for the message, error code, etc.
+                    using JsonDocument doc = JsonDocument.Parse(content);
+                    if (doc.RootElement.TryGetProperty("error", out JsonElement errorElement))
+                    {
+                        FormRecognizerError error = FormRecognizerError.DeserializeFormRecognizerError(errorElement);
+                        message ??= error?.Message;
+                        errorCode ??= error?.ErrorCode;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore any failures - unexpected content will be
+                    // included verbatim in the detailed error message
+                }
+            }
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -360,7 +360,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var damagedFile = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x55, 0x55, 0x55 };
             using var stream = new MemoryStream(damagedFile);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeContentAsync(stream));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeContentAsync(stream));
+            Assert.AreEqual("InvalidImage", ex.ErrorCode);
         }
 
         /// <summary>
@@ -373,7 +374,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var client = CreateFormRecognizerClient();
             var invalidUri = new Uri("https://idont.ex.ist");
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeContentFromUriAsync(invalidUri));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeContentFromUriAsync(invalidUri));
+            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
         }
 
         /// <summary>
@@ -734,7 +736,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var damagedFile = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x55, 0x55, 0x55 };
             using var stream = new MemoryStream(damagedFile);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeReceiptsAsync(stream));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeReceiptsAsync(stream));
+            Assert.AreEqual("BadArgument", ex.ErrorCode);
         }
 
         /// <summary>
@@ -747,7 +750,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var client = CreateFormRecognizerClient();
             var invalidUri = new Uri("https://idont.ex.ist");
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeReceiptsFromUriAsync(invalidUri));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartRecognizeReceiptsFromUriAsync(invalidUri));
+            Assert.AreEqual("FailedToDownloadImage", ex.ErrorCode);
         }
 
         /// <summary>
@@ -1180,7 +1184,12 @@ namespace Azure.AI.FormRecognizer.Tests
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels);
             var operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            string expectedErrorCode = useTrainingLabels ? "3014" : "2005";
+            Assert.AreEqual(expectedErrorCode, ex.ErrorCode);
+
+            Assert.True(operation.HasCompleted);
+            Assert.False(operation.HasValue);
         }
 
         /// <summary>
@@ -1198,25 +1207,13 @@ namespace Azure.AI.FormRecognizer.Tests
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels);
 
             var operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, invalidUri);
-            RequestFailedException capturedException = default;
 
-            try
-            {
-                await operation.WaitForCompletionAsync(PollingInterval);
-            }
-            catch (RequestFailedException ex)
-            {
-                capturedException = ex;
-            }
-
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
             string expectedErrorCode = useTrainingLabels ? "3003" : "2003";
-
-            Assert.NotNull(capturedException);
-            Assert.AreEqual(expectedErrorCode, capturedException.ErrorCode);
+            Assert.AreEqual(expectedErrorCode, ex.ErrorCode);
 
             Assert.True(operation.HasCompleted);
             Assert.False(operation.HasValue);
-            Assert.Throws<RequestFailedException>(() => operation.Value.GetType());
         }
 
         private void ValidateFormPage(FormPage formPage, bool includeFieldElements, int expectedPageNumber)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -122,7 +122,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var filter = new TrainingFileFilter { IncludeSubFolders = true, Prefix = "invalidPrefix" };
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, filter);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            Assert.AreEqual("2014", ex.ErrorCode);
         }
 
         [Test]
@@ -133,7 +134,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var containerUrl = new Uri("https://someUrl");
 
             TrainingOperation operation = await client.StartTrainingAsync(containerUrl, useTrainingLabels: false);
-            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            Assert.AreEqual("2001", ex.ErrorCode);
 
             Assert.False(operation.HasValue);
             Assert.Throws<RequestFailedException>(() => operation.Value.GetType());
@@ -204,7 +206,8 @@ namespace Azure.AI.FormRecognizer.Tests
 
             await client.DeleteModelAsync(trainedModel.ModelId);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => client.GetCustomModelAsync(trainedModel.ModelId));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(() => client.GetCustomModelAsync(trainedModel.ModelId));
+            Assert.AreEqual("1022", ex.ErrorCode);
         }
 
         [Test]
@@ -213,7 +216,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var client = CreateFormTrainingClient();
             var fakeModelId = "00000000-0000-0000-0000-000000000000";
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await client.DeleteModelAsync(fakeModelId));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.DeleteModelAsync(fakeModelId));
+            Assert.AreEqual("1022", ex.ErrorCode);
         }
 
         [Test]
@@ -268,7 +272,8 @@ namespace Azure.AI.FormRecognizer.Tests
 
             var operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            Assert.AreEqual("ResourceResolverError", ex.ErrorCode);
         }
 
         [Test]


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13739

With this change, we expose more information about the exception to the user, instead of asking the user to parse a our `Content` value.

i.e. for Method [`StartRecognizeContentThrowsForDamagedFile` ](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs#L354)

Output before:
```
Service request failed.
Status: 400

Content:
{"error":{"code":"InvalidImage","message":"The input data is not a valid image or password protected."}}
```

Output After:
```
The input data is not a valid image or password protected.
Status: 400
ErrorCode: InvalidImage

Content:
{"error":{"code":"InvalidImage","message":"The input data is not a valid image or password protected."}}
```