### PR TITLE
Add support for per API configurable options

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - The library now targets the service's v2.0 API, instead of the v2.0-preview.1 API.
 - Updated version number from `1.0.0-preview.5` to `3.0.0-preview.5`.
+- Added models `RecognizeCustomFormsOptions`, `RecognizeReceiptsOptions`, and `RecognizeContentOptions` instead of a generic `RecognizeOptions` to support passing configurable options to recognize API's.
+- Added model`TrainingOptions` to support passing configurable options to training API's. This type now includes `TrainingFileFilter`.
 - Renamed the `FieldValue` property `Type` to `ValueType`.
 - Renamed the `TrainingDocumentInfo` property `DocumentName` to `Name`.
 - Renamed the `TrainingFileFilter` property `IncludeSubFolders` to `IncludeSubfolders`.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldData.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldData.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary>
-        /// When <see cref="RecognizeOptions.IncludeFieldElements"/> is set to <c>true</c>, a list of references to
+        /// When `IncludeFieldElements` is set to <c>true</c>, a list of references to
         /// the field elements constituting this <see cref="FieldData"/>. An empty list otherwise. For calls to
         /// recognize content, this list is always populated.
         /// </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormContentType.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormContentType.cs
@@ -3,7 +3,7 @@
 
 using Azure.Core;
 
