### PR TITLE
[Event Hubs Client] Idempotent Producer Support Scaffolding

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/Argument.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/Argument.cs
@@ -101,6 +101,25 @@ namespace Azure.Core
         }
 
         /// <summary>
+        ///   Ensures that an argument's value is at least as large as a given lower bound, throwing
+        ///   <see cref="ArgumentException" /> if that invariant is not met.
+        /// </summary>
+        ///
+        /// <param name="argumentValue">The value of the argument to verify.</param>
+        /// <param name="minimumValue">The minimum to use for comparison; <paramref name="argumentValue"/> must be greater than or equal to this value.</param>
+        /// <param name="argumentName">The name of the argument being considered.</param>
+        ///
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="argumentValue"/> is less than <paramref name="minimumValue"/>.</exception>
+        ///
+        public static void AssertAtLeast(int argumentValue, int minimumValue, string argumentName)
+        {
+            if (argumentValue < minimumValue)
+            {
+                throw new ArgumentOutOfRangeException(argumentName, $"The value supplied must be greater than or equal to {minimumValue}.");
+            }
+        }
+
+        /// <summary>
         ///   Ensures that an instance has not been disposed, throwing an
         ///   <see cref="ObjectDisposedException" /> if that invariant is not met.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ArgumentTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ArgumentTests.cs
@@ -99,8 +99,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(0, 1)]
         [TestCase(1000, 2000)]
         [TestCase(-1001, -1000)]
