### PR TITLE
Use ConcurrentBag when testing progress reports

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -813,7 +813,7 @@ namespace Azure.Storage.Blobs.Test
                 // Changing from Assert.AreEqual because these don't always update fast enough
                 if (progressBag.Count > 0)
                 {
-                    Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
+                    Assert.GreaterOrEqual(data.LongLength, progressBag.Max(), "Final progress has unexpected value");
                 }
             }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -795,8 +795,8 @@ namespace Azure.Storage.Blobs.Test
             await blob.CreateAsync();
 
             var data = GetRandomBuffer(blobSize);
-            var progressList = new List<long>();
-            var progressHandler = new Progress<long>(progress => progressList.Add(progress));
+            var progressBag = new System.Collections.Concurrent.ConcurrentBag<long>();
+            var progressHandler = new Progress<long>(progress => progressBag.Add(progress));
             var timesFaulted = 0;
 
             // Act
@@ -808,12 +808,12 @@ namespace Azure.Storage.Blobs.Test
                 () => timesFaulted++))
             {
                 await blobFaulty.AppendBlockAsync(stream, progressHandler: progressHandler);
-                await WaitForProgressAsync(progressList, data.LongLength);
-                Assert.IsTrue(progressList.Count > 1, "Too few progress received");
+                await WaitForProgressAsync(progressBag, data.LongLength);
+                Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                if (progressList.Count > 0)
+                if (progressBag.Count > 0)
                 {
-                    Assert.GreaterOrEqual(data.LongLength, progressList.Last(), "Final progress has unexpected value");
+                    Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
                 }
             }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -351,8 +351,8 @@ namespace Azure.Storage.Blobs.Test
             BlockBlobClient blob = InstrumentClient(test.Container.GetBlockBlobClient(blockBlobName));
             var data = GetRandomBuffer(blobSize);
 
