### PR TITLE
Service Bus Migration Guide improvements

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -227,21 +227,21 @@ The below code snippet shows you the session variation of the `ServiceBusProcess
 
 ```cs
 // create a processor to receive events from the next available session
-ServiceBusProcessor processor = client.CreateSessionProcessor(queueName);
+ServiceBusSessionProcessor processor = client.CreateSessionProcessor(queueName);
 
 // create a processor to receive events from the given set of sessions
 var options = new ServiceBusSessionProcessorOptions
 {
     SessionIds = ["my-session", "your-session"],
 };
-ServiceBusProcessor processor = client.CreateSessionProcessor(queueName, options);
+ServiceBusSessionProcessor processor = client.CreateSessionProcessor(queueName, options);
 
 // create a processor to receive events from the 3 next available sessions
 var options = new ServiceBusSessionProcessorOptions
 {
     MaxConcurrentSessions = 3
 };
-ServiceBusProcessor processor = client.CreateSessionProcessor(queueName);
+ServiceBusSessionProcessor processor = client.CreateSessionProcessor(queueName);
 ```
 
 The below code snippet shows you the session variation of the receiver. Please note that creating a session receiver is an async operation because the library will need to get a lock on the session by connecting to the service first.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -116,7 +116,8 @@ for (var i = 0; i < inputMessageArray.Length; i++)
 {
     if (!messageBatch.TryAddMessage(inputMessageArray[i]))
     {
-      if (messageBatch.Count == 0) {
+      if (messageBatch.Count == 0) 
+      {
         Console.WriteLine($"Failed to fit message number in a batch {i}");
         break;
       }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -177,7 +177,7 @@ Console.WriteLine($"Received message with Body:{Encoding.UTF8.GetString(received
 await receiver.CompleteAsync(receivedMessage);
 ```
 
-Now in `Azure.Messaging.ServiceBus`, we introduce the concept of a "processor" which takes your message and error handlers to provide you a simple way to get started with processing your messages. This provides a graceful shutdown via the `StopProcessingAsync` method which will ensure that no more messages will be received, but at the same time you can continue the prcoessing and settling the messages already in flight.
+Now in `Azure.Messaging.ServiceBus`, we introduce a dedicated class `ServiceBusProcessor` which takes your message and error handlers to provide you with the same simple way to get started with processing your messages as message handlers in the previous packages, with auto-complete and auto-lock renewal features. This class also provides a graceful shutdown via the `StopProcessingAsync` method which will ensure that no more messages will be received, but at the same time you can continue the processing and settling the messages already in flight.
 
 The concept of a "receiver" remains for users who need to have a more fine grained control over the receiving and settling messages. The difference is that this is now created from the top-level `ServiceBusClient` via the `CreateReceiver()` method that would take the queue or subscription you want to target.
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -179,7 +179,7 @@ await receiver.CompleteAsync(receivedMessage);
 
 Now in `Azure.Messaging.ServiceBus`, we introduce a dedicated class `ServiceBusProcessor` which takes your message and error handlers to provide you with the same simple way to get started with processing your messages as message handlers in the previous packages, with auto-complete and auto-lock renewal features. This class also provides a graceful shutdown via the `StopProcessingAsync` method which will ensure that no more messages will be received, but at the same time you can continue the processing and settling the messages already in flight.
 
-The concept of a "receiver" remains for users who need to have a more fine grained control over the receiving and settling messages. The difference is that this is now created from the top-level `ServiceBusClient` via the `CreateReceiver()` method that would take the queue or subscription you want to target.
+The concept of a receiver remains for users who need to have a more fine grained control over the receiving and settling messages. The difference is that this is now created from the top-level `ServiceBusClient` via the `CreateReceiver()` method that would take the queue or subscription you want to target.
 
 ```cs
 // create the ServiceBusClient
@@ -223,7 +223,7 @@ While the first option is similar to what you would do in a non-session scenario
 
 Now in `Azure.Messaging.ServiceBus`, we simplfify this by giving session variants of the same methods and classes that are available when working with queues/subscriptions that do not have sessions enabled.
 
-The below code snippet shows you the session variation of the "processor".
+The below code snippet shows you the session variation of the `ServiceBusProcessor`.
 
 ```cs
 // create a processor to receive events from the next available session
