### PR TITLE
[Event Hubs Client] Test Expectation Adjustments

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
                 try
                 {
-                    // Randomly pick one of the available partitons.
+                    // Randomly pick one of the available partitions.
                     var partitions = await this.GetPartitionsAsync(ehClient);
                     var partitionId = partitions[new Random().Next(partitions.Length)];
                     TestUtility.Log($"Randomly picked partition {partitionId}");
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     TestUtility.Log($"Creating a new receiver with offset EndOFStream");
                     receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnd());
 
-                    // Attemp to receive the message. This should return only 1 message.
+                    // Attempt to receive the message. This should return only 1 message.
                     var receiveTask = receiver.ReceiveAsync(100);
 
                     // Send a new message which is expected to go to the end of stream.
@@ -609,7 +609,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                         ehClient.CloseAsync());
                 }
 
-                await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 {
                     TestUtility.Log("Receiving another event from partition 0 on the closed receiver, this should fail");
                     await pReceiver.ReceiveAsync(1);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                         await pSender.CloseAsync();
                     }
 
-                    await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                     {
                         TestUtility.Log("Sending another event to partition 0 on the closed sender, this should fail");
                         using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     yield return new EventData(Encoding.UTF8.GetBytes(i.ToString()));
                 }
             }
-            
+
             await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);


### PR DESCRIPTION
# Summary

The focus of these changes is to update expectations for tests to account for the recent behavioral change when closing clients.

# Last Upstream Rebase

Monday, August 10, 8:54am (EDT)

# References and Related Issues 

- [Sample test failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=489037&view=ms.vss-test-web.build-test-results-tab)