### PR TITLE
[Event Hubs Client] Test Support for Multi-Cloud

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/assets/samples-azure-deploy.json
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/assets/samples-azure-deploy.json
@@ -1,134 +1,141 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "namespaceName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the Event Hubs namespace"
-            }
-        },
-        "eventHubName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the Event Hub"
-            }
-        },
-        "storageAccountName": {
-            "type": "string"
-        },
-        "blobContainerName" : {
-            "type": "string"
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Event Hubs namespace"
+      }
     },
-    "variables": {
-        "location": "[resourceGroup().location]",
-        "defaultSASKeyName": "RootManageSharedAccessKey",
-        "eventHubsAuthRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
+    "eventHubName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Event Hub"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "2015-08-01",
-            "name": "[parameters('namespaceName')]",
-            "type": "Microsoft.EventHub/Namespaces",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "Standard",
-                "tier": "Standard"
-            },
-            "resources": [
-                {
-                    "apiVersion": "2015-08-01",
-                    "name": "[parameters('eventHubName')]",
-                    "type": "EventHubs",
-                    "dependsOn": [
-                        "[concat('Microsoft.EventHub/namespaces/', parameters('namespaceName'))]"
-                    ],
-                    "properties": {
-                        "path": "[parameters('eventHubName')]"
-                    },
-                    "resources": [
-                    ]
-                }
-            ]
-        },
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2019-04-01",
-            "name": "[parameters('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "Standard_LRS",
-                "tier": "Standard"
-            },
-            "kind": "BlobStorage",
-            "properties": {
-                "networkAcls": {
-                    "bypass": "AzureServices",
-                    "virtualNetworkRules": [],
-                    "ipRules": [],
-                    "defaultAction": "Allow"
-                },
-                "supportsHttpsTrafficOnly": true,
-                "encryption": {
-                    "services": {
-                        "file": {
-                            "enabled": true
-                        },
-                        "blob": {
-                            "enabled": true
-                        }
-                    },
-                    "keySource": "Microsoft.Storage"
-                },
-                "accessTier": "Hot"
-            }
-        },
-        {
-            "type": "Microsoft.Storage/storageAccounts/blobServices",
-            "apiVersion": "2019-04-01",
-            "name": "[concat(parameters('storageAccountName'), '/default')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-            ],
-            "properties": {
-                "cors": {
-                    "corsRules": []
-                },
-                "deleteRetentionPolicy": {
-                    "enabled": false
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2019-04-01",
-            "name": "[concat(parameters('storageAccountName'), '/default/', parameters('blobContainerName'))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccountName'), 'default')]",
-                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-            ],
-            "properties": {
-                "publicAccess": "None"
-            }
-        }
-    ],
-    "outputs": {
-        "NamespaceConnectionString": {
-            "type": "string",
-            "value": "[listkeys(variables('eventHubsAuthRuleResourceId'),  '2015-08-01').primaryConnectionString]"
-        },
-        "EventHubName": {
-            "type": "string",
-            "value": "[parameters('namespaceName')]"
-        },
-        "StorageConnectionString": {
-            "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-        },
-        "BlobContainerName": {
-            "type": "string",
-            "value": "[parameters('blobContainerName')]"
-        }
+    "storageAccountName": {
+      "type": "string"
+    },
+    "blobContainerName": {
+      "type": "string"
+    },
+    "storageEndpointSuffix": {
+      "type": "string",
+      "defaultValue": "core.windows.net",
+      "metadata": {
+        "description": "The url suffix to use when creating storage connection strings."
+      }
     }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "eventHubsAuthRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]",
+    "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-08-01",
+      "name": "[parameters('namespaceName')]",
+      "type": "Microsoft.EventHub/Namespaces",
+      "location": "[variables('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
+      "resources": [
+        {
+          "apiVersion": "2015-08-01",
+          "name": "[parameters('eventHubName')]",
+          "type": "EventHubs",
+          "dependsOn": [
+            "[concat('Microsoft.EventHub/namespaces/', parameters('namespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('eventHubName')]"
+          },
+          "resources": []
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-04-01",
+      "name": "[parameters('storageAccountName')]",
+      "location": "[variables('location')]",
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
+      },
+      "kind": "BlobStorage",
+      "properties": {
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "virtualNetworkRules": [],
+          "ipRules": [],
+          "defaultAction": "Allow"
+        },
+        "supportsHttpsTrafficOnly": true,
+        "encryption": {
+          "services": {
+            "file": {
+              "enabled": true
+            },
+            "blob": {
+              "enabled": true
+            }
+          },
+          "keySource": "Microsoft.Storage"
+        },
+        "accessTier": "Hot"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices",
+      "apiVersion": "2019-04-01",
+      "name": "[concat(parameters('storageAccountName'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ],
+      "properties": {
+        "cors": {
+          "corsRules": []
+        },
+        "deleteRetentionPolicy": {
+          "enabled": false
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2019-04-01",
+      "name": "[concat(parameters('storageAccountName'), '/default/', parameters('blobContainerName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccountName'), 'default')]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ],
+      "properties": {
+        "publicAccess": "None"
+      }
+    }
+  ],
+  "outputs": {
+    "NamespaceConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('eventHubsAuthRuleResourceId'), '2015-08-01').primaryConnectionString]"
+    },
+    "EventHubName": {
+      "type": "string",
+      "value": "[parameters('namespaceName')]"
+    },
+    "StorageConnectionString": {
+      "type": "string",
+      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
+    },
+    "BlobContainerName": {
+      "type": "string",
+      "value": "[parameters('blobContainerName')]"
+    }
+  }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs
@@ -28,6 +28,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// <summary>The manager for common live test resource operations.</summary>
         private static readonly LiveResourceManager ResourceManager = new LiveResourceManager();
 
+        /// <summary>The location of the Azure Resource Manager for the active cloud environment.</summary>
+        private static readonly Uri AzureResourceManagerUri = new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl);
+
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
         private bool _disposed = false;
 
@@ -62,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var storageAccount = StorageTestEnvironment.Instance.StorageAccountName;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
+            var client = new StorageManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
             {
@@ -104,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new StorageManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 BlobContainer container = await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.CreateAsync(resourceGroup, storageAccount, CreateName(), PublicAccess.None)).ConfigureAwait(false);
                 return new StorageScope(container.Name);
@@ -126,7 +129,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             static string CreateName() => $"neteventhubs{ Guid.NewGuid().ToString("N").Substring(0, 12) }";
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription).ConfigureAwait(false);
                 var sku = new Sku(SkuName.StandardLRS, SkuTier.Standard);