@@ -244,7 +244,7 @@ var options = new ServiceBusSessionProcessorOptions
 ServiceBusProcessor processor = client.CreateSessionProcessor(queueName);
 ```
 
-The below code snippet shows you the session variation of the "receiver". Please note that creating a session receiver is an async operation because the library will need to get a lock on the session by connecting to the service first.
+The below code snippet shows you the session variation of the receiver. Please note that creating a session receiver is an async operation because the library will need to get a lock on the session by connecting to the service first.
 
 ```cs
 // create a receiver to receive events from the next available session

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -44,7 +44,7 @@ In the interest of simplifying the API surface we've made a single top level cli
 By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can explore all available features through methods from a single client, as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, using sessions or not, you will start your applications by constructing the same client.
  
 #### Consistency
-Having similarly named and structured methods to create senders, receivers and receivers for individual sessions on the same client provides consistency and predictability on the various features of the library. We have attempted to have the session/non-session usage be as seamless as possible. This allows you to make less changes to your code when you want to move from sessions to non-sessions or the other way around.
+We now have methods with similar names, signature and location to create senders and receivers. This provides consistency and predictability on the various features of the library. We have attempted to have the session/non-session usage be as seamless as possible. This allows you to make less changes to your code when you want to move from sessions to non-sessions or the other way around.
  
 #### Connection Pooling
 By using a single top-level client, we can implicitly share a single AMQP connection for all operations that an application performs. In the previous library `Microsoft.Azure.ServiceBus`, connection sharing was implicit when using the `SessionClient`, but when using other clients, senders or receivers, you would need to explicitly pass in a `ServiceBusConnection` object in order to share a connection. 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -54,8 +54,7 @@ By making this connection sharing be implicit to a `ServiceBusClient` instance, 
 
 ### Client constructors
 
