### PR TITLE
Setting sessionId to be same as partition key and adding validation

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Release History
+## 4.1.4 (2020-08-05)
+- Setting sessionId to be same as partition key and adding validation
 
 ## 4.1.3 (2020-04-17)
 - Add `GetQueuesRuntimeInfoAsync`, `GetTopicsRuntimeInfoAsync` and `GetSubscriptionsRuntimeInfoAsync` to `ManagementClient` to allow retrieval of batched entity runtime information. [PR 10261](https://github.com/Azure/azure-sdk-for-net/pull/10261)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs
@@ -99,10 +99,10 @@ namespace Microsoft.Azure.ServiceBus
 
             set
             {
-                if (this.sessionId != null && !this.sessionId.Equals(value))
+                if (this.sessionId != null && this.sessionId != value)
                 {
                     // SessionId is set. Then partition key must be same as session id.
-                    throw new InvalidOperationException("PartitionKey:" + value + " is not same as SessionId:" + this.sessionId);
+                    throw new InvalidOperationException($"PartitionKey:{value} is not same as SessionId:{this.sessionId}");
                 }
 
                 Message.ValidatePartitionKey(nameof(this.PartitionKey), value);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs
@@ -99,6 +99,12 @@ namespace Microsoft.Azure.ServiceBus
 
             set
             {
+                if (this.sessionId != null && !this.sessionId.Equals(value))
+                {
+                    // SessionId is set. Then partition key must be same as session id.
+                    throw new InvalidOperationException("PartitionKey:" + value + " is not same as SessionId:" + this.sessionId);
+                }
+
                 Message.ValidatePartitionKey(nameof(this.PartitionKey), value);
                 this.partitionKey = value;
             }
@@ -140,6 +146,7 @@ namespace Microsoft.Azure.ServiceBus
             {
                 Message.ValidateSessionId(nameof(this.SessionId), value);
                 this.sessionId = value;
+                this.PartitionKey = value;
             }
         }
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Azure ServiceBus SDK</AssemblyTitle>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
-    <Version>4.1.3</Version>
+    <Version>4.1.4</Version>
     <PackageTags>Microsoft;Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;CS1573;NU5125</NoWarn>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/AmqpConverterTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/AmqpConverterTests.cs
@@ -75,7 +75,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         {
             var messageBody = Encoding.UTF8.GetBytes("hello");
             var messageId = Guid.NewGuid().ToString();
-            var partitionKey = Guid.NewGuid().ToString();
             var viaPartitionKey = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var correlationId = Guid.NewGuid().ToString();
@@ -90,7 +89,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var sbMessage = new Message(messageBody)
             {
                 MessageId = messageId,
-                PartitionKey = partitionKey,
                 ViaPartitionKey = viaPartitionKey,
                 SessionId = sessionId,
                 CorrelationId = correlationId,
@@ -109,7 +107,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.Equal("SomeUserProperty", convertedSbMessage.UserProperties["UserProperty"]);
             Assert.Equal(messageBody, convertedSbMessage.Body);
             Assert.Equal(messageId, convertedSbMessage.MessageId);
-            Assert.Equal(partitionKey, convertedSbMessage.PartitionKey);
             Assert.Equal(viaPartitionKey, convertedSbMessage.ViaPartitionKey);
             Assert.Equal(sessionId, convertedSbMessage.SessionId);
             Assert.Equal(correlationId, convertedSbMessage.CorrelationId);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageTests.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         {
             var messageBody = Encoding.UTF8.GetBytes("test");
             var messageId = Guid.NewGuid().ToString();
-            var partitionKey = Guid.NewGuid().ToString();
             var viaPartitionKey = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var correlationId = Guid.NewGuid().ToString();
@@ -34,7 +33,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var brokeredMessage = new Message(messageBody)
             {
                 MessageId = messageId,
-                PartitionKey = partitionKey,
                 ViaPartitionKey = viaPartitionKey,
                 SessionId = sessionId,
                 CorrelationId = correlationId,
@@ -53,7 +51,6 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.NotNull(clone.Body);
             Assert.Equal("SomeUserProperty", clone.UserProperties["UserProperty"]);
             Assert.Equal(messageId, clone.MessageId);
-            Assert.Equal(partitionKey, clone.PartitionKey);
             Assert.Equal(viaPartitionKey, clone.ViaPartitionKey);
             Assert.Equal(sessionId, clone.SessionId);
             Assert.Equal(correlationId, clone.CorrelationId);
@@ -62,6 +59,29 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             Assert.Equal(contentType, clone.ContentType);
             Assert.Equal(replyTo, clone.ReplyTo);
             Assert.Equal(replyToSessionId, clone.ReplyToSessionId);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void TestSessionIdOverwritePartitionKey()
+        {
+            var messageBody = Encoding.UTF8.GetBytes("test");
+            var brokeredMessage = new Message(messageBody);
+            string partitionKey1 = "partitionKey1";
+            string sessionId1 = "sessionId1";
+            brokeredMessage.PartitionKey = partitionKey1;
+            Assert.Equal(partitionKey1, brokeredMessage.PartitionKey);
+            brokeredMessage.SessionId = sessionId1;
+            Assert.Equal(sessionId1, brokeredMessage.PartitionKey);
+            try
+            {
+                brokeredMessage.PartitionKey = partitionKey1;
+                Assert.False(true, "PartitionKey should not be set to a value different from SessionId");
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
         }
 
         public class WhenQueryingIsReceivedProperty


### PR DESCRIPTION
To prevent setting partition key to be different from sessionid. ServiceBus requires that SessionId and PartitionKey should be same, if SessionId is set on a message.