### PR TITLE
[Service Bus Client] Guard Against Management Cleanup Failures

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure.Tests/TaskExtensionTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure.Tests/TaskExtensionTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -7,10 +6,10 @@ using Xunit;
 namespace Microsoft.Azure.ServiceBus.UnitTests
 {
     public class TaskExtensionsTests
-    {  
-        // It has been observed during the CI build that test runs can cause delays that were noted at 
-        // 1-2 seconds and were causing intermitten failures as a result.  The long delay has been set at 5 
-        // seconds arbitrarily, which may delay results should tests fail but is otherwise not expected to 
+    {
+        // It has been observed during the CI build that test runs can cause delays that were noted at
+        // 1-2 seconds and were causing intermittent failures as a result.  The long delay has been set at 5
+        // seconds arbitrarily, which may delay results should tests fail but is otherwise not expected to
         // be an actual wait time under normal circumstances.
         private readonly TimeSpan LongDelay = TimeSpan.FromSeconds(5);
         private readonly TimeSpan TinyDelay = TimeSpan.FromMilliseconds(1);
@@ -18,10 +17,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Fact]
         public void WithTimeoutThrowsWhenATimeoutOccursAndNoActionIsSpecified()
         {
-            Func<Task> actionUnderTest = async () =>  
+            Func<Task> actionUnderTest = async () =>
                 await Task.Delay(LongDelay)
                     .WithTimeout(TinyDelay);
-              
+
             Assert.ThrowsAsync<TimeoutException>(actionUnderTest);
         }
 
@@ -31,7 +30,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var timeoutActionInvoked = false;
 
             Action timeoutAction = () => { timeoutActionInvoked = true; };
-            
+
             await Task.Delay(LongDelay).WithTimeout(TinyDelay, null, timeoutAction);
             Assert.True(timeoutActionInvoked, "The timeout action should have been invoked.");
         }
@@ -39,7 +38,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Fact]
         public async Task WithTimeoutGenericThrowsWhenATimeoutOccursAndNoActionIsSpecified()
         {
-            Func<Task> actionUnderTest = async () => 
+            Func<Task> actionUnderTest = async () =>
                 await Task.Delay(LongDelay)
                     .ContinueWith( _ => "blue")
                     .WithTimeout(TinyDelay);
@@ -53,9 +52,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             var timeoutActionInvoked = false;
             var expectedResult = "green";
 
-            Func<string> timeoutCallback = () => 
-            { 
-                timeoutActionInvoked = true; 
+            Func<string> timeoutCallback = () =>
+            {
+                timeoutActionInvoked = true;
                 return expectedResult;
             };
 
@@ -88,13 +87,13 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         public async Task WithTimeoutGenericDoesNotThrowsWhenATimeoutDoesNotOccur()
         {
             var exceptionObserved = false;
-                        
+
             try
             {
                 await Task.Delay(TinyDelay).ContinueWith( _ => "blue").WithTimeout(LongDelay);
             }
             catch (TimeoutException)
-            {                
+            {
                 exceptionObserved = true;
             }
 
@@ -122,7 +121,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Fact]
         public async Task WithTimeoutPropagatesAnExceptionThatCompletesBeforeTimeout()
         {
-            Func<Task> actionUnderTest = async () => 
+            Func<Task> actionUnderTest = async () =>
                 await Task.Delay(TinyDelay)
                     .ContinueWith( _ => throw new MissingMemberException("oh no"))
                     .WithTimeout(LongDelay);
@@ -133,7 +132,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         [Fact]
         public async Task WithTimeoutGenericPropagatesAnExceptionThatCompletesBeforeTimeout()
         {
-           Func<Task> actionUnderTest = async () => 
+           Func<Task> actionUnderTest = async () =>
                await Task.Delay(TinyDelay)
                    .ContinueWith<string>( _ => throw new MissingMemberException("oh no"))
                    .WithTimeout(LongDelay);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
@@ -11,26 +11,26 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using Polly;
 
     internal static class ServiceBusScope
-    {   
+    {
         private static int randomSeed = Environment.TickCount;
 
         private static readonly ThreadLocal<Random> Rng = new ThreadLocal<Random>( () => new Random(Interlocked.Increment(ref randomSeed)), false);
-        private static readonly ManagementClient ManagementClient = new ManagementClient(TestUtility.NamespaceConnectionString);        
+        private static readonly ManagementClient ManagementClient = new ManagementClient(TestUtility.NamespaceConnectionString);
 
         /// <summary>
         ///   Creates a temporary Service Bus queue to be used within a given scope and then removed.
         /// </summary>
-        /// 
+        ///
         /// <param name="partitioned">If <c>true</c>, a partitioned queue will be used.</param>
         /// <param name="sessionEnabled">If <c>true</c>, a session will be enabled on the queue.</param>
         /// <param name="configureQueue">If provided, an action that can override the default properties used for queue creation.</param>
         /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        /// 
+        ///
         /// <returns>The queue scope that was created.</returns>
-        /// 
-        public static async Task<QueueScope> CreateQueueAsync(bool partitioned, 
-                                                              bool sessionEnabled,                                                   
-                                                              Action<QueueDescription> configureQueue = null, 
+        ///
+        public static async Task<QueueScope> CreateQueueAsync(bool partitioned,
+                                                              bool sessionEnabled,
+                                                              Action<QueueDescription> configureQueue = null,
                                                               [CallerMemberName] string caller = "")
         {
             var name = $"{ caller }-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             configureQueue?.Invoke(queueDescription);
             await CreateRetryPolicy<QueueDescription>().ExecuteAsync( () => ManagementClient.CreateQueueAsync(queueDescription));
 
-            return new QueueScope(name, async () => 
+            return new QueueScope(name, async () =>
             {
-                try 
-                { 
-                    await CreateRetryPolicy().ExecuteAsync( () => ManagementClient.DeleteQueueAsync(name)); 
-                }  
+                try
+                {
+                    await CreateRetryPolicy().ExecuteAsync( () => ManagementClient.DeleteQueueAsync(name));
+                }
                 catch (Exception ex)
                 {
                     TestUtility.Log($"There was an issue removing the queue: [{ name }].  This is considered non-fatal, but you should remove this manually from the Service Bus namespace. Exception: [{ ex.Message }]");
@@ -55,19 +55,19 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         /// <summary>
         ///   Creates a temporary Service Bus topic, with subscription to be used within a given scope and then removed.
         /// </summary>
-        /// 
+        ///
         /// <param name="partitioned">If <c>true</c>, a partitioned topic will be used.</param>
         /// <param name="sessionEnabled">If <c>true</c>, a session will be enabled  on the subscription.</param>
         /// <param name="configureTopic">If provided, an action that can override the default properties used for topic creation.</param>
         /// <param name="configureSubscription">If provided, an action that can override the default properties used for topic creation.</param>
         /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        /// 
+        ///
         /// <returns>The topic scope that was created.</returns>
-        /// 
-        public static async Task<TopicScope> CreateTopicAsync(bool partitioned, 
-                                                              bool sessionEnabled,                                                   
-                                                              Action<TopicDescription> configureTopic = null, 
-                                                              Action<SubscriptionDescription> configureSubscription = null, 
+        ///
+        public static async Task<TopicScope> CreateTopicAsync(bool partitioned,
+                                                              bool sessionEnabled,
+                                                              Action<TopicDescription> configureTopic = null,
+                                                              Action<SubscriptionDescription> configureSubscription = null,
                                                               [CallerMemberName] string caller = "")
         {
             var topicName = $"{ caller }-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
@@ -80,74 +80,86 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
             await CreateRetryPolicy<TopicDescription>().ExecuteAsync( () => ManagementClient.CreateTopicAsync(topicDescription));
             await CreateRetryPolicy<SubscriptionDescription>().ExecuteAsync( () => ManagementClient.CreateSubscriptionAsync(subscriptionDescription));
-                             
+
             return new TopicScope(topicName, subscripionName, async () =>
             {
-                try 
-                { 
-                    await CreateRetryPolicy().ExecuteAsync( () => ManagementClient.DeleteTopicAsync(topicName)); 
-                }  
+                try
+                {
+                    await CreateRetryPolicy().ExecuteAsync( () => ManagementClient.DeleteTopicAsync(topicName));
+                }
                 catch (Exception ex)
                 {
                     TestUtility.Log($"There was an issue removing the topic: [{ topicName }].  This is considered non-fatal, but you should remove this manually from the Service Bus namespace. Exception: [{ ex.Message }]");
                 }
             });
-        } 
+        }
 
         /// <summary>
         ///   Performs an operation within the scope of a temporary Service Bus queue.
         /// </summary>
-        /// 
+        ///
         /// <param name="partitioned">If <c>true</c>, a partitioned queue will be used.</param>
         /// <param name="sessionEnabled">If <c>true</c>, a session will be required on the queue.</param>
         /// <param name="scopedOperationAsync">The asynchronous operation to be performed; the name of the queue will be passed to the operation.</param>
         /// <param name="configureQueue">If provided, an action that can override the default properties used for queue creation.</param>
         /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        /// 
+        ///
         /// <returns>The task representing the operation being performed</returns>
-        /// 
-        public static async Task UsingQueueAsync(bool partitioned, 
-                                                 bool sessionEnabled, 
-                                                 Func<string, Task> scopedOperationAsync, 
-                                                 Action<QueueDescription> configureQueue = null, 
+        ///
+        public static async Task UsingQueueAsync(bool partitioned,
+                                                 bool sessionEnabled,
+                                                 Func<string, Task> scopedOperationAsync,
+                                                 Action<QueueDescription> configureQueue = null,
                                                  [CallerMemberName] string caller = "")
         {
             if (scopedOperationAsync == null)
             {
                 throw new ArgumentNullException(nameof(scopedOperationAsync));
-            }          
-            
+            }
+
             var scope = default(QueueScope);
 
             try
             {
-                 scope = await CreateQueueAsync(partitioned, sessionEnabled, configureQueue, caller);                 
+                 scope = await CreateQueueAsync(partitioned, sessionEnabled, configureQueue, caller);
                  await scopedOperationAsync(scope.Name);
             }
             finally
             {
-                await scope?.CleanupAsync();
+                try
+                {
+                    await scope?.CleanupAsync();
+                }
+                catch
+                {
+                    // This should not be considered a critical failure that results in a test failure.  Some management
+                    // operations may be temperamental.  Throwing here does not help to ensure resource cleanup, rather
+                    // only accomplishes flagging the test itself as a failure.
+                    //
+                    // If a queue fails to be deleted, removing of the associated namespace at the end of the
+                    // test run will also remove the orphan.
+                }
             }
         }
 
         /// <summary>
         ///   Performs an operation within the scope of a temporary Service Bus topic, with subscription.
         /// </summary>
-        /// 
+        ///
         /// <param name="partitioned">If <c>true</c>, a partitioned topic will be used.</param>
         /// <param name="sessionEnabled">If <c>true</c>, a session will be required on the subscription.</param>
         /// <param name="scopedOperationAsync">The asynchronous operation to be performed; the name of the topic and subscription will be passed to the operation.</param>
         /// <param name="configureTopic">If provided, an action that can override the default properties used for topic creation.</param>
         /// <param name="configureTSubscription">If provided, an action that can override the default properties used for topic creation.</param>
         /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        /// 
+        ///
         /// <returns>The task representing the operation being performed</returns>
-        /// 
-        public static async Task UsingTopicAsync(bool partitioned, 
-                                                 bool sessionEnabled, 
-                                                 Func<string, string, Task> scopedOperationAsync, 
-                                                 Action<TopicDescription> configureTopic = null, 
-                                                 Action<SubscriptionDescription> configureSubscription = null, 
+        ///
+        public static async Task UsingTopicAsync(bool partitioned,
+                                                 bool sessionEnabled,
+                                                 Func<string, string, Task> scopedOperationAsync,
+                                                 Action<TopicDescription> configureTopic = null,
+                                                 Action<SubscriptionDescription> configureSubscription = null,
                                                  [CallerMemberName] string caller = "")
         {
             if (scopedOperationAsync == null)
@@ -164,9 +176,21 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             }
             finally
             {
-                await scope?.CleanupAsync();
+                try
+                {
+                    await scope?.CleanupAsync();
+                }
+                catch
+                {
+                    // This should not be considered a critical failure that results in a test failure.  Some management
+                    // operations may be temperamental.  Throwing here does not help to ensure resource cleanup, rather
+                    // only accomplishes flagging the test itself as a failure.
+                    //
+                    // If a topic fails to be deleted, removing of the associated namespace at the end of the
+                    // test run will also remove the orphan.
+                }
             }
-        } 
+        }
 
         private static IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = TestConstants.RetryMaxAttempts, double exponentialBackoffSeconds = TestConstants.RetryExponentialBackoffSeconds, double baseJitterSeconds = TestConstants.RetryBaseJitterSeconds) =>
             Policy<T>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestConstants.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestConstants.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
     static class TestConstants
     {
-        // Enviornment Variables
+        // Environment Variables
         internal const string ConnectionStringEnvironmentVariable = "SERVICEBUS_T1_CONNECTION_STRING";
 
         // General

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestUtility.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestUtility.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
     static class TestUtility
     {
-        private static readonly Lazy<string> NamespaceConnectionStringInstance = 
+        private static readonly Lazy<string> NamespaceConnectionStringInstance =
             new Lazy<string>( () => new ServiceBusConnectionStringBuilder(ReadEnvironmentConnectionString()).ToString(), LazyThreadSafetyMode.PublicationOnly);
-        
-        private static readonly Lazy<string> SocketNamespaceConnectionStringInstance = 
+
+        private static readonly Lazy<string> SocketNamespaceConnectionStringInstance =
             new Lazy<string>( () => new ServiceBusConnectionStringBuilder(ReadEnvironmentConnectionString()){TransportType = TransportType.AmqpWebSockets}.ToString(), LazyThreadSafetyMode.PublicationOnly);
 
         internal static string NamespaceConnectionString => NamespaceConnectionStringInstance.Value;
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         }
 
         // String extension methods
-        
+
         internal static string GetString(this byte[] bytes)
         {
             return Encoding.ASCII.GetString(bytes);


### PR DESCRIPTION
# Summary

The focus of these changes is to add an additional guard against failures that occur when attempting to clean Azure resources using the `ManagementClient`.

# Last Upstream Rebase

Friday, August 7, 11:16am (EDT)

# References and Related Issues 

- [Failure example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=485709&view=ms.vss-test-web.build-test-results-tab&runId=12451382&resultId=100752&paneView=debug)