-        public void ArgumentAtLeastEnforcesInvariants(long value,
-                                                      long minValue)
+        public void ArgumentAtLeastEnforcesInvariantsForLongs(long value,
+                                                             long minValue)
         {
             Assert.That(() => Argument.AssertAtLeast(value, minValue, nameof(value)), Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
@@ -116,8 +116,40 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(99, 0)]
         [TestCase(0, 0)]
         [TestCase(100, 0)]
-        public void ArgumentAtLeastAllowsValidValues(long value,
-                                                     long minValue)
+        public void ArgumentAtLeastAllowsValidValuesForLongs(long value,
+                                                             long minValue)
+        {
+            Assert.That(() => Argument.AssertAtLeast(value, minValue, nameof(value)), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="Argument.AssertAtLeast" /> method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(2, 3)]
+        [TestCase(0, 1)]
+        [TestCase(1000, 2000)]
+        [TestCase(-1001, -1000)]
+        public void ArgumentAtLeastEnforcesInvariantsForInts(int value,
+                                                             int minValue)
+        {
+            Assert.That(() => Argument.AssertAtLeast(value, minValue, nameof(value)), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="Argument.AssertAtLeast" /> method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(1, 0)]
+        [TestCase(10, -100)]
+        [TestCase(-5, -10)]
+        [TestCase(99, 0)]
+        [TestCase(0, 0)]
+        [TestCase(100, 0)]
+        public void ArgumentAtLeastAllowsValidValuesForInts(int value,
+                                                            int minValue)
         {
             Assert.That(() => Argument.AssertAtLeast(value, minValue, nameof(value)), Throws.Nothing);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -10,6 +10,7 @@ namespace Azure.Messaging.EventHubs
         public long Offset { get { throw null; } }
         public string PartitionKey { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
+        public int? PublishedSequenceNumber { get { throw null; } }
         public long SequenceNumber { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, object> SystemProperties { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -83,6 +84,8 @@ namespace Azure.Messaging.EventHubs
             ServiceBusy = 6,
             ServiceTimeout = 7,
             ServiceCommunicationProblem = 8,
+            ProducerDisconnected = 9,
+            InvalidClientState = 10,
         }
     }
     public enum EventHubsRetryMode
@@ -434,6 +437,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public int Count { get { throw null; } }
         public long MaximumSizeInBytes { get { throw null; } }
         public long SizeInBytes { get { throw null; } }
+        public int? StartingPublishedSequenceNumber { get { throw null; } }
         public void Dispose() { }
         public bool TryAdd(Azure.Messaging.EventHubs.EventData eventData) { throw null; }
     }
@@ -470,6 +474,8 @@ namespace Azure.Messaging.EventHubs.Producer
     {
         public EventHubProducerClientOptions() { }
         public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
+        public bool EnableIdempotentPartitions { get { throw null; } set { } }
+        public System.Collections.Generic.Dictionary<string, Azure.Messaging.EventHubs.Producer.PartitionPublishingOptions> PartitionOptions { get { throw null; } }
         public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
@@ -477,6 +483,21 @@ namespace Azure.Messaging.EventHubs.Producer
         public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
+    }
+    public partial class PartitionPublishingOptions
+    {
+        public PartitionPublishingOptions() { }
+        public short? OwnerLevel { get { throw null; } set { } }
+        public long? ProducerGroupId { get { throw null; } set { } }
+        public int? StartingSequenceNumber { get { throw null; } set { } }
+    }
+    public partial class PartitionPublishingProperties
+    {
+        protected internal PartitionPublishingProperties(bool isIdempotentPublishingEnabled, long? producerGroupId, short? ownerLevel, int? lastPublishedSequenceNumber) { }
+        public bool IsIdempotentPublishingEnabled { get { throw null; } }
+        public int? LastPublishedSequenceNumber { get { throw null; } set { } }
+        public short? OwnerLevel { get { throw null; } set { } }
+        public long? ProducerGroupId { get { throw null; } set { } }
     }
     public partial class SendEventOptions
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -52,6 +52,18 @@ namespace Azure.Messaging.EventHubs.Amqp
         public override long SizeInBytes => _sizeBytes;
 
         /// <summary>
+        ///   The publishing sequence number assigned to the first event in the batch at the time
+        ///   the batch was successfully published.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   The starting published sequence number is only populated and relevant when certain features
+        ///   of the producer are enabled.  For example, it is used by idempotent publishing.
+        /// </remarks>
+        ///
+        public override int? StartingPublishedSequenceNumber { get; set; }
+
+        /// <summary>
         ///   The count of events contained in the batch.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -315,7 +315,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
         public virtual async Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                             CancellationToken cancellationToken = default)
+                                                                                   CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubConsumerClient));
             return await Connection.GetPartitionPropertiesAsync(partitionId, RetryPolicy, cancellationToken).ConfigureAwait(false);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
@@ -26,11 +26,11 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <summary>
         ///   When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the
         ///   requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership
-        ///   over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same
-        ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
+        ///   over the partition; in the case where more than one exclusive reader in the consumer group attempts to assert ownership
+        ///   for the same partition, the one having a larger <see cref="OwnerLevel"/> value will "win".
         ///
-        ///   When an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either
-        ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
+        ///   <para>When an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either
+        ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.</para>
         /// </summary>
         ///
         /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
@@ -71,8 +71,8 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   If specified, should there be no events available before this waiting period expires, an empty event will be returned,
         ///   allowing control to return to the reader that was waiting.
         ///
-        ///   If <c>null</c>, the reader will wait forever for items to be available unless reading is canceled. Empty items will
-        ///   not be returned.
+        ///   <para>If <c>null</c>, the reader will wait forever for items to be available unless reading is canceled. Empty items will
+        ///   not be returned.</para>
         /// </value>
         ///
         public TimeSpan? MaximumWaitTime

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
@@ -31,6 +31,25 @@ namespace Azure.Messaging.EventHubs.Core
         public abstract long SizeInBytes { get; }
 
         /// <summary>
+        ///   The publishing sequence number assigned to the first event in the batch at the time
+        ///   the batch was successfully published.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The sequence number of the first event in the batch, if the batch was successfully
+        ///   published by a sequence-aware producer.  If the producer was not configured to apply
+        ///   sequence numbering or if the batch has not yet been successfully published, this member
+        ///   will be <c>null</c>.
+        ///</value>
+        ///
+        /// <remarks>
+        ///   The starting published sequence number is only populated and relevant when certain features
+        ///   of the producer are enabled.  For example, it is used by idempotent publishing.
+        /// </remarks>
+        ///
+        public abstract int? StartingPublishedSequenceNumber { get; set; }
+
+        /// <summary>
         ///   The count of events contained in the batch.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using Azure.Core;
 using Azure.Messaging.EventHubs.Consumer;
 
 namespace Azure.Messaging.EventHubs
@@ -16,6 +17,9 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventData
     {
+        /// <summary>The sequence number associated with publishing of the event.</summary>
+        private int? _publishedSequenceNumber = null;
+
         /// <summary>
         ///   The data associated with the event.
         /// </summary>
@@ -83,6 +87,37 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         public IReadOnlyDictionary<string, object> SystemProperties { get; }
+
+        /// <summary>
+        ///   The publishing sequence number assigned to the event at the time it was successfully published.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The sequence number that was assigned during publishing, if the event was successfully
+        ///   published by a sequence-aware producer.  If the producer was not configured to apply
+        ///   sequence numbering or if the event has not yet been successfully published, this member
+        ///   will be <c>null</c>.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   The published sequence number is only populated and relevant when certain features
+        ///   of the producer are enabled.  For example, it is used by idempotent publishing.
+        /// </remarks>
+        ///
+        public int? PublishedSequenceNumber
+        {
+            get => _publishedSequenceNumber;
+
+            internal set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertAtLeast(value.Value, 0, nameof(PublishedSequenceNumber));
+                }
+
+                _publishedSequenceNumber = value;
+            }
+        }
 
         /// <summary>
         ///   The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Producer;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -216,7 +217,13 @@ namespace Azure.Messaging.EventHubs
             ServiceTimeout,
 
             /// <summary>There was a general communications error encountered when interacting with the Azure Event Hubs service.</summary>
