### PR TITLE
fix(iot-hub): Regenerate IotHub models with correct visibilitity

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
@@ -190,7 +190,7 @@ namespace Azure.Iot.Hub.Service.Models
     public partial class DeviceCapabilities
     {
         public DeviceCapabilities() { }
-        public bool? IotEdge { get { throw null; } set { } }
+        public bool? IsIotEdgeDevice { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DeviceConnectionState : System.IEquatable<Azure.Iot.Hub.Service.Models.DeviceConnectionState>
@@ -567,38 +567,6 @@ namespace Azure.Iot.Hub.Service.Models
         public static implicit operator Azure.Iot.Hub.Service.Models.ExportImportDeviceStatus (string value) { throw null; }
         public static bool operator !=(Azure.Iot.Hub.Service.Models.ExportImportDeviceStatus left, Azure.Iot.Hub.Service.Models.ExportImportDeviceStatus right) { throw null; }
         public override string ToString() { throw null; }
-    }
-    public partial class FaultInjectionConnectionProperties
-    {
-        public FaultInjectionConnectionProperties() { }
-        public Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction? Action { get { throw null; } set { } }
-        public int? BlockDurationInMinutes { get { throw null; } set { } }
-    }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct FaultInjectionConnectionPropertiesAction : System.IEquatable<Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction>
-    {
-        private readonly object _dummy;
-        private readonly int _dummyPrimitive;
-        public FaultInjectionConnectionPropertiesAction(string value) { throw null; }
-        public static Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction CloseAll { get { throw null; } }
-        public static Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction None { get { throw null; } }
-        public static Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction Periodic { get { throw null; } }
-        public bool Equals(Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction other) { throw null; }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool Equals(object obj) { throw null; }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction left, Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction right) { throw null; }
-        public static implicit operator Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction (string value) { throw null; }
-        public static bool operator !=(Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction left, Azure.Iot.Hub.Service.Models.FaultInjectionConnectionPropertiesAction right) { throw null; }
-        public override string ToString() { throw null; }
-    }
-    public partial class FaultInjectionProperties
-    {
-        public FaultInjectionProperties() { }
-        public Azure.Iot.Hub.Service.Models.FaultInjectionConnectionProperties Connection { get { throw null; } set { } }
-        public string IotHubName { get { throw null; } set { } }
-        public System.DateTimeOffset? LastUpdatedTimeUtc { get { throw null; } set { } }
     }
     public partial class JobProperties
     {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/DeviceCapabilities.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/DeviceCapabilities.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Azure.Iot.Hub.Service.Models
+{
+    public partial class DeviceCapabilities
+    {
+        [CodeGenMember("IotEdge")]
+        public bool? IsIotEdgeDevice { get; set; }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/FaultInjectionConnectionProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/FaultInjectionConnectionProperties.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Hub.Service.Models
+{
+    internal partial class FaultInjectionConnectionProperties
+    {
+        /// <summary> The action to perform. </summary>
+        internal FaultInjectionConnectionPropertiesAction? Action { get; set; }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/FaultInjectionConnectionPropertiesAction.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/FaultInjectionConnectionPropertiesAction.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Hub.Service.Models
+{
+    internal readonly partial struct FaultInjectionConnectionPropertiesAction
+    {
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/FaultInjectionProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Customized/Models/FaultInjectionProperties.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Iot.Hub.Service.Models
+{
+    internal partial class FaultInjectionProperties
+    {
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceCapabilities.Serialization.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceCapabilities.Serialization.cs
@@ -15,10 +15,10 @@ namespace Azure.Iot.Hub.Service.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            if (Optional.IsDefined(IotEdge))
+            if (Optional.IsDefined(IsIotEdgeDevice))
             {
                 writer.WritePropertyName("iotEdge");
-                writer.WriteBooleanValue(IotEdge.Value);
+                writer.WriteBooleanValue(IsIotEdgeDevice.Value);
             }
             writer.WriteEndObject();
         }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceCapabilities.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceCapabilities.cs
@@ -16,13 +16,10 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of DeviceCapabilities. </summary>
-        /// <param name="iotEdge"> The property that determines if the device is an edge device or not. </param>
-        internal DeviceCapabilities(bool? iotEdge)
+        /// <param name="isIotEdgeDevice"> The property that determines if the device is an edge device or not. </param>
+        internal DeviceCapabilities(bool? isIotEdgeDevice)
         {
-            IotEdge = iotEdge;
+            IsIotEdgeDevice = isIotEdgeDevice;
         }
-
-        /// <summary> The property that determines if the device is an edge device or not. </summary>
-        public bool? IotEdge { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionProperties.Serialization.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionProperties.Serialization.cs
@@ -10,7 +10,7 @@ using Azure.Core;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    public partial class FaultInjectionConnectionProperties : IUtf8JsonSerializable
+    internal partial class FaultInjectionConnectionProperties : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionProperties.cs
@@ -8,7 +8,7 @@
 namespace Azure.Iot.Hub.Service.Models
 {
     /// <summary> The FaultInjectionConnectionProperties. </summary>
-    public partial class FaultInjectionConnectionProperties
+    internal partial class FaultInjectionConnectionProperties
     {
         /// <summary> Initializes a new instance of FaultInjectionConnectionProperties. </summary>
         public FaultInjectionConnectionProperties()
@@ -23,9 +23,6 @@ namespace Azure.Iot.Hub.Service.Models
             Action = action;
             BlockDurationInMinutes = blockDurationInMinutes;
         }
-
-        /// <summary> The action to perform. </summary>
-        public FaultInjectionConnectionPropertiesAction? Action { get; set; }
         public int? BlockDurationInMinutes { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionPropertiesAction.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionPropertiesAction.cs
@@ -11,7 +11,7 @@ using System.ComponentModel;
 namespace Azure.Iot.Hub.Service.Models
 {
     /// <summary> The action to perform. </summary>
-    public readonly partial struct FaultInjectionConnectionPropertiesAction : IEquatable<FaultInjectionConnectionPropertiesAction>
+    internal readonly partial struct FaultInjectionConnectionPropertiesAction : IEquatable<FaultInjectionConnectionPropertiesAction>
     {
         private readonly string _value;
 

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionProperties.Serialization.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionProperties.Serialization.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    public partial class FaultInjectionProperties : IUtf8JsonSerializable
+    internal partial class FaultInjectionProperties : IUtf8JsonSerializable
     {
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionProperties.cs
@@ -10,7 +10,7 @@ using System;
 namespace Azure.Iot.Hub.Service.Models
 {
     /// <summary> The FaultInjectionProperties. </summary>
-    public partial class FaultInjectionProperties
+    internal partial class FaultInjectionProperties
     {
         /// <summary> Initializes a new instance of FaultInjectionProperties. </summary>
         public FaultInjectionProperties()


### PR DESCRIPTION
This was discussed and concluded on the previous PR but I checked it in to unblock everyone. This PR renames one of the fields and makes all the fault injection models internal.