### PR TITLE
Fixing track1 FR version to 0.9.0

### DIFF
--- a/sdk/cognitiveservices/FormRecognizer/CHANGELOG.md
+++ b/sdk/cognitiveservices/FormRecognizer/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Release History
 
-## 1.0.0-preview.1 (Unreleased)
+## 0.9.0 (Unreleased)

--- a/sdk/cognitiveservices/FormRecognizer/src/Microsoft.Azure.CognitiveServices.Vision.FormRecognizer.csproj
+++ b/sdk/cognitiveservices/FormRecognizer/src/Microsoft.Azure.CognitiveServices.Vision.FormRecognizer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Microsoft Cognitive Services Form Recognizer SDK</AssemblyTitle>
     <Description>This client library provides access to the Microsoft Cognitive Services Form Recognizer APIs.</Description>
-    <Version>1.0.0-preview.1</Version>
+    <Version>0.9.0</Version>
     <PackageTags>FormRecognizer;Form Recognizer;</PackageTags>
     <PackageReleaseNotes>
 <![CDATA[


### PR DESCRIPTION
Following guidelines, existing version of FR track1 is 0.8.0, so next version should be 0.9.0