### PR TITLE
Copy older 4.1.0-preview.1 changelogs

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.1.0 (2020-08-11)
 
+### Added
+
+- Added `RecoverableDays` property to `CertificateProperties`.
+
 ### Changed
 
 - Default service version is now 7.1.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 4.1.0 (2020-08-11)
 
+### Added
+
+- Added "import" value to `KeyOperation` enumeration.
+- Added `RecoverableDays` property to `KeyProperties`.
+
 ### Changed
 
 - Default service version is now 7.1.

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.1.0 (2020-08-11)
 
+### Added
+
+- Added `RecoverableDays` property to `SecretProperties`.
+
 ### Changed
 
 - Default service version is now 7.1.


### PR DESCRIPTION
We released a couple servicing versions after shipping 4.1.0-preview.1, so it made the new 4.1.0 CHANGELOG entries look really lightweight.