### PR TITLE
[Azure.Core] Extend Test Environment with Storage Endpoint

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -117,6 +117,11 @@ namespace Azure.Core.TestFramework
         public string AuthorityHostUrl => GetRecordedOptionalVariable("AZURE_AUTHORITY_HOST");
 
         /// <summary>
+        ///   The suffix for Azure Storage accounts for the active cloud environment, such as "core.windows.net".  Recorded.
+        /// </summary>
+        public string StorageEndpointSuffix => GetRecordedOptionalVariable("STORAGE_ENDPOINT_SUFFIX");
+
+        /// <summary>
         ///   The client id of the Azure Active Directory service principal to use during Live tests. Recorded.
         /// </summary>
         public string ClientId => GetRecordedVariable("CLIENT_ID");


### PR DESCRIPTION
# Summary

The focus of these changes is to expose the Storage Endpoint Suffix for the active Azure environment to the execution environment for tests. This
value differs between cloud environments and there is no convenient way to query it from the data plane.

This is needed to allow for building a full connection string for a storage account within within the scope of a test execution.

# Last Upstream Rebase

Wednesday, July 28, 4:14pm (EDT)

# References and Related Issues 

- [[Test Resources] Extend with Storage Endpoint](https://github.com/Azure/azure-sdk-tools/issues/828) (#828)
- [New-TestResources.ps1 should set AZURE_AUTHORITY_HOST environment variable](https://github.com/Azure/azure-sdk-tools/issues/757) (#757)
- [Event Hubs: AAD Auth failure when testing against other clouds](https://github.com/Azure/azure-sdk-for-net/issues/12964) (#12964)
- [Event Hub Live Test Change](https://github.com/Azure/azure-sdk-for-net/issues/13217) (#13217)