@@ -134,7 +137,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 StorageAccount storageAccount = await ResourceManager.CreateRetryPolicy<StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters)).ConfigureAwait(false);
 
                 StorageAccountListKeysResult storageKeys = await ResourceManager.CreateRetryPolicy<StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name)).ConfigureAwait(false);
-                return new StorageTestEnvironment.StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix=core.windows.net", shouldRemoveAtCompletion: true);
+                return new StorageTestEnvironment.StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix={ StorageTestEnvironment.Instance.StorageEndpointSuffix }", shouldRemoveAtCompletion: true);
             }
         }
 
@@ -151,7 +154,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName)).ConfigureAwait(false);
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs
@@ -28,7 +28,12 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         public static StorageTestEnvironment Instance => Singleton.Value;
 
         /// <summary>The environment variable value for the storage account connection string, lazily evaluated.</summary>
-        private string StorageAccountConnectionString => GetOptionalVariable("EVENT_PROCESSOR_STORAGE_CONNECTION_STRING");
+        private string StorageAccountConnectionString => GetOptionalVariable("EVENTHUB_PROCESSOR_STORAGE_CONNECTION_STRING");
+
+        /// <summary>
+        ///   The storage account endpoint suffix of the cloud to use during Live tests.
+        /// </summary>
+        public new string StorageEndpointSuffix => base.StorageEndpointSuffix ?? "core.windows.net";
 
         /// <summary>
         ///   Indicates whether or not an ephemeral storage account was created for the current test execution.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -26,6 +26,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <summary>The manager for common live test resource operations.</summary>
         private static readonly LiveResourceManager ResourceManager = new LiveResourceManager();
 
+        /// <summary>The location of the Azure Resource Manager for the active cloud environment.</summary>
+        private static readonly Uri AzureResourceManagerUri = new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl);
+
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
         private bool _disposed = false;
 
@@ -86,7 +89,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
-            var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
+            var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
             {
@@ -148,7 +151,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             string CreateName() => $"net-eventhubs-{ Guid.NewGuid().ToString("D") }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription).ConfigureAwait(false);
 
@@ -173,7 +176,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName)).ConfigureAwait(false);
             }