-            ServiceCommunicationProblem
+            ServiceCommunicationProblem,
+
+            /// <summary>A client was forcefully disconnected from an Event Hub instance.  This typically occurs when another consumer with higher <see cref="PartitionPublishingOptions.OwnerLevel" /> asserts ownership over the partition and producer group.</summary>
+            ProducerDisconnected,
+
+            /// <summary>A client is in an invalid state from which it cannot recover.  It is recommended that the client be closed and recreated to force reinitialization of state.</summary>
+            InvalidClientState
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -42,6 +42,38 @@ namespace Azure.Messaging.EventHubs.Producer
         public long SizeInBytes => InnerBatch.SizeInBytes;
 
         /// <summary>
+        ///   The publishing sequence number assigned to the first event in the batch at the time
+        ///   the batch was successfully published.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The sequence number of the first event in the batch, if the batch was successfully
+        ///   published by a sequence-aware producer.  If the producer was not configured to apply
+        ///   sequence numbering or if the batch has not yet been successfully published, this member
+        ///   will be <c>null</c>.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   The starting published sequence number is only populated and relevant when certain features
+        ///   of the producer are enabled.  For example, it is used by idempotent publishing.
+        /// </remarks>
+        ///
+        public int? StartingPublishedSequenceNumber
+        {
+            get => InnerBatch.StartingPublishedSequenceNumber;
+
+            internal set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertAtLeast(value.Value, 0, nameof(StartingPublishedSequenceNumber));
+                }
+
+                InnerBatch.StartingPublishedSequenceNumber = value;
+            }
+        }
+
+        /// <summary>
         ///   The count of events contained in the batch.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Core;
