### PR TITLE
Add query client to IoT Hub service client

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/api/Azure.Iot.Hub.Service.netstandard2.0.cs
@@ -72,6 +72,7 @@ namespace Azure.Iot.Hub.Service
         public virtual Azure.Iot.Hub.Service.JobsClient Jobs { get { throw null; } }
         public virtual Azure.Iot.Hub.Service.CloudToDeviceMessagesClient Messages { get { throw null; } }
         public virtual Azure.Iot.Hub.Service.ModulesClient Modules { get { throw null; } }
+        public virtual Azure.Iot.Hub.Service.QueryClient Query { get { throw null; } }
         public virtual Azure.Iot.Hub.Service.StatisticsClient Statistics { get { throw null; } }
     }
     public partial class IotHubServiceClientOptions : Azure.Core.ClientOptions
@@ -116,6 +117,12 @@ namespace Azure.Iot.Hub.Service
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.Hub.Service.Models.TwinData>> UpdateTwinAsync(Azure.Iot.Hub.Service.Models.TwinData twinUpdate, Azure.Iot.Hub.Service.IfMatchPrecondition precondition = Azure.Iot.Hub.Service.IfMatchPrecondition.IfMatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Iot.Hub.Service.Models.BulkRegistryOperationResponse> UpdateTwins(System.Collections.Generic.IEnumerable<Azure.Iot.Hub.Service.Models.TwinData> twinUpdates, Azure.Iot.Hub.Service.BulkIfMatchPrecondition precondition = Azure.Iot.Hub.Service.BulkIfMatchPrecondition.IfMatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Iot.Hub.Service.Models.BulkRegistryOperationResponse>> UpdateTwinsAsync(System.Collections.Generic.IEnumerable<Azure.Iot.Hub.Service.Models.TwinData> twinUpdates, Azure.Iot.Hub.Service.BulkIfMatchPrecondition precondition = Azure.Iot.Hub.Service.BulkIfMatchPrecondition.IfMatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class QueryClient
+    {
+        protected QueryClient() { }
+        public virtual Azure.Pageable<Azure.Iot.Hub.Service.Models.TwinData> Query(string query, int? pageSize = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.Iot.Hub.Service.Models.TwinData> QueryAsync(string query, int? pageSize = default(int?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class StatisticsClient
     {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/IotHubServiceClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/IotHubServiceClient.cs
@@ -61,6 +61,8 @@ namespace Azure.Iot.Hub.Service
         /// </summary>
         public virtual JobsClient Jobs { get; private set; }
 
+        public virtual QueryClient Query { get; private set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="IotHubServiceClient"/> class.
         /// </summary>
@@ -146,8 +148,13 @@ namespace Azure.Iot.Hub.Service
             _statisticsRestClient = new StatisticsRestClient(_clientDiagnostics, _httpPipeline, credential.Endpoint, options.GetVersionString());
             _configurationRestClient = new ConfigurationRestClient(_clientDiagnostics, _httpPipeline, credential.Endpoint, options.GetVersionString());
 
-            Devices = new DevicesClient(_devicesRestClient, _queryRestClient);
-            Modules = new ModulesClient(_devicesRestClient, _modulesRestClient, _queryRestClient);
+            // Note that the devices and modules subclient take a reference to the Query convenience layer client. This
+            // is because they each expose a helper function that uses the query client for listing twins. By passing in
+            // the convenience layer query client rather than the protocol layer query client, we minimize rewriting the
+            // same pagination logic that now exists only in the query convenience layer client.
+            Query = new QueryClient(_queryRestClient);
+            Devices = new DevicesClient(_devicesRestClient, Query);
+            Modules = new ModulesClient(_devicesRestClient, _modulesRestClient, Query);
             Statistics = new StatisticsClient(_statisticsRestClient);
             Configurations = new ConfigurationsClient(_configurationRestClient);
 

--- a/sdk/iot/Azure.Iot.Hub.Service/src/ModulesClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/ModulesClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,12 +16,11 @@ namespace Azure.Iot.Hub.Service
     /// </summary>
     public class ModulesClient
     {
-        private const string ContinuationTokenHeader = "x-ms-continuation";
         private const string HubModuleQuery = "select * from devices.modules";
 
         private readonly DevicesRestClient _devicesRestClient;
         private readonly ModulesRestClient _modulesRestClient;
-        private readonly QueryRestClient _queryRestClient;
+        private readonly QueryClient _queryClient;
 
         /// <summary>
         /// Initializes a new instance of ModulesClient.
@@ -35,17 +33,17 @@ namespace Azure.Iot.Hub.Service
         /// Initializes a new instance of DevicesClient.
         /// <param name="devicesRestClient"> The REST client to perform bulk operations on the module. </param>
         /// <param name="modulesRestClient"> The REST client to perform module and module twin operations. </param>
-        /// <param name="queryRestClient"> The REST client to perform query operations for the device. </param>
+        /// <param name="queryClient"> The convenience layer query client to perform query operations for the device. </param>
         /// </summary>
-        internal ModulesClient(DevicesRestClient devicesRestClient, ModulesRestClient modulesRestClient, QueryRestClient queryRestClient)
+        internal ModulesClient(DevicesRestClient devicesRestClient, ModulesRestClient modulesRestClient, QueryClient queryClient)
         {
             Argument.AssertNotNull(devicesRestClient, nameof(devicesRestClient));
             Argument.AssertNotNull(modulesRestClient, nameof(modulesRestClient));
-            Argument.AssertNotNull(queryRestClient, nameof(queryRestClient));
+            Argument.AssertNotNull(queryClient, nameof(queryClient));
 
             _devicesRestClient = devicesRestClient;
             _modulesRestClient = modulesRestClient;
-            _queryRestClient = queryRestClient;
+            _queryClient = queryClient;
         }
 
         /// <summary>
@@ -365,80 +363,29 @@ namespace Azure.Iot.Hub.Service
         /// <summary>
         /// List a set of module twins.
         /// </summary>
+        /// <remarks>
+        /// This service request returns the full set of module twins. To get a subset of module twins, you can use the <see cref="QueryClient.QueryAsync(string, int?, CancellationToken)">query API</see> that this method uses but with additional qualifiers for selection.
+        /// </remarks>
         /// <param name="pageSize">The size of each page to be retrieved from the service. Service may override this size.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A pageable set of module twins <see cref="AsyncPageable{T}"/>.</returns>
         public virtual AsyncPageable<TwinData> GetTwinsAsync(int? pageSize = null, CancellationToken cancellationToken = default)
         {
-            async Task<Page<TwinData>> FirstPageFunc(int? pageSizeHint)
-            {
-                var querySpecification = new QuerySpecification
-                {
-                    Query = HubModuleQuery
-                };
-
-                Response<IReadOnlyList<TwinData>> response =
-                    await _queryRestClient.GetTwinsAsync(querySpecification, null, pageSizeHint?.ToString(CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
-
-                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
-
-                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
-            }
-
-            async Task<Page<TwinData>> NextPageFunc(string nextLink, int? pageSizeHint)
-            {
-                var querySpecification = new QuerySpecification();
-
-                Response<IReadOnlyList<TwinData>> response =
-                    await _queryRestClient.GetTwinsAsync(querySpecification, nextLink, pageSizeHint?.ToString(CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
-
-                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
-                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
-            }
-
-            return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc, pageSize);
+            return _queryClient.QueryAsync(HubModuleQuery, pageSize, cancellationToken);
         }
 
         /// <summary>
         /// List a set of module twins.
         /// </summary>
+        /// <remarks>
+        /// This service request returns the full set of module twins. To get a subset of module twins, you can use the <see cref="QueryClient.Query(string, int?, CancellationToken)">query API</see> that this method uses but with additional qualifiers for selection.
+        /// </remarks>
         /// <param name="pageSize">The size of each page to be retrieved from the service. Service may override this size.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A pageable set of module twins <see cref="Pageable{T}"/>.</returns>
         public virtual Pageable<TwinData> GetTwins(int? pageSize = null, CancellationToken cancellationToken = default)
         {
-            Page<TwinData> FirstPageFunc(int? pageSizeHint)
-            {
-                var querySpecification = new QuerySpecification
-                {
-                    Query = HubModuleQuery
-                };
-
-                Response<IReadOnlyList<TwinData>> response = _queryRestClient.GetTwins(
-                    querySpecification,
-                    null,
-                    pageSizeHint?.ToString(CultureInfo.InvariantCulture),
-                    cancellationToken);
-
-                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
-
-                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
-            }
-
-            Page<TwinData> NextPageFunc(string nextLink, int? pageSizeHint)
-            {
-                var querySpecification = new QuerySpecification();
-                Response<IReadOnlyList<TwinData>> response = _queryRestClient.GetTwins(
-                    querySpecification,
-                    nextLink,
-                    pageSizeHint?.ToString(CultureInfo.InvariantCulture),
-                    cancellationToken);
-
-                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
-                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
-            }
-
-            return PageableHelpers.CreateEnumerable(FirstPageFunc, NextPageFunc, pageSize);
+            return _queryClient.Query(HubModuleQuery, pageSize, cancellationToken);
         }
 
         /// <summary>

--- a/sdk/iot/Azure.Iot.Hub.Service/src/QueryClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/QueryClient.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Iot.Hub.Service.Models;
+
+namespace Azure.Iot.Hub.Service
+{
+    /// <summary>
+    /// Query client that can be used to query device and module twins.
+    /// See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#device-twin-queries">Device Twin query examples</see> and
+    /// see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#module-twin-queries">Module Twin query examples</see>.
+    /// </summary>
+    public class QueryClient
+    {
+        private const string ContinuationTokenHeader = "x-ms-continuation";
+
+        private readonly QueryRestClient _queryRestClient;
+
+        /// <summary>
+        /// Initializes a new instance of DevicesClient.
+        /// </summary>
+        protected QueryClient()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of DevicesClient.
+        /// <param name="queryRestClient"> The REST client to perform query operations for the device. </param>
+        /// </summary>
+        internal QueryClient(QueryRestClient queryRestClient)
+        {
+            Argument.AssertNotNull(queryRestClient, nameof(queryRestClient));
+            _queryRestClient = queryRestClient;
+        }
+
+        /// <summary>
+        /// List a set of device twins.
+        /// </summary>
+        /// <param name="query">
+        /// The query for device twins or module twins. See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#device-twin-queries">Device Twin query examples</see>
+        /// and see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#module-twin-queries">Module Twin query examples</see>.
+        /// </param>
+        /// <param name="pageSize">The size of each page to be retrieved from the service. Service may override this size.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A pageable set of device or module twins <see cref="AsyncPageable{T}"/>.</returns>
+        public virtual AsyncPageable<TwinData> QueryAsync(string query, int? pageSize = null, CancellationToken cancellationToken = default)
+        {
+            async Task<Page<TwinData>> FirstPageFunc(int? pageSizeHint)
+            {
+                var querySpecification = new QuerySpecification
+                {
+                    Query = query
+                };
+                Response<IReadOnlyList<TwinData>> response = await _queryRestClient.GetTwinsAsync(
+                    querySpecification,
+                    null,
+                    pageSizeHint?.ToString(CultureInfo.InvariantCulture),
+                    cancellationToken).ConfigureAwait(false);
+
+                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
+
+                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
+            }
+
+            async Task<Page<TwinData>> NextPageFunc(string nextLink, int? pageSizeHint)
+            {
+                var querySpecification = new QuerySpecification()
+                {
+                    Query = query
+                };
+                Response<IReadOnlyList<TwinData>> response = await _queryRestClient.GetTwinsAsync(
+                    querySpecification,
+                    nextLink,
+                    pageSizeHint?.ToString(CultureInfo.InvariantCulture),
+                    cancellationToken).ConfigureAwait(false);
+
+                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
+                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
+            }
+
+            return PageableHelpers.CreateAsyncEnumerable(FirstPageFunc, NextPageFunc, pageSize);
+        }
+
+        /// <summary>
+        /// List a set of device twins.
+        /// </summary>
+        /// <param name="query">
+        /// The query for device twins or module twins. See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#device-twin-queries">Device Twin query examples</see>
+        /// and see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#module-twin-queries">Module Twin query examples</see>.
+        /// </param>
+        /// <param name="pageSize">The size of each page to be retrieved from the service. Service may override this size.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A pageable set of device twins <see cref="Pageable{T}"/>.</returns>
+        public virtual Pageable<TwinData> Query(string query, int? pageSize = null, CancellationToken cancellationToken = default)
+        {
+            Page<TwinData> FirstPageFunc(int? pageSizeHint)
+            {
+                var querySpecification = new QuerySpecification
+                {
+                    Query = query
+                };
+
+                Response<IReadOnlyList<TwinData>> response = _queryRestClient.GetTwins(
+                    querySpecification,
+                    null,
+                    pageSizeHint?.ToString(CultureInfo.InvariantCulture),
+                    cancellationToken);
+
+                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
+
+                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
+            }
+
+            Page<TwinData> NextPageFunc(string nextLink, int? pageSizeHint)
+            {
+                var querySpecification = new QuerySpecification()
+                {
+                    Query = query
+                };
+                Response<IReadOnlyList<TwinData>> response = _queryRestClient.GetTwins(
+                    querySpecification,
+                    nextLink,
+                    pageSizeHint?.ToString(CultureInfo.InvariantCulture),
+                    cancellationToken);
+
+                response.GetRawResponse().Headers.TryGetValue(ContinuationTokenHeader, out string continuationToken);
+                return Page.FromValues(response.Value, continuationToken, response.GetRawResponse());
+            }
+
+            return PageableHelpers.CreateEnumerable(FirstPageFunc, NextPageFunc, pageSize);
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/QueryClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/QueryClient.cs
@@ -22,15 +22,15 @@ namespace Azure.Iot.Hub.Service
         private readonly QueryRestClient _queryRestClient;
 
         /// <summary>
-        /// Initializes a new instance of DevicesClient.
+        /// Initializes a new instance of QueryClient. This constructor should only be used for mocking purposes.
         /// </summary>
         protected QueryClient()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of DevicesClient.
-        /// <param name="queryRestClient"> The REST client to perform query operations for the device. </param>
+        /// Initializes a new instance of QueryClient.
+        /// <param name="queryRestClient"> The REST client to perform query operations. </param>
         /// </summary>
         internal QueryClient(QueryRestClient queryRestClient)
         {
@@ -39,7 +39,7 @@ namespace Azure.Iot.Hub.Service
         }
 
         /// <summary>
-        /// List a set of device twins.
+        /// Query a set of device or module twins asynchronously.
         /// </summary>
         /// <param name="query">
         /// The query for device twins or module twins. See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#device-twin-queries">Device Twin query examples</see>
@@ -87,7 +87,7 @@ namespace Azure.Iot.Hub.Service
         }
 
         /// <summary>
-        /// List a set of device twins.
+        /// Query a set of device or module twins synchronously.
         /// </summary>
         /// <param name="query">
         /// The query for device twins or module twins. See <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language#device-twin-queries">Device Twin query examples</see>
@@ -95,7 +95,7 @@ namespace Azure.Iot.Hub.Service
         /// </param>
         /// <param name="pageSize">The size of each page to be retrieved from the service. Service may override this size.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>A pageable set of device twins <see cref="Pageable{T}"/>.</returns>
+        /// <returns>A pageable set of device or module twins <see cref="Pageable{T}"/>.</returns>
         public virtual Pageable<TwinData> Query(string query, int? pageSize = null, CancellationToken cancellationToken = default)
         {
             Page<TwinData> FirstPageFunc(int? pageSizeHint)


### PR DESCRIPTION
This PR also centralizes the pagination logic we had in both the modulesclient and devicesclient so that we don't repeat that code in multiple places