### PR TITLE
[TA] Move library to service v3.1-preview.1

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
@@ -1,4 +1,4 @@
-# Azure.AI.FormRecognizer
+# Azure.AI.TextAnalytics
 
 Run `dotnet msbuild /t:GenerateCode` to generate code.
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -11,16 +11,10 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Tests
 {
-    [ClientTestFixture(
-        /*TextAnalyticsClientOptions.ServiceVersion.V3_0,*/
-        TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_1)]
     public class TextAnalyticsClientLiveTests : RecordedTestBase<TextAnalyticsTestEnvironment>
     {
-        private readonly TextAnalyticsClientOptions.ServiceVersion _serviceVersion;
-
-        public TextAnalyticsClientLiveTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion) : base(isAsync)
+        public TextAnalyticsClientLiveTests(bool isAsync) : base(isAsync)
         {
-            _serviceVersion = serviceVersion;
             Sanitizer = new TextAnalyticsRecordedTestSanitizer();
         }
 
@@ -28,7 +22,7 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             string apiKey = TestEnvironment.ApiKey;
             credential ??= new AzureKeyCredential(apiKey);
-            options ??= new TextAnalyticsClientOptions(_serviceVersion);
+            options ??= new TextAnalyticsClientOptions();
             return InstrumentClient (
                 new TextAnalyticsClient(
                     new Uri(TestEnvironment.Endpoint),
@@ -88,7 +82,7 @@ namespace Azure.AI.TextAnalytics.Tests
         [Test]
         public async Task DetectLanguageWithNoneDefaultCountryHintTest()
         {
-            var options = new TextAnalyticsClientOptions(_serviceVersion)
+            var options = new TextAnalyticsClientOptions()
             {
                 DefaultCountryHint = DetectLanguageInput.None
             };


### PR DESCRIPTION
Because we are moving TA to codegen and the way the TA [swagger ](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.1/TextAnalytics.json#L26)is specified we can only have one generated version, we are moving to `v3.1-preview.1` for testing too.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13905