### PR TITLE
[Event Hubs Client] Processor Release Preparation (5.2.0-preview.2)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0-preview.1" /> <!--Version override exists to bind to the preview; this will be removed when v5.2.0 is released for GA -->
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0-preview.2" /> <!--Version override exists to bind to the preview; this will be removed when v5.2.0 is released for GA -->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />


### PR DESCRIPTION
# Summary

The focus of these changes is to update the processor references for the v5.2.0-preview.2 release.

# Last Upstream Rebase

Monday, August 10, 12:56pm (EDT)