-namespace Azure.AI.FormRecognizer.Models
+namespace Azure.AI.FormRecognizer
 {
     /// <summary>
     /// The content type for local form files.

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
@@ -58,7 +58,7 @@ namespace Azure.AI.FormRecognizer.Models
         public LengthUnit Unit { get; }
 
         /// <summary>
-        /// When <see cref="RecognizeOptions.IncludeFieldElements"/> is set to <c>true</c>, a list of recognized lines of text.
+        /// When `IncludeFieldElements` is set to <c>true</c>, a list of recognized lines of text.
         /// An empty list otherwise. For calls to recognize content, this list is always populated. The maximum number of
         /// lines returned is 300 per page. The lines are sorted top to bottom, left to right, although in certain cases
         /// proximity is treated with higher priority. As the sorting order depends on the detected text, it may change across

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -120,22 +120,22 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes layout elements from one or more passed-in forms.
         /// </summary>
         /// <param name="form">The stream containing one or more forms to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeContentOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeContentOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeContentOperation.Value"/> upon successful
         /// completion will contain layout elements extracted from the form.</returns>
-        public virtual RecognizeContentOperation StartRecognizeContent(Stream form, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeContentOperation StartRecognizeContent(Stream form, RecognizeContentOptions recognizeContentOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(form, nameof(form));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeContentOptions ??= new RecognizeContentOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeContent)}");
             scope.Start();
 
             try
             {
-                FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
+                FormContentType contentType = recognizeContentOptions.ContentType ?? DetectContentType(form, nameof(form));
 
                 Response response = ServiceClient.AnalyzeLayoutAsync(contentType, form, cancellationToken);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
@@ -153,22 +153,22 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes layout elements from one or more passed-in forms.
         /// </summary>
         /// <param name="form">The stream containing one or more forms to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeContentOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeContentOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeContentOperation.Value"/> upon successful
         /// completion will contain layout elements extracted from the form.</returns>
-        public virtual async Task<RecognizeContentOperation> StartRecognizeContentAsync(Stream form, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeContentOperation> StartRecognizeContentAsync(Stream form, RecognizeContentOptions recognizeContentOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(form, nameof(form));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeContentOptions ??= new RecognizeContentOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeContent)}");
             scope.Start();
 
             try
             {
-                FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
+                FormContentType contentType = recognizeContentOptions.ContentType ?? DetectContentType(form, nameof(form));
 
                 Response response = await ServiceClient.AnalyzeLayoutAsyncAsync(contentType, form, cancellationToken).ConfigureAwait(false);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
@@ -186,15 +186,15 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes layout elements from one or more passed-in forms.
         /// </summary>
         /// <param name="formUri">The absolute URI of the remote file to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeContentOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeContentOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeContentOperation.Value"/> upon successful
         /// completion will contain layout elements extracted from the form.</returns>
-        public virtual RecognizeContentOperation StartRecognizeContentFromUri(Uri formUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeContentOperation StartRecognizeContentFromUri(Uri formUri, RecognizeContentOptions recognizeContentOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(formUri, nameof(formUri));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeContentOptions ??= new RecognizeContentOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeContentFromUri)}");
             scope.Start();
@@ -218,15 +218,15 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes layout elements from one or more passed-in forms.
         /// </summary>
         /// <param name="formUri">The absolute URI of the remote file to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeContentOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeContentOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeContentOperation.Value"/> upon successful
         /// completion will contain layout elements extracted from the form.</returns>
-        public virtual async Task<RecognizeContentOperation> StartRecognizeContentFromUriAsync(Uri formUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeContentOperation> StartRecognizeContentFromUriAsync(Uri formUri, RecognizeContentOptions recognizeContentOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(formUri, nameof(formUri));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeContentOptions ??= new RecognizeContentOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeContentFromUri)}");
             scope.Start();
@@ -254,24 +254,24 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes values from one or more receipts.
         /// </summary>
         /// <param name="receipt">The stream containing the one or more receipts to recognize values from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeReceiptsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeReceiptsOperation.Value"/> upon successful
         /// completion will contain the extracted receipt.</returns>
-        public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsAsync(Stream receipt, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsAsync(Stream receipt, RecognizeReceiptsOptions recognizeReceiptsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(receipt, nameof(receipt));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeReceiptsOptions ??= new RecognizeReceiptsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeReceipts)}");
             scope.Start();
 
             try
             {
-                FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(receipt, nameof(receipt));
+                FormContentType contentType = recognizeReceiptsOptions.ContentType ?? DetectContentType(receipt, nameof(receipt));
 
-                Response response = await ServiceClient.AnalyzeReceiptAsyncAsync(contentType, receipt, includeTextDetails: recognizeOptions.IncludeFieldElements, cancellationToken).ConfigureAwait(false);
+                Response response = await ServiceClient.AnalyzeReceiptAsyncAsync(contentType, receipt, includeTextDetails: recognizeReceiptsOptions.IncludeFieldElements, cancellationToken).ConfigureAwait(false);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, location);
@@ -287,24 +287,24 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes values from one or more receipts.
         /// </summary>
         /// <param name="receipt">The stream containing the one or more receipts to recognize values from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeReceiptsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeReceiptsOperation.Value"/> upon successful
         /// completion will contain the extracted receipt.</returns>
-        public virtual RecognizeReceiptsOperation StartRecognizeReceipts(Stream receipt, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeReceiptsOperation StartRecognizeReceipts(Stream receipt, RecognizeReceiptsOptions recognizeReceiptsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(receipt, nameof(receipt));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeReceiptsOptions ??= new RecognizeReceiptsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeReceipts)}");
             scope.Start();
 
             try
             {
-                FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(receipt, nameof(receipt));
+                FormContentType contentType = recognizeReceiptsOptions.ContentType ?? DetectContentType(receipt, nameof(receipt));
 
-                Response response = ServiceClient.AnalyzeReceiptAsync(contentType, receipt, includeTextDetails: recognizeOptions.IncludeFieldElements, cancellationToken);
+                Response response = ServiceClient.AnalyzeReceiptAsync(contentType, receipt, includeTextDetails: recognizeReceiptsOptions.IncludeFieldElements, cancellationToken);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, location);
@@ -320,15 +320,15 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes values from one or more receipts.
         /// </summary>
         /// <param name="receiptUri">The absolute URI of the remote file to recognize values from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeReceiptsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeReceiptsOperation.Value"/> upon successful
         /// completion will contain the extracted receipt.</returns>
-        public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsFromUriAsync(Uri receiptUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsFromUriAsync(Uri receiptUri, RecognizeReceiptsOptions recognizeReceiptsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(receiptUri, nameof(receiptUri));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeReceiptsOptions ??= new RecognizeReceiptsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeReceiptsFromUri)}");
             scope.Start();
@@ -336,7 +336,7 @@ namespace Azure.AI.FormRecognizer
             try
             {
                 SourcePath sourcePath = new SourcePath() { Source = receiptUri.AbsoluteUri };
-                Response response = await ServiceClient.AnalyzeReceiptAsyncAsync(includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken).ConfigureAwait(false);
+                Response response = await ServiceClient.AnalyzeReceiptAsyncAsync(includeTextDetails: recognizeReceiptsOptions.IncludeFieldElements, sourcePath, cancellationToken).ConfigureAwait(false);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, location);
@@ -352,15 +352,15 @@ namespace Azure.AI.FormRecognizer
         /// Recognizes values from one or more receipts.
         /// </summary>
         /// <param name="receiptUri">The absolute URI of the remote file to recognize values from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeReceiptsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeReceiptsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeReceiptsOperation.Value"/> upon successful
         /// completion will contain the extracted receipt.</returns>
-        public virtual RecognizeReceiptsOperation StartRecognizeReceiptsFromUri(Uri receiptUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeReceiptsOperation StartRecognizeReceiptsFromUri(Uri receiptUri, RecognizeReceiptsOptions recognizeReceiptsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(receiptUri, nameof(receiptUri));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeReceiptsOptions ??= new RecognizeReceiptsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeReceiptsFromUri)}");
             scope.Start();
@@ -368,7 +368,7 @@ namespace Azure.AI.FormRecognizer
             try
             {
                 SourcePath sourcePath = new SourcePath() { Source = receiptUri.AbsoluteUri };
-                Response response = ServiceClient.AnalyzeReceiptAsync(includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken);
+                Response response = ServiceClient.AnalyzeReceiptAsync(includeTextDetails: recognizeReceiptsOptions.IncludeFieldElements, sourcePath, cancellationToken);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeReceiptsOperation(ServiceClient, Diagnostics, location);
@@ -389,16 +389,16 @@ namespace Azure.AI.FormRecognizer
         /// </summary>
         /// <param name="modelId">The ID of the model to use for recognizing form values.</param>
         /// <param name="form">The stream containing one or more forms to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeCustomFormsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation.Value"/> upon successful
         /// completion will contain recognized pages from the input document.</returns>
-        public virtual RecognizeCustomFormsOperation StartRecognizeCustomForms(string modelId, Stream form, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeCustomFormsOperation StartRecognizeCustomForms(string modelId, Stream form, RecognizeCustomFormsOptions recognizeCustomFormsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(form, nameof(form));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeCustomFormsOptions ??= new RecognizeCustomFormsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeCustomForms)}");
             scope.Start();
@@ -406,9 +406,9 @@ namespace Azure.AI.FormRecognizer
             try
             {
                 Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
-                FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
+                FormContentType contentType = recognizeCustomFormsOptions.ContentType ?? DetectContentType(form, nameof(form));
 
-                Response response = ServiceClient.AnalyzeWithCustomModel(guid, contentType, form, includeTextDetails: recognizeOptions.IncludeFieldElements, cancellationToken);
+                Response response = ServiceClient.AnalyzeWithCustomModel(guid, contentType, form, includeTextDetails: recognizeCustomFormsOptions.IncludeFieldElements, cancellationToken);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, location);
@@ -425,16 +425,16 @@ namespace Azure.AI.FormRecognizer
         /// </summary>
         /// <param name="modelId">The ID of the model to use for recognizing form values.</param>
         /// <param name="formUri">The absolute URI of the remote file to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeCustomFormsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation.Value"/> upon successful
         /// completion will contain recognized pages from the input document.</returns>
-        public virtual RecognizeCustomFormsOperation StartRecognizeCustomFormsFromUri(string modelId, Uri formUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual RecognizeCustomFormsOperation StartRecognizeCustomFormsFromUri(string modelId, Uri formUri, RecognizeCustomFormsOptions recognizeCustomFormsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formUri, nameof(formUri));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeCustomFormsOptions ??= new RecognizeCustomFormsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeCustomFormsFromUri)}");
             scope.Start();
@@ -444,7 +444,7 @@ namespace Azure.AI.FormRecognizer
                 Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
                 SourcePath sourcePath = new SourcePath() { Source = formUri.AbsoluteUri };
-                Response response = ServiceClient.AnalyzeWithCustomModel(guid, includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken);
+                Response response = ServiceClient.AnalyzeWithCustomModel(guid, includeTextDetails: recognizeCustomFormsOptions.IncludeFieldElements, sourcePath, cancellationToken);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, location);
@@ -461,16 +461,16 @@ namespace Azure.AI.FormRecognizer
         /// </summary>
         /// <param name="modelId">The ID of the model to use for recognizing form values.</param>
         /// <param name="form">The stream containing one or more forms to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeCustomFormsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation.Value"/> upon successful
         /// completion will contain recognized pages from the input document.</returns>
-        public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsAsync(string modelId, Stream form, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsAsync(string modelId, Stream form, RecognizeCustomFormsOptions recognizeCustomFormsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(form, nameof(form));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeCustomFormsOptions ??= new RecognizeCustomFormsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeCustomForms)}");
             scope.Start();
@@ -478,9 +478,9 @@ namespace Azure.AI.FormRecognizer
             try
             {
                 Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
-                FormContentType contentType = recognizeOptions.ContentType ?? DetectContentType(form, nameof(form));
+                FormContentType contentType = recognizeCustomFormsOptions.ContentType ?? DetectContentType(form, nameof(form));
 
-                Response response = await ServiceClient.AnalyzeWithCustomModelAsync(guid, contentType, form, includeTextDetails: recognizeOptions.IncludeFieldElements, cancellationToken).ConfigureAwait(false);
+                Response response = await ServiceClient.AnalyzeWithCustomModelAsync(guid, contentType, form, includeTextDetails: recognizeCustomFormsOptions.IncludeFieldElements, cancellationToken).ConfigureAwait(false);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, location);
@@ -497,16 +497,16 @@ namespace Azure.AI.FormRecognizer
         /// </summary>
         /// <param name="modelId">The ID of the model to use for recognizing form values.</param>
         /// <param name="formUri">The absolute URI of the remote file to recognize elements from.</param>
-        /// <param name="recognizeOptions">A set of options available for configuring the recognize request.</param>
+        /// <param name="recognizeCustomFormsOptions">A set of options available for configuring the recognize request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation.Value"/> upon successful
         /// completion will contain recognized pages from the input document.</returns>
-        public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsFromUriAsync(string modelId, Uri formUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsFromUriAsync(string modelId, Uri formUri, RecognizeCustomFormsOptions recognizeCustomFormsOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formUri, nameof(formUri));
 
-            recognizeOptions ??= new RecognizeOptions();
+            recognizeCustomFormsOptions ??= new RecognizeCustomFormsOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormRecognizerClient)}.{nameof(StartRecognizeCustomFormsFromUri)}");
             scope.Start();
@@ -516,7 +516,7 @@ namespace Azure.AI.FormRecognizer
                 Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
                 SourcePath sourcePath = new SourcePath() { Source = formUri.AbsoluteUri };
-                Response response = await ServiceClient.AnalyzeWithCustomModelAsync(guid, includeTextDetails: recognizeOptions.IncludeFieldElements, sourcePath, cancellationToken).ConfigureAwait(false);
+                Response response = await ServiceClient.AnalyzeWithCustomModelAsync(guid, includeTextDetails: recognizeCustomFormsOptions.IncludeFieldElements, sourcePath, cancellationToken).ConfigureAwait(false);
                 string location = ClientCommon.GetResponseHeader(response.Headers, Constants.OperationLocationHeader);
 
                 return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, location);
