### PR TITLE
[FormRecognizer] Make default FieldValue return null when AsString is called

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Made the `TrainingFileFilter` constructor public.
 - Fixed a bug in which `FormTrainingClient.GetCustomModel` threw an exception if the model was still being created ([#13813](https://github.com/Azure/azure-sdk-for-net/issues/13813)).
 - Fixed a bug in which the `BoundingBox` indexer and `ToString` method threw a `NullReferenceException` if it had no points ([#13971](https://github.com/Azure/azure-sdk-for-net/issues/13971)).
+- Fixed a bug in which a default `FieldValue` threw a `NullReferenceException` if `AsString` was called. The method now returns `null`.
 
 ### New Features
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValue.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValue.cs
@@ -39,7 +39,7 @@ namespace Azure.AI.FormRecognizer.Models
                 throw new InvalidOperationException($"Cannot get field as String.  Field value's type is {ValueType}.");
             }
 
-            return _fieldValue.ValueString;
+            return _fieldValue?.ValueString;
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/FieldValueTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/FieldValueTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.FormRecognizer.Models;
+using NUnit.Framework;
+
+namespace Azure.AI.FormRecognizer.Tests
+{
+    /// <summary>
+    /// The suite of tests for the <see cref="FieldValue"/> struct.
+    /// </summary>
+    public class FieldValueTests
+    {
+        [Test]
+        public void AsStringReturnsNullWhenFieldValueIsDefault()
+        {
+            FieldValue value = default;
+            Assert.IsNull(value.AsString());
+        }
+    }
+}


### PR DESCRIPTION
The following code throws a `NullReferenceException`:
```cs
FieldValue value = default;
value.AsString();
```

We're returning a `null` string here as a fix for this scenario.