### PR TITLE
Adding the CPlat SDK team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,9 @@
 # Extensions
 /sdk/extensions/                                @pakrym
 
+# Compute
+/sdk/compute/                                   @bilaakpan-ms @sandido @dkulkarni-ms @haagha @madewithsmiles @MS-syh2qs @grizzlytheodore
+
 # Service teams
 # PRLabel: %AzConfig
 /sdk/appconfiguration/                          @annelo-msft @AlexanderSher

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 /sdk/extensions/                                @pakrym
 
 # Compute
+# PRLabel: %Compute
 /sdk/compute/                                   @bilaakpan-ms @sandido @dkulkarni-ms @haagha @madewithsmiles @MS-syh2qs @grizzlytheodore
 
 # Service teams


### PR DESCRIPTION
We should be notified and made code owners of any change to the Compute Platform's SDK repo since we own the SDK for Compute. Please contact cplatsdkdev _at_ microsoft.com if you have any questions