### PR TITLE
Add back partition tests; fix bug in envelope generation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -77,18 +77,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Builds a batch <see cref="AmqpMessage" /> from a set of <see cref="AmqpMessage" />.
         /// </summary>
         ///
-        /// <param name="source">The set of messages to use as the body of the batch message.</param>
+        /// <param name="batchMessages">The set of messages to use as the body of the batch message.</param>
         /// <param name="firstMessage"></param>
         ///
         /// <returns>The batch <see cref="AmqpMessage" /> containing the source messages.</returns>
         ///
         private static AmqpMessage BuildAmqpBatchFromMessages(
-            IEnumerable<AmqpMessage> source,
+            IList<AmqpMessage> batchMessages,
             SBMessage firstMessage = null)
         {
             AmqpMessage batchEnvelope;
-
-            var batchMessages = source.ToList();
 
             if (batchMessages.Count == 1)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -70,7 +70,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     {
                         return SBMessageToAmqpMessage(sbMessage);
                     }
-                }), firstMessage);
+                }).ToList(), firstMessage);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/13717
- The service made an update to require that sessionId matches partitionKey even on non-partitioned entities.

While fixing the test, I ran into a bug where our batch envelope was not correctly setting properties based on the first message. The fix is to force the Select enumeration before calling the `BuildAmpMessageFromBatch` method, because otherwise `firstMessage` is always passed as null.