### PR TITLE
[TA] LanguageInput and DetectedLanguage allow null values

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/DetectedLanguage_internal.Serialization.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/DetectedLanguage_internal.Serialization.cs
@@ -21,11 +21,21 @@ namespace Azure.AI.TextAnalytics.Models
             {
                 if (property.NameEquals("name"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        name = null;
+                        continue;
+                    }
                     name = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("iso6391Name"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        iso6391Name = null;
+                        continue;
+                    }
                     iso6391Name = property.Value.GetString();
                     continue;
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/DetectedLanguage_internal.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/DetectedLanguage_internal.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.TextAnalytics.Models
 {
     /// <summary> The DetectedLanguage. </summary>
@@ -16,18 +14,8 @@ namespace Azure.AI.TextAnalytics.Models
         /// <param name="name"> Long name of a detected language (e.g. English, French). </param>
         /// <param name="iso6391Name"> A two letter representation of the detected language according to the ISO 639-1 standard (e.g. en, fr). </param>
         /// <param name="confidenceScore"> A confidence score between 0 and 1. Scores close to 1 indicate 100% certainty that the identified language is true. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="name"/> or <paramref name="iso6391Name"/> is null. </exception>
         internal DetectedLanguage_internal(string name, string iso6391Name, double confidenceScore)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (iso6391Name == null)
-            {
-                throw new ArgumentNullException(nameof(iso6391Name));
-            }
-
             Name = name;
             Iso6391Name = iso6391Name;
             ConfidenceScore = confidenceScore;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/LanguageInput.Serialization.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/LanguageInput.Serialization.cs
@@ -15,10 +15,24 @@ namespace Azure.AI.TextAnalytics.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("id");
-            writer.WriteStringValue(Id);
-            writer.WritePropertyName("text");
-            writer.WriteStringValue(Text);
+            if (Id != null)
+            {
+                writer.WritePropertyName("id");
+                writer.WriteStringValue(Id);
+            }
+            else
+            {
+                writer.WriteNull("id");
+            }
+            if (Text != null)
+            {
+                writer.WritePropertyName("text");
+                writer.WriteStringValue(Text);
+            }
+            else
+            {
+                writer.WriteNull("text");
+            }
             if (Optional.IsDefined(CountryHint))
             {
                 writer.WritePropertyName("countryHint");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/LanguageInput.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Generated/Models/LanguageInput.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.TextAnalytics.Models
 {
     /// <summary> The LanguageInput. </summary>
@@ -15,18 +13,8 @@ namespace Azure.AI.TextAnalytics.Models
         /// <summary> Initializes a new instance of LanguageInput. </summary>
         /// <param name="id"> Unique, non-empty document identifier. </param>
         /// <param name="text"> . </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="id"/> or <paramref name="text"/> is null. </exception>
         public LanguageInput(string id, string text)
         {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
             Id = id;
             Text = text;
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/autorest.md
@@ -19,3 +19,23 @@ directive:
   transform: >
     $["x-accessibility"] = "internal"
 ```
+
+### Add nullable annotations
+This is to guarantee that we don't introduce breaking changes now that we autogerate the code.
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.DetectedLanguage
+  transform: >
+    $.properties.name["x-nullable"] = true;
+    $.properties.iso6391Name["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.LanguageInput
+  transform: >
+    $.properties.id["x-nullable"] = true;
+    $.properties.text["x-nullable"] = true;
+```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullIdTest.json
@@ -1,0 +1,53 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://azsdknet-test-ta.cognitiveservices.azure.com/text/analytics/v3.1-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "48",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-901c09f18ea227429f3886bd9b61aaad-de63af437422b24c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.1.0-dev.20200814.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "7f6f73c6d06dd1a82275221d1a0c6d59",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": null,
+            "text": "Hello world"
+          }
+        ]
+      },
+      "StatusCode": 400,
+      "ResponseHeaders": {
+        "apim-request-id": "9ccf1dd6-9db5-4fcc-b385-576996313a40",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 14 Aug 2020 19:56:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "799"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Invalid document in request.",
+          "innererror": {
+            "code": "InvalidDocument",
+            "message": "At least one document is missing an Id attribute."
+          }
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1095465208",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://azsdknet-test-ta.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullIdTestAsync.json
@@ -1,0 +1,53 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://azsdknet-test-ta.cognitiveservices.azure.com/text/analytics/v3.1-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "48",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-efa3e5b4d2883848b98d67aa9394178f-7f2e48fdafb14f45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.1.0-dev.20200814.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "2ddf49c8be31af616b47ab79ee132141",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": null,
+            "text": "Hello world"
+          }
+        ]
+      },
+      "StatusCode": 400,
+      "ResponseHeaders": {
+        "apim-request-id": "1f4819a7-1abb-4ee0-9380-92bb66ca5e02",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 14 Aug 2020 19:56:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "822"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Invalid document in request.",
+          "innererror": {
+            "code": "InvalidDocument",
+            "message": "At least one document is missing an Id attribute."
+          }
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "130550458",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://azsdknet-test-ta.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullTextTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullTextTest.json
@@ -1,0 +1,60 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://azsdknet-test-ta.cognitiveservices.azure.com/text/analytics/v3.1-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "38",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6e0ef40433f4144798f7366bd7613d6b-3cc18ad6c5465448-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.1.0-dev.20200814.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e02424dc39e0f1eeb5c607560e5f7b82",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": "1",
+            "text": null
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d9b4827d-cbce-4306-8955-4e6b86e0adc2",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 14 Aug 2020 19:56:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "899"
+      },
+      "ResponseBody": {
+        "documents": [],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "message": "Invalid document in request.",
+              "innererror": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              }
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "93526110",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://azsdknet-test-ta.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullTextTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithNullTextTestAsync.json
@@ -1,0 +1,60 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://azsdknet-test-ta.cognitiveservices.azure.com/text/analytics/v3.1-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "38",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7703048648f7ec46a380917fde47444f-7eba4248f6f63544-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.1.0-dev.20200814.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "102789a0d3f16b6052eaf8641b307b7e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": "1",
+            "text": null
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5cfdc202-9bd1-498d-b3e3-adf69a0ff597",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 14 Aug 2020 19:56:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "931"
+      },
+      "ResponseBody": {
+        "documents": [],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "message": "Invalid document in request.",
+              "innererror": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              }
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1170714343",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://azsdknet-test-ta.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -246,6 +246,31 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        public void DetectLanguageBatchWithNullIdTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var documents = new List<DetectLanguageInput> { new DetectLanguageInput(null, "Hello world") };
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
+                async () => await client.DetectLanguageBatchAsync(documents, options: new TextAnalyticsRequestOptions() { ModelVersion = "2019-10-01" }));
+            Assert.AreEqual(TextAnalyticsErrorCode.InvalidDocument, ex.ErrorCode);
+        }
+
+        [Test]
+        public async Task DetectLanguageBatchWithNullTextTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var documents = new List<DetectLanguageInput> { new DetectLanguageInput("1", null) };
+
+            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(documents, options: new TextAnalyticsRequestOptions() { ModelVersion = "2019-10-01" });
+
+            var exceptionMessage = "Cannot access result for document 1, due to error InvalidDocument: Document text is empty.";
+            Assert.IsTrue(results[0].HasError);
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => results[0].PrimaryLanguage.GetType());
+            Assert.AreEqual(exceptionMessage, ex.Message);
+        }
+
+        [Test]
         public async Task AnalyzeSentimentTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
