### PR TITLE
feat(sdk-iot-tests): Add unit tests for IotHubSasCredential

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
@@ -120,6 +120,7 @@ namespace Azure.Iot.Hub.Service.Authentication
         public System.TimeSpan SasTokenTimeToLive { get { throw null; } }
         public string SharedAccessKey { get { throw null; } }
         public string SharedAccessPolicy { get { throw null; } }
+        public string GetSasToken() { throw null; }
     }
 }
 namespace Azure.Iot.Hub.Service.Models

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/IotHubSasCredential.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/IotHubSasCredential.cs
@@ -104,7 +104,7 @@ namespace Azure.Iot.Hub.Service.Authentication
             }.Uri;
         }
 
-        string ISasTokenProvider.GetSasToken()
+        public string GetSasToken()
         {
             lock (_lock)
             {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureBuilder.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureBuilder.cs
@@ -64,7 +64,7 @@ namespace Azure.Iot.Hub.Service.Authentication
         private static string BuildExpiresOn(TimeSpan timeToLive)
         {
             DateTimeOffset expiresOn = DateTimeOffset.UtcNow.Add(timeToLive);
-            TimeSpan secondsFromBaseTime = expiresOn.Subtract(SharedAccessSignatureConstants.EpochTime);
+            TimeSpan secondsFromBaseTime = expiresOn.Subtract(SharedAccessSignatureConstants.s_epochTime);
             long seconds = Convert.ToInt64(secondsFromBaseTime.TotalSeconds, CultureInfo.InvariantCulture);
             return Convert.ToString(seconds, CultureInfo.InvariantCulture);
         }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureConstants.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SharedAccessSignatureConstants.cs
@@ -10,20 +10,21 @@ namespace Azure.Iot.Hub.Service.Authentication
     /// </summary>
     internal static class SharedAccessSignatureConstants
     {
-        internal const int MaxKeyNameLength = 256;
-        internal const int MaxKeyLength = 256;
-        internal const string SharedAccessSignatureIdentifier = "SharedAccessSignature";
+        // The following keys are used to parse the relevant fields from an IoT hub connection string.
         internal const string HostNameIdentifier = "HostName";
         internal const string SharedAccessKeyIdentifier = "SharedAccessKey";
         internal const string SharedAccessPolicyIdentifier = "SharedAccessKeyName";
+
+        // The following keys are used for constructing the shared access signature token.
+        // Example returned string:
+        // SharedAccessSignature sr=<Audience>&sig=<Signature>&se=<ExpiresOnValue>[&skn=<KeyName>]
+        internal const string SharedAccessSignatureIdentifier = "SharedAccessSignature";
         internal const string AudienceFieldName = "sr";
         internal const string SignatureFieldName = "sig";
         internal const string KeyNameFieldName = "skn";
         internal const string ExpiryFieldName = "se";
-        internal const string SignedResourceFullFieldName = SharedAccessSignatureIdentifier + " " + AudienceFieldName;
-        internal const string KeyValueSeparator = "=";
-        internal const string PairSeparator = "&";
-        internal static readonly DateTime EpochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-        internal static readonly TimeSpan MaxClockSkew = TimeSpan.FromMinutes(5);
+
+        // The Unix time representation of January 1, 1970 midnight UTC.
+        internal static readonly DateTime s_epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Properties/AssemblyInfo.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Azure.Iot.Hub.Service.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/Azure.Iot.Hub.Service.Tests.csproj
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/Azure.Iot.Hub.Service.Tests.csproj
@@ -33,10 +33,4 @@
     <PackageReference Include="Castle.Core" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs">
-      <LinkBase>Shared\Azure.Core</LinkBase>
-    </Compile>
-  </ItemGroup>
-  
 </Project>

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/IotHubSasCredentialTests.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/IotHubSasCredentialTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Iot.Hub.Service.Authentication;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Azure.Iot.Hub.Service.Tests
+{
+    [Category("Unit")]
+    [Parallelizable(ParallelScope.All)]
+    public class IotHubSasCredentialTests
+    {
+        private static readonly Uri s_endpoint = new Uri("https://fake_endpoint");
+        private static readonly string s_testSharedAccessKey;
+
+        static IotHubSasCredentialTests()
+        {
+            // Create a base64 encoded key to be used for mocking the shared access key value.
+            var rnd = new Random();
+            var rndBytes = new byte[32];
+            rnd.NextBytes(rndBytes);
+
+            s_testSharedAccessKey = Convert.ToBase64String(rndBytes);
+        }
+
+        [Test]
+        public void ValidateCtorParameters()
+        {
+            // Arrange
+            string sharedAccessPolicy = "policy";
+            string sharedAccessKey = "key";
+
+            // Act and Assert
+            Assert.Throws<ArgumentNullException>(() => new IotHubSasCredential(sharedAccessPolicy, null));
+            Assert.Throws<ArgumentNullException>(() => new IotHubSasCredential(null, sharedAccessKey));
+        }
+
+        [Test]
+        public void CtorParametersNegativeTimeToLiveThrowsException()
+        {
+            // Arrange
+            string sharedAccessPolicy = "policy";
+            string sharedAccessKey = "key";
+            var ttl = TimeSpan.FromSeconds(-10);
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => new IotHubSasCredential(sharedAccessPolicy, sharedAccessKey, ttl));
+        }
+
+        [Test]
+        public void CtorSetsDefaultTimeToLive()
+        {
+            // Arrange
+            string sharedAccessPolicy = "policy";
+            string sharedAccessKey = "key";
+
+            // Act
+            var credentials = new IotHubSasCredential(sharedAccessPolicy, sharedAccessKey);
+
+            // Assert
+            credentials.SasTokenTimeToLive.Should().BePositive();
+        }
+
+        [Test]
+        public async Task CachesTokenIfNotExpired()
+        {
+            // Arrange
+            var ttl = TimeSpan.FromMinutes(1);
+
+            // Act
+            var credential = new IotHubSasCredential("policy", s_testSharedAccessKey, ttl)
+            {
+                Endpoint = s_endpoint,
+            };
+
+            string initialToken = credential.GetSasToken();
+            await Task.Delay(2000);
+            string newToken = credential.GetSasToken();
+
+            // Assert
+            newToken.Should().BeEquivalentTo(initialToken, "Token should be cached and returned");
+        }
+
+        [Test]
+        public async Task RegeneratesTokenIfExpired()
+        {
+            // Arrange
+            var ttl = TimeSpan.FromSeconds(1);
+
+            // Act
+            var credential = new IotHubSasCredential("policy", s_testSharedAccessKey, ttl)
+            {
+                Endpoint = s_endpoint,
+            };
+
+            string initialToken = credential.GetSasToken();
+            await Task.Delay(2000);
+            string newToken = credential.GetSasToken();
+
+            // Assert
+            newToken.Should().NotBeEquivalentTo(initialToken, "Token has expired, and should be regenerated");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds test around validating constructors and the cache/renewal logic in `IotHubSasCredential`.

Let me know if you see other tests cases that are relevant here.