### PR TITLE
Increase test run timeout

### DIFF
--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceLiveTestsBase.cs
@@ -249,7 +249,7 @@ namespace Azure.Data.Tables.Tests
         protected async Task<TResult> CosmosThrottleWrapper<TResult>(Func<Task<TResult>> action)
         {
             int retryCount = 0;
-            int delay = 500;
+            int delay = 1500;
             while (true)
             {
                 try

--- a/sdk/tables/tests.yml
+++ b/sdk/tables/tests.yml
@@ -4,3 +4,4 @@ extends:
   template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: tables
+    TimeoutInMinutes: 120


### PR DESCRIPTION
Due to Cosmos 429 retry back-offs, some tests run much longer than the equivalent storage backed tests.