### PR TITLE
[FormRecognizer] Bug fix: GetCustomModel throws when model is being created

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Constructor in `TrainingFileFilter` made public.
+- Fixed a bug in which `FormTrainingClient.GetCustomModel` threw an exception if the model was still being created ([#13813](https://github.com/Azure/azure-sdk-for-net/issues/13813)).
 
 ### New Features
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample7_CopyCustomModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample7_CopyCustomModel.md
@@ -62,8 +62,8 @@ Now that we have authorization from the target Form Recognizer resource, we exec
 string modelId = "<source_modelId>";
 CustomFormModelInfo newModel = await sourceClient.StartCopyModelAsync(modelId, targetCopyAuth).WaitForCompletionAsync();
 
-Console.WriteLine($"Original modelID => {modelId}");
-Console.WriteLine($"Copied modelID => {newModel.ModelId}");
+Console.WriteLine($"Original model ID => {modelId}");
+Console.WriteLine($"Copied model ID => {newModel.ModelId}");
 ```
 
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
@@ -22,16 +22,11 @@ namespace Azure.AI.FormRecognizer.Training
 
             // TrainResult can be null if model is not ready yet.
 
-            if (model.TrainResult != null)
-            {
-                TrainingDocuments = ConvertToTrainingDocuments(model.TrainResult);
-                Errors = model.TrainResult.Errors;
-            }
-            else
-            {
-                TrainingDocuments = new List<TrainingDocumentInfo>();
-                Errors = new List<FormRecognizerError>();
-            }
+            TrainingDocuments = model.TrainResult != null
+                ? ConvertToTrainingDocuments(model.TrainResult)
+                : new List<TrainingDocumentInfo>();
+
+            Errors = model.TrainResult?.Errors ?? new List<FormRecognizerError>();
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
@@ -19,8 +19,19 @@ namespace Azure.AI.FormRecognizer.Training
             TrainingStartedOn = model.ModelInfo.TrainingStartedOn;
             TrainingCompletedOn = model.ModelInfo.TrainingCompletedOn;
             Submodels = ConvertToSubmodels(model);
-            TrainingDocuments = ConvertToTrainingDocuments(model.TrainResult);
-            Errors = ConvertToFormRecognizerError(model.TrainResult);
+
+            // TrainResult can be null if model is not ready yet.
+
+            if (model.TrainResult != null)
+            {
+                TrainingDocuments = ConvertToTrainingDocuments(model.TrainResult);
+                Errors = ConvertToFormRecognizerError(model.TrainResult);
+            }
+            else
+            {
+                TrainingDocuments = new List<TrainingDocumentInfo>();
+                Errors = new List<FormRecognizerError>();
+            }
         }
 
         /// <summary>
@@ -112,17 +123,14 @@ namespace Azure.AI.FormRecognizer.Training
         private static IReadOnlyList<TrainingDocumentInfo> ConvertToTrainingDocuments(TrainResult trainResult)
         {
             var trainingDocs = new List<TrainingDocumentInfo>();
-            if (trainResult?.TrainingDocuments != null)
+            foreach (var docs in trainResult.TrainingDocuments)
             {
-                foreach (var docs in trainResult?.TrainingDocuments)
-                {
-                    trainingDocs.Add(
-                        new TrainingDocumentInfo(
-                            docs.DocumentName,
-                            docs.PageCount,
-                            docs.Errors ?? new List<FormRecognizerError>(),
-                            docs.Status));
-                }
+                trainingDocs.Add(
+                    new TrainingDocumentInfo(
+                        docs.DocumentName,
+                        docs.PageCount,
+                        docs.Errors ?? new List<FormRecognizerError>(),
+                        docs.Status));
             }
             return trainingDocs;
         }
@@ -130,7 +138,7 @@ namespace Azure.AI.FormRecognizer.Training
         private static IReadOnlyList<FormRecognizerError> ConvertToFormRecognizerError(TrainResult trainResult)
         {
             var errors = new List<FormRecognizerError>();
-            foreach (var error in trainResult?.Errors)
+            foreach (var error in trainResult.Errors)
             {
                 errors.Add(new FormRecognizerError(error.ErrorCode, error.Message));
             }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CustomFormModel.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.FormRecognizer.Training
             if (model.TrainResult != null)
             {
                 TrainingDocuments = ConvertToTrainingDocuments(model.TrainResult);
-                Errors = ConvertToFormRecognizerError(model.TrainResult);
+                Errors = model.TrainResult.Errors;
             }
             else
             {
@@ -133,16 +133,6 @@ namespace Azure.AI.FormRecognizer.Training
                         docs.Status));
             }
             return trainingDocs;
-        }
-
-        private static IReadOnlyList<FormRecognizerError> ConvertToFormRecognizerError(TrainResult trainResult)
-        {
-            var errors = new List<FormRecognizerError>();
-            foreach (var error in trainResult.Errors)
-            {
-                errors.Add(new FormRecognizerError(error.ErrorCode, error.Message));
-            }
-            return errors;
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValueType.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValueType.cs
@@ -40,7 +40,7 @@ namespace Azure.AI.FormRecognizer.Models
         Float,
 
         /// <summary>
-        /// Used for <see cref="int"/> type.
+        /// Used for <see cref="long"/> type.
         /// </summary>
         Integer,
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -225,12 +225,12 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             var sourceClient = CreateFormTrainingClient();
             var targetClient = CreateFormTrainingClient();
-            var resourceID = TestEnvironment.TargetResourceId;
+            var resourceId = TestEnvironment.TargetResourceId;
             var region = TestEnvironment.TargetResourceRegion;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
 
-            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceID, region);
+            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, region);
 
             CopyModelOperation operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
@@ -251,7 +251,7 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             var sourceClient = CreateFormTrainingClient();
             var targetClient = CreateFormTrainingClient();
-            var resourceID = TestEnvironment.TargetResourceId;
+            var resourceId = TestEnvironment.TargetResourceId;
             var region = TestEnvironment.TargetResourceRegion;
 
             CopyAuthorization targetAuth = CopyAuthorization.FromJson("{\"modelId\":\"328c3b7d - a563 - 4ba2 - 8c2f - 2f26d664486a\",\"accessToken\":\"5b5685e4 - 2f24 - 4423 - ab18 - 000000000000\",\"expirationDateTimeTicks\":1591932653,\"resourceId\":\"resourceId\",\"resourceRegion\":\"westcentralus\"}");
@@ -264,11 +264,11 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             var sourceClient = CreateFormTrainingClient();
             var targetClient = CreateFormTrainingClient();
-            var resourceID = TestEnvironment.TargetResourceId;
+            var resourceId = TestEnvironment.TargetResourceId;
             var wrongRegion = TestEnvironment.TargetResourceRegion == "westcentralus" ? "eastus2" : "westcentralus";
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
-            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceID, wrongRegion);
+            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, wrongRegion);
 
             var operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
@@ -280,15 +280,15 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task GetCopyAuthorization()
         {
             var targetClient = CreateFormTrainingClient();
-            var resourceID = TestEnvironment.TargetResourceId;
+            var resourceId = TestEnvironment.TargetResourceId;
             var region = TestEnvironment.TargetResourceRegion;
 
-            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceID, region);
+            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, region);
 
             Assert.IsNotNull(targetAuth.ModelId);
             Assert.IsNotNull(targetAuth.AccessToken);
             Assert.IsNotNull(targetAuth.ExpiresOn);
-            Assert.AreEqual(resourceID, targetAuth.ResourceId);
+            Assert.AreEqual(resourceId, targetAuth.ResourceId);
             Assert.AreEqual(region, targetAuth.Region);
         }
 
@@ -296,10 +296,10 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task SerializeDeserializeCopyAuthorizationAsync()
         {
             var targetClient = CreateFormTrainingClient();
-            var resourceID = TestEnvironment.TargetResourceId;
+            var resourceId = TestEnvironment.TargetResourceId;
             var region = TestEnvironment.TargetResourceRegion;
 
-            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceID, region);
+            CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, region);
 
             string jsonTargetAuth = targetAuth.ToJson();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientMockTests.cs
@@ -69,6 +69,41 @@ namespace Azure.AI.FormRecognizer.Tests
             }
         }
 
+        [Test]
+        public async Task GetCustomModelDoesNotNeedTrainResult()
+        {
+            // When a model is not Ready, the "trainResult" property is not returned.
+            // We're mimicking this behavior here to make sure that we can parse the
+            // response even without the "trainResult" property.
+
+            // Ideally this test should be live, but the service behavior is
+            // non-deterministic. Any delay in sending the request could give the
+            // model enough time to change its status to Ready.
+
+            using var Stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
+                {
+                    ""modelInfo"": {
+                        ""modelId"": ""00000000-0000-0000-0000-000000000000"",
+                        ""status"": ""creating"",
+                        ""createdDateTime"": ""1975-04-04T00:00:00Z"",
+                        ""lastUpdatedTime"": ""1975-04-04T00:00:00Z""
+                    }
+                }"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = Stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse });
+            var options = new FormRecognizerClientOptions() { Transport = mockTransport };
+            var client = CreateInstrumentedClient(options);
+
+            var response = await client.GetCustomModelAsync("00000000-0000-0000-0000-000000000000");
+            var model = response.Value;
+
+            Assert.IsEmpty(model.TrainingDocuments);
+            Assert.IsEmpty(model.Errors);
+        }
+
         private static string GetString(RequestContent content)
         {
             using var stream = new MemoryStream();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientMockTests.cs
@@ -72,9 +72,9 @@ namespace Azure.AI.FormRecognizer.Tests
         [Test]
         public async Task GetCustomModelDoesNotNeedTrainResult()
         {
-            // When a model is not Ready, the "trainResult" property is not returned.
-            // We're mimicking this behavior here to make sure that we can parse the
-            // response even without the "trainResult" property.
+            // When a model is still being created, the "trainResult" property is
+            // not returned. We're mimicking this behavior here to make sure that
+            // we can parse the response even without the "trainResult" property.
 
             // Ideally this test should be live, but the service behavior is
             // non-deterministic. Any delay in sending the request could give the

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
@@ -111,11 +111,11 @@ namespace Azure.AI.FormRecognizer.Tests
             // making the test fail.
 
             var client = CreateFormTrainingClient(skipInstrumenting: true);
-            var resourceID = TestEnvironment.TargetResourceId;
+            var resourceId = TestEnvironment.TargetResourceId;
             var region = TestEnvironment.TargetResourceRegion;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: false);
-            CopyAuthorization targetAuth = await client.GetCopyAuthorizationAsync(resourceID, region);
+            CopyAuthorization targetAuth = await client.GetCopyAuthorizationAsync(resourceId, region);
 
             var operation = await client.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample8_CopyModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample8_CopyModel.cs
@@ -59,8 +59,8 @@ namespace Azure.AI.FormRecognizer.Samples
             //@@ string modelId = "<source_modelId>";
             CustomFormModelInfo newModel = await sourceClient.StartCopyModelAsync(modelId, targetCopyAuth).WaitForCompletionAsync();
 
-            Console.WriteLine($"Original modelID => {modelId}");
-            Console.WriteLine($"Copied modelID => {newModel.ModelId}");
+            Console.WriteLine($"Original model ID => {modelId}");
+            Console.WriteLine($"Copied model ID => {newModel.ModelId}");
             #endregion
         }
     }


### PR DESCRIPTION
Fixes #13813.

I suggest reading the issue description for context.

The solution was a simple null check.