-While we continue to support connection strings when constructing a client, the main difference is when using Azure Active Directory.
-We now use the new [Azure.Identity](https://www.nuget.org/packages/Azure.Identity) library to share a single authentication solution between clients of different Azure services.
+While we continue to support connection strings when constructing a client, the main difference is when using Azure Active Directory. We now use the new [Azure.Identity](https://www.nuget.org/packages/Azure.Identity) library to share a single authentication solution between clients of different Azure services.
 
 ```cs
 // Create a ServiceBusClient that will authenticate through Active Directory
@@ -70,8 +69,8 @@ ServiceBusClient client = new ServiceBusClient(connectionString);
 ### Sending messages
 
 Previously, in `Microsoft.Azure.ServiceBus`, you could send messages either by using a `QueueClient` (or `TopicClient` if you are targetting a topic) or the `MessageSender`.
-While the `QueueClient` supported the simple send operation, the `MessageSender` supported that and advanced scenarios like scheduling to send messages
-at a later time and cancelling such scheduled messages.
+
+While the `QueueClient` supported the simple send operation, the `MessageSender` supported that and advanced scenarios like scheduling to send messages at a later time and cancelling such scheduled messages.
 
 ```cs
 // create a message to send
@@ -86,8 +85,7 @@ MessageSender sender = new MessageSender(connectionString, queueName);
 await sender.SendAsync(message);
 ```
 
-Now in `Azure.Messaging.ServiceBus`, we combine all the send related features under a common class `ServiceBusSender` that you can create from the top level client using the `CreateSender()` method. This method takes the queue or topic you want to target.
-This way, we give you a one stop shop for all your send related needs. 
+Now in `Azure.Messaging.ServiceBus`, we combine all the send related features under a common class `ServiceBusSender` that you can create from the top level client using the `CreateSender()` method. This method takes the queue or topic you want to target. This way, we give you a one stop shop for all your send related needs. 
 
 We continue to support sending bytes in the message. Though, if you are working with strings, you can now create a message directly without having to convert it to bytes first.
 
@@ -106,8 +104,8 @@ await sender.SendMessageAsync(message);
 ```
 
 The feature to send a list of messages in a single call was implemented by batching all the messages into a single AMQP message and sending that to the service.
-While we continue to support this feature, it always had the potential to fail unexpectedly when the resulting batched AMQP message exceeded the size limit of the sender.
-To help with this, we now provide a safe way to batch multiple messages to be sent at once using the new `ServiceBusMessageBatch` class.
+
+While we continue to support this feature, it always had the potential to fail unexpectedly when the resulting batched AMQP message exceeded the size limit of the sender. To help with this, we now provide a safe way to batch multiple messages to be sent at once using the new `ServiceBusMessageBatch` class.
 
 ```cs
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -122,7 +122,7 @@ for (var i = 0; i < inputMessageArray.Length; i++)
       }
 
       // Decrement counter so that message number i can get another chance in a new batch
-      i = i - 1;
+      i--;
 
       // send the message batch and create a new batch
       await sender.SendMessagesAsync(messageBatch);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -219,7 +219,7 @@ Previously, in `Microsoft.Azure.ServiceBus`, you had the below options to receiv
 - Register message and error handlers using the `QueueClient.RegisterSessionHandler()` method to receive messages from an available set of sessions 
 - Use the `SessionClient.AcceptMessageSessionAsync()` method to get an instance of the `MessageSession` class that will be tied to a given sessionId or to the next available session if no sessionId is provided.
 
-While the first option is similar to what you would do in a non session scenario, the second that allows you finer grained control is very different from any other pattern used in the library.
+While the first option is similar to what you would do in a non-session scenario, the second that allows you finer-grained control is very different from any other pattern used in the library.
 
 Now in `Azure.Messaging.ServiceBus`, we simplfify this by giving session variants of the same methods and classes that are available when working with queues/subscriptions that do not have sessions enabled.
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -128,7 +128,9 @@ for (var i = 0; i < inputMessageArray.Length; i++)
       await sender.SendMessagesAsync(messageBatch);
       messageBatch.Dispose();
       messageBatch = await sender.CreateMessageBatchAsync();
-    } else if (i == inputMessageArray.Length) {
+    } 
+    else if (i == inputMessageArray.Length) 
+    {
       // send the final batch
       await sender.SendMessagesAsync(messageBatch);
       messageBatch.Dispose();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -38,10 +38,10 @@ In the case of Service Bus, the modern client libraries have packages and namesp
 
 ### Client hierarchy
 
-In the interest of simplifying the API surface we've made a single top level client called `ServiceBusClient`, rather than one for each of queue, topic, subscription and session. This acts as the single entry point in contrast with six different entry points in the previous library. You can create senders and receivers off of this client to the queue/topic/subscription/session of your choice and start sending/receiving messages.
+In the interest of simplifying the API surface we've made a single top level client called `ServiceBusClient`, rather than one for each of queue, topic, subscription and session. This acts as the single entry point in contrast with multiple entry points from before. You can create senders and receivers off of this client to the queue/topic/subscription/session of your choice and start sending/receiving messages.
 
 #### Approachability
-By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can dot into the client and see all the available methods as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, or using sessions or not, users will start their applications by constructing the same client.
+By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can explore all available features through methods off of a single client, as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, or using sessions or not, users will start their applications by constructing the same client.
  
 #### Consistency
 Having similar methods to create senders, receivers and receivers for individual sessions on the same client provides consistency and predictability on the various features of the library. We have attempted to have the session/non-session usage be as seamless as possible. This allows users to make less changes to their code when they want to move from sessions to non-sessions or the other way around.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -24,9 +24,9 @@ There were several areas of consistent feedback expressed across the Azure clien
 
 To try and improve the development experience across Azure services, including Service Bus, a set of uniform [design guidelines](https://azure.github.io/azure-sdk/general_introduction.html) was created for all languages to drive a consistent experience with established API patterns for all services. A set of [.NET-specific guidelines](https://azure.github.io/azure-sdk/dotnet_introduction.html) was also introduced to ensure that .NET clients have a natural and idiomatic feel that mirrors that of the .NET base class libraries. Further details are available in the guidelines for those interested.
 
-The modern Service Bus client library provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as using the new `Azure.Identity` library to share a single authentication between clients and a unified diagnostics pipeline offering a common view of the activities across each of the client libraries. 
+The new Service Bus library `Azure.Messaging.ServiceBus` provides the ability to share in some of the cross-service improvements made to the Azure development experience, such as using the new `Azure.Identity` library to share a single authentication between clients and a unified diagnostics pipeline offering a common view of the activities across each of the client libraries. 
 
-While we believe that there is significant benefit to adopting the modern version of the Service Bus library, it is important to be aware that the legacy version has not been officially deprecated. It will continue to be supported with security and bug fixes as well as receiving some minor refinements. However, in the near future it will not be under active development and new features are unlikely to be added.
+While we believe that there is significant benefit to adopting the new Service Bus library `Azure.Messaging.ServiceBus`, it is important to be aware that the previous two versions `WindowsAzure.ServiceBus` and `Microsoft.Azure.ServiceBus` have not been officially deprecated. They will continue to be supported with security and bug fixes as well as receiving some minor refinements. However, in the near future they will not be under active development and new features are unlikely to be added to them.
 
 ## General changes
 
@@ -38,16 +38,16 @@ In the case of Service Bus, the modern client libraries have packages and namesp
 
 ### Client hierarchy
 
-In the interest of simplifying the API surface we've made a single top level client called `ServiceBusClient`, rather than one for each of queue, topic, subscription and session. This acts as the single entry point in contrast with multiple entry points from before. You can create senders and receivers off of this client to the queue/topic/subscription/session of your choice and start sending/receiving messages.
+In the interest of simplifying the API surface we've made a single top level client called `ServiceBusClient`, rather than one for each of queue, topic, subscription and session. This acts as the single entry point in contrast with multiple entry points from before. You can create senders and receivers from this client to the queue/topic/subscription/session of your choice and start sending/receiving messages.
 
 #### Approachability
-By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can explore all available features through methods off of a single client, as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, or using sessions or not, users will start their applications by constructing the same client.
+By having a single entry point, the `ServiceBusClient` helps with the discoverability of the API as you can explore all available features through methods from a single client, as opposed to searching through documentation or exploring namespace for the types that you can instantiate. Whether sending or receiving, using sessions or not, you will start your applications by constructing the same client.
  
 #### Consistency
-Having similar methods to create senders, receivers and receivers for individual sessions on the same client provides consistency and predictability on the various features of the library. We have attempted to have the session/non-session usage be as seamless as possible. This allows users to make less changes to their code when they want to move from sessions to non-sessions or the other way around.
+Having similar methods to create senders, receivers and receivers for individual sessions on the same client provides consistency and predictability on the various features of the library. We have attempted to have the session/non-session usage be as seamless as possible. This allows you to make less changes to your code when you want to move from sessions to non-sessions or the other way around.
  
-#### Resource usage
-By using a single top-level client, we can implicitly share a single AMQP connection for all operations that an application performs. In the previous library, connection sharing was implicit when using the `SessionClient`, but when using other clients, users would need to explicitly pass in a `ServiceBusConnection` object in order to share a connection. By making this sharing be implicit to a ServiceBusClient instance, we can help ensure that applications will not use multiple connections unless they explicitly opt in by creating multiple `ServiceBusClient` instances.
+#### Connection Pooling
+By using a single top-level client, we can implicitly share a single AMQP connection for all operations that an application performs. In the previous library `Microsoft.Azure.ServiceBus`, connection sharing was implicit when using the `SessionClient`, but when using other clients, you would need to explicitly pass in a `ServiceBusConnection` object in order to share a connection. By making this connection sharing be implicit to a `ServiceBusClient` instance, we can help ensure that applications will not use multiple connections unless they explicitly opt in by creating multiple `ServiceBusClient` instances.
  
 
 ### Client constructors
@@ -67,7 +67,7 @@ ServiceBusClient client = new ServiceBusClient(connectionString);
 
 ### Sending messages
 
-In v4, you could send messages either by using a `QueueClient` (or `TopicClient` if you are targetting a topic) or the `MessageSender`.
+Previously, in `Microsoft.Azure.ServiceBus`, you could send messages either by using a `QueueClient` (or `TopicClient` if you are targetting a topic) or the `MessageSender`.
 While the `QueueClient` supported the simple send operation, the `MessageSender` supported that and advanced scenarios like scheduling to send messages
 at a later time and cancelling such scheduled messages.
 
@@ -84,10 +84,10 @@ MessageSender sender = new MessageSender(connectionString, queueName);
 await sender.SendAsync(message);
 ```
 
-In v7, we combine all the send related features under a common class `ServiceBusSender` that you can create off of the top level client using the `CreateSender()` method.
+Now in `Azure.Messaging.ServiceBus`, we combine all the send related features under a common class `ServiceBusSender` that you can create from the top level client using the `CreateSender()` method which takes the queue or topic you want to target.
 This provides a one stop shop for all your send related needs. 
 
-While we continue to support sending bytes in the message, if you are working with strings, you can now create a message directly without having to convert it to bytes first.
+We continue to support sending bytes in the message. If you are working with strings, you can now create a message directly without having to convert it to bytes first.
 
 ```cs
 // create the client
@@ -103,9 +103,9 @@ ServiceBusMessage message = new ServiceBusMessage("Hello world!");
 await sender.SendMessageAsync(message);
 ```
 
-While we continue to support sending a list of messages in a single call, this feature has always had the potential to fail unexpectedly when the messages exceeded the size limit of the sender.
+The feature to send a list of messages in a single call was implemneted by batching all the messages into a single AMQP message and sending that to the service.
+While we continue to support this feature, it always had the potential to fail unexpectedly when the resulting batched AMQP message exceeded the size limit of the sender.
 To help with this, we now provide a safe way to batch multiple messages to be sent at once using the new `ServiceBusMessageBatch` class.
-
 
 ```cs
 ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
@@ -128,7 +128,7 @@ await sender.SendMessagesAsync(messageBatch);
 
 ### Receiving messages
 
-In v4, you could receive messages either by using a `QueueClient` (or `SubscriptionClient` if you are targetting a subscription) or the `MessageReceiver`.
+Previously, in `Microsoft.Azure.ServiceBus`, you could receive messages either by using a `QueueClient` (or `SubscriptionClient` if you are targetting a subscription) or the `MessageReceiver`.
 
 While the `QueueClient` supported the simple push model where you could register message and error handlers/callbacks, the `MessageReceiver` provided you with ways to receive messages (both normal and deferred) in batches, settle messages and renew locks.
 
@@ -164,8 +164,9 @@ Console.WriteLine($"Received message with Body:{Encoding.UTF8.GetString(received
 await receiver.CompleteAsync(receivedMessage);
 ```
 
-In v7, we introduce the concept of a "processor" which takes your message and error handlers to provide you a simple way to get started with processing your messages.
-The concept of a "receiver" remains for users who need to have a more fine grained control over the receiving and settling messages.
+Now in `Azure.Messaging.ServiceBus`, we introduce the concept of a "processor" which takes your message and error handlers to provide you a simple way to get started with processing your messages. This provides a graceful shutdown via the `StopProcessingAsync` method which will ensure that no more messages will be received, but at the same time you can continue the prcoessing and settling the messages already in flight.
+
+The concept of a "receiver" remains for users who need to have a more fine grained control over the receiving and settling messages. The difference is that this is now created from the top-level `ServiceBusClient` via the `CreateReceiver()` method that would take the queue or subscription you want to target.
 
 ```cs
 // create the ServiceBusClient
@@ -201,13 +202,15 @@ await receiver.CompleteMessageAsync(receivedMessage);
 ```
 ### Working with sessions
 
-In v4, you had the below options to receive messages from a session enabled queue/subscription
+Previously, in `Microsoft.Azure.ServiceBus`, you had the below options to receive messages from a session enabled queue/subscription
 - Register message and error handlers using the `QueueClient.RegisterSessionHandler()` method to receive messages from an available set of sessions 
 - Use the `SessionClient.AcceptMessageSessionAsync()` method to get an instance of the `MessageSession` class that will be tied to a given sessionId or to the next available session if no sessionId is provided.
 
 While the first option is similar to what you would do in a non session scenario, the second that allows you finer grained control is very different from any other pattern used in the library.
 
-In v7, we simplfify this by giving session variants of the same methods and classes that are available when working with queues/subscriptions that do not have sessions enabled.
+Now in `Azure.Messaging.ServiceBus`, we simplfify this by giving session variants of the same methods and classes that are available when working with queues/subscriptions that do not have sessions enabled.
+
+The below code snippet shows you the session variation of the "processor".
 
 ```cs
 // create a processor to receive events from the next available session
@@ -228,7 +231,7 @@ var options = new ServiceBusSessionProcessorOptions
 ServiceBusProcessor processor = client.CreateSessionProcessor(queueName);
 ```
 
-You have similar options when working with the receivers. Please note that creating a session receiver is an async operation because the library will need to get a lock on the session by connecting to the service first.
+The below code snippet shows you the session variation of the "receiver". Please note that creating a session receiver is an async operation because the library will need to get a lock on the session by connecting to the service first.
 
 ```cs
 // create a receiver to receive events from the next available session

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -85,7 +85,7 @@ await sender.SendAsync(message);
 ```
 
 In v7, we combine all the send related features under a common class `ServiceBusSender` that you can create off of the top level client using the `CreateSender()` method.
-This provides a single stop shop for all your send related needs. 
+This provides a one stop shop for all your send related needs. 
 
 While we continue to support sending bytes in the message, if you are working with strings, you can now create a message directly without having to convert it to bytes first.
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -116,8 +116,7 @@ for (var i = 0; i < 10; i++)
     ServiceBusMessage message = new ServiceBusMessage($"Hello world! - {i}");
 
     // Add message the batch
-    var tryAddResult = messageBatch.TryAddMessage((message);
-    if (!tryAddResult)
+    if (!messageBatch.TryAddMessage(message))
     {
       Console.WriteLine($"Failed to add message number {i}");
       break;
@@ -233,14 +232,14 @@ You have similar options when working with the receivers. Please note that creat
 
 ```cs
 // create a receiver to receive events from the next available session
-ServiceBusSessionReceiver receiver = await client.CreateSessionReceiver(queueName);
+ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
 
 // create a receiver to receive events from the given session
 var options = new ServiceBusSessionReceiverOptions
 {
     SessionId = "my-session"
 };
-ServiceBusSessionReceiver receiver = await client.CreateSessionReceiver(queueName, options);
+ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName, options);
 ```
 
 ## Additional samples

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md
@@ -113,12 +113,13 @@ ServiceBusMessageBatch messageBatch = await sender.CreateMessageBatchAsync();
 for (var i = 0; i < 10; i++)
 {
     // create a message
-    ServiceBusMessage message = new ServiceBusMessage("Hello world!" + i);
+    ServiceBusMessage message = new ServiceBusMessage($"Hello world! - {i}");
 
     // Add message the batch
     var tryAddResult = messageBatch.TryAddMessage((message);
-    if (!tryAddResult) {
-      Console.WriteLine("Failed to add message number " + i);
+    if (!tryAddResult)
+    {
+      Console.WriteLine($"Failed to add message number {i}");
       break;
     }
 }
@@ -194,8 +195,8 @@ await processor.StartProcessingAsync();
 
 // Or receive using the receiver
 var receiver = client.CreateReceiver(queueName);
-var receivedMessage = await receiver.ReceiveAsync();
-Console.WriteLine($"Received message with Body:{Encoding.UTF8.GetString(receivedMessage.Body)}");
+var receivedMessage = await receiver.ReceiveMessageAsync();
+Console.WriteLine($"Received message with Body: {receivedMessage.Body}");
 await receiver.CompleteMessageAsync(receivedMessage);
 
 ```
@@ -232,14 +233,14 @@ You have similar options when working with the receivers. Please note that creat
 
 ```cs
 // create a receiver to receive events from the next available session
-await ServiceBusReceiver receiver = client.CreateSessionReceiver(queueName);
+ServiceBusSessionReceiver receiver = await client.CreateSessionReceiver(queueName);
 
 // create a receiver to receive events from the given session
 var options = new ServiceBusSessionReceiverOptions
 {
     SessionId = "my-session"
 };
-await ServiceBusReceiver receiver = client.CreateSessionReceiver(queueName, options);
+ServiceBusSessionReceiver receiver = await client.CreateSessionReceiver(queueName, options);
 ```
 
 ## Additional samples


### PR DESCRIPTION
This PR attempts to improve the Migration Guide for Service Bus along the below lines:
- Highlight the benefits of the new client structure which is one of the biggest changes
- Remove the tables used for comparing before and after. This is not very readable. This was good enough in Event Hubs where the surface area of APIs was much smaller
- Merge the topics of sending & receiving with the corresponding sample code

Please note, I am no C# expert. I have copied some of the code snippets and made up most of the others :)
Relying on @JoshLove-msft to catch my mistakes 