### PR TITLE
Avoid disposing buffered responses

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -189,12 +189,14 @@ namespace Azure.Core.Pipeline
         private sealed class HttpWebResponseImplementation: Response
         {
             private readonly HttpWebResponse _webResponse;
+            private Stream? _contentStream;
+            private Stream? _originalContentStream;
 
             public HttpWebResponseImplementation(string clientRequestId, HttpWebResponse webResponse)
             {
                 _webResponse = webResponse;
-
-                ContentStream = _webResponse.GetResponseStream();
+                _originalContentStream = _webResponse.GetResponseStream();
+                _contentStream = _originalContentStream;
                 ClientRequestId = clientRequestId;
             }
 
@@ -202,13 +204,23 @@ namespace Azure.Core.Pipeline
 
             public override string ReasonPhrase => _webResponse.StatusDescription;
 
-            public override Stream? ContentStream { get; set; }
+            public override Stream? ContentStream
+            {
+                get => _contentStream;
+                set
+                {
+                    // Make sure we don't dispose the content if the stream was replaced
+                    _originalContentStream = null;
+
+                    _contentStream = value;
+                }
+            }
 
             public override string ClientRequestId { get; set; }
 
             public override void Dispose()
             {
-                ContentStream?.Dispose();
+                _originalContentStream?.Dispose();
             }
 
             protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -159,6 +159,47 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public async Task BufferedResponsesReadableAfterMessageDisposed()
+        {
+            byte[] buffer = { 0 };
+
+            HttpPipeline httpPipeline = HttpPipelineBuilder.Build(GetOptions());
+
+            int bodySize = 1000;
+
+            using TestServer testServer = new TestServer(
+                async context =>
+                {
+                    for (int i = 0; i < bodySize; i++)
+                    {
+                        await context.Response.Body.WriteAsync(buffer, 0, 1);
+                    }
+                });
+
+            // Make sure we dispose things correctly and not exhaust the connection pool
+            var requestCount = 100;
+            for (int i = 0; i < requestCount; i++)
+            {
+                Response response;
+                using (HttpMessage message = httpPipeline.CreateMessage())
+                {
+                    message.Request.Uri.Reset(testServer.Address);
+                    message.BufferResponse = false;
+
+                    await ExecuteRequest(message, httpPipeline);
+
+                    Assert.AreEqual(message.Response.ContentStream.CanSeek, false);
+
+                    response = message.Response;
+                }
+
+                var memoryStream = new MemoryStream();
+                await response.ContentStream.CopyToAsync(memoryStream);
+                Assert.AreEqual(memoryStream.Length, bodySize);
+            }
+        }
+
+        [Test]
         public async Task RetriesTransportFailures()
         {
             int i = 0;


### PR DESCRIPTION
Mirrors behavior from HttpClientTransport:
https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs#L370-L379