@@ -19,6 +20,31 @@ namespace Azure.Messaging.EventHubs.Producer
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
+
+        /// <summary>
+        ///   Indicates whether or not the producer should enable idempotent publishing to the Event Hub partitions.  If
+        ///   enabled, the producer will only be able to publish directly to partitions; it will not be able to publish to
+        ///   the Event Hubs gateway for automatic partition routing nor using a partition key.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if the producer should enable idempotent partition publishing; otherwise, <c>false</c>.</value>
+        ///
+        public bool EnableIdempotentPartitions { get; set; }
+
+        /// <summary>
+        ///   The set of options that can be specified to influence publishing behavior specific to the configured Event Hub partition.  These
+        ///   options are not necessary in the majority of scenarios and are intended for use with specialized scenarios, such as when
+        ///   recovering the state used for idempotent publishing.
+        ///
+        ///   <para>It is highly recommended that these options only be specified if there is a proven need to do so; Incorrectly configuring these
+        ///   values may result in an <see cref="EventHubProducerClient" /> instance that is unable to publish to the Event Hubs.</para>
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   These options are ignored when publishing to the Event Hubs gateway for automatic routing or when using a partition key.
+        /// </remarks>
+        ///
+        public Dictionary<string, PartitionPublishingOptions> PartitionOptions { get; } = new Dictionary<string, PartitionPublishingOptions>();
 
         /// <summary>
         ///   The options used for configuring the connection to the Event Hubs service.
@@ -85,11 +111,21 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>A new copy of <see cref="EventHubProducerClientOptions" />.</returns>
         ///