-            var progressList = new List<long>();
-            var progressHandler = new Progress<long>(progress => progressList.Add(progress));
+            var progressBag = new System.Collections.Concurrent.ConcurrentBag<long>();
+            var progressHandler = new Progress<long>(progress => progressBag.Add(progress));
             var timesFaulted = 0;
             // Act
             using (var stream = new FaultyStream(
@@ -364,10 +364,10 @@ namespace Azure.Storage.Blobs.Test
             {
                 await blobFaulty.StageBlockAsync(ToBase64(blockName), stream, null, null, progressHandler: progressHandler);
 
-                await WaitForProgressAsync(progressList, data.LongLength);
-                Assert.IsTrue(progressList.Count > 1, "Too few progress received");
+                await WaitForProgressAsync(progressBag, data.LongLength);
+                Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                Assert.GreaterOrEqual(data.LongLength, progressList.Last(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
             }
 
             // Assert
@@ -1975,8 +1975,8 @@ namespace Azure.Storage.Blobs.Test
             BlockBlobClient blob = InstrumentClient(test.Container.GetBlockBlobClient(blockBlobName));
             var data = GetRandomBuffer(blobSize);
 
-            var progressList = new List<long>();
-            var progressHandler = new Progress<long>(progress => progressList.Add(progress));
+            var progressBag = new System.Collections.Concurrent.ConcurrentBag<long>();
+            var progressHandler = new Progress<long>(progress => progressBag.Add(progress));
             var timesFaulted = 0;
 
             // Act
@@ -1989,10 +1989,10 @@ namespace Azure.Storage.Blobs.Test
             {
                 await blobFaulty.UploadAsync(stream, null, metadata, null, progressHandler: progressHandler);
 
-                await WaitForProgressAsync(progressList, data.LongLength);
-                Assert.IsTrue(progressList.Count > 1, "Too few progress received");
+                await WaitForProgressAsync(progressBag, data.LongLength);
+                Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                Assert.GreaterOrEqual(data.LongLength, progressList.LastOrDefault(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.LastOrDefault(), "Final progress has unexpected value");
             }
 
             // Assert

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -367,7 +367,7 @@ namespace Azure.Storage.Blobs.Test
                 await WaitForProgressAsync(progressBag, data.LongLength);
                 Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Max(), "Final progress has unexpected value");
             }
 
             // Assert
@@ -1992,7 +1992,7 @@ namespace Azure.Storage.Blobs.Test
                 await WaitForProgressAsync(progressBag, data.LongLength);
                 Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                Assert.GreaterOrEqual(data.LongLength, progressBag.LastOrDefault(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Max(), "Final progress has unexpected value");
             }
 
             // Assert

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -723,7 +723,7 @@ namespace Azure.Storage.Blobs.Test
                 await WaitForProgressAsync(progressBag, data.LongLength);
                 Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Max(), "Final progress has unexpected value");
             }
 
             // Assert

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -706,8 +706,8 @@ namespace Azure.Storage.Blobs.Test
 
             var offset = 0 * Constants.KB;
             var data = GetRandomBuffer(blobSize);
-            var progressList = new List<long>();
-            var progressHandler = new Progress<long>(progress => progressList.Add(progress));
+            var progressBag = new System.Collections.Concurrent.ConcurrentBag<long>();
+            var progressHandler = new Progress<long>(progress => progressBag.Add(progress));
             var timesFaulted = 0;
 
             // Act
@@ -720,10 +720,10 @@ namespace Azure.Storage.Blobs.Test
             {
                 await blobFaulty.UploadPagesAsync(stream, offset, progressHandler: progressHandler);
 
-                await WaitForProgressAsync(progressList, data.LongLength);
-                Assert.IsTrue(progressList.Count > 1, "Too few progress received");
+                await WaitForProgressAsync(progressBag, data.LongLength);
+                Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
                 // Changing from Assert.AreEqual because these don't always update fast enough
-                Assert.GreaterOrEqual(data.LongLength, progressList.Last(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
             }
 
             // Assert

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -335,11 +335,12 @@ namespace Azure.Storage.Test.Shared
         /// </param>
         /// <param name="totalSize">The total size we should eventually see.</param>
         /// <returns>A task that will (optionally) delay.</returns>
-        protected async Task WaitForProgressAsync(List<long> progressList, long totalSize)
+        protected async Task WaitForProgressAsync(System.Collections.Concurrent.ConcurrentBag<long> progressBag, long totalSize)
         {
             for (var attempts = 0; attempts < 10; attempts++)
             {
-                if (progressList.LastOrDefault() >= totalSize)
+                // ConcurrentBag.GetEnumerator() returns a snapshot in time; we can safely use linq queries
+                if (progressBag.Max() >= totalSize)
                 {
                     return;
                 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -340,7 +340,7 @@ namespace Azure.Storage.Test.Shared
             for (var attempts = 0; attempts < 10; attempts++)
             {
                 // ConcurrentBag.GetEnumerator() returns a snapshot in time; we can safely use linq queries
-                if (progressBag.Max() >= totalSize)
+                if (progressBag.Count > 0 && progressBag.Max() >= totalSize)
                 {
                     return;
                 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -2186,7 +2186,7 @@ namespace Azure.Storage.Files.Shares.Test
 
                 await WaitForProgressAsync(progressBag, data.LongLength);
                 Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
-                Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Max(), "Final progress has unexpected value");
             }
 
             // Assert

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -2161,8 +2161,8 @@ namespace Azure.Storage.Files.Shares.Test
             await file.CreateAsync(maxSize: fileSize);
 
             var data = GetRandomBuffer(dataSize);
-            var progressList = new List<long>();
-            var progressHandler = new Progress<long>(progress => progressList.Add(progress));
+            var progressBag = new System.Collections.Concurrent.ConcurrentBag<long>();
+            var progressHandler = new Progress<long>(progress => progressBag.Add(progress));
             var timesFaulted = 0;
 
             // Act
@@ -2184,9 +2184,9 @@ namespace Azure.Storage.Files.Shares.Test
                 result.GetRawResponse().Headers.TryGetValue("x-ms-version", out var version);
                 Assert.IsNotNull(version);
 
-                await WaitForProgressAsync(progressList, data.LongLength);
-                Assert.IsTrue(progressList.Count > 1, "Too few progress received");
-                Assert.GreaterOrEqual(data.LongLength, progressList.Last(), "Final progress has unexpected value");
+                await WaitForProgressAsync(progressBag, data.LongLength);
+                Assert.IsTrue(progressBag.Count > 1, "Too few progress received");
+                Assert.GreaterOrEqual(data.LongLength, progressBag.Last(), "Final progress has unexpected value");
             }
 
             // Assert


### PR DESCRIPTION
Hitting a race condition when using LastOrDefault on a List<T> populated by Progress<T> in some tests. Using ConcurrentBag<T> instead.