### PR TITLE
Use ReadOnlyMemoryStream for BinaryData.ToStream

### DIFF
--- a/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
@@ -224,16 +224,8 @@ namespace Azure.Core
         /// Converts the BinaryData to a stream.
         /// </summary>
         /// <returns>A stream representing the data.</returns>
-        public Stream ToStream()
-        {
-            if (MemoryMarshal.TryGetArray(
-                Bytes,
-                out ArraySegment<byte> data))
-            {
-                return new MemoryStream(data.Array, data.Offset, data.Count);
-            }
-            return new MemoryStream(Bytes.ToArray());
-        }
+        public Stream ToStream() =>
+            new ReadOnlyMemoryStream(Bytes);
 
         /// <summary>
         /// Converts the BinaryData to the specified type using

--- a/sdk/core/Azure.Core.Experimental/src/Primitives/ReadOnlyMemoryStream.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/ReadOnlyMemoryStream.cs
@@ -1,0 +1,130 @@
+﻿#pragma warning disable SA1636 // File header copyright text should match
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#pragma warning restore SA1636 // File header copyright text should match
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Core
+{
+    /// <summary>Provides a <see cref="Stream"/> for the contents of a <see cref="ReadOnlyMemory{Byte}"/>.</summary>
+    internal sealed class ReadOnlyMemoryStream : Stream
+    {
+        private readonly ReadOnlyMemory<byte> _content;
+        private int _position;
+
+        public ReadOnlyMemoryStream(ReadOnlyMemory<byte> content)
+        {
+            _content = content;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+
+        public override long Length => _content.Length;
+
+        public override long Position
+        {
+            get => _position;
+            set
+            {
+                if (value < 0 || value > int.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _position = (int)value;
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long pos =
+                origin == SeekOrigin.Begin ? offset :
+                origin == SeekOrigin.Current ? _position + offset :
+                origin == SeekOrigin.End ? _content.Length + offset :
+                throw new ArgumentOutOfRangeException(nameof(origin));
+
+            if (pos > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            else if (pos < 0)
+            {
+                throw new IOException("An attempt was made to move the position before the beginning of the stream.");
+            }
+
+            _position = (int)pos;
+            return _position;
+        }
+
+        public override int ReadByte()
+        {
+            ReadOnlySpan<byte> s = _content.Span;
+            return _position < s.Length ? s[_position++] : -1;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateReadArrayArguments(buffer, offset, count);
+            return Read(new Span<byte>(buffer, offset, count));
+        }
+
+        public int Read(Span<byte> buffer)
+        {
+            int remaining = _content.Length - _position;
+
+            if (remaining <= 0 || buffer.Length == 0)
+            {
+                return 0;
+            }
+            else if (remaining <= buffer.Length)
+            {
+                _content.Span.Slice(_position).CopyTo(buffer);
+                _position = _content.Length;
+                return remaining;
+            }
+            else
+            {
+                _content.Span.Slice(_position, buffer.Length).CopyTo(buffer);
+                _position += buffer.Length;
+                return buffer.Length;
+            }
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateReadArrayArguments(buffer, offset, count);
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled<int>(cancellationToken) :
+                Task.FromResult(Read(new Span<byte>(buffer, offset, count)));
+        }
+
+        public override void Flush() { }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        private static void ValidateReadArrayArguments(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0 || buffer.Length - offset < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/src/Primitives/ReadOnlyMemoryStream.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/ReadOnlyMemoryStream.cs
@@ -73,7 +73,7 @@ namespace Azure.Core
             return Read(new Span<byte>(buffer, offset, count));
         }
 
-        public int Read(Span<byte> buffer)
+        private int Read(Span<byte> buffer)
         {
             int remaining = _content.Length - _position;
 

--- a/sdk/core/Azure.Core.Experimental/tests/BinaryDataTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/BinaryDataTests.cs
@@ -74,7 +74,27 @@ namespace Azure.Core.Tests
             var stream = data.ToStream();
             var sr = new StreamReader(stream);
             Assert.AreEqual("payload", await sr.ReadToEndAsync());
+        }
 
+        [Test]
+        public async Task CannotWriteToReadOnlyMemoryStream()
+        {
+            var buffer = Encoding.UTF8.GetBytes("some data");
+            var payload = new MemoryStream(buffer);
+            var data = BinaryData.FromStream(payload);
+            var stream = data.ToStream();
+            Assert.That(
+                () => stream.Write(buffer, 0, buffer.Length),
+                Throws.InstanceOf<NotSupportedException>());
+            Assert.That(
+                async () => await stream.WriteAsync(buffer, 0, buffer.Length),
+                Throws.InstanceOf<NotSupportedException>());
+            Assert.That(
+                () => stream.WriteByte(1),
+                Throws.InstanceOf<NotSupportedException>());
+            Assert.IsFalse(stream.CanWrite);
+            var sr = new StreamReader(stream);
+            Assert.AreEqual("some data", await sr.ReadToEndAsync());
         }
 
         [Test]

--- a/sdk/core/Azure.Core.Experimental/tests/ReadOnlyMemoryStreamTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/ReadOnlyMemoryStreamTests.cs
@@ -38,6 +38,7 @@ namespace Azure.Core.Experimental.Tests
             stream.Seek(1, SeekOrigin.Current);
             Assert.AreEqual(buffer[7], stream.ReadByte());
             stream.Seek(-2, SeekOrigin.End);
+            Assert.AreEqual(buffer.Length - 2, stream.Position);
             Assert.AreEqual(buffer[buffer.Length - 2], stream.ReadByte());
             stream.Seek(-2, SeekOrigin.End);
             var read = new byte[buffer.Length - stream.Position];
@@ -70,6 +71,19 @@ namespace Azure.Core.Experimental.Tests
             Assert.AreEqual(
                 new ReadOnlyMemory<byte>(buffer, 3, buffer.Length - 3).ToArray(),
                 read);
+        }
+
+        [Test]
+        public void ValidatesPositionValue()
+        {
+            var buffer = Encoding.UTF8.GetBytes("some data");
+            var stream = new ReadOnlyMemoryStream(buffer);
+            Assert.That(
+                () => stream.Position = -1,
+                Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+                () => stream.Position = (long)int.MaxValue + 1,
+                Throws.InstanceOf<ArgumentException>());
         }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/tests/ReadOnlyMemoryStreamTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/ReadOnlyMemoryStreamTests.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace Azure.Core.Experimental.Tests
+namespace Azure.Core.Tests
 {
     public class ReadOnlyMemoryStreamTests
     {

--- a/sdk/core/Azure.Core.Experimental/tests/ReadOnlyMemoryStreamTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/ReadOnlyMemoryStreamTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Core.Experimental.Tests
+{
+    public class ReadOnlyMemoryStreamTests
+    {
+        [Test]
+        public async Task CanRead()
+        {
+            var buffer = Encoding.UTF8.GetBytes("some data");
+            var stream = new ReadOnlyMemoryStream(buffer);
+
+            var read = new byte[buffer.Length];
+            stream.Read(read, 0, buffer.Length);
+            Assert.AreEqual(buffer, read);
+
+            read = new byte[buffer.Length];
+            stream.Position = 0;
+            await stream.ReadAsync(read, 0, buffer.Length);
+            Assert.AreEqual(buffer, read);
+        }
+
+        [Test]
+        public async Task CanSeek()
+        {
+            var buffer = Encoding.UTF8.GetBytes("some data");
+            var stream = new ReadOnlyMemoryStream(buffer);
+
+            stream.Seek(5, SeekOrigin.Begin);
+            Assert.AreEqual(buffer[5], stream.ReadByte());
+            stream.Seek(1, SeekOrigin.Current);
+            Assert.AreEqual(buffer[7], stream.ReadByte());
+            stream.Seek(-2, SeekOrigin.End);
+            Assert.AreEqual(buffer[buffer.Length - 2], stream.ReadByte());
+            stream.Seek(-2, SeekOrigin.End);
+            var read = new byte[buffer.Length - stream.Position];
+            await stream.ReadAsync(read, 0, read.Length);
+            Assert.AreEqual(
+                new ReadOnlyMemory<byte>(buffer, buffer.Length - 2, 2).ToArray(),
+                read);
+        }
+
+        [Test]
+        public async Task ValidatesReadArguments()
+        {
+            var buffer = Encoding.UTF8.GetBytes("some data");
+            var stream = new ReadOnlyMemoryStream(buffer);
+            stream.Seek(3, SeekOrigin.Begin);
+            var read = new byte[buffer.Length - stream.Position];
+            Assert.That(
+               async () => await stream.ReadAsync(read, 0, buffer.Length),
+               Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+               async () => await stream.ReadAsync(null, 0, buffer.Length),
+               Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+               async () => await stream.ReadAsync(read, -1, read.Length),
+               Throws.InstanceOf<ArgumentException>());
+            Assert.That(
+               async () => await stream.ReadAsync(read, 0, -1),
+               Throws.InstanceOf<ArgumentException>());
+            await stream.ReadAsync(read, 0, read.Length);
+            Assert.AreEqual(
+                new ReadOnlyMemory<byte>(buffer, 3, buffer.Length - 3).ToArray(),
+                read);
+        }
+    }
+}


### PR DESCRIPTION
ReadOnlyMemoryStream copied from https://github.com/dotnet/runtime/blob/6072e4d3a7a2a1493f514cdf4be75a3d56580e84/src/libraries/Common/src/System/IO/ReadOnlyMemoryStream.cs

Removed overrides that are not part of .NET Standard 2.0:
-  `public override int Read(Span<byte> buffer)`
-  `public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))`

Also not including as it would require copying additional files:
- ` public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)`
-  `public override int EndRead(IAsyncResult asyncResult)`

Also not overriding `CopyTo/CopyToAsync` as the implementation in .NET Core relies on .NET Core Stream `WriteAsync` method that takes a `Span` (which is not included in Standard 2.0).