-        internal EventHubProducerClientOptions Clone() =>
-            new EventHubProducerClientOptions
+        internal EventHubProducerClientOptions Clone()
+        {
+            var copiedOptions = new EventHubProducerClientOptions
             {
+                EnableIdempotentPartitions = EnableIdempotentPartitions,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone()
             };
+
+            foreach (var pair in PartitionOptions)
+            {
+                copiedOptions.PartitionOptions.Add(pair.Key, pair.Value.Clone());
+            }
+
+            return copiedOptions;
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.Producer
+{
+    /// <summary>
+    ///   The set of options that can be specified for an <see cref="EventHubProducerClient" />
+    ///   to influence its behavior when publishing directly to an Event Hub partition.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These options are ignored when publishing to the Event Hubs gateway for automatic
+    ///   routing or when using a partition key.
+    /// </remarks>
+    ///
+    public class PartitionPublishingOptions
+    {
+        /// <summary>
+        ///   The identifier of the producer group that this producer is associated with when publishing to the associated partition.
+        ///   Events will be published in the context of this group.
+        /// </summary>
+        ///
+        /// <value>The identifier of the producer group to associate with the partition; if <c>null</c>, the Event Hubs service will control the value.</value>
+        ///
+        /// <remarks>
+        ///   The producer group is only recognized and relevant when certain features of the producer are enabled.  For example, it is used by
+        ///   idempotent publishing.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventHubProducerClientOptions.EnableIdempotentPartitions" />
+        ///
+        public long? ProducerGroupId  { get; set; }
+
+        /// <summary>
+        ///   The owner level indicates that a publishing is intended to be performed exclusively for events in the
+        ///   requested partition in the context of the associated producer group.  To do so, publishing will attempt to assert ownership
+        ///   over the partition; in the case where more than one publisher in the producer group attempts to assert ownership for the same
+        ///   partition, the one having a larger <see cref="OwnerLevel"/> value will "win".
+        ///
+        ///   <para>When an owner level is specified, other exclusive publishers which have a lower owner level within the context of the same producer
+        ///   group will either not be allowed to be created or, if they already exist, will encounter an exception during the next attempted operation.  Should
+        ///   there be multiple producers in the producer group with the same owner level, each of them will be able to publish to the partition.</para>
+        ///
+        ///   <para>Producers with no owner level or which belong to a different producer group are permitted to publish to the associated partition without
+        /// restriction or awareness of other exclusive producers.</para>
+        /// </summary>
+        ///
+        /// <value>The relative priority to associate with an exclusive publisher; if <c>null</c>, the Event Hubs service will control the value.</value>
+        ///
+        /// <remarks>
+        ///   The owner level is only recognized and relevant when certain features of the producer are enabled.  For example, it is used by
+        ///   idempotent publishing.
+        ///
+        ///   <para>An <see cref="EventHubsException"/> will occur if an <see cref="EventHubProducerClient"/> is unable to read events from the
+        ///   requested Event Hub partition for the given consumer group.  In this case, the <see cref="EventHubsException.FailureReason"/>
+        ///   will be set to <see cref="EventHubsException.FailureReason.ProducerDisconnected"/>.</para>
+        /// </remarks>
+        ///
+        /// <seealso cref="EventHubsException" />
+        /// <seealso cref="EventHubsException.FailureReason.ProducerDisconnected" />
+        /// <seealso cref="EventHubProducerClientOptions.EnableIdempotentPartitions" />
+        ///
+        public short? OwnerLevel { get; set; }
+
+        /// <summary>
+        ///   The starting number that should be used for the automatic sequencing of events for the associated partition, when published by this producer.
+        /// </summary>
+        ///
+        /// <value>The starting sequence number to associate with the partition; if <c>null</c>, the Event Hubs service will control the value.</value>
+        ///
+        /// <remarks>
+        ///   The starting sequence number is only recognized and relevant when certain features of the producer are enabled.  For example, it is used by
+        ///   idempotent publishing.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventHubProducerClientOptions.EnableIdempotentPartitions" />
+        ///
+        public int? StartingSequenceNumber { get; set; }
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="PartitionPublishingOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="PartitionPublishingOptions" />.</returns>
+        ///
+        internal PartitionPublishingOptions Clone() =>
+            new PartitionPublishingOptions
+            {
+                ProducerGroupId = ProducerGroupId,
+                OwnerLevel = OwnerLevel,
+                StartingSequenceNumber = StartingSequenceNumber
+            };
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.Producer
+{
+    /// <summary>
+    ///   A set of information for an Event Hub.
+    /// </summary>
+    ///
+    public class PartitionPublishingProperties
+    {
+        /// <summary>
+        ///   Indicates whether or not idempotent publishing is enabled for the producer and, by extension, the associated partition.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if the idempotent publishing is enabled; otherwise, <c>false</c>.</value>
+        ///
+        public bool IsIdempotentPublishingEnabled { get; }
+
+        /// <summary>
+        ///   The identifier of the producer group for which this producer is publishing to the associated partition.
+        /// </summary>
+        ///
+        public long? ProducerGroupId  { get; set; }
+
+        /// <summary>
+        ///   The owner level of this producer for publishing to the associated partition.
+        /// </summary>
+        ///
+        public short? OwnerLevel { get; set; }
+
+        /// <summary>
+        ///   The sequence number assigned to the event that was most recently published to the associated partition
+        ///   successfully.
+        /// </summary>
+        ///
+        public int? LastPublishedSequenceNumber   { get; set; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="isIdempotentPublishingEnabled">Indicates whether idempotent publishing is enabled.</param>
+        /// <param name="producerGroupId">The identifier of the producer group associated with the partition.</param>
+        /// <param name="ownerLevel">The owner level associated with the partition.</param>
+        /// <param name="lastPublishedSequenceNumber">The sequence number assigned to the event that was last successfully published to the partition.</param>
+        ///
+        protected internal PartitionPublishingProperties(bool isIdempotentPublishingEnabled,
+                                                         long? producerGroupId,
+                                                         short? ownerLevel,
+                                                         int? lastPublishedSequenceNumber) =>
+            (IsIdempotentPublishingEnabled, ProducerGroupId, OwnerLevel, LastPublishedSequenceNumber) = (isIdempotentPublishingEnabled, producerGroupId, ownerLevel, lastPublishedSequenceNumber);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -55,6 +55,41 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.PublishedSequenceNumber "/>
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void PublishedSequenceNumberValidatesOnSet(int value)
+        {
+            var eventData = new EventData(Array.Empty<byte>());
+            Assert.That(() => eventData.PublishedSequenceNumber = value, Throws.InstanceOf<ArgumentException>(), "Negative values should not be allowed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.PublishedSequenceNumber "/>
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(10)]
+        [TestCase(100)]
+        [TestCase(32768)]
+        public void PublishedSequenceNumberAllowsValidValues(int? value)
+        {
+            var eventData = new EventData(Array.Empty<byte>());
+            eventData.PublishedSequenceNumber = value;
+
+            Assert.That(eventData.PublishedSequenceNumber, Is.EqualTo(value), "The value should have been accepted.");
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="EventData.Clone" />
         ///   method.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -96,6 +96,45 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(batch.MaximumSizeInBytes, Is.EqualTo(mockBatch.MaximumSizeInBytes), "The maximum size should have been delegated.");
             Assert.That(batch.SizeInBytes, Is.EqualTo(mockBatch.SizeInBytes), "The size should have been delegated.");
             Assert.That(batch.Count, Is.EqualTo(mockBatch.Count), "The count should have been delegated.");
+            Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(mockBatch.StartingPublishedSequenceNumber), "The starting published sequence number should have been delegated.");
+        }
+
+        /// <summary>
+        ///   Verifies property accessors for the <see cref="EventDataBatch" />
+        ///   class.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void StartingPublishedSequenceNumberValidatesOnSet(int value)
+        {
+            var mockBatch = new MockTransportBatch();
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
+
+            Assert.That(() => batch.StartingPublishedSequenceNumber = value, Throws.InstanceOf<ArgumentException>(), "Negative values should not be allowed.");
+        }
+
+        // <summary>
+        ///   Verifies property accessors for the <see cref="EventDataBatch" />
+        ///   class.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(10)]
+        [TestCase(100)]
+        [TestCase(32768)]
+        public void StartingPublishedSequenceNumberValidatesAllowsValidValues(int? value)
+        {
+            var mockBatch = new MockTransportBatch();
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
+
+            batch.StartingPublishedSequenceNumber = value;
+            Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(value), "The value should have been accepted.");
         }
 
         /// <summary>
@@ -272,8 +311,12 @@ namespace Azure.Messaging.EventHubs.Tests
             public EventData TryAddCalledWith = null;
 
             public override long MaximumSizeInBytes { get; } = 200;
+
             public override long SizeInBytes { get; } = 100;
-            public override int Count { get; } = 300;
+
+            public override int? StartingPublishedSequenceNumber { get; set; } = 300;
+
+            public override int Count { get; } = 400;
 
             public override void Clear() => ClearInvoked = true;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -1431,6 +1431,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
+            public override int? StartingPublishedSequenceNumber { get; set; }
             public override int Count { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
             public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/PartitionPublishingOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/PartitionPublishingOptionsTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Messaging.EventHubs.Producer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="PartitionPublishingOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class PartitionPublishingOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new PartitionPublishingOptions
+            {
+                OwnerLevel = 3,
+                ProducerGroupId = 99,
+                StartingSequenceNumber = 42
+            };
+
+            var clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+
+            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level should have been copied.");
+            Assert.That(clone.ProducerGroupId, Is.EqualTo(options.ProducerGroupId), "The producer group identifier should have been copied.");
+            Assert.That(clone.StartingSequenceNumber, Is.EqualTo(options.StartingSequenceNumber), "The starting sequence number should have been copied.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -378,6 +378,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
             public override int Count { get; }
+            public override int? StartingPublishedSequenceNumber { get; set; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
             public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the idempotent publishing feature scaffolding for the supporting types.  The `EventHubProducerClient` changes
are not included in this set, and no service operations are yet active.

**Note:**  These API changes are part of a preview feature.  The design and API surface were informally reviewed with the language architect but have not yet undergone formal review with the architecture board.  I expect some changes, particularly around naming.

# Last Upstream Rebase

Friday, August 14, 1:28pm (EDT)

# References and Related Issues

- [Idempotent Publishing Design](https://gist.github.com/jsquire/1cc4db6b3ca4ef13d26dc5315483555b)
- [Idempotent Publishing Requirements with Usage](https://gist.github.com/jsquire/0f3bc5701388fe03ccd027e86f1994f1)
- [Idempotent Publishing Support](https://github.com/Azure/azure-sdk-for-net/issues/13941) ([#13941](https://github.com/Azure/azure-sdk-for-net/issues/13941))