### PR TITLE
Convert enumerator of EventData to re-scannable collection

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventDataSender.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventDataSender.cs
@@ -24,14 +24,6 @@ namespace Microsoft.Azure.EventHubs
 
         public async Task SendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
         {
-            // Convert enumerator to a rescannable collection to avoid skipping events if underlying enumerator is not rescannabled.
-            var eventDataList = eventDatas.ToList();
-
-            await this.SendInternalAsync(eventDataList, partitionKey).ConfigureAwait(false);
-        }
-
-        public async Task SendInternalAsync(IEnumerable<EventData> eventDatas, string partitionKey)
-        {
             var processedEvents = await this.ProcessEvents(eventDatas).ConfigureAwait(false);
 
             await this.OnSendAsync(processedEvents, partitionKey)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventDataSender.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventDataSender.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Azure.EventHubs
 
         public async Task SendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
         {
+            // Convert enumerator to a rescannable collection to avoid skipping events if underlying enumerator is not rescannabled.
+            var eventDataList = eventDatas.ToList();
+
+            await this.SendInternalAsync(eventDataList, partitionKey).ConfigureAwait(false);
+        }
+
+        public async Task SendInternalAsync(IEnumerable<EventData> eventDatas, string partitionKey)
+        {
             var processedEvents = await this.ProcessEvents(eventDatas).ConfigureAwait(false);
 
             await this.OnSendAsync(processedEvents, partitionKey)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.EventHubs
         /// <see cref="PartitionSender.SendAsync(EventData)"/>
         public async Task SendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
         {
-            // Convert enumerator to a rescannable collection to avoid skipping events if underlying enumerator is not rescannabled.
+            // Convert enumerator to a rescannable collection to avoid skipping events if underlying enumerator is not re-scannabled.
             var eventDataList = eventDatas?.ToList();
 
             // eventDatas null check is inside ValidateEvents
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.EventHubs
             Task sendTask = null;
             try
             {
-                sendTask = this.InnerSender.SendInternalAsync(eventDataList, partitionKey);
+                sendTask = this.InnerSender.SendAsync(eventDataList, partitionKey);
                 await sendTask.ConfigureAwait(false);
             }
             catch (Exception exception)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.EventHubs
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Amqp;
@@ -297,28 +298,31 @@ namespace Microsoft.Azure.EventHubs
         /// <see cref="PartitionSender.SendAsync(EventData)"/>
         public async Task SendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
         {
+            // Convert enumerator to a rescannable collection to avoid skipping events if underlying enumerator is not rescannabled.
+            var eventDataList = eventDatas?.ToList();
+
             // eventDatas null check is inside ValidateEvents
-            int count = EventDataSender.ValidateEvents(eventDatas);
+            int count = EventDataSender.ValidateEvents(eventDataList);
 
             EventHubsEventSource.Log.EventSendStart(this.ClientId, count, partitionKey);
-            Activity activity = EventHubsDiagnosticSource.StartSendActivity(this.ClientId, this.ConnectionStringBuilder, partitionKey, eventDatas, count);
+            Activity activity = EventHubsDiagnosticSource.StartSendActivity(this.ClientId, this.ConnectionStringBuilder, partitionKey, eventDataList, count);
 
             Task sendTask = null;
             try
             {
-                sendTask = this.InnerSender.SendAsync(eventDatas, partitionKey);
+                sendTask = this.InnerSender.SendInternalAsync(eventDataList, partitionKey);
                 await sendTask.ConfigureAwait(false);
             }
             catch (Exception exception)
             {
                 EventHubsEventSource.Log.EventSendException(this.ClientId, exception.ToString());
-                EventHubsDiagnosticSource.FailSendActivity(activity, this.ConnectionStringBuilder, partitionKey, eventDatas, exception);
+                EventHubsDiagnosticSource.FailSendActivity(activity, this.ConnectionStringBuilder, partitionKey, eventDataList, exception);
                 throw;
             }
             finally
             {
                 EventHubsEventSource.Log.EventSendStop(this.ClientId);
-                EventHubsDiagnosticSource.StopSendActivity(activity, this.ConnectionStringBuilder, partitionKey, eventDatas, sendTask);
+                EventHubsDiagnosticSource.StopSendActivity(activity, this.ConnectionStringBuilder, partitionKey, eventDataList, sendTask);
             }
         }
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/PartitionSender.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/PartitionSender.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.EventHubs
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
 
@@ -131,26 +132,29 @@ namespace Microsoft.Azure.EventHubs
                 throw Fx.Exception.InvalidOperation(Resources.PartitionSenderInvalidWithPartitionKeyOnBatch);
             }
 
-            int count = EventDataSender.ValidateEvents(eventDatas);
+            // Convert enumerator to a rescannable collection to avoid skipping events if underlying enumerator is not re-scannabled.
+            var eventDataList = eventDatas?.ToList();
+
+            int count = EventDataSender.ValidateEvents(eventDataList);
             EventHubsEventSource.Log.EventSendStart(this.ClientId, count, null);
-            Activity activity = EventHubsDiagnosticSource.StartSendActivity(this.ClientId, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDatas, count);
+            Activity activity = EventHubsDiagnosticSource.StartSendActivity(this.ClientId, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDataList, count);
 
             Task sendTask = null;
             try
             {
-                sendTask = this.InnerSender.SendAsync(eventDatas, null);
+                sendTask = this.InnerSender.SendAsync(eventDataList, null);
                 await sendTask.ConfigureAwait(false);
             }
             catch (Exception exception)
             {
                 EventHubsEventSource.Log.EventSendException(this.ClientId, exception.ToString());
-                EventHubsDiagnosticSource.FailSendActivity(activity, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDatas, exception);
+                EventHubsDiagnosticSource.FailSendActivity(activity, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDataList, exception);
                 throw;
             }
             finally
             {
                 EventHubsEventSource.Log.EventSendStop(this.ClientId);
-                EventHubsDiagnosticSource.StopSendActivity(activity, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDatas, sendTask);
+                EventHubsDiagnosticSource.StopSendActivity(activity, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDataList, sendTask);
             }
         }
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
@@ -338,12 +338,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task SendNonrescannableEnumerator()
         {
             int numberOfEvents = 10;
-            int maxBatchSize = 3;
             string partitionId = "0";
 
             IEnumerable<EventData> GetBatch()
             {
-                for (int i = 0; i < maxBatchSize; i++)
+                for (int i = 0; i < numberOfEvents; i++)
                 {
                     yield return new EventData(Encoding.UTF8.GetBytes(i.ToString()));
                 }


### PR DESCRIPTION
This fix addresses the issue reported here https://github.com/Azure/azure-sdk-for-net/issues/8060

Fix will ensure we convert enumerator to a re-scannable collection before processing it any further. This helps to avoid skipping events if underlying enumerator is not re-scannabled.