### PR TITLE
change TableEntity to ITableEntity

### DIFF
--- a/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
+++ b/sdk/tables/Azure.Data.Tables/api/Azure.Data.Tables.netstandard2.0.cs
@@ -1,19 +1,19 @@
 namespace Azure.Data.Tables
 {
-    public partial class DynamicTableEntity : Azure.Data.Tables.TableEntity, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
+    public partial class DynamicTableEntity : Azure.Data.Tables.ITableEntity, System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IDictionary<string, object>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable
     {
         public DynamicTableEntity() { }
         public DynamicTableEntity(System.Collections.Generic.IDictionary<string, object> values) { }
         public DynamicTableEntity(string partitionKey, string rowKey) { }
         public int Count { get { throw null; } }
-        public override string ETag { get { throw null; } set { } }
+        public string ETag { get { throw null; } set { } }
         public object this[string key] { get { throw null; } set { } }
         public System.Collections.Generic.ICollection<string> Keys { get { throw null; } }
-        public override string PartitionKey { get { throw null; } set { } }
-        public override string RowKey { get { throw null; } set { } }
+        public string PartitionKey { get { throw null; } set { } }
+        public string RowKey { get { throw null; } set { } }
         bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<System.String,System.Object>>.IsReadOnly { get { throw null; } }
         System.Collections.Generic.ICollection<object> System.Collections.Generic.IDictionary<System.String,System.Object>.Values { get { throw null; } }
-        public override System.DateTimeOffset? Timestamp { get { throw null; } }
+        public System.DateTimeOffset? Timestamp { get { throw null; } set { } }
         public void Add(string key, object value) { }
         public void Clear() { }
         public bool ContainsKey(string key) { throw null; }
@@ -34,6 +34,13 @@ namespace Azure.Data.Tables
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         public bool TryGetValue(string key, out object value) { throw null; }
     }
+    public partial interface ITableEntity
+    {
+        string ETag { get; set; }
+        string PartitionKey { get; set; }
+        string RowKey { get; set; }
+        System.DateTimeOffset? Timestamp { get; set; }
+    }
     public partial class TableClient
     {
         protected TableClient() { }
@@ -43,8 +50,8 @@ namespace Azure.Data.Tables
         public virtual Azure.Response<System.Collections.ObjectModel.ReadOnlyDictionary<string, object>> CreateEntity(System.Collections.Generic.IDictionary<string, object> entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Data.Tables.DynamicTableEntity>> CreateEntityAsync(Azure.Data.Tables.DynamicTableEntity entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.ObjectModel.ReadOnlyDictionary<string, object>>> CreateEntityAsync(System.Collections.Generic.IDictionary<string, object> entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<T>> CreateEntityAsync<T>(T entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
-        public virtual Azure.Response<T> CreateEntity<T>(T entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<T>> CreateEntityAsync<T>(T entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
+        public virtual Azure.Response<T> CreateEntity<T>(T entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
         public static string CreateFilter<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> filter) { throw null; }
         public virtual Azure.Response Delete(string partitionKey, string rowKey, string eTag = "*", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteAsync(string partitionKey, string rowKey, string eTag = "*", System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -52,26 +59,26 @@ namespace Azure.Data.Tables
         public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.Data.Tables.Models.SignedIdentifier>>> GetAccessPolicyAsync(int? timeout = default(int?), string requestId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<System.Collections.Generic.IDictionary<string, object>> GetEntity(string partitionKey, string rowKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IDictionary<string, object>>> GetEntityAsync(string partitionKey, string rowKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetEntityAsync<T>(string partitionKey, string rowKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
-        public virtual Azure.Response<T> GetEntity<T>(string partitionKey, string rowKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetEntityAsync<T>(string partitionKey, string rowKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
+        public virtual Azure.Response<T> GetEntity<T>(string partitionKey, string rowKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
         public virtual Azure.Data.Tables.Sas.TableSasBuilder GetSasBuilder(Azure.Data.Tables.Sas.TableSasPermissions permissions, System.DateTimeOffset expiresOn) { throw null; }
         public virtual Azure.Data.Tables.Sas.TableSasBuilder GetSasBuilder(string rawPermissions, System.DateTimeOffset expiresOn) { throw null; }
         public virtual Azure.Pageable<System.Collections.Generic.IDictionary<string, object>> Query(System.Linq.Expressions.Expression<System.Func<System.Collections.Generic.IDictionary<string, object>, bool>> filter, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<System.Collections.Generic.IDictionary<string, object>> Query(string filter = null, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<System.Collections.Generic.IDictionary<string, object>> QueryAsync(System.Linq.Expressions.Expression<System.Func<System.Collections.Generic.IDictionary<string, object>, bool>> filter, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<System.Collections.Generic.IDictionary<string, object>> QueryAsync(string filter = null, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<T> QueryAsync<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> filter, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
-        public virtual Azure.AsyncPageable<T> QueryAsync<T>(string filter = null, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
-        public virtual Azure.Pageable<T> Query<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> filter, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
-        public virtual Azure.Pageable<T> Query<T>(string filter = null, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
+        public virtual Azure.AsyncPageable<T> QueryAsync<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> filter, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
+        public virtual Azure.AsyncPageable<T> QueryAsync<T>(string filter = null, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
+        public virtual Azure.Pageable<T> Query<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> filter, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
+        public virtual Azure.Pageable<T> Query<T>(string filter = null, int? maxPerPage = default(int?), string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
         public virtual Azure.Response SetAccessPolicy(System.Collections.Generic.IEnumerable<Azure.Data.Tables.Models.SignedIdentifier> tableAcl, int? timeout = default(int?), string requestId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> SetAccessPolicyAsync(System.Collections.Generic.IEnumerable<Azure.Data.Tables.Models.SignedIdentifier> tableAcl = null, int? timeout = default(int?), string requestId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response UpdateEntity(System.Collections.Generic.IDictionary<string, object> entity, string eTag, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> UpdateEntityAsync(System.Collections.Generic.IDictionary<string, object> entity, string eTag, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response UpsertEntity(System.Collections.Generic.IDictionary<string, object> entity, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> UpsertEntityAsync(System.Collections.Generic.IDictionary<string, object> entity, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response> UpsertEntityAsync<T>(T entity, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
-        public virtual Azure.Response UpsertEntity<T>(T entity, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Data.Tables.TableEntity, new() { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> UpsertEntityAsync<T>(T entity, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
+        public virtual Azure.Response UpsertEntity<T>(T entity, Azure.Data.Tables.UpdateMode mode = Azure.Data.Tables.UpdateMode.Merge, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : class, Azure.Data.Tables.ITableEntity, new() { throw null; }
     }
     public partial class TableClientOptions : Azure.Core.ClientOptions
     {
@@ -80,15 +87,6 @@ namespace Azure.Data.Tables
         {
             V2019_02_02 = 1,
         }
-    }
-    public partial class TableEntity
-    {
-        public TableEntity() { }
-        public TableEntity(string partitionKey, string rowKey) { }
-        public virtual string ETag { get { throw null; } set { } }
-        public virtual string PartitionKey { get { throw null; } set { } }
-        public virtual string RowKey { get { throw null; } set { } }
-        public virtual System.DateTimeOffset? Timestamp { get { throw null; } set { } }
     }
     public partial class TableServiceClient
     {

--- a/sdk/tables/Azure.Data.Tables/src/DynamicTableEntity.cs
+++ b/sdk/tables/Azure.Data.Tables/src/DynamicTableEntity.cs
@@ -10,9 +10,9 @@ using Azure.Core;
 namespace Azure.Data.Tables
 {
     /// <summary>
-    /// A <see cref="TableEntity"/> type which allows callers direct access to the property map of the entity.
+    /// A <see cref="ITableEntity"/> type which allows callers direct access to the property map of the entity.
     /// </summary>
-    public partial class DynamicTableEntity : TableEntity
+    public partial class DynamicTableEntity : ITableEntity
     {
         private readonly IDictionary<string, object> _properties;
 
@@ -20,7 +20,7 @@ namespace Azure.Data.Tables
         /// The partition key is a unique identifier for the partition within a given table and forms the first part of an entity's primary key.
         /// </summary>
         /// <value>A string containing the partition key for the entity.</value>
-        public override string PartitionKey
+        public string PartitionKey
         {
             get { return GetString(TableConstants.PropertyNames.PartitionKey); }
             set { _properties[TableConstants.PropertyNames.PartitionKey] = value; }
@@ -30,7 +30,7 @@ namespace Azure.Data.Tables
         /// The row key is a unique identifier for an entity within a given partition. Together the <see cref="PartitionKey" /> and RowKey uniquely identify every entity within a table.
         /// </summary>
         /// <value>A string containing the row key for the entity.</value>
-        public override string RowKey
+        public string RowKey
         {
             get { return GetString(TableConstants.PropertyNames.RowKey); }
             set { _properties[TableConstants.PropertyNames.RowKey] = value; }
@@ -42,23 +42,24 @@ namespace Azure.Data.Tables
         /// meaning that each time the entity is modified, the value of Timestamp increases for that entity. This property should not be set on insert or update operations (the value will be ignored).
         /// </summary>
         /// <value>A <see cref="DateTimeOffset"/> containing the timestamp of the entity.</value>
-        public override DateTimeOffset? Timestamp
+        public DateTimeOffset? Timestamp
         {
             get { return GetDateTime(TableConstants.PropertyNames.TimeStamp); }
+            set { _properties[TableConstants.PropertyNames.TimeStamp] = value; }
         }
 
         /// <summary>
         /// Gets or sets the entity's ETag. Set this value to '*' in order to force an overwrite to an entity as part of an update operation.
         /// </summary>
         /// <value>A string containing the ETag value for the entity.</value>
-        public override string ETag
+        public string ETag
         {
             get { return GetString(TableConstants.PropertyNames.Etag); }
             set { _properties[TableConstants.PropertyNames.Etag] = value; }
         }
 
         /// <summary>
-        /// Constructs an instance of a <see cref="TableEntity" />.
+        /// Constructs an instance of a <see cref="ITableEntity" />.
         /// </summary>
         public DynamicTableEntity()
             : this(null)

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/DictionaryTableExtensions.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/DictionaryTableExtensions.cs
@@ -154,7 +154,7 @@ namespace Azure.Data.Tables
         /// <summary>
         /// Converts a List of Dictionaries containing properties and Odata type annotations to a custom entity type.
         /// </summary>
-        internal static List<T> ToTableEntityList<T>(this IReadOnlyList<IDictionary<string, object>> entityList) where T : TableEntity, new()
+        internal static List<T> ToTableEntityList<T>(this IReadOnlyList<IDictionary<string, object>> entityList) where T : class, ITableEntity, new()
         {
             PropertyInfo[] properties = s_propertyInfoCache.GetOrAdd(typeof(T), (type) =>
             {
@@ -176,7 +176,7 @@ namespace Azure.Data.Tables
         /// <summary>
         /// Cleans a Dictionary of its Odata type annotations, while using them to cast its entities accordingly.
         /// </summary>
-        internal static T ToTableEntity<T>(this IDictionary<string, object> entity, PropertyInfo[]? properties = null) where T : TableEntity, new()
+        internal static T ToTableEntity<T>(this IDictionary<string, object> entity, PropertyInfo[]? properties = null) where T : class, ITableEntity, new()
         {
             properties ??= s_propertyInfoCache.GetOrAdd(typeof(T), (type) =>
             {

--- a/sdk/tables/Azure.Data.Tables/src/Extensions/TableEntityExtensions.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/TableEntityExtensions.cs
@@ -14,7 +14,7 @@ namespace Azure.Data.Tables
         /// The default case is intentionally unhandled as this means that no type annotation for the specified type is required.
         /// This is because the type is naturally serialized in a way that the table service can interpret without hints.
         /// </summary>
-        internal static Dictionary<string, object> ToOdataAnnotatedDictionary<T>(this T entity) where T : TableEntity
+        internal static Dictionary<string, object> ToOdataAnnotatedDictionary<T>(this T entity) where T : class, ITableEntity
         {
             var properties = typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public);
             var annotatedDictionary = new Dictionary<string, object>(properties.Length * 2);

--- a/sdk/tables/Azure.Data.Tables/src/ITableEntity.cs
+++ b/sdk/tables/Azure.Data.Tables/src/ITableEntity.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,19 +6,19 @@ using System;
 namespace Azure.Data.Tables
 {
 
-    public class TableEntity
+    public interface ITableEntity
     {
         /// <summary>
         /// The partition key is a unique identifier for the partition within a given table and forms the first part of an entity's primary key.
         /// </summary>
         /// <value>A string containing the partition key for the entity.</value>
-        public virtual string PartitionKey { get; set; }
+        string PartitionKey { get; set; }
 
         /// <summary>
         /// The row key is a unique identifier for an entity within a given partition. Together the <see cref="PartitionKey" /> and RowKey uniquely identify every entity within a table.
         /// </summary>
         /// <value>A string containing the row key for the entity.</value>
-        public virtual string RowKey { get; set; }
+        string RowKey { get; set; }
 
         /// <summary>
         /// The Timestamp property is a DateTime value that is maintained on the server side to record the time an entity was last modified.
@@ -26,30 +26,12 @@ namespace Azure.Data.Tables
         /// meaning that each time the entity is modified, the value of Timestamp increases for that entity. This property should not be set on insert or update operations (the value will be ignored).
         /// </summary>
         /// <value>A <see cref="DateTimeOffset"/> containing the timestamp of the entity.</value>
-        public virtual DateTimeOffset? Timestamp { get; set; }
+        DateTimeOffset? Timestamp { get; set; }
 
         /// <summary>
         /// Gets or sets the entity's ETag. Set this value to '*' in order to force an overwrite to an entity as part of an update operation.
         /// </summary>
         /// <value>A string containing the ETag value for the entity.</value>
-        public virtual string ETag { get; set; }
-
-        /// <summary>
-        /// Constructs an instance of a <see cref="TableEntity" />.
-        /// </summary>
-        public TableEntity()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TableEntity"/> class with the specified partition key and row key.
-        /// </summary>
-        /// <param name="partitionKey">A string containing the partition key of the <see cref="TableEntity"/> to be initialized.</param>
-        /// <param name="rowKey">A string containing the row key of the <see cref="TableEntity"/> to be initialized.</param>
-        public TableEntity(string partitionKey, string rowKey)
-        {
-            PartitionKey = partitionKey;
-            RowKey = rowKey;
-        }
+        string ETag { get; set; }
     }
 }

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -244,7 +244,7 @@ namespace Azure.Data.Tables
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>The created Table entity.</returns>
         /// <exception cref="RequestFailedException">Exception thrown if entity already exists.</exception>
-        public virtual async Task<Response<T>> CreateEntityAsync<T>(T entity, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual async Task<Response<T>> CreateEntityAsync<T>(T entity, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             Argument.AssertNotNull(entity, nameof(entity));
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(CreateEntity)}");
@@ -273,7 +273,7 @@ namespace Azure.Data.Tables
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>The created Table entity.</returns>
         /// <exception cref="RequestFailedException">Exception thrown if entity already exists.</exception>
-        public virtual Response<T> CreateEntity<T>(T entity, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual Response<T> CreateEntity<T>(T entity, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             Argument.AssertNotNull(entity, nameof(entity));
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(CreateEntity)}");
@@ -304,7 +304,7 @@ namespace Azure.Data.Tables
         /// <returns>The <see cref="Response"/> indicating the result of the operation.</returns>
         /// <exception cref="RequestFailedException">Exception thrown if the entity doesn't exist.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="partitionKey"/> or <paramref name="rowKey"/> is null.</exception>
-        public virtual Response<T> GetEntity<T>(string partitionKey, string rowKey, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual Response<T> GetEntity<T>(string partitionKey, string rowKey, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             Argument.AssertNotNull("message", nameof(partitionKey));
             Argument.AssertNotNull("message", nameof(rowKey));
@@ -339,7 +339,7 @@ namespace Azure.Data.Tables
         /// <returns>The <see cref="Response"/> indicating the result of the operation.</returns>
         /// <exception cref="RequestFailedException">Exception thrown if the entity doesn't exist.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="partitionKey"/> or <paramref name="rowKey"/> is null.</exception>
-        public virtual async Task<Response<T>> GetEntityAsync<T>(string partitionKey, string rowKey, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual async Task<Response<T>> GetEntityAsync<T>(string partitionKey, string rowKey, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             Argument.AssertNotNull("message", nameof(partitionKey));
             Argument.AssertNotNull("message", nameof(rowKey));
@@ -554,7 +554,7 @@ namespace Azure.Data.Tables
         /// <param name="mode">An enum that determines which upsert operation to perform.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>The <see cref="Response"/> indicating the result of the operation.</returns>
-        public virtual async Task<Response> UpsertEntityAsync<T>(T entity, UpdateMode mode = UpdateMode.Merge, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual async Task<Response> UpsertEntityAsync<T>(T entity, UpdateMode mode = UpdateMode.Merge, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             Argument.AssertNotNull(entity?.PartitionKey, nameof(entity.PartitionKey));
             Argument.AssertNotNull(entity?.RowKey, nameof(entity.RowKey));
@@ -599,7 +599,7 @@ namespace Azure.Data.Tables
         /// <param name="mode">An enum that determines which upsert operation to perform.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>The <see cref="Response"/> indicating the result of the operation.</returns>
-        public virtual Response UpsertEntity<T>(T entity, UpdateMode mode = UpdateMode.Merge, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual Response UpsertEntity<T>(T entity, UpdateMode mode = UpdateMode.Merge, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             Argument.AssertNotNull(entity?.PartitionKey, nameof(entity.PartitionKey));
             Argument.AssertNotNull(entity?.RowKey, nameof(entity.RowKey));
@@ -917,7 +917,7 @@ namespace Azure.Data.Tables
         /// <param name="select">Returns the desired properties of an entity from the set. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
 
-        public virtual AsyncPageable<T> QueryAsync<T>(Expression<Func<T, bool>> filter, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual AsyncPageable<T> QueryAsync<T>(Expression<Func<T, bool>> filter, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
             scope.Start();
@@ -940,7 +940,7 @@ namespace Azure.Data.Tables
         /// <param name="select">Returns the desired properties of an entity from the set. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns></returns>
-        public virtual AsyncPageable<T> QueryAsync<T>(string filter = null, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual AsyncPageable<T> QueryAsync<T>(string filter = null, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
             scope.Start();
@@ -987,7 +987,7 @@ namespace Azure.Data.Tables
         /// <param name="select">Returns the desired properties of an entity from the set. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
 
-        public virtual Pageable<T> Query<T>(Expression<Func<T, bool>> filter, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual Pageable<T> Query<T>(Expression<Func<T, bool>> filter, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
             using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
             scope.Start();
@@ -1010,7 +1010,7 @@ namespace Azure.Data.Tables
         /// <param name="select">Returns the desired properties of an entity from the set. </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
 
-        public virtual Pageable<T> Query<T>(string filter = null, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : TableEntity, new()
+        public virtual Pageable<T> Query<T>(string filter = null, int? maxPerPage = null, string select = null, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
         {
 
             return PageableHelpers.CreateEnumerable((int? _) =>
@@ -1203,7 +1203,7 @@ namespace Azure.Data.Tables
         /// <summary>
         /// Creates an Odata filter query string from the provided expression.
         /// </summary>
-        /// <typeparam name="T">The type of the entity being queried. Typically this will be derrived from <see cref="TableEntity"/> or <see cref="Dictionary{String, Object}"/>.</typeparam>
+        /// <typeparam name="T">The type of the entity being queried. Typically this will be derrived from <see cref="ITableEntity"/> or <see cref="Dictionary{String, Object}"/>.</typeparam>
         /// <param name="filter">A filter expresssion.</param>
         /// <returns>The string representation of the filter expression.</returns>
         public static string CreateFilter<T>(Expression<Func<T, bool>> filter) => Bind(filter);

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
@@ -38,13 +38,13 @@ namespace Azure.Tables.Tests
         {
             Assert.That(async () => await client_Instrumented.CreateEntityAsync(null), Throws.InstanceOf<ArgumentNullException>(), "The method should validate the entity is not null.");
 
-            Assert.That(async () => await client_Instrumented.CreateEntityAsync<TableEntity>(null), Throws.InstanceOf<ArgumentNullException>(), "The method should validate the entity is not null.");
+            Assert.That(async () => await client_Instrumented.CreateEntityAsync<MinEntity>(null), Throws.InstanceOf<ArgumentNullException>(), "The method should validate the entity is not null.");
 
-            Assert.That(async () => await client_Instrumented.UpsertEntityAsync<TableEntity>(null, UpdateMode.Replace), Throws.InstanceOf<ArgumentNullException>(), "The method should validate the entity is not null.");
+            Assert.That(async () => await client_Instrumented.UpsertEntityAsync<MinEntity>(null, UpdateMode.Replace), Throws.InstanceOf<ArgumentNullException>(), "The method should validate the entity is not null.");
 
-            Assert.That(async () => await client_Instrumented.UpsertEntityAsync(new TableEntity { PartitionKey = null, RowKey = "row" }, UpdateMode.Replace), Throws.InstanceOf<ArgumentException>(), $"The method should validate the entity has a {TableConstants.PropertyNames.PartitionKey}.");
+            Assert.That(async () => await client_Instrumented.UpsertEntityAsync(new MinEntity { PartitionKey = null, RowKey = "row" }, UpdateMode.Replace), Throws.InstanceOf<ArgumentException>(), $"The method should validate the entity has a {TableConstants.PropertyNames.PartitionKey}.");
 
-            Assert.That(async () => await client_Instrumented.UpsertEntityAsync(new TableEntity { PartitionKey = "partition", RowKey = null }, UpdateMode.Replace), Throws.InstanceOf<ArgumentException>(), $"The method should validate the entity has a {TableConstants.PropertyNames.RowKey}.");
+            Assert.That(async () => await client_Instrumented.UpsertEntityAsync(new MinEntity { PartitionKey = "partition", RowKey = null }, UpdateMode.Replace), Throws.InstanceOf<ArgumentException>(), $"The method should validate the entity has a {TableConstants.PropertyNames.RowKey}.");
 
             Assert.That(async () => await client_Instrumented.UpdateEntityAsync(null, "etag", UpdateMode.Replace), Throws.InstanceOf<ArgumentNullException>(), "The method should validate the entity is not null.");
 
@@ -77,6 +77,14 @@ namespace Azure.Tables.Tests
 
             Assert.That(sas.Permissions, Is.EqualTo(permissions.ToPermissionsString()));
             Assert.That(sas.ExpiresOn, Is.EqualTo(expiry));
+        }
+
+        public class MinEntity : ITableEntity
+        {
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+            public DateTimeOffset? Timestamp { get; set; }
+            public string ETag { get; set; }
         }
     }
 }

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
@@ -267,11 +267,11 @@ namespace Azure.Data.Tables.Tests
             }
         }
 
-        protected async Task CreateTestEntities<T>(List<T> entitiesToCreate) where T : TableEntity, new()
+        protected async Task CreateTestEntities<T>(List<T> entitiesToCreate) where T : class, ITableEntity, new()
         {
             foreach (var entity in entitiesToCreate)
             {
-                await CosmosThrottleWrapper(async () => await client.CreateEntityAsync(entity).ConfigureAwait(false));
+                await CosmosThrottleWrapper(async () => await client.CreateEntityAsync<T>(entity).ConfigureAwait(false));
             }
         }
 
@@ -283,7 +283,7 @@ namespace Azure.Data.Tables.Tests
             }
         }
 
-        protected async Task UpsertTestEntities<T>(List<T> entitiesToCreate, UpdateMode updateMode) where T : TableEntity, new()
+        protected async Task UpsertTestEntities<T>(List<T> entitiesToCreate, UpdateMode updateMode) where T : class, ITableEntity, new()
         {
             foreach (var entity in entitiesToCreate)
             {
@@ -299,7 +299,7 @@ namespace Azure.Data.Tables.Tests
             }
         }
 
-        public class TestEntity : TableEntity
+        public class TestEntity : ITableEntity
         {
             public string StringTypeProperty { get; set; }
 
@@ -316,25 +316,33 @@ namespace Azure.Data.Tables.Tests
             public double DoubleTypeProperty { get; set; }
 
             public int IntTypeProperty { get; set; }
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+            public DateTimeOffset? Timestamp { get; set; }
+            public string ETag { get; set; }
         }
 
-        public class SimpleTestEntity : TableEntity
+        public class SimpleTestEntity : ITableEntity
         {
             public string StringTypeProperty { get; set; }
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+            public DateTimeOffset? Timestamp { get; set; }
+            public string ETag { get; set; }
         }
 
-        public class ComplexEntity : TableEntity
+        public class ComplexEntity : ITableEntity
         {
             public const int NumberOfNonNullProperties = 28;
 
             public ComplexEntity()
-                : base()
             {
             }
 
             public ComplexEntity(string pk, string rk)
-                : base(pk, rk)
             {
+                PartitionKey = pk;
+                RowKey = rk;
             }
 
             private DateTimeOffset? dateTimeOffsetNull = null;
@@ -444,6 +452,12 @@ namespace Azure.Data.Tables.Tests
             public Int64 Int64 { get; set; } = 123456789012;
 
             public string String { get; set; } = "test";
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+
+            public DateTimeOffset? Timestamp { get; set; }
+
+            public string ETag { get; set; }
 
             public static void AssertEquality(ComplexEntity a, ComplexEntity b)
             {

--- a/sdk/tables/Azure.Data.Tables/tests/perf/GenericTableEntityCreationBenchmark.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/perf/GenericTableEntityCreationBenchmark.cs
@@ -47,14 +47,16 @@ namespace Azure.Data.Tables.Performance
             _items.ToTableEntityList<BenchmarkEntity>();
         }
 
-        public class BenchmarkEntity : TableEntity
+        public class BenchmarkEntity : ITableEntity
         {
             public BenchmarkEntity()
             {
             }
 
-            public BenchmarkEntity(string partitionKey, string rowKey) : base(partitionKey, rowKey)
+            public BenchmarkEntity(string partitionKey, string rowKey)
             {
+                PartitionKey = partitionKey;
+                RowKey = rowKey;
             }
 
             public Guid SomeGuid { get; set; }
@@ -62,6 +64,10 @@ namespace Azure.Data.Tables.Performance
             public int SomeInt { get; set; }
             public DateTime SomeDateTime { get; set; }
             public byte[] SomeBinary { get; set; }
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+            public DateTimeOffset? Timestamp { get; set; }
+            public string ETag { get; set; }
         }
     }
 }

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs
@@ -80,14 +80,6 @@ namespace Azure.Data.Tables.Samples
         // Define a strongly typed entity by extending the <see cref="TableEntity"> class.
         public class OfficeSupplyEntity : ITableEntity
         {
-            public OfficeSupplyEntity() { }
-
-            public OfficeSupplyEntity(string partitionKey, string rowKey)
-            {
-                PartitionKey = partitionKey;
-                RowKey = rowKey;
-            }
-
             public string Product { get; set; }
             public double Price { get; set; }
             public string PartitionKey { get; set; }

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs
@@ -78,10 +78,22 @@ namespace Azure.Data.Tables.Samples
 
         #region Snippet:TablesSample2DefineStronglyTypedEntity
         // Define a strongly typed entity by extending the <see cref="TableEntity"> class.
-        public class OfficeSupplyEntity : TableEntity
+        public class OfficeSupplyEntity : ITableEntity
         {
+            public OfficeSupplyEntity() { }
+
+            public OfficeSupplyEntity(string partitionKey, string rowKey)
+            {
+                PartitionKey = partitionKey;
+                RowKey = rowKey;
+            }
+
             public string Product { get; set; }
             public double Price { get; set; }
+            public string PartitionKey { get; set; }
+            public string RowKey { get; set; }
+            public DateTimeOffset? Timestamp { get; set; }
+            public string ETag { get; set; }
         }
         #endregion
     }


### PR DESCRIPTION
#13789

- Changed `TableEntity` to `ITableEntity` as an interface
- `TableClient` generic methods apply class constraint
- Classes implementing `ITableEntity` must have either implicit or explicit parameterless .ctor