@@ -6,7 +6,9 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -136,6 +138,90 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual("5", resultCollection[1].Id);
             Assert.AreEqual("2", resultCollection[2].Id);
             Assert.AreEqual("3", resultCollection[3].Id);
+        }
+
+        [Test]
+        public async Task DetectedLanguageNullName()
+        {
+
+            using var Stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
+                {
+                    ""documents"": [
+                    {
+                        ""id"": ""1"",
+                        ""detectedLanguage"": {
+                            ""name"": null,
+                            ""iso6391Name"": ""en"",
+                            ""confidenceScore"": 1
+                            },
+                            ""warnings"": []
+                        }
+                    ],
+                    ""errors"": [],
+                    ""modelVersion"": ""2020 -07-01""
+                }"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = Stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<DetectLanguageInput>
+            {
+                new DetectLanguageInput("1", "Hello world")
+                {
+                     CountryHint = "us",
+                }
+            };
+
+            DetectLanguageResultCollection response = await client.DetectLanguageBatchAsync(documents);
+
+            Assert.IsNull(response.FirstOrDefault().PrimaryLanguage.Name);
+            Assert.IsNotNull(response.FirstOrDefault().PrimaryLanguage.Iso6391Name);
+
+        }
+
+        [Test]
+        public async Task DetectedLanguageNullIso6391Name()
+        {
+
+            using var Stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
+                {
+                    ""documents"": [
+                    {
+                        ""id"": ""1"",
+                        ""detectedLanguage"": {
+                            ""name"": ""English"",
+                            ""iso6391Name"": null,
+                            ""confidenceScore"": 1
+                            },
+                            ""warnings"": []
+                        }
+                    ],
+                    ""errors"": [],
+                    ""modelVersion"": ""2020 -07-01""
+                }"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = Stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<DetectLanguageInput>
+            {
+                new DetectLanguageInput("1", "Hello world")
+                {
+                     CountryHint = "us",
+                }
+            };
+
+            DetectLanguageResultCollection response = await client.DetectLanguageBatchAsync(documents);
+
+            Assert.IsNotNull(response.FirstOrDefault().PrimaryLanguage.Name);
+            Assert.IsNull(response.FirstOrDefault().PrimaryLanguage.Iso6391Name);
+
         }
 
         private void SerializeRecognizeEntitiesResultCollection(ref Utf8JsonWriter json, RecognizeEntitiesResultCollection resultCollection)


### PR DESCRIPTION
This in order to follow the behavior we were doing before codegen and therefore not introducing breaking changes.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/14130