### PR TITLE
Bumping up packaging version to 4.3.1 for testing purpose

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 4.3.1 (Unreleased)
+
 ## 4.3.0 (2020-08-11)
 ### Breaking Changes
 - Built-in checkpoint store moved from WindowsAzure.Storage SDK to Microsoft.Azure.Storage SDK due to former being deprecated. (https://github.com/Azure/azure-sdk-for-net/pull/13956)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the legacy Azure Event Hubs .NET Standard Event Processor Host library. To view releases for the current generation of the Azure client libraries for .NET, please see: https://aka.ms/azsdk/releases.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;Event Processor Host</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.Processor.xml</DocumentationFile>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 4.3.1 (Unreleased)
+
 ## 4.3.0 (2020-08-11)
 ### Breaking Changes
 None

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the legacy Azure Event Hubs .NET Standard client library. To view releases for the current generation of the Azure client libraries for .NET, please see: https://aka.ms/azsdk/releases.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.xml</DocumentationFile>


### PR DESCRIPTION
Stress tests  need higher version than public release in order to link latest dev package.