### PR TITLE
Add private endpoint name to net sdk

### DIFF
--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncGroup.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncGroup.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// <param name="schema">Sync schema of the sync group.</param>
         /// <param name="usePrivateLinkConnection">If use private link
         /// connection is enabled.</param>
-        public SyncGroup(string id = default(string), string name = default(string), string type = default(string), int? interval = default(int?), System.DateTime? lastSyncTime = default(System.DateTime?), string conflictResolutionPolicy = default(string), string syncDatabaseId = default(string), string hubDatabaseUserName = default(string), string hubDatabasePassword = default(string), string syncState = default(string), SyncGroupSchema schema = default(SyncGroupSchema), bool? usePrivateLinkConnection = default(bool?))
+        /// <param name="privateEndpointName">Private endpoint name of the sync
+        /// group if use private link connection is enabled.</param>
+        public SyncGroup(string id = default(string), string name = default(string), string type = default(string), int? interval = default(int?), System.DateTime? lastSyncTime = default(System.DateTime?), string conflictResolutionPolicy = default(string), string syncDatabaseId = default(string), string hubDatabaseUserName = default(string), string hubDatabasePassword = default(string), string syncState = default(string), SyncGroupSchema schema = default(SyncGroupSchema), bool? usePrivateLinkConnection = default(bool?), string privateEndpointName = default(string))
             : base(id, name, type)
         {
             Interval = interval;
@@ -65,6 +67,7 @@ namespace Microsoft.Azure.Management.Sql.Models
             SyncState = syncState;
             Schema = schema;
             UsePrivateLinkConnection = usePrivateLinkConnection;
+            PrivateEndpointName = privateEndpointName;
             CustomInit();
         }
 
@@ -129,6 +132,13 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.usePrivateLinkConnection")]
         public bool? UsePrivateLinkConnection { get; set; }
+
+        /// <summary>
+        /// Gets private endpoint name of the sync group if use private link
+        /// connection is enabled.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.privateEndpointName")]
+        public string PrivateEndpointName { get; private set; }
 
     }
 }

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncMember.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncMember.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// Azure.</param>
         /// <param name="usePrivateLinkConnection">Whether to use private link
         /// connection.</param>
+        /// <param name="privateEndpointName">Private endpoint name of the sync
+        /// member if use private link connection is enabled, for sync members
+        /// in Azure.</param>
         /// <param name="serverName">Server name of the member database in the
         /// sync member</param>
         /// <param name="databaseName">Database name of the member database in
@@ -65,7 +68,7 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// 'UnProvisioned', 'Provisioning', 'Provisioned', 'ProvisionFailed',
         /// 'DeProvisioning', 'DeProvisioned', 'DeProvisionFailed',
         /// 'Reprovisioning', 'ReprovisionFailed', 'UnReprovisioned'</param>
-        public SyncMember(string id = default(string), string name = default(string), string type = default(string), string databaseType = default(string), string syncAgentId = default(string), System.Guid? sqlServerDatabaseId = default(System.Guid?), string syncMemberAzureDatabaseResourceId = default(string), bool? usePrivateLinkConnection = default(bool?), string serverName = default(string), string databaseName = default(string), string userName = default(string), string password = default(string), string syncDirection = default(string), string syncState = default(string))
+        public SyncMember(string id = default(string), string name = default(string), string type = default(string), string databaseType = default(string), string syncAgentId = default(string), System.Guid? sqlServerDatabaseId = default(System.Guid?), string syncMemberAzureDatabaseResourceId = default(string), bool? usePrivateLinkConnection = default(bool?), string privateEndpointName = default(string), string serverName = default(string), string databaseName = default(string), string userName = default(string), string password = default(string), string syncDirection = default(string), string syncState = default(string))
             : base(id, name, type)
         {
             DatabaseType = databaseType;
@@ -73,6 +76,7 @@ namespace Microsoft.Azure.Management.Sql.Models
             SqlServerDatabaseId = sqlServerDatabaseId;
             SyncMemberAzureDatabaseResourceId = syncMemberAzureDatabaseResourceId;
             UsePrivateLinkConnection = usePrivateLinkConnection;
+            PrivateEndpointName = privateEndpointName;
             ServerName = serverName;
             DatabaseName = databaseName;
             UserName = userName;
@@ -118,6 +122,13 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.usePrivateLinkConnection")]
         public bool? UsePrivateLinkConnection { get; set; }
+
+        /// <summary>
+        /// Gets private endpoint name of the sync member if use private link
+        /// connection is enabled, for sync members in Azure.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.privateEndpointName")]
+        public string PrivateEndpointName { get; private set; }
 
         /// <summary>
         /// Gets or sets server name of the member database in the sync member


### PR DESCRIPTION
This review is associated with the swagger changes at https://github.com/Azure/azure-rest-api-specs/pull/10264

SyncGroupCRUD and SyncMemberCRUD tests are passing with this change.

Code change has reached production. Rest api specs has been merged.