### PR TITLE
Fix typo in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /sdk/core/                                      @pakrym @KrzysztofCwalina
 
 # Extensions
-/sdk/extensions/                                @parkym
+/sdk/extensions/                                @pakrym
 
 # Service teams
 # PRLabel: %AzConfig


### PR DESCRIPTION
I was perusing the CODEOWNERS and happened to notice this.