### PR TITLE
Changed clientside encryption metadata behavior

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideEncryptor.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientSideEncryptor.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.Blobs
                 cancellationToken).ConfigureAwait(false);
 
             metadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            metadata.Add(Constants.ClientSideEncryption.EncryptionDataKey, EncryptionDataSerializer.Serialize(encryptionData));
+            metadata[Constants.ClientSideEncryption.EncryptionDataKey] = EncryptionDataSerializer.Serialize(encryptionData);
 
             return (nonSeekableCiphertext, metadata);
         }


### PR DESCRIPTION
Previously, using clientside encryption, downloading a blob for edits
and reuploading while following our suggested mechanisms for preserving
metadata would cause a dictionary collision that would throw. This
behavior has been changed to match our legacy behavior, where new
encryption metadata overwrites any previously existing encryption
metadata.