@@ -544,17 +544,17 @@ namespace Azure.AI.FormRecognizer
 
             if (!stream.CanSeek)
             {
-                throw new ArgumentException($"Content type cannot be detected because stream is not seekable. It can be manually set in the {nameof(RecognizeOptions)}.", paramName);
+                throw new ArgumentException($"Content type cannot be detected because stream is not seekable. It can be manually set in the options parameter of the start operation method.", paramName);
             }
 
             if (!stream.CanRead)
             {
-                throw new ArgumentException($"Content type cannot be detected because stream is not readable. It can be manually set in the {nameof(RecognizeOptions)}.", paramName);
+                throw new ArgumentException($"Content type cannot be detected because stream is not readable. It can be manually set in the options parameter of the start operation method.", paramName);
             }
 
             if (!stream.TryGetContentType(out contentType))
             {
-                throw new ArgumentException($"Content type of the stream could not be detected. It can be manually set in the {nameof(RecognizeOptions)}.", paramName);
+                throw new ArgumentException($"Content type of the stream could not be detected. It can be manually set in the options parameter of the start operation method.", paramName);
             }
 
             return contentType;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTableCell.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTableCell.cs
@@ -61,7 +61,7 @@ namespace Azure.AI.FormRecognizer.Models
         public int RowSpan { get; }
 
         /// <summary>
