### PR TITLE
ServiceBus: Fix lines breaks in docs

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 7.0.0-preview.5 (Unreleased)
 
-
 ## 7.0.0-preview.4 (2020-07-07)
+
 ### Acknowledgements
 Thank you to our developer community members who helped to make the Service Bus client library better with their contributions and design input for this release:
 - Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
@@ -22,8 +22,8 @@ Thank you to our developer community members who helped to make the Service Bus 
 - Change output list type from IList<ServiceBusReceivedMessage> to IReadOnlyList<ServiceBusReceivedMessage>
 - Removed ServiceBusException.FailureReason.ClientClosed in favor of throwing ObjectDisposedException
 
-
 ## 7.0.0-preview.3 (2020-06-08)
+
 ### Acknowledgements
 Thank you to our developer community members who helped to make the Service Bus client library better with their contributions and design input for this release:
 - Daniel Marbach _([GitHub](https://github.com/danielmarbach))_

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CONTRIBUTING.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CONTRIBUTING.md
@@ -31,20 +31,20 @@ Tests in the Service Bus client library are split into two categories:
 
 The Live tests read information from the following environment variables:
 
-`SERVICE_BUS_RESOURCEGROUP`  
- The name of the Azure resource group that contains the Service Bus namespace
+`SERVICE_BUS_RESOURCEGROUP`\
+The name of the Azure resource group that contains the Service Bus namespace
 
-`SERVICE_BUS_SUBSCRIPTION`  
- The identifier (GUID) of the Azure subscription to which the service principal belongs
+`SERVICE_BUS_SUBSCRIPTION`\
+The identifier (GUID) of the Azure subscription to which the service principal belongs
 
-`SERVICE_BUS_TENANT`  
- The identifier (GUID) of the Azure Active Directory tenant that contains the service principal
+`SERVICE_BUS_TENANT`\
+The identifier (GUID) of the Azure Active Directory tenant that contains the service principal
 
-`SERVICE_BUS_CLIENT`  
- The identifier (GUID) of the Azure Active Directory application that is associated with the service principal
+`SERVICE_BUS_CLIENT`\
+The identifier (GUID) of the Azure Active Directory application that is associated with the service principal
 
-`SERVICE_BUS_SECRET`  
- The client secret (password) of the Azure Active Directory application that is associated with the service principal
+`SERVICE_BUS_SECRET`\
+The client secret (password) of the Azure Active Directory application that is associated with the service principal
 
 ### Samples
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -70,7 +70,7 @@ The v4 client allowed for sending a single message or a list of messages, which 
 | `QueueClient.SendAsync(Message)` or `MessageSender.SendAsync(Message)`                          | `ServiceBusSender.SendMessageAsync(ServiceBusMessage)`                               | [Send a message](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-message) |
 | `QueueClient.SendAsync(IList<Message>)` or `MessageSender.SendAsync(IList<Message>)`                          | `messageBatch = ServiceBusSender.CreateMessageBatchAsync()` `messageBatch.TryAddMessage(ServiceBusMessage)` `ServiceBusSender.SendMessagesAsync(messageBatch)` or `ServiceBusSender.SendMessagesAsync(IEnumerable<ServiceBusMessage>)`                              | [Send a batch of messages](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-batch-of-messages) |
 
-### Receiving messages 
+### Receiving messages
 
 | In v4                                          | Equivalent in v7                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
@@ -78,7 +78,7 @@ The v4 client allowed for sending a single message or a list of messages, which 
 | `MessageReceiver.ReceiveAsync()`                      | `ServiceBusReceiver.ReceiveMessagesAsync()`                               | [Receive a batch of messages](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md#sending-and-receiving-a-batch-of-messages) |
 | `QueueClient.RegisterMessageHandler()` or   `MessageReceiver.RegisterMessageHandler()`                    | `ServiceBusProcessor.ProcessMessageAsync += MessageHandler` `ServiceBusProcessor.ProcessErrorAsync += ErrorHandler` `ServiceBusProcessor.StartProcessingAsync()`                               | [Receive messages using processor](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample04_Processor.md) |
 
-### Working with sessions 
+### Working with sessions
 
 | In v4                                          | Equivalent in v7                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
@@ -157,18 +157,11 @@ Console.WriteLine(body);
 
 In v4, `QueueClient`/`MessageSender`/`MessageReceiver` would be created directly, after which user would call `SendAsync()` method via `QueueClient`/`MessageSender` to send a batch of messages and `ReceiveAsync()` method via `MessageReceiver` to receive a batch of messages.
 
-In v7, user would initialize the `ServiceBusClient` and call `CreateSender()` method to create a `ServiceBusSender` and 
-`CreateReceiver()` method to create a `ServiceBusReceiver`. There are two ways of sending several messages at once. 
+In v7, user would initialize the `ServiceBusClient` and call `CreateSender()` method to create a `ServiceBusSender` and `CreateReceiver()` method to create a `ServiceBusReceiver`. There are two ways of sending several messages at once.
 
-The first way uses the `SendMessagesAsync`overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will 
-attempt to fit all of the supplied messages in a single message batch that we will send to the service. If the messages are 
-too large to fit in a single batch, the operation will throw an exception. 
+The first way uses the `SendMessagesAsync`overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of the supplied messages in a single message batch that we will send to the service. If the messages are too large to fit in a single batch, the operation will throw an exception.
 
-The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object, 
-which will allow you to attempt to add messages one at a time to the batch using the `TryAddMessage` method. If the message cannot 
-fit in the batch, `TryAddMessage` will return false. If the `ServiceBusMessageBatch` accepts a message, user can be confident that 
-it will not violate size constraints when calling `SendMessagesAsync()` via `ServiceBusSender`. To receive a set of messages, a
-user would call `ReceiveMessagesAsync()` method via `ServiceBusReceiver`. 
+The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object, which will allow you to attempt to add messages one at a time to the batch using the `TryAddMessage` method. If the message cannot fit in the batch, `TryAddMessage` will return false. If the `ServiceBusMessageBatch` accepts a message, user can be confident that it will not violate size constraints when calling `SendMessagesAsync()` via `ServiceBusSender`. To receive a set of messages, a user would call `ReceiveMessagesAsync()` method via `ServiceBusReceiver`.
 
 In v4:
 
@@ -211,6 +204,7 @@ await receiver.CloseAsync();
 ```
 
 In v7:
+
 ```C# Snippet:ServiceBusInitializeSend
 string connectionString = "<connection_string>";
 string queueName = "<queue_name>";
@@ -238,6 +232,7 @@ await sender.SendMessagesAsync(messageBatch);
 ```
 
 And to receive a batch:
+
 ```C# Snippet:ServiceBusReceiveBatch
 // create a receiver that we can use to receive the messages
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -45,6 +45,7 @@ dotnet add package Azure.Messaging.ServiceBus --version 7.0.0-preview.4
 For the Service Bus client library to interact with a queue or topic, it will need to understand how to connect and authorize with it.  The easiest means for doing so is to use a connection string, which is created automatically when creating a Service Bus namespace.  If you aren't familiar with shared access policies in Azure, you may wish to follow the step-by-step guide to [get a Service Bus connection string](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quickstart-topics-subscriptions-portal#get-the-connection-string).
 
 Once you have a connection string, you can authenticate your client with it.
+
 ```C# Snippet:ServiceBusAuthConnString
 // Create a ServiceBusClient that will authenticate using a connection string
 string connectionString = "<connection_string>";
@@ -79,7 +80,7 @@ To interact with these resources, one should be familiar with the following SDK 
 
 - A [Service Bus session receiver](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebussessionreceiver?view=azure-dotnet-preview) is scoped to a particular session-enabled queue or subscription, and is created using the Service Bus client. The session receiver is almost identical to the standard receiver, with the difference being that session management operations are exposed which only apply to session-enabled entities. These operations include getting and setting session state, as well as renewing session locks.
 
-- A [Service Bus processor](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusprocessor?view=azure-dotnet-preview) is scoped to a particular queue or subscription, and is created using the Service Bus client. The `ServiceBusProcessor` can be thought of as an abstraction around a set of receivers. It uses a callback model to allow code to be specified when a message is received and when an exception occurs. It offers automatic completion of processed messages, automatic message lock renewal, and concurrent execution of user specified event handlers. Because of its feature set, it should be the go to tool for writing applications that receive from Service Bus entities. The ServiceBusReceiver is recommended for more complex scenarios in which the processor is not able to provide the fine-grained control that one can expect when using the ServiceBusReceiver directly. 
+- A [Service Bus processor](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusprocessor?view=azure-dotnet-preview) is scoped to a particular queue or subscription, and is created using the Service Bus client. The `ServiceBusProcessor` can be thought of as an abstraction around a set of receivers. It uses a callback model to allow code to be specified when a message is received and when an exception occurs. It offers automatic completion of processed messages, automatic message lock renewal, and concurrent execution of user specified event handlers. Because of its feature set, it should be the go to tool for writing applications that receive from Service Bus entities. The ServiceBusReceiver is recommended for more complex scenarios in which the processor is not able to provide the fine-grained control that one can expect when using the ServiceBusReceiver directly.
 
 - A [Service Bus session processor](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebussessionprocessor?view=azure-dotnet-preview) is scoped to a particular session-enabled queue or subscription, and is created using the Service Bus client. The session processor is almost identical to the standard processor, with the difference being that session management operations are exposed which only apply to session-enabled entities.
 
@@ -100,8 +101,7 @@ For more concepts and deeper discussion, see: [Service Bus Advanced Features](ht
 
 ### Send and receive a message
 
-Message sending is performed using the `ServiceBusSender`. Receiving is performed using the 
-`ServiceBusReceiver`.
+Message sending is performed using the `ServiceBusSender`. Receiving is performed using the `ServiceBusReceiver`.
 
 ```C# Snippet:ServiceBusSendAndReceive
 string connectionString = "<connection_string>";
@@ -131,10 +131,7 @@ Console.WriteLine(body);
 
 ### Send and receive a batch of messages
 
-There are two ways of sending several messages at once. The first way uses the `SendMessagesAsync`
-overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of
-the supplied messages in a single message batch that we will send to the service. If the messages are too large
-to fit in a single batch, the operation will throw an exception.
+There are two ways of sending several messages at once. The first way uses the `SendMessagesAsync` overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of the supplied messages in a single message batch that we will send to the service. If the messages are too large to fit in a single batch, the operation will throw an exception.
 
 ```C# Snippet:ServiceBusSendAndReceiveBatch
 IList<ServiceBusMessage> messages = new List<ServiceBusMessage>();
@@ -143,9 +140,8 @@ messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 // send the messages
 await sender.SendMessagesAsync(messages);
 ```
-The second way of doing this is using safe-batching. With safe-batching, you can create a 
-`ServiceBusMessageBatch` object, which will allow you to attempt to add messages one at a time to the 
-batch using the `TryAdd` method. If the message cannot fit in the batch, `TryAdd` will return false.
+
+The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object, which will allow you to attempt to add messages one at a time to the batch using the `TryAdd` method. If the message cannot fit in the batch, `TryAdd` will return false.
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
@@ -198,9 +194,7 @@ await receiver.AbandonMessageAsync(receivedMessage);
 
 ### Defer a message
 
-Deferring a message will prevent it from being received again using the `ReceiveMessageAsync` or `ReceiveMessagesAsync` methods.
-Instead, there are separate methods, `ReceiveDeferredMessageAsync` and `ReceiveDeferredMessagesAsync` 
-for receiving deferred messages.
+Deferring a message will prevent it from being received again using the `ReceiveMessageAsync` or `ReceiveMessagesAsync` methods. Instead, there are separate methods, `ReceiveDeferredMessageAsync` and `ReceiveDeferredMessagesAsync` for receiving deferred messages.
 
 ```C# Snippet:ServiceBusDeferMessage
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -216,9 +210,7 @@ ServiceBusReceivedMessage deferredMessage = await receiver.ReceiveDeferredMessag
 
 ### Dead letter a message
 
-Dead lettering a message is similar to deferring with one main difference being that messages will be automatically dead lettered
-by the service after they have been received a certain number of times. Applications can choose to manually dead letter messages based on
-their requirements. When a message is dead lettered it is actually moved to a subqueue of the original queue.
+Dead lettering a message is similar to deferring with one main difference being that messages will be automatically dead lettered by the service after they have been received a certain number of times. Applications can choose to manually dead letter messages based on their requirements. When a message is dead lettered it is actually moved to a subqueue of the original queue.
 
 ```C# Snippet:ServiceBusDeadLetterMessage
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -233,11 +225,7 @@ ServiceBusReceivedMessage dlqMessage = await dlqReceiver.ReceiveMessageAsync();
 
 ### Using the Processor
 
-The `ServiceBusProcessor` can be thought of as an abstraction around a set of receivers. It uses a callback model to allow code to be specified
-when a message is received and when an exception occurs. It offers automatic completion of processed messages, automatic message lock renewal, 
-and concurrent execution of user specified event handlers. Because of its feature set, it should be the go to tool for writing applications that receive
-from Service Bus entities. The ServiceBusReceiver is recommended for more complex scenarios in which the processor is not able to provide the fine-grained control 
-that one can expect when using the ServiceBusReceiver directly. 
+The `ServiceBusProcessor` can be thought of as an abstraction around a set of receivers. It uses a callback model to allow code to be specified when a message is received and when an exception occurs. It offers automatic completion of processed messages, automatic message lock renewal, and concurrent execution of user specified event handlers. Because of its feature set, it should be the go to tool for writing applications that receive from Service Bus entities. The ServiceBusReceiver is recommended for more complex scenarios in which the processor is not able to provide the fine-grained control that one can expect when using the ServiceBusReceiver directly.
 
 ```C# Snippet:ServiceBusProcessMessages
 string connectionString = "<connection_string>";
@@ -310,6 +298,7 @@ await processor.StopProcessingAsync();
 ### Authenticating with Azure.Identity
 
 The [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity/README.md) provides easy Azure Active Directory support for authentication.
+
 ```C# Snippet:ServiceBusAuthAAD
 // Create a ServiceBusClient that will authenticate through Active Directory
 string fullyQualifiedNamespace = "yournamespace.servicebus.windows.net";
@@ -333,13 +322,14 @@ A `ServiceBusException` is triggered when an operation specific to Service Bus h
 
 - `Reason` : Provides a set of well-known reasons for the failure that help to categorize and clarify the root cause.  These are intended to allow for applying exception filtering and other logic where inspecting the text of an exception message wouldn't be ideal.   Some key failure reasons are:
 
-  - **Service Timeout** : This indicates that the Service Bus service did not respond to an operation within the expected amount of time.  This may have been caused by a transient network issue or service problem.  The Service Bus service may or may not have successfully completed the request; the status is not known.  It is recommended to attempt to verify the current state and retry if necessary.  
+  - **Service Timeout** : This indicates that the Service Bus service did not respond to an operation within the expected amount of time.  This may have been caused by a transient network issue or service problem.  The Service Bus service may or may not have successfully completed the request; the status is not known.  It is recommended to attempt to verify the current state and retry if necessary.
 
   - **Message Lock Lost** : This can occur if the processing takes longer than the lock duration specified at the entity level for a message. If this error occurs consistently, it may be worth increasing the message lock duration. Otherwise, callers can renew the message lock while they are processing the message to ensure that this error doesn't occur.
-  
+
   - **Messaging Entity Not Found**: A Service Bus resource, such as a queue, topic, or subscription could not be found by the Service Bus service. This may indicate that it has been deleted from the service or that there is an issue with the Service Bus service itself.
-  
+
 Reacting to a specific failure reason for the `ServiceBusException` can be accomplished in several ways, such as by applying an exception filter clause as part of the `catch` block:
+
 ```csharp
 try
 {
@@ -351,19 +341,18 @@ catch (ServiceBusExceptions ex) where
     // Take action based on a service timeout
 }
 ```
-  
+
 ### Other exceptions
 
 For detailed information about the failures represented by the `ServiceBusException` and other exceptions that may occur, please refer to [Service Bus messaging exceptions](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-exceptions).
 
-You can also easily [enable console logging](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/samples/Diagnostics.md#logging) if you want to dig
-deeper into the requests you're making against the service.
+You can also easily [enable console logging](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/samples/Diagnostics.md#logging) if you want to dig deeper into the requests you're making against the service.
 
 ## Next steps
 
 Beyond the introductory scenarios discussed, the Azure Service Bus client library offers support for additional scenarios to help take advantage of the full feature set of the Azure Service Bus service. In order to help explore some of these scenarios, the Service Bus client library offers a project of samples to serve as an illustration for common scenarios. Please see the [samples README](./samples/README.md) for details.
 
-## Contributing  
+## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample01_HelloWorld.md
@@ -4,8 +4,7 @@ This sample demonstrates how to send and receive messages from a Service Bus que
 
 ### Send and receive a message
 
-Message sending is performed using the `ServiceBusSender`. Receiving is performed using the 
-`ServiceBusReceiver`.
+Message sending is performed using the `ServiceBusSender`. Receiving is performed using the `ServiceBusReceiver`.
 
 ```C# Snippet:ServiceBusSendAndReceive
 string connectionString = "<connection_string>";
@@ -35,10 +34,7 @@ Console.WriteLine(body);
 
 ### Send and receive a batch of messages
 
-There are two ways of sending several messages at once. The first way uses the `SendMessagesAsync`
-overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of
-the supplied messages in a single message batch that we will send to the service. If the messages are too large
-to fit in a single batch, the operation will throw an exception.
+There are two ways of sending several messages at once. The first way uses the `SendMessagesAsync` overload that accepts an IEnumerable of `ServiceBusMessage`. With this method, we will attempt to fit all of the supplied messages in a single message batch that we will send to the service. If the messages are too large to fit in a single batch, the operation will throw an exception.
 
 ```C# Snippet:ServiceBusSendAndReceiveBatch
 IList<ServiceBusMessage> messages = new List<ServiceBusMessage>();
@@ -47,9 +43,8 @@ messages.Add(new ServiceBusMessage(Encoding.UTF8.GetBytes("Second")));
 // send the messages
 await sender.SendMessagesAsync(messages);
 ```
-The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object,
-which will allow you to attempt to messages one at a time to the batch using TryAdd. If the message cannot fit in the batch,
-TryAdd will return false.
+
+The second way of doing this is using safe-batching. With safe-batching, you can create a `ServiceBusMessageBatch` object, which will allow you to attempt to messages one at a time to the batch using TryAdd. If the message cannot fit in the batch, TryAdd will return false.
 
 ```C# Snippet:ServiceBusSendAndReceiveSafeBatch
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
@@ -70,9 +65,7 @@ ServiceBusReceivedMessage peekedMessage = await receiver.PeekMessageAsync();
 
 ### Schedule a message
 
-We can schedule a message to be enqueued at a later time. The message won't be able to be received
-until that time, though it can still be peeked before that. We get back the message sequence number
-which can be used to cancel the scheduled message.
+We can schedule a message to be enqueued at a later time. The message won't be able to be received until that time, though it can still be peeked before that. We get back the message sequence number which can be used to cancel the scheduled message.
 
 ```C# Snippet:ServiceBusSchedule
 long seq = await sender.ScheduleMessageAsync(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample02_MessageSettlement.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample02_MessageSettlement.md
@@ -1,7 +1,6 @@
 # Settling Messages
 
-This sample demonstrates how to [settle](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations) received messages. Message settlement can only be used when using a receiver
-in [PeekLock](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock) mode, which is the default behavior.
+This sample demonstrates how to [settle](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#settling-receive-operations) received messages. Message settlement can only be used when using a receiver in [PeekLock](https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock) mode, which is the default behavior.
 
 ## Completing a message
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
@@ -4,8 +4,7 @@ This sample demonstrates how to send and receive session messages from a session
 
 ### Receiving from next available session
 
-Receiving from sessions is performed using the `ServiceBusSessionReceiver`. This
-type derives from `ServiceBusReceiver` and exposes session-related functionality.
+Receiving from sessions is performed using the `ServiceBusSessionReceiver`. This type derives from `ServiceBusReceiver` and exposes session-related functionality.
 
 ```C# Snippet:ServiceBusSendAndReceiveSessionMessage
 string connectionString = "<connection_string>";

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample05_SessionProcessor.md
@@ -4,8 +4,7 @@ This sample demonstrates how to use the session processor. The session processor
 
 ### Processing messages from a session-enabled queue
 
-Processing session messages is performed with a `ServiceBusSessionProcessor`. This type
-derives from `ServiceBusProcessor` and exposes session-related functionality.
+Processing session messages is performed with a `ServiceBusSessionProcessor`. This type derives from `ServiceBusProcessor` and exposes session-related functionality.
 
 ```C# Snippet:ServiceBusProcessSessionMessages
 string connectionString = "<connection_string>";

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
@@ -23,6 +23,7 @@ using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
 ```
 
 ### Sending and completing a message in a transaction across two entities
+
 There may be cases where you want to involve multiple entities in a single transaction. Service Bus offers support for this if your transaction involves sending to one entity and settling on a different entity. In order to accomplish this, you would use the send-via feature to route your message through the entity that you wish to settle a message on. The transaction will occur on that entity, and then Service Bus will forward the message onto its final destination.
 
 ```C# Snippet:ServiceBusTransactionalSendVia
@@ -51,6 +52,7 @@ using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
 ```
 
 ### Setting session state within a transaction
+
 ```C# Snippet:ServiceBusTransactionalSetSessionState
 string connectionString = "<connection_string>";
 string queueName = "<queue_name>";

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample07_CrudOperations.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample07_CrudOperations.md
@@ -34,6 +34,7 @@ QueueProperties createdQueue = await client.CreateQueueAsync(options);
 ```
 
 ### Get a queue
+
 You can retrieve an already created queue by supplying the queue name.
 
 ```C# Snippet:GetQueue
@@ -42,8 +43,7 @@ QueueProperties queue = await client.GetQueueAsync(queueName);
 
 ### Update a queue
 
-In order to update a queue, you will need to pass in the `QueueDescription` after 
-getting it from `GetQueueAsync`.
+In order to update a queue, you will need to pass in the `QueueDescription` after getting it from `GetQueueAsync`.
 
 ```C# Snippet:UpdateQueue
 queue.LockDuration = TimeSpan.FromSeconds(60);
@@ -111,8 +111,7 @@ SubscriptionProperties subscription = await client.GetSubscriptionAsync(topicNam
 
 ### Update a topic
 
-In order to update a topic, you will need to pass in the `TopicDescription` after 
-getting it from `GetTopicAsync`.
+In order to update a topic, you will need to pass in the `TopicDescription` after getting it from `GetTopicAsync`.
 
 ```C# Snippet:UpdateTopic
 topic.UserMetadata = "some metadata";
@@ -121,8 +120,7 @@ TopicProperties updatedTopic = await client.UpdateTopicAsync(topic);
 
 ### Update a subscription
 
-In order to update a subscription, you will need to pass in the 
-`SubscriptionDescription` after getting it from `GetSubscriptionAsync`.
+In order to update a subscription, you will need to pass in the `SubscriptionDescription` after getting it from `GetSubscriptionAsync`.
 
 ```C# Snippet:UpdateSubscription
 subscription.UserMetadata = "some metadata";
@@ -139,8 +137,7 @@ await client.DeleteSubscriptionAsync(topicName, subscriptionName);
 
 ### Delete a topic
 
-A topic can be deleted using the topic name. Deleting a topic will automatically delete the 
-associated subscriptions.
+A topic can be deleted using the topic name. Deleting a topic will automatically delete the associated subscriptions.
 
 ```C# Snippet:DeleteTopic
 await client.DeleteTopicAsync(topicName);


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13550

Added consistency to line breaks and whitespace. Used explicit line breaks (backslash instead of double spaces) in certain cases.
**Note**: Most of the docs correctly had single lines for paragraphs. I simply fixed the ones that had manual line breaks.