### PR TITLE
Enable live tests on .NET Framework with latest packages

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -54,6 +54,10 @@ jobs:
         Windows_NetFramework:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
+        Windows_NetFramework_ProjectReferences:
+          OSVmImage: "windows-2019"
+          TestTargetFramework: net461
+          ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         MacOs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -70,6 +70,10 @@ namespace Azure.Core.Pipeline
                         message.Request.Content.WriteTo(requestStream, message.CancellationToken);
                     }
                 }
+                else
+                {
+                    request.ContentLength = 0;
+                }
 
                 WebResponse webResponse;
                 try

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -507,6 +507,27 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public async Task ContentLength0WhenNoContent()
+        {
+            StringValues contentLengthHeader = default;
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    Assert.True(context.Request.Headers.TryGetValue("Content-Length", out contentLengthHeader));
+                });
+
+            var transport = GetTransport();
+
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Post;
+            request.Uri.Reset(testServer.Address);
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual(contentLengthHeader.ToString(), "0");
+        }
+
+        [Test]
         public async Task RequestAndResponseHasRequestId()
         {
             using TestServer testServer = new TestServer(context => { });


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-net/issues/13893 made me realize we are not running live tests with project references on .net framework.

Fixes: #13893