-        /// When <see cref="RecognizeOptions.IncludeFieldElements"/> is set to <c>true</c>, a list of references to
+        /// When `IncludeFieldElements` is set to <c>true</c>, a list of references to
         /// the field elements constituting this cell is returned. An empty list otherwise. For calls to recognize content, this
         /// list is always populated.
         /// </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -109,7 +109,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.
         /// For more information see <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data"/>.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, use a label file created in the &lt;link-to-label-tool-doc&gt; to provide training-time labels for training a model. If <c>false</c>, the model will be trained from forms only.</param>
-        /// <param name="trainingFileFilter">Filter to apply to the documents in the source path for training.</param>
+        /// <param name="trainingOptions">A set of options available for configuring the training request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
         /// <para>A <see cref="TrainingOperation"/> to wait on this long-running operation. Its <see cref="TrainingOperation.Value"/> upon successful
@@ -117,16 +117,17 @@ namespace Azure.AI.FormRecognizer.Training
         /// <para>Even if training fails, a model is created in the Form Recognizer account with an "invalid" status.
         /// A <see cref="RequestFailedException"/> will be raised containing the modelId to access this invalid model.</para>
         /// </returns>
-        public virtual TrainingOperation StartTraining(Uri trainingFilesUri, bool useTrainingLabels, TrainingFileFilter trainingFileFilter = default, CancellationToken cancellationToken = default)
+        public virtual TrainingOperation StartTraining(Uri trainingFilesUri, bool useTrainingLabels, TrainingOptions trainingOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(trainingFilesUri, nameof(trainingFilesUri));
+            trainingOptions ??= new TrainingOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormTrainingClient)}.{nameof(StartTraining)}");
             scope.Start();
 
             try
             {
-                var trainRequest = new TrainRequest(trainingFilesUri.AbsoluteUri) { SourceFilter = trainingFileFilter, UseLabelFile = useTrainingLabels };
+                var trainRequest = new TrainRequest(trainingFilesUri.AbsoluteUri) { SourceFilter = trainingOptions.TrainingFileFilter, UseLabelFile = useTrainingLabels };
 
                 ResponseWithHeaders<ServiceTrainCustomModelAsyncHeaders> response = ServiceClient.TrainCustomModelAsync(trainRequest);
                 return new TrainingOperation(response.Headers.Location, ServiceClient, Diagnostics);
@@ -144,7 +145,7 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.
         /// For more information see <a href="https://docs.microsoft.com/azure/cognitive-services/form-recognizer/build-training-data-set#upload-your-training-data"/>.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, use a label file created in the &lt;link-to-label-tool-doc&gt; to provide training-time labels for training a model. If <c>false</c>, the model will be trained from forms only.</param>
-        /// <param name="trainingFileFilter">Filter to apply to the documents in the source path for training.</param>
+        /// <param name="trainingOptions">A set of options available for configuring the training request.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
         /// <para>A <see cref="TrainingOperation"/> to wait on this long-running operation. Its <see cref="TrainingOperation.Value"/> upon successful
@@ -152,16 +153,17 @@ namespace Azure.AI.FormRecognizer.Training
         /// <para>Even if training fails, a model is created in the Form Recognizer account with an "invalid" status.
         /// A <see cref="RequestFailedException"/> will be raised containing the modelId to access this invalid model.</para>
         /// </returns>
-        public virtual async Task<TrainingOperation> StartTrainingAsync(Uri trainingFilesUri, bool useTrainingLabels, TrainingFileFilter trainingFileFilter = default, CancellationToken cancellationToken = default)
+        public virtual async Task<TrainingOperation> StartTrainingAsync(Uri trainingFilesUri, bool useTrainingLabels, TrainingOptions trainingOptions = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(trainingFilesUri, nameof(trainingFilesUri));
+            trainingOptions ??= new TrainingOptions();
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(FormTrainingClient)}.{nameof(StartTraining)}");
             scope.Start();
 
             try
             {
-                var trainRequest = new TrainRequest(trainingFilesUri.AbsoluteUri) { SourceFilter = trainingFileFilter, UseLabelFile = useTrainingLabels };
+                var trainRequest = new TrainRequest(trainingFilesUri.AbsoluteUri) { SourceFilter = trainingOptions.TrainingFileFilter, UseLabelFile = useTrainingLabels };
 
                 ResponseWithHeaders<ServiceTrainCustomModelAsyncHeaders> response = await ServiceClient.TrainCustomModelAsyncAsync(trainRequest).ConfigureAwait(false);
                 return new TrainingOperation(response.Headers.Location, ServiceClient, Diagnostics);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FormContentType.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FormContentType.Serialization.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace Azure.AI.FormRecognizer.Models
+namespace Azure.AI.FormRecognizer
 {
     internal static class FormContentTypeExtensions
     {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.FormRecognizer
+{
+    /// <summary>
+    /// The set of options that can be specified when calling a recognition content method
+    /// to configure the behavior of the request.
+    /// </summary>
+    public class RecognizeContentOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecognizeContentOptions"/> class.
+        /// </summary>
+        public RecognizeContentOptions()
+        {
+        }
+
+        /// <summary>
+        /// When set, specifies the content type for uploaded streams and skips automatic
+        /// content type detection.
+        /// </summary>
+        public FormContentType? ContentType { get; set; } = null;
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOptions.cs
@@ -1,19 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.AI.FormRecognizer.Models
+namespace Azure.AI.FormRecognizer
 {
     /// <summary>
-    /// The set of options that can be specified when calling a recognition method in
-    /// a <see cref="FormRecognizerClient" /> instance to configure the behavior of the
-    /// request.
+    /// The set of options that can be specified when calling a recognize custom form method
+    /// to configure the behavior of the request.
     /// </summary>
-    public class RecognizeOptions
+    public class RecognizeCustomFormsOptions
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RecognizeOptions"/> class.
+        /// Initializes a new instance of the <see cref="RecognizeCustomFormsOptions"/> class.
         /// </summary>
-        public RecognizeOptions()
+        public RecognizeCustomFormsOptions()
         {
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOptions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.FormRecognizer
+{
+    /// <summary>
+    /// The set of options that can be specified when calling a recognize receipt method
+    /// to configure the behavior of the request.
+    /// </summary>
+    public class RecognizeReceiptsOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecognizeReceiptsOptions"/> class.
+        /// </summary>
+        public RecognizeReceiptsOptions()
+        {
+        }
+
+        /// <summary>
+        /// Whether or not to include form elements such as lines and words in addition to form fields.
+        /// </summary>
+        public bool IncludeFieldElements { get; set; } = false;
+
+        /// <summary>
+        /// When set, specifies the content type for uploaded streams and skips automatic
+        /// content type detection.
+        /// </summary>
+        public FormContentType? ContentType { get; set; } = null;
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOptions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.FormRecognizer.Training
+{
+    /// <summary>
+    /// The set of options that can be specified when calling a recognize receipt method
+    /// to configure the behavior of the request.
+    /// </summary>
+    public class TrainingOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrainingOptions"/> class.
+        /// </summary>
+        public TrainingOptions()
+        {
+        }
+
+        /// <summary>
+        /// Filter to apply to the documents in the source path for training.
+        /// </summary>
+        public TrainingFileFilter TrainingFileFilter { get; set; }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/TrainingOptions.cs
@@ -4,7 +4,7 @@
 namespace Azure.AI.FormRecognizer.Training
 {
     /// <summary>
-    /// The set of options that can be specified when calling a recognize receipt method
+    /// The set of options that can be specified when calling the training method
     /// to configure the behavior of the request.
     /// </summary>
     public class TrainingOptions

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -293,7 +293,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeContentCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeContentOptions();
             RecognizeContentOperation operation;
 
             using var stream = FormRecognizerTestEnvironment.CreateStream(TestFile.Blank);
@@ -602,7 +602,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeReceiptsCanParseMultipageForm(bool useStream)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeReceiptsOptions() { IncludeFieldElements = true };
             RecognizeReceiptsOperation operation;
 
             if (useStream)
@@ -653,7 +653,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeReceiptsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeReceiptsOptions() { IncludeFieldElements = true };
             RecognizeReceiptsOperation operation;
 
             using var stream = FormRecognizerTestEnvironment.CreateStream(TestFile.Blank);
@@ -681,7 +681,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeReceiptsCanParseMultipageFormWithBlankPage()
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeReceiptsOptions() { IncludeFieldElements = true };
             RecognizeReceiptsOperation operation;
 
             using var stream = FormRecognizerTestEnvironment.CreateStream(TestFile.InvoiceMultipageBlank);
@@ -766,7 +766,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithLabels(bool useStream, bool includeFieldElements)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions { IncludeFieldElements = includeFieldElements };
+            var options = new RecognizeCustomFormsOptions { IncludeFieldElements = includeFieldElements };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
@@ -817,7 +817,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithLabelsCanParseMultipageForm(bool useStream)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true, useMultipageFiles: true);
@@ -869,7 +869,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithLabelsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
@@ -899,7 +899,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithLabelsCanParseMultipageFormWithBlankPage(bool useStream)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
@@ -982,7 +982,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithoutLabels(bool useStream, bool includeFieldElements)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions { IncludeFieldElements = includeFieldElements };
+            var options = new RecognizeCustomFormsOptions { IncludeFieldElements = includeFieldElements };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: false);
@@ -1034,7 +1034,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithoutLabelsCanParseMultipageForm(bool useStream)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: false, useMultipageFiles: true);
@@ -1082,7 +1082,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithoutLabelsCanParseBlankPage()
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: false);
@@ -1114,7 +1114,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeCustomFormsWithoutLabelsCanParseMultipageFormWithBlankPage(bool useStream)
         {
             var client = CreateFormRecognizerClient();
-            var options = new RecognizeOptions() { IncludeFieldElements = true };
+            var options = new RecognizeCustomFormsOptions() { IncludeFieldElements = true };
             RecognizeCustomFormsOperation operation;
 
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels: false);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientMockTests.cs
@@ -54,7 +54,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var client = CreateInstrumentedClient(options);
 
             using var stream = FormRecognizerTestEnvironment.CreateStream(TestFile.InvoiceLeTiff);
-            var recognizeOptions = new RecognizeOptions { ContentType = FormContentType.Jpeg };
+            var recognizeOptions = new RecognizeContentOptions { ContentType = FormContentType.Jpeg };
             await client.StartRecognizeContentAsync(stream, recognizeOptions);
 
             var request = mockTransport.Requests.Single();
@@ -120,7 +120,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var client = CreateInstrumentedClient(options);
 
             using var stream = FormRecognizerTestEnvironment.CreateStream(TestFile.InvoiceLeTiff);
-            var recognizeOptions = new RecognizeOptions { ContentType = FormContentType.Jpeg };
+            var recognizeOptions = new RecognizeReceiptsOptions { ContentType = FormContentType.Jpeg };
             await client.StartRecognizeReceiptsAsync(stream, recognizeOptions);
 
             var request = mockTransport.Requests.Single();
@@ -186,7 +186,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var client = CreateInstrumentedClient(options);
 
             using var stream = FormRecognizerTestEnvironment.CreateStream(TestFile.InvoiceLeTiff);
-            var recognizeOptions = new RecognizeOptions { ContentType = FormContentType.Jpeg };
+            var recognizeOptions = new RecognizeCustomFormsOptions { ContentType = FormContentType.Jpeg };
             await client.StartRecognizeCustomFormsAsync("00000000000000000000000000000000", stream, recognizeOptions);
 
             var request = mockTransport.Requests.Single();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -135,7 +135,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public void StartRecognizeContentRespectsTheCancellationToken()
         {
             var client = CreateInstrumentedClient();
-            var options = new RecognizeOptions { ContentType = FormContentType.Pdf };
+            var options = new RecognizeContentOptions { ContentType = FormContentType.Pdf };
 
             using var stream = new MemoryStream(Array.Empty<byte>());
             using var cancellationSource = new CancellationTokenSource();
@@ -190,13 +190,13 @@ namespace Azure.AI.FormRecognizer.Tests
         public void StartRecognizeReceiptsRespectsTheCancellationToken()
         {
             var client = CreateInstrumentedClient();
-            var options = new RecognizeOptions { ContentType = FormContentType.Pdf };
+            var options = new RecognizeReceiptsOptions { ContentType = FormContentType.Pdf };
 
             using var stream = new MemoryStream(Array.Empty<byte>());
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeReceiptsAsync(stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeReceiptsAsync(stream, recognizeReceiptsOptions: options, cancellationToken: cancellationSource.Token));
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 : typeof(ArgumentException);
 
             using var stream = new MemoryStream(Array.Empty<byte>());
-            var options = new RecognizeOptions { ContentType = FormContentType.Jpeg };
+            var options = new RecognizeCustomFormsOptions { ContentType = FormContentType.Jpeg };
 
             Assert.ThrowsAsync(expectedType, async () => await client.StartRecognizeCustomFormsAsync(modelId, stream, options));
         }
@@ -266,7 +266,7 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             var client = CreateClient();
             using var stream = new MemoryStream(Array.Empty<byte>());
-            var options = new RecognizeOptions { ContentType = FormContentType.Jpeg };
+            var options = new RecognizeCustomFormsOptions { ContentType = FormContentType.Jpeg };
 
             Assert.ThrowsAsync<ArgumentException>(async () => await client.StartRecognizeCustomFormsAsync("1975-04-04", stream, options));
         }
@@ -279,13 +279,13 @@ namespace Azure.AI.FormRecognizer.Tests
         public void StartRecognizeCustomFormsRespectsTheCancellationToken()
         {
             var client = CreateInstrumentedClient();
-            var options = new RecognizeOptions { ContentType = FormContentType.Pdf };
+            var options = new RecognizeCustomFormsOptions { ContentType = FormContentType.Pdf };
 
             using var stream = new MemoryStream(Array.Empty<byte>());
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeCustomFormsAsync("00000000-0000-0000-0000-000000000000", stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
+            Assert.ThrowsAsync(Is.InstanceOf<OperationCanceledException>(), async () => await client.StartRecognizeCustomFormsAsync("00000000-0000-0000-0000-000000000000", stream, recognizeCustomFormsOptions: options, cancellationToken: cancellationSource.Token));
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -105,7 +105,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var trainingFilesUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 
             var filter = new TrainingFileFilter { IncludeSubfolders = true, Prefix = "subfolder" };
-            TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, filter);
+            TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, new TrainingOptions() { TrainingFileFilter = filter});
 
             await operation.WaitForCompletionAsync(PollingInterval);
 
@@ -120,7 +120,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var trainingFilesUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 
             var filter = new TrainingFileFilter { IncludeSubfolders = true, Prefix = "invalidPrefix" };
-            TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, filter);
+            TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, new TrainingOptions() { TrainingFileFilter = filter });
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
             Assert.AreEqual("2014", ex.ErrorCode);


### PR DESCRIPTION
- Creates an `{operation}Options` object per `operation`
  - RecognizeCustomFormOptions
  - RecognizeContentOptions
  - RecognizeReceiptOptions 
  - TrainingOptions
- Each `option` is located next to the client namespace
- Moved `ContentType` to main namespace as it is an input parameter and now encapsulated by the other `Option` objects

API view: https://apiview.dev/Assemblies/Review/cf2c57b3d4c44ef08c2e8284f7441a2d?diffRevisionId=0ee80a9f9a204a379ffca0e21f251fd0

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/14097