### PR TITLE
Adding content-type as first-class property to EventData

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -142,6 +142,11 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     }
                 }
             }
+
+            if (eventData.ContentType != null)
+            {
+                message.Properties.ContentType = eventData.ContentType;
+            }
         }
 
         static void UpdateEventDataHeaderAndProperties(AmqpMessage amqpMessage, EventData data)
@@ -231,6 +236,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     AddFieldToSystemProperty(amqpMessage.Properties.GroupId != null, data.SystemProperties, Properties.GroupIdName, amqpMessage.Properties.GroupId);
                     AddFieldToSystemProperty(amqpMessage.Properties.GroupSequence != null, data.SystemProperties, Properties.GroupSequenceName, amqpMessage.Properties.GroupSequence);
                     AddFieldToSystemProperty(amqpMessage.Properties.ReplyToGroupId != null, data.SystemProperties, Properties.ReplyToGroupIdName, amqpMessage.Properties.ReplyToGroupId);
+                    data.ContentType = amqpMessage.Properties.ContentType.Value;
                 }
             }
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventData.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Azure.EventHubs
             get; set;
         }
 
+        /// <summary>
+        /// Gets and sets type of the content.
+        /// </summary>
+        public string ContentType { get; set; }
+
         internal AmqpMessage AmqpMessage { get; set; }
 
         internal long LastSequenceNumber { get; set; }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Amqp/AmqpMEssageCoverterTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Amqp/AmqpMEssageCoverterTests.cs
@@ -37,6 +37,27 @@ namespace Microsoft.Azure.EventHubs.Tests.Amqp
             Assert.Equal("42", eventData.SystemProperties[Properties.CorrelationIdName].ToString());
         }
 
+        [Fact]
+        [DisplayTestMethodName]
+        public void ContentTypeFromAmqpMessage()
+        {
+            var message = AmqpMessage.Create(new MemoryStream(new byte[12]), true);
+            AddSection(message, SectionFlag.Properties);
+            message.Properties.ContentType = "this content type";
+            var eventData = AmqpMessageConverter.AmqpMessageToEventData(message);
+            Assert.Equal(message.Properties.ContentType.Value, eventData.ContentType);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void ContentTypeToAmqpMessage()
+        {
+            var eventData = new EventData(new byte[10]);
+            eventData.ContentType = "this content type";
+            var message = AmqpMessageConverter.EventDataToAmqpMessage(eventData);
+            Assert.Equal(message.Properties.ContentType.Value, eventData.ContentType);
+        }
+
         // for more information please take a look at https://github.com/Azure/azure-amqp/blob/339708e6390447004c3eec8ae28e6577199a4328/test/TestCases/AmqpMessageTests.cs#L160
         private static void AddSection(AmqpMessage message, SectionFlag sections)
         {


### PR DESCRIPTION
Addressing feature request by Clemens in https://github.com/Azure/azure-sdk-for-net/issues/8653