### PR TITLE
Fix nightly live test run failures

### DIFF
--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableAsync.cs
@@ -19,7 +19,7 @@ namespace Azure.Data.Tables.Samples
             string storageUri = StorageUri;
             string accountName = StorageAccountName;
             string storageAccountKey = PrimaryStorageAccountKey;
-            string tableName = "OfficeSupplies1p2";
+            string tableName = "OfficeSupplies1p2a";
 
             // Construct a new <see cref="TableServiceClient" /> using a <see cref="TableSharedKeyCredential" />.
             var serviceClient = new TableServiceClient(

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTablesAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTablesAsync.cs
@@ -29,7 +29,7 @@ namespace Azure.Data.Tables.Samples
 
             #region Snippet:TablesSample3QueryTablesAsync
             // Use the <see cref="TableServiceClient"> to query the service. Passing in OData filter strings is optional.
-            AsyncPageable<TableItem> queryTableResults = serviceClient.GetTablesAsync(filter: $"TableName eq {tableName}'");
+            AsyncPageable<TableItem> queryTableResults = serviceClient.GetTablesAsync(filter: $"TableName eq '{tableName}'");
 
             Console.WriteLine("The following are the names of the tables in the query result:");
             // Iterate the <see cref="Pageable"> in order to access individual queried tables.


### PR DESCRIPTION
The `tableName` change is to prevent a conflict with the sync version of the same test.