### PR TITLE
Normalize exceptions thrown by transports

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -86,7 +86,7 @@ namespace Azure.Core.Pipeline
             // WebException is thrown in the case of .Abort() call
             catch (WebException) when (message.CancellationToken.IsCancellationRequested)
             {
-                message.CancellationToken.ThrowIfCancellationRequested();
+                throw new TaskCanceledException();
             }
             catch (WebException webException)
             {

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -254,7 +254,7 @@ namespace Azure.Core.Tests
 
             cts.Cancel();
 
-            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await task);
+            Assert.ThrowsAsync(Is.InstanceOf<TaskCanceledException>(), async () => await task);
             Assert.AreEqual(1, i);
 
             testDoneTcs.Cancel();

--- a/sdk/core/Azure.Core/tests/PipelineTestBase.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTestBase.cs
@@ -16,9 +16,10 @@ namespace Azure.Core.Tests
             _isAsync = isAsync;
         }
 
-        protected async Task<Response> ExecuteRequest(Request request, HttpPipelineTransport transport)
+        protected async Task<Response> ExecuteRequest(Request request, HttpPipelineTransport transport, CancellationToken cancellationToken = default)
         {
             var message = new HttpMessage(request, new ResponseClassifier());
+            message.CancellationToken = cancellationToken;
             if (_isAsync)
             {
                 await transport.ProcessAsync(message);


### PR DESCRIPTION
HttpWebRequest transport doesn't throw OperationCancelledException anymore.