@@ -217,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 var consumerGroups = client.ConsumerGroups.ListByEventHub
                 (
@@ -254,7 +257,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
+            using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
                 eventHub = await ResourceManager.CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub)).ConfigureAwait(false);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
@@ -115,6 +115,24 @@ namespace Azure.Messaging.EventHubs.Tests
         public string SharedAccessKey => ParsedConnectionString.Value.SharedAccessKey;
 
         /// <summary>
+        ///   The Azure Authority host to be used for authentication with the active cloud environment.
+        /// </summary>
+        ///
+        public new string AuthorityHostUrl => base.AuthorityHostUrl ?? "https://login.microsoftonline.com/";
+
+        /// <summary>
+        ///   The Azure Service Management endpoint to be used for management plane authentication with the active cloud environment.
+        /// </summary>
+        ///
+        public new string ServiceManagementUrl => base.ServiceManagementUrl ?? "https://management.core.windows.net/";
+
+        /// <summary>
+        ///   The location of the resource manager for the active cloud environment.
+        /// </summary>
+        ///
+        public new string ResourceManagerUrl  => base.ResourceManagerUrl ?? "https://management.azure.com/";
+
+        /// <summary>
         ///   Initializes a new instance of <see cref="EventHubsTestEnvironment"/>.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                   string resourceGroupName,
                                                                   string subscriptionId)
         {
-            using (var client = new ResourceManagementClient(new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            using (var client = new ResourceManagementClient(new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl), new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
             {
                 ResourceGroup resourceGroup = await CreateRetryPolicy<ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName)).ConfigureAwait(false);
                 return resourceGroup.Location;
@@ -87,8 +87,8 @@ namespace Azure.Messaging.EventHubs.Tests
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
                 var credential = new ClientCredential(EventHubsTestEnvironment.Instance.ClientId, EventHubsTestEnvironment.Instance.ClientSecret);
-                var context = new AuthenticationContext($"https://login.windows.net/{ EventHubsTestEnvironment.Instance.TenantId }");
-                AuthenticationResult result = await context.AcquireTokenAsync("https://management.core.windows.net/", credential).ConfigureAwait(false);
+                var context = new AuthenticationContext($"{ EventHubsTestEnvironment.Instance.AuthorityHostUrl }{ EventHubsTestEnvironment.Instance.TenantId }");
+                var result = await context.AcquireTokenAsync(EventHubsTestEnvironment.Instance.ServiceManagementUrl, credential).ConfigureAwait(false);
 
                 if ((string.IsNullOrEmpty(result?.AccessToken)))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -31,23 +31,38 @@ Tests in the Event Hubs client library are split into two categories:
 
 The Live tests read information from the following environment variables:
 
-`EVENTHUB_RESOURCE_GROUP`  
+- `EVENTHUB_RESOURCE_GROUP`  
  The name of the Azure resource group that contains the Event Hubs namespace
 
-`EVENTHUB_SUBSCRIPTION_ID`  
+- `EVENTHUB_SUBSCRIPTION_ID`  
  The identifier (GUID) of the Azure subscription to which the service principal belongs
 
-`EVENTHUB_TENANT_ID`  
+- `EVENTHUB_TENANT_ID`  
  The identifier (GUID) of the Azure Active Directory tenant that contains the service principal
 
-`EVENTHUB_CLIENT_ID`  
+- `EVENTHUB_CLIENT_ID`  
  The identifier (GUID) of the Azure Active Directory application that is associated with the service principal
 
-`EVENTHUB_CLIENT_SECRET`  
+- `EVENTHUB_CLIENT_SECRET`  
  The client secret (password) of the Azure Active Directory application that is associated with the service principal
  
-`EVENTHUB_PER_TEST_LIMIT_MINUTES`
+- `EVENTHUB_PER_TEST_LIMIT_MINUTES`
 The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.  If not provided, a default suitable for most local development environment runs is assumed.
+
+- `EVENTHUB_NAMESPACE_CONNECTION_STRING` _**(optional)**_  
+  The connection string to an existing Event Hubs namespace to use for testing.  If specified, this namespace will be used as the basis for the test run, with Event Hub instances dynamically managed by the tests.  When the run is complete, the namespace will be left in the state that it was in before the test run took place.  If not specified, a new namespace will be dynamically created for the test run and removed at the end of the run.
+  
+- `EVENTHUB_PROCESSOR_STORAGE_CONNECTION_STRING` _**(optional)**_  
+  The connection string to an existing Blob Storage account to use for `EventProcessorClient` testing.  If specified, this account will be used as the basis for the test run, with container instances dynamically managed by the tests.  When the run is complete, the account will be left in the state that it was in before the test run took place.  If not specified, a new storage account will be dynamically created for the test run and removed at the end of the run.
+  
+- `AZURE_AUTHORITY_HOST` _**(optional)**_  
+  The name of the Azure Authority to use for authenticating resource management operations.  The default for this is appropriate for use with the Azure public cloud; when testing in other cloud instances, this may be needed.  ****
+  
+- `SERVICE_MANAGEMENT_URL` _**(optional)**_  
+  The URL of the endpoint responsible for servivce management operations in Azure.  The default for this is appropriate for use with the Azure public cloud; when testing in other cloud instances, this may be needed.
+  
+- `RESOURCE_MANAGER_URL` _**(optional)**_  
+  The URL of the endpoint responsible for resource management operations in Azure.  The default for this is appropriate for use with the Azure public cloud; when testing in other cloud instances, this may be needed.
 
 To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.  You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>This is the next generation Azure Event Hubs .NET Standard Event Processor Host library. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
+    <Description>This is the legacy Azure Event Hubs .NET Standard Event Processor Host library. To view releases for the current generation of the Azure client libraries for .NET, please see: https://aka.ms/azsdk/releases.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <Version>4.2.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;Event Processor Host</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/releases</PackageReleaseNotes>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>This is the next generation Azure Event Hubs .NET Standard client library. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
+    <Description>This is the legacy Azure Event Hubs .NET Standard client library. To view releases for the current generation of the Azure client libraries for .NET, please see: https://aka.ms/azsdk/releases.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <Version>4.2.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/releases</PackageReleaseNotes>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var eventHubNamespace = TestUtility.EventHubsNamespace;
             var token = await AquireManagementTokenAsync();
-            var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
+            var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
 
             try
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription })
+            using (var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
                 eventHub = await CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub));
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"net-eventhubs-track-one-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.EventHubs.Tests
                 eventHubsNamespace = await CreateRetryPolicy<EHNamespace>().ExecuteAsync(() => client.Namespaces.CreateOrUpdateAsync(resourceGroup, CreateName(), eventHubsNamespace));
 
                 var accessKey = await CreateRetryPolicy<AccessKeys>().ExecuteAsync(() => client.Namespaces.ListKeysAsync(resourceGroup, eventHubsNamespace.Name, "RootManageSharedAccessKey"));
-                return new AzureResourceProperties(eventHubsNamespace.Name, accessKey.PrimaryConnectionString);
+                return new AzureResourceProperties(eventHubsNamespace.Name, accessKey.PrimaryConnectionString, true);
             }
         }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var token = await AquireManagementTokenAsync();
 
-            using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new EventHubManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));
                 ;
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             string CreateName() => $"neteventhubstrackone{ Guid.NewGuid().ToString("D").Substring(0, 4) }";
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 var location = await QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.EventHubs.Tests
                 var storageAccount = await CreateRetryPolicy<StorageManagement.StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters));
 
                 var storageKeys = await CreateRetryPolicy<StorageManagement.StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name));
-                return new AzureResourceProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix=core.windows.net");
+                return new AzureResourceProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix={ TestUtility.StorageEndpointSuffix }", true);
             }
         }
 
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var resourceGroup = TestUtility.EventHubsResourceGroup;
             var token = await AquireManagementTokenAsync();
 
-            using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
+            using (var client = new StorageManagementClient(TestUtility.ResourceManager, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
                 await CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName));
             }
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.EventHubs.Tests
                                                                           string resourceGroupName,
                                                                           string subscriptionId)
         {
-            using (var client = new ResourceManagementClient(new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
+            using (var client = new ResourceManagementClient(TestUtility.ResourceManager, new TokenCredentials(accessToken)) { SubscriptionId = subscriptionId })
             {
                 var resourceGroup = await CreateRetryPolicy<Microsoft.Azure.Management.ResourceManager.Models.ResourceGroup>().ExecuteAsync(() => client.ResourceGroups.GetAsync(resourceGroupName));
                 return resourceGroup.Location;
@@ -274,8 +274,8 @@ namespace Microsoft.Azure.EventHubs.Tests
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
                 var credential = new ClientCredential(TestUtility.EventHubsClient, TestUtility.EventHubsSecret);
-                var context = new AuthenticationContext($"https://login.windows.net/{ TestUtility.EventHubsTenant }");
-                var result = await context.AcquireTokenAsync("https://management.core.windows.net/", credential);
+                var context = new AuthenticationContext($"{ TestUtility.AuthorityHost }{ TestUtility.EventHubsTenant }");
+                var result = await context.AcquireTokenAsync(TestUtility.ServiceManagementUrl, credential).ConfigureAwait(false);
 
                 if ((String.IsNullOrEmpty(result?.AccessToken)))
                 {
@@ -293,12 +293,15 @@ namespace Microsoft.Azure.EventHubs.Tests
         {
             public readonly string Name;
             public readonly string ConnectionString;
+            public readonly bool ShouldRemoveAtCompletion;
 
             internal AzureResourceProperties(string name,
-                                             string connectionString)
+                                             string connectionString,
+                                             bool shouldRemoveAtCompletion)
             {
                 Name = name;
                 ConnectionString = connectionString;
+                ShouldRemoveAtCompletion = shouldRemoveAtCompletion;
             }
         }
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string EventHubsTenantEnvironmentVariableName = "EVENTHUB_TENANT_ID";
         internal const string EventHubsClientEnvironmentVariableName = "EVENTHUB_CLIENT_ID";
         internal const string EventHubsSecretEnvironmentVariableName = "EVENTHUB_CLIENT_SECRET";
+        internal const string AuthorityHostEnvironmentVariableName = "AZURE_AUTHORITY_HOST";
+        internal const string ServiceManagementUrlEnvironmentVariableName = "SERVICE_MANAGEMENT_URL";
+        internal const string ResourceManagerEnvironmentVariableName = "RESOURCE_MANAGER_URL";
+        internal const string StorageEndpointSuffixEnvironmentVariableName = "STORAGE_ENDPOINT_SUFFIX";
+        internal const string EventHubsNamespaceConnectionStringEnvironmentVariable = "EVENTHUB_T1_NAMESPACE_CONNECTION_STRING";
+        internal const string StorageConnectionStringEnvironmentVariable = "EVENTHUB_T1_STORAGE_CONNECTION_STRING";
 
         // General
         internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(180);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestRunFixture.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestRunFixture.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Azure.EventHubs.Tests
             Task namespaceDeleteTask = null;
             Task storageDeleteTask = null;
 
-            if (TestUtility.WasEventHubsNamespaceCreated)
+            if (TestUtility.ShouldRemoveNamespaceAfterTestRunCompletion)
             {
                 namespaceDeleteTask = EventHubScope.DeleteNamespaceAsync(TestUtility.EventHubsNamespace);
             }
 
-            if (TestUtility.WasStorageAccountCreated)
+            if (TestUtility.ShouldRemoveStorageAfterTestRunCompletion)
             {
                 storageDeleteTask = EventHubScope.DeleteStorageAsync(TestUtility.StorageAccountName);
             }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -28,15 +28,27 @@ namespace Microsoft.Azure.EventHubs.Tests
         private static readonly Lazy<string> EventHubsSecretInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSecretEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 
+        private static readonly Lazy<string> AuthorityHostInstance =
+            new Lazy<string>(() => ReadOptionalEnvironmentVariable(TestConstants.AuthorityHostEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        private static readonly Lazy<string> ServiceManagementUrlInstance =
+            new Lazy<string>(() => ReadOptionalEnvironmentVariable(TestConstants.ServiceManagementUrlEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        private static readonly Lazy<string> ResourceManagerInstance =
+            new Lazy<string>(() => ReadOptionalEnvironmentVariable(TestConstants.ResourceManagerEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        private static readonly Lazy<string> StorageEndpointSuffixInstance =
+           new Lazy<string>(() => ReadOptionalEnvironmentVariable(TestConstants.StorageEndpointSuffixEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
         private static readonly Lazy<EventHubScope.AzureResourceProperties> ActiveEventHubsNamespace =
             new Lazy<EventHubScope.AzureResourceProperties>(CreateNamespace, LazyThreadSafetyMode.ExecutionAndPublication);
 
         private static readonly Lazy<EventHubScope.AzureResourceProperties> ActiveStorageAccount =
             new Lazy<EventHubScope.AzureResourceProperties>(CreateStorageAccount, LazyThreadSafetyMode.ExecutionAndPublication);
 
-        internal static bool WasEventHubsNamespaceCreated => ActiveEventHubsNamespace.IsValueCreated;
+        public static bool ShouldRemoveNamespaceAfterTestRunCompletion => (ActiveEventHubsNamespace.IsValueCreated && ActiveEventHubsNamespace.Value.ShouldRemoveAtCompletion);
 
-        internal static bool WasStorageAccountCreated => ActiveStorageAccount.IsValueCreated;
+        public static bool ShouldRemoveStorageAfterTestRunCompletion => (ActiveStorageAccount.IsValueCreated && ActiveStorageAccount.Value.ShouldRemoveAtCompletion);
 
         internal static string EventHubsConnectionString => ActiveEventHubsNamespace.Value.ConnectionString;
 
@@ -55,6 +67,14 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal static string EventHubsClient => EventHubsClientInstance.Value;
 
         internal static string EventHubsSecret => EventHubsSecretInstance.Value;
+
+        internal static string AuthorityHost => AuthorityHostInstance.Value ?? "https://login.microsoftonline.com/";
+
+        internal static string ServiceManagementUrl => ServiceManagementUrlInstance.Value ?? "https://management.core.windows.net/";
+
+        internal static Uri ResourceManager => new Uri(ResourceManagerInstance.Value ?? "https://management.azure.com/");
+
+        internal static string StorageEndpointSuffix => StorageEndpointSuffixInstance.Value ?? "core.windows.net";
 
         internal static string GetEntityConnectionString(string entityName) =>
             new EventHubsConnectionStringBuilder(EventHubsConnectionString) { EntityPath = entityName }.ToString();
@@ -120,7 +140,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         private static string ReadEnvironmentVariable(string variableName)
         {
-            var environmentVar = Environment.GetEnvironmentVariable(variableName);
+            var environmentVar = ReadOptionalEnvironmentVariable(variableName);
 
             if (string.IsNullOrWhiteSpace(environmentVar))
             {
@@ -130,18 +150,50 @@ namespace Microsoft.Azure.EventHubs.Tests
             return environmentVar;
         }
 
-        private static EventHubScope.AzureResourceProperties CreateNamespace() =>
-            Task
+        private static string ReadOptionalEnvironmentVariable(string variableName) => Environment.GetEnvironmentVariable(variableName);
+
+        private static EventHubScope.AzureResourceProperties CreateNamespace()
+        {
+            var environmentConnectionString = ReadOptionalEnvironmentVariable(TestConstants.EventHubsNamespaceConnectionStringEnvironmentVariable);
+
+            if (!string.IsNullOrEmpty(environmentConnectionString))
+            {
+                var parsed = new EventHubsConnectionStringBuilder(environmentConnectionString);
+
+                return new EventHubScope.AzureResourceProperties
+                (
+                    parsed.Endpoint.Host.Substring(0, parsed.Endpoint.Host.IndexOf('.')),
+                    environmentConnectionString.Replace($";EntityPath={ parsed.EntityPath }", string.Empty),
+                    shouldRemoveAtCompletion: false
+                );
+            }
+
+            return Task
                 .Run(async () => await EventHubScope.CreateNamespaceAsync().ConfigureAwait(false))
                 .ConfigureAwait(false)
                 .GetAwaiter()
                 .GetResult();
+        }
 
-        private static EventHubScope.AzureResourceProperties CreateStorageAccount() =>
-            Task
+        private static EventHubScope.AzureResourceProperties CreateStorageAccount()
+        {
+            var environmentConnectionString = ReadOptionalEnvironmentVariable(TestConstants.StorageConnectionStringEnvironmentVariable);
+
+            if (!string.IsNullOrEmpty(environmentConnectionString))
+            {
+                return new EventHubScope.AzureResourceProperties
+                (
+                    TestConstants.StorageConnectionStringEnvironmentVariable,
+                    environmentConnectionString,
+                    shouldRemoveAtCompletion: false
+                );
+            }
+
+            return Task
                 .Run(async () => await EventHubScope.CreateStorageAsync().ConfigureAwait(false))
                 .ConfigureAwait(false)
                 .GetAwaiter()
                 .GetResult();
+        }
     }
 }

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -1,91 +1,223 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "baseName": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().name]",
-            "metadata": {
-                "description": "The base resource name."
-            }
-        },
-        "subscriptionId": {
-            "type": "string",
-            "defaultValue": "[subscription().subscriptionId]",
-            "metadata": {
-                "description": "The subscription ID to which the application and resources belong."
-            }
-        },
-        "tenantId": {
-            "type": "string",
-            "defaultValue": "[subscription().tenantId]",
-            "metadata": {
-                "description": "The tenant ID to which the application and resources belong."
-            }
-        },
-        "testApplicationOid": {
-            "type": "string",
-            "metadata": {
-                "description": "The client OID to grant access to test resources."
-            }
-        },
-        "testApplicationId": {
-            "type": "string",
-            "metadata": {
-                "description": "The application client ID used to run tests."
-            }
-        },
-        "testApplicationSecret": {
-            "type": "string",
-            "metadata": {
-                "description": "The application client secret used to run tests."
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "metadata": {
-                "description": "The location of the resources. By default, this is the same as the resource group."
-            }
-        },
-        "perTestExecutionLimitMinutes": {
-            "type": "string",
-            "defaultValue": "10",
-            "metadata": {
-                "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "baseName": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]",
+      "metadata": {
+        "description": "The base resource name."
+      }
     },
-    "variables": {
-        "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c",
-        "eventHubsDataOwnerRoleId": "f526a384-b230-433a-b45c-95f59c4a2dec"
+    "subscriptionId": {
+      "type": "string",
+      "defaultValue": "[subscription().subscriptionId]",
+      "metadata": {
+        "description": "The subscription ID to which the application and resources belong."
+      }
     },
-    "resources": [
-      {
-        "type": "Microsoft.Authorization/roleAssignments",
-        "apiVersion": "2019-04-01-preview",
-        "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('eventHubsDataOwnerRoleId'))]",
-        "properties": {
-          "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('eventHubsDataOwnerRoleId'))]",
-          "principalId": "[parameters('testApplicationOid')]",
-          "scope": "[resourceGroup().id]"
-        }
+    "tenantId": {
+      "type": "string",
+      "defaultValue": "[subscription().tenantId]",
+      "metadata": {
+        "description": "The tenant ID to which the application and resources belong."
+      }
+    },
+    "testApplicationOid": {
+      "type": "string",
+      "metadata": {
+        "description": "The client OID to grant access to test resources."
+      }
+    },
+    "testApplicationId": {
+      "type": "string",
+      "metadata": {
+        "description": "The application client ID used to run tests."
+      }
+    },
+    "testApplicationSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "The application client secret used to run tests."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location of the resources. By default, this is the same as the resource group."
+      }
+    },
+    "storageEndpointSuffix": {
+      "type": "string",
+      "defaultValue": "core.windows.net",
+      "metadata": {
+        "description": "The url suffix to use when creating storage connection strings."
+      }
+    },
+    "perTestExecutionLimitMinutes": {
+      "type": "string",
+      "defaultValue": "10",
+      "metadata": {
+        "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
+      }
+    }
+  },
+  "variables": {
+    "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+    "eventHubsDataOwnerRoleId": "f526a384-b230-433a-b45c-95f59c4a2dec",
+    "eventHubsNamespace": "[concat('eh-', parameters('baseName'))]",
+    "storageAccount": "[concat('blb', parameters('baseName'))]",
+    "eventHubsNamespace_T1": "[concat('t1-', variables('eventHubsNamespace'))]",
+    "storageAccount_T1": "[concat('t1', variables('storageAccount'))]",
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "eventHubsAuthRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubsNamespace'), variables('defaultSASKeyName'))]",
+    "eventHubsAuthRuleResourceId_T1": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubsNamespace_T1'), variables('defaultSASKeyName'))]",
+    "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]",
+    "storageAccountId_T1": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount_T1'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-08-01",
+      "name": "[variables('eventHubsNamespace')]",
+      "type": "Microsoft.EventHub/Namespaces",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-04-01",
+      "name": "[variables('storageAccount')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
       },
-      {
-        "type": "Microsoft.Authorization/roleAssignments",
-        "apiVersion": "2019-04-01-preview",
-        "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'))]",
-        "properties": {
-          "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
-          "principalId": "[parameters('testApplicationOid')]",
-          "scope": "[resourceGroup().id]"
+      "kind": "BlobStorage",
+      "properties": {
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "virtualNetworkRules": [],
+          "ipRules": [],
+          "defaultAction": "Allow"
+        },
+        "supportsHttpsTrafficOnly": true,
+        "encryption": {
+          "services": {
+            "file": {
+              "enabled": true
+            },
+            "blob": {
+              "enabled": true
+            }
+          },
+          "keySource": "Microsoft.Storage"
+        },
+        "accessTier": "Hot"
+      }
+    },
+    {
+      "apiVersion": "2015-08-01",
+      "name": "[variables('eventHubsNamespace_T1')]",
+      "type": "Microsoft.EventHub/Namespaces",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-04-01",
+      "name": "[variables('storageAccount_T1')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
+      },
+      "kind": "BlobStorage",
+      "properties": {
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "virtualNetworkRules": [],
+          "ipRules": [],
+          "defaultAction": "Allow"
+        },
+        "supportsHttpsTrafficOnly": true,
+        "encryption": {
+          "services": {
+            "file": {
+              "enabled": true
+            },
+            "blob": {
+              "enabled": true
+            }
+          },
+          "keySource": "Microsoft.Storage"
+        },
+        "accessTier": "Hot"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices",
+      "apiVersion": "2019-04-01",
+      "name": "[concat(variables('storageAccount'), '/default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]"
+      ],
+      "properties": {
+        "cors": {
+          "corsRules": []
+        },
+        "deleteRetentionPolicy": {
+          "enabled": false
         }
       }
-    ],
-    "outputs": {
-        "EVENTHUB_PER_TEST_LIMIT_MINUTES": {
-            "type": "string",
-            "value": "[parameters('perTestExecutionLimitMinutes')]"
-        }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2019-04-01-preview",
+      "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('eventHubsDataOwnerRoleId'))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('eventHubsDataOwnerRoleId'))]",
+        "principalId": "[parameters('testApplicationOid')]",
+        "scope": "[resourceGroup().id]"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2019-04-01-preview",
+      "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
+        "principalId": "[parameters('testApplicationOid')]",
+        "scope": "[resourceGroup().id]"
+      }
     }
+  ],
+  "outputs": {
+    "EVENTHUB_PER_TEST_LIMIT_MINUTES": {
+      "type": "string",
+      "value": "[parameters('perTestExecutionLimitMinutes')]"
+    },
+    "EVENTHUB_NAMESPACE_CONNECTION_STRING": {
+        "type": "string",
+        "value": "[listkeys(variables('eventHubsAuthRuleResourceId'), '2015-08-01').primaryConnectionString]"
+    },
+    "EVENTHUB_PROCESSOR_STORAGE_CONNECTION_STRING": {
+      "type": "string",
+      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccount'), ';AccountKey=', listKeys(variables('storageAccountId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
+    },
+    "EVENTHUB_T1_NAMESPACE_CONNECTION_STRING": {
+        "type": "string",
+        "value": "[listkeys(variables('eventHubsAuthRuleResourceId_T1'), '2015-08-01').primaryConnectionString]"
+    },
+    "EVENTHUB_T1_STORAGE_CONNECTION_STRING": {
+      "type": "string",
+      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccount_T1'), ';AccountKey=', listKeys(variables('storageAccountId_T1'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
+    }
+  }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to remove hardcoded assumptions about the Azure cloud environment in which tests are running and, instead, take
advantage of an extended set of environment variables in `Azure.Core`.

# Last Upstream Rebase

Thursday, July 29, 3:22pm (EDT)

# References and Related Issues 

- [[Azure.Core] Extend Test Environment with Storage Endpoint](https://github.com/Azure/azure-sdk-for-net/pull/13812) (#13812)
- [[Test Resources] Extend with Storage Endpoint](https://github.com/Azure/azure-sdk-tools/issues/828) (#828)
- [New-TestResources.ps1 should set AZURE_AUTHORITY_HOST environment variable](https://github.com/Azure/azure-sdk-tools/issues/757) (#757)
- [Event Hubs: AAD Auth failure when testing against other clouds](https://github.com/Azure/azure-sdk-for-net/issues/12964) (#12964)
- [Event Hub Live Test Change](https://github.com/Azure/azure-sdk-for-net/issues/13217) (#13217)
