### PR TITLE
[NetAppFiles]Remove ServiceLevel from pool patch test

### DIFF
--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/src/Microsoft.Azure.Management.NetApp.csproj
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/src/Microsoft.Azure.Management.NetApp.csproj
@@ -9,11 +9,11 @@
     <Description>Provides NetApp storage management capabilities for Microsoft Azure.</Description>
     <AssemblyTitle>Microsoft Azure NetApp Management</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Management.NetApp</AssemblyName>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <PackageTags>MicrosoftAzure Management;NetApp</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-        Version 1.5.1 relates to NetApp Files (ANF) 2019-11-01.
+        Version 1.5.2 relates to NetApp Files (ANF) 2019-11-01.
           - Fix MountTarget property in Volume
 
         Azure NetApp Files:

--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/src/Properties/AssemblyInfo.cs
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/src/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides management functionality for Azure NetApp Storage.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyFileVersion("1.5.2.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]

--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/ResourceTests/PoolTests.cs
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/ResourceTests/PoolTests.cs
@@ -200,12 +200,10 @@ namespace NetApp.Tests.ResourceTests
                 // and must also be provided otherwise Bad Request
                 var dict = new Dictionary<string, string>();
                 dict.Add("Tag3", "Value3");
-                pool.Tags = dict;
-                pool.ServiceLevel = "Standard";
+                pool.Tags = dict;                
 
                 var updatedPool = netAppMgmtClient.Pools.CreateOrUpdate(pool, ResourceUtils.resourceGroup, ResourceUtils.accountName1, ResourceUtils.poolName1);
-                Assert.Equal("Standard", updatedPool.ServiceLevel);
-                Assert.Equal(4398046511104, updatedPool.Size); // unchanged
+                Assert.Equal("Standard", updatedPool.ServiceLevel);                
                 Assert.True(updatedPool.Tags.ContainsKey("Tag3"));
                 Assert.Equal("Value3", updatedPool.Tags["Tag3"]);
 
@@ -236,13 +234,11 @@ namespace NetApp.Tests.ResourceTests
                 // size should remain unchanged
                 var poolPatch = new CapacityPoolPatch()
                 {
-                    Tags = dict,
-                    ServiceLevel = "Standard"
+                    Tags = dict,                    
                 };
 
                 var resource = netAppMgmtClient.Pools.Update(poolPatch, ResourceUtils.resourceGroup, ResourceUtils.accountName1, ResourceUtils.poolName1);
-                Assert.Equal("Standard", resource.ServiceLevel);
-                Assert.Equal(4398046511104, resource.Size); // unchanged
+                Assert.Equal("Standard", resource.ServiceLevel);                
                 Assert.True(resource.Tags.ContainsKey("Tag1"));
                 Assert.Equal("Value1", resource.Tags["Tag1"]);
 


### PR DESCRIPTION
In the next upcoming version of the NetAppFiles API specs version 2020-06-01 the property ServiceLevel is removed from Pool Patch as that is no longer supported. 
To be able to pass validation on the spec this PR is needed to remove the reference to the ServiceLevel in Patch operations from the SDK test code as that breaks the Automation SDK Pipeline in the rest-api-specs repo since that property no longer exists in updated SDK.