### PR TITLE
[FormRecognizer] Enabling tests after service-side fixes

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -1197,7 +1197,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Recognizer cognitive service and handle returned errors.
         /// </summary>
         [Test]
-        [TestCase(true, Ignore = "https://github.com/Azure/azure-sdk-for-net/issues/12319")]
+        [TestCase(true)]
         [TestCase(false)]
         public async Task StartRecognizeCustomFormsFromUriThrowsForNonExistingContent(bool useTrainingLabels)
         {
@@ -1209,9 +1209,8 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, invalidUri);
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
-            string expectedErrorCode = useTrainingLabels ? "3003" : "2003";
-            Assert.AreEqual(expectedErrorCode, ex.ErrorCode);
 
+            Assert.AreEqual("2003", ex.ErrorCode);
             Assert.True(operation.HasCompleted);
             Assert.False(operation.HasValue);
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -246,7 +246,6 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         [Test]
-        [Ignore("Issue: https://github.com/Azure/azure-sdk-for-net/issues/12319")]
         public void CopyModelError()
         {
             var sourceClient = CreateFormTrainingClient();
@@ -256,7 +255,10 @@ namespace Azure.AI.FormRecognizer.Tests
 
             CopyAuthorization targetAuth = CopyAuthorization.FromJson("{\"modelId\":\"328c3b7d - a563 - 4ba2 - 8c2f - 2f26d664486a\",\"accessToken\":\"5b5685e4 - 2f24 - 4423 - ab18 - 000000000000\",\"expirationDateTimeTicks\":1591932653,\"resourceId\":\"resourceId\",\"resourceRegion\":\"westcentralus\"}");
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await sourceClient.StartCopyModelAsync("00000000-0000-0000-0000-000000000000", targetAuth));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await sourceClient.StartCopyModelAsync("00000000-0000-0000-0000-000000000000", targetAuth));
+
+            Assert.AreEqual(400, ex.Status);
+            Assert.AreEqual("1002", ex.ErrorCode);
         }
 
         [Test]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormRecognizerClientLiveTests/StartRecognizeCustomFormsFromUriThrowsForNonExistingContent(True).json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormRecognizerClientLiveTests/StartRecognizeCustomFormsFromUriThrowsForNonExistingContent(True).json
@@ -1,41 +1,44 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Content-Length": "236",
+        "Content-Length": "42",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8757fdade33fc242953ded377bdea56b-c1127f5079338743-00",
+        "traceparent": "00-44e3991e38f27d4fbd5197d564e2ecaf-d4277d1addae844f-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "64cc3d42f69cf5fc86b521026bb498ce",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": null,
+      "RequestBody": {
+        "source": "Sanitized",
+        "useLabelFile": true
+      },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f1587694-8c7c-44c5-be30-1421ee2a85d8",
+        "apim-request-id": "70f94704-8cbc-4d06-8ec7-8f1da5222541",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:33:16 GMT",
-        "Location": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e",
+        "Date": "Mon, 17 Aug 2020 16:28:35 GMT",
+        "Location": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "108"
+        "x-envoy-upstream-service-time": "152"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bdbcfe419b2d266e38c3b089fd4cb8a5",
         "x-ms-return-client-request-id": "true"
@@ -43,31 +46,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60a8baa7-ae32-4263-b202-a64829bb79e9",
+        "apim-request-id": "eaabed5f-77f1-4898-9a9c-08b4c8ace57b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:33:16 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "83edd960-2d86-407b-8022-269aa743f59e",
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:33:16Z",
-          "lastUpdatedDateTime": "2020-04-29T19:33:16Z"
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:36Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2075920363516e43d091c529f3c47b53",
         "x-ms-return-client-request-id": "true"
@@ -75,31 +78,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a173fbd-b390-429a-a900-3be6aadb3b3b",
+        "apim-request-id": "390ccb71-1099-476b-a1ec-1d6a8c9a6de9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:33:17 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "x-envoy-upstream-service-time": "140"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "83edd960-2d86-407b-8022-269aa743f59e",
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:33:16Z",
-          "lastUpdatedDateTime": "2020-04-29T19:33:16Z"
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:36Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b6176744d43fa78ecea52bd84572f839",
         "x-ms-return-client-request-id": "true"
@@ -107,31 +110,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "021fc2d6-bcc1-42ef-bb8e-da8c81882288",
+        "apim-request-id": "82f7f215-970c-4d85-99fa-b2d6894273b1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:33:18 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "50"
+        "x-envoy-upstream-service-time": "83"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "83edd960-2d86-407b-8022-269aa743f59e",
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:33:16Z",
-          "lastUpdatedDateTime": "2020-04-29T19:33:16Z"
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:36Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d8ff7cfc783ede7cbb4ded9bd5453373",
         "x-ms-return-client-request-id": "true"
@@ -139,23 +142,119 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4cbf2b1d-1b11-4730-a80f-643652377ade",
+        "apim-request-id": "126947c3-4d6a-498e-9ac3-1ddf21777a2a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:33:19 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "66"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "83edd960-2d86-407b-8022-269aa743f59e",
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
+          "status": "creating",
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:36Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "95455c4801352f6603ce51ac376a295e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6b0fc3dc-da28-4ecb-b3b2-d3820accc3c4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 17 Aug 2020 16:28:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
+          "status": "creating",
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:36Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "772c8c99a2c5cb14ea38fbf2e7f3d189",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "111fa76e-70d2-4056-9494-43ce98bf592b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 17 Aug 2020 16:28:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "39"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
+          "status": "creating",
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:36Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e890b872622cfa0416cfd47026d0a651",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "63339d88-6b4e-4c7c-803d-9db9f5d6a56e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 17 Aug 2020 16:28:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "101"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
           "status": "ready",
-          "createdDateTime": "2020-04-29T19:33:16Z",
-          "lastUpdatedDateTime": "2020-04-29T19:33:20Z"
+          "createdDateTime": "2020-08-17T16:28:36Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:43Z"
         },
         "trainResult": {
-          "averageModelAccuracy": 0.973,
+          "averageModelAccuracy": 0.96,
           "trainingDocuments": [
             {
               "documentName": "Form_1.jpg",
@@ -222,7 +321,7 @@
             },
             {
               "fieldName": "Signature",
-              "accuracy": 1.0
+              "accuracy": 0.8
             },
             {
               "fieldName": "Subtotal",
@@ -250,124 +349,125 @@
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Content-Length": "34",
+        "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-95c07faaf2929a479ae9a8dee28eab51-eea8917b701ef042-00",
+        "traceparent": "00-1eba8a7f02850f4c9336c7c0af6b18cd-9528bbe743ed7e4b-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "95455c4801352f6603ce51ac376a295e",
+        "x-ms-client-request-id": "48028f23bb18a5ad4779abfc06734810",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "source": "https://idont.ex.ist/"
+        "source": "Sanitized"
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "63f149cc-a49c-4334-93d6-514a99ab7ae9",
+        "apim-request-id": "dbd5fdb4-6c2a-4aa1-a5a9-726f3197c53a",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:33:19 GMT",
-        "Operation-Location": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e/analyzeresults/686b8e26-303f-4464-a3f3-20584cd1e518",
+        "Date": "Mon, 17 Aug 2020 16:28:43 GMT",
+        "Operation-Location": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27/analyzeresults/711df4f5-8b41-4683-af83-6eef297473e2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101"
+        "x-envoy-upstream-service-time": "149"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e/analyzeResults/686b8e26-303f-4464-a3f3-20584cd1e518",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27/analyzeResults/711df4f5-8b41-4683-af83-6eef297473e2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "772c8c99a2c5cb14ea38fbf2e7f3d189",
+        "x-ms-client-request-id": "7f39c8fc40d93631883261f5cda3a51a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1944c55f-746f-4955-baeb-7371709e2961",
+        "apim-request-id": "3b9e3677-f192-43bf-a20a-ec7dc2829e21",
+        "Content-Length": "109",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:33:20 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "19"
+        "x-envoy-upstream-service-time": "117"
       },
       "ResponseBody": {
         "status": "notStarted",
-        "createdDateTime": "2020-04-29T19:33:20Z",
-        "lastUpdatedDateTime": "2020-04-29T19:33:20Z"
+        "createdDateTime": "2020-08-17T16:28:43Z",
+        "lastUpdatedDateTime": "2020-08-17T16:28:43Z"
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e/analyzeResults/686b8e26-303f-4464-a3f3-20584cd1e518",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27/analyzeResults/711df4f5-8b41-4683-af83-6eef297473e2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "e890b872622cfa0416cfd47026d0a651",
+        "x-ms-client-request-id": "58ceaa9288f0b6700aeba1b2b707f4a2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "17345e10-3582-43b4-98c0-b32781aa75e3",
+        "apim-request-id": "5210c429-b087-4b34-8a92-eac5c90c666f",
+        "Content-Length": "221",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:33:21 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "33",
+        "x-ms-cs-error-code": "2003"
       },
       "ResponseBody": {
         "status": "failed",
-        "createdDateTime": "2020-04-29T19:33:20Z",
-        "lastUpdatedDateTime": "2020-04-29T19:33:20Z",
+        "createdDateTime": "2020-08-17T16:28:43Z",
+        "lastUpdatedDateTime": "2020-08-17T16:28:44Z",
         "analyzeResult": {
           "version": "2.0.0",
           "errors": [
             {
-              "code": "3003",
-              "message": "OCR extraction error: [Wrong response code: FailedToDownloadImage. Message: Failed to download image from input URL..]"
+              "code": "2003",
+              "message": "Failed to download image from input URL."
             }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/83edd960-2d86-407b-8022-269aa743f59e",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/73d3ae3b-3008-4a00-9e5e-cf66fec00e27",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-eeb5051cbeb74c46a3ba11f0cd13ad7f-5ee30299cc856847-00",
+        "traceparent": "00-dec39fd483ae9b419c3512c183eded11-cd6079c0562e7844-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "48028f23bb18a5ad4779abfc06734810",
+        "x-ms-client-request-id": "5e74c4872796e3775dcbc0e65ab7d7a3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c90bb549-3a3d-4401-a936-130496bde955",
+        "apim-request-id": "9eb6d902-8a97-4e54-9ad2-5c3bcc328038",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:33:21 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "5053"
       },
       "ResponseBody": []
     }
@@ -375,7 +475,7 @@
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
     "FORM_RECOGNIZER_BLOB_CONTAINER_SAS_URL": "https://sanitized.blob.core.windows.net",
-    "FORM_RECOGNIZER_ENDPOINT": "https://camaior-formrec.cognitiveservices.azure.com/",
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/",
     "RandomSeed": "235370684"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormRecognizerClientLiveTests/StartRecognizeCustomFormsFromUriThrowsForNonExistingContent(True)Async.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormRecognizerClientLiveTests/StartRecognizeCustomFormsFromUriThrowsForNonExistingContent(True)Async.json
@@ -1,41 +1,44 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Content-Length": "236",
+        "Content-Length": "42",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5caf912185dc2c43afd8f1a960c0c4c1-75f874198de41d4b-00",
+        "traceparent": "00-0e4422e63333d847851374bdfe3c5d2d-2abcfd24afaf8c42-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "75f68acc67ca20073579e4cb132cfc31",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": null,
+      "RequestBody": {
+        "source": "Sanitized",
+        "useLabelFile": true
+      },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ac0b51b2-9fc3-4e80-8a42-7930eb59f5ce",
+        "apim-request-id": "34d8c54e-aff1-4f04-8105-4affea80b13c",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:35:09 GMT",
-        "Location": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96",
+        "Date": "Mon, 17 Aug 2020 16:27:53 GMT",
+        "Location": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "x-envoy-upstream-service-time": "95"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1b8bf3e3b730f394ccabb31fb19cf866",
         "x-ms-return-client-request-id": "true"
@@ -43,31 +46,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0d6721fb-1aa3-4962-b3bb-9d58229e4336",
+        "apim-request-id": "b3240a6a-958f-4d6b-90dc-53c570d067ee",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:09 GMT",
+        "Date": "Mon, 17 Aug 2020 16:27:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "5156"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d215b8eb-bbed-432a-8343-f82f5483ff96",
+          "modelId": "7173e6fd-af89-4bdb-b1a9-7834a2d931b6",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:35:09Z",
-          "lastUpdatedDateTime": "2020-04-29T19:35:09Z"
+          "createdDateTime": "2020-08-17T16:27:54Z",
+          "lastUpdatedDateTime": "2020-08-17T16:27:54Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b84d69efd50921790759d8b32cf3ed77",
         "x-ms-return-client-request-id": "true"
@@ -75,31 +78,31 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3b2c6ea4-deea-42a3-8fc2-7f1b4141cead",
+        "apim-request-id": "d4249a0d-f144-4185-bfe3-933b1a0f1c0a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:10 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "55"
+        "x-envoy-upstream-service-time": "121"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d215b8eb-bbed-432a-8343-f82f5483ff96",
+          "modelId": "7173e6fd-af89-4bdb-b1a9-7834a2d931b6",
           "status": "creating",
-          "createdDateTime": "2020-04-29T19:35:09Z",
-          "lastUpdatedDateTime": "2020-04-29T19:35:09Z"
+          "createdDateTime": "2020-08-17T16:27:54Z",
+          "lastUpdatedDateTime": "2020-08-17T16:27:54Z"
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96?includeKeys=true",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6?includeKeys=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c17cff08e5fa146ef502a91eb4e76f98",
         "x-ms-return-client-request-id": "true"
@@ -107,55 +110,23 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "48fa3235-2ee4-40ff-8c83-7626cad9a0e2",
+        "apim-request-id": "dcfa21cc-ad6e-4bb5-86fe-f9875b3773ee",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:11 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "5107"
       },
       "ResponseBody": {
         "modelInfo": {
-          "modelId": "d215b8eb-bbed-432a-8343-f82f5483ff96",
-          "status": "creating",
-          "createdDateTime": "2020-04-29T19:35:09Z",
-          "lastUpdatedDateTime": "2020-04-29T19:35:09Z"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96?includeKeys=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "aadb7d8143df0d28796913d6dfe1c7d9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5b3043bd-f2e6-4276-b933-b87cc43eb223",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:13 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
-      },
-      "ResponseBody": {
-        "modelInfo": {
-          "modelId": "d215b8eb-bbed-432a-8343-f82f5483ff96",
+          "modelId": "7173e6fd-af89-4bdb-b1a9-7834a2d931b6",
           "status": "ready",
-          "createdDateTime": "2020-04-29T19:35:09Z",
-          "lastUpdatedDateTime": "2020-04-29T19:35:12Z"
+          "createdDateTime": "2020-08-17T16:27:54Z",
+          "lastUpdatedDateTime": "2020-08-17T16:28:01Z"
         },
         "trainResult": {
-          "averageModelAccuracy": 0.973,
+          "averageModelAccuracy": 0.96,
           "trainingDocuments": [
             {
               "documentName": "Form_1.jpg",
@@ -222,7 +193,7 @@
             },
             {
               "fieldName": "Signature",
-              "accuracy": 1.0
+              "accuracy": 0.8
             },
             {
               "fieldName": "Subtotal",
@@ -250,43 +221,72 @@
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyze?includeTextDetails=false",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6/analyze?includeTextDetails=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Content-Length": "34",
+        "Content-Length": "22",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5fec761432287043a51295610e10d67b-52a98ebe509ebe44-00",
+        "traceparent": "00-fbb9dfae47f85f4e9a8e8d0edb1db63a-6eb37baacd3fbe4a-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "b1173bbe36200a6cfb38c2072c5a6c20",
+        "x-ms-client-request-id": "aadb7d8143df0d28796913d6dfe1c7d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "source": "https://idont.ex.ist/"
+        "source": "Sanitized"
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "32512bbf-35bd-489a-970c-ea3ea1f827f5",
+        "apim-request-id": "a2190f6a-cf3b-47f9-b5ca-cd6e71eb7885",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:35:13 GMT",
-        "Operation-Location": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeresults/71b4eb44-c51b-47bb-9b38-53710477a18f",
+        "Date": "Mon, 17 Aug 2020 16:28:06 GMT",
+        "Operation-Location": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6/analyzeresults/b7bb2913-d170-40cb-8430-e24c2fd8f82d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "94"
+        "x-envoy-upstream-service-time": "260"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeResults/71b4eb44-c51b-47bb-9b38-53710477a18f",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6/analyzeResults/b7bb2913-d170-40cb-8430-e24c2fd8f82d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b1173bbe36200a6cfb38c2072c5a6c20",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e2b1581c-6433-45a8-8b8b-261e0c07913e",
+        "Content-Length": "109",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 17 Aug 2020 16:28:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "22"
+      },
+      "ResponseBody": {
+        "status": "notStarted",
+        "createdDateTime": "2020-08-17T16:28:07Z",
+        "lastUpdatedDateTime": "2020-08-17T16:28:07Z"
+      }
+    },
+    {
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6/analyzeResults/b7bb2913-d170-40cb-8430-e24c2fd8f82d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "af323fea4217c597d76e4890d1973514",
         "x-ms-return-client-request-id": "true"
@@ -294,196 +294,52 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5b4c4036-c43b-4b23-9d20-73280e543cae",
+        "apim-request-id": "ea5941b5-1671-48f0-81d5-46fda495e31e",
+        "Content-Length": "221",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:13 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-04-29T19:35:13Z",
-        "lastUpdatedDateTime": "2020-04-29T19:35:13Z"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeResults/71b4eb44-c51b-47bb-9b38-53710477a18f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "7860cf3bbdcf4b7710d1afa68020e11f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f93e6c23-a51f-40d6-a75c-c4316df5abe0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:15 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "793"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-04-29T19:35:13Z",
-        "lastUpdatedDateTime": "2020-04-29T19:35:13Z"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeResults/71b4eb44-c51b-47bb-9b38-53710477a18f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "9fecf3fc17af7bc1a452d9b2eddc3863",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6f4c361c-7190-470c-a356-19ead549698c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:16 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-04-29T19:35:13Z",
-        "lastUpdatedDateTime": "2020-04-29T19:35:13Z"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeResults/71b4eb44-c51b-47bb-9b38-53710477a18f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "5cccae03f4f92c50c7e79f4593f144b6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "163f8d07-7269-4877-b517-cb3a76ef4d96",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:17 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-04-29T19:35:13Z",
-        "lastUpdatedDateTime": "2020-04-29T19:35:13Z"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeResults/71b4eb44-c51b-47bb-9b38-53710477a18f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "de93288c95ab23640ee5d47de3c55d33",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9447867a-2a3b-4755-94ac-0fa99df9052f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:18 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
-      },
-      "ResponseBody": {
-        "status": "notStarted",
-        "createdDateTime": "2020-04-29T19:35:13Z",
-        "lastUpdatedDateTime": "2020-04-29T19:35:13Z"
-      }
-    },
-    {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96/analyzeResults/71b4eb44-c51b-47bb-9b38-53710477a18f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "d1a24b9884540825a3bfd8c8787be8b2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "cb514a4d-27c2-439c-b178-f8b4a7b593b9",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 29 Apr 2020 19:35:19 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "20"
+        "x-envoy-upstream-service-time": "22",
+        "x-ms-cs-error-code": "2003"
       },
       "ResponseBody": {
         "status": "failed",
-        "createdDateTime": "2020-04-29T19:35:13Z",
-        "lastUpdatedDateTime": "2020-04-29T19:35:18Z",
+        "createdDateTime": "2020-08-17T16:28:07Z",
+        "lastUpdatedDateTime": "2020-08-17T16:28:07Z",
         "analyzeResult": {
           "version": "2.0.0",
           "errors": [
             {
-              "code": "3003",
-              "message": "OCR extraction error: [Wrong response code: FailedToDownloadImage. Message: Failed to download image from input URL..]"
+              "code": "2003",
+              "message": "Failed to download image from input URL."
             }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://camaior-formrec.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/d215b8eb-bbed-432a-8343-f82f5483ff96",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/7173e6fd-af89-4bdb-b1a9-7834a2d931b6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5fe889a034088943b0d5d0525af23685-33c89a54648d554a-00",
+        "traceparent": "00-4e04f5134304c14ba28cb16b5f92baeb-2c5b18cf4d3c4640-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200429.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c525220d5a496eb84aa84e141fd24801",
+        "x-ms-client-request-id": "7860cf3bbdcf4b7710d1afa68020e11f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e0952beb-e731-4c50-9001-10adcfe9c54d",
+        "apim-request-id": "24647065-073f-4e2b-a209-1bce3adf4d37",
         "Content-Length": "0",
-        "Date": "Wed, 29 Apr 2020 19:35:19 GMT",
+        "Date": "Mon, 17 Aug 2020 16:28:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "86"
+        "x-envoy-upstream-service-time": "5084"
       },
       "ResponseBody": []
     }
@@ -491,7 +347,7 @@
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
     "FORM_RECOGNIZER_BLOB_CONTAINER_SAS_URL": "https://sanitized.blob.core.windows.net",
-    "FORM_RECOGNIZER_ENDPOINT": "https://camaior-formrec.cognitiveservices.azure.com/",
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/",
     "RandomSeed": "1927114979"
   }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/CopyModelError.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/CopyModelError.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/00000000-0000-0000-0000-000000000000/copy",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/00000000-0000-0000-0000-000000000000/copy",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Content-Length": "214",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "Request-Id": "|a672d89f-4d7f0ad75e146332.",
+        "traceparent": "00-da2c41b099cea746a378a24060c3db31-3ab8884f9f7f6f4f-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200610.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4a1ed720d3f4a8e2414f001be48d9102",
         "x-ms-return-client-request-id": "true"
@@ -26,13 +26,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "aa8bfe6f-0d90-4545-9fb0-1cc5d9bb8c9b",
+        "apim-request-id": "bcae53d5-86d1-4114-ab04-de891a2ba2ec",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 11 Jun 2020 03:45:10 GMT",
+        "Date": "Mon, 17 Aug 2020 16:45:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "3"
       },
       "ResponseBody": {
         "error": {
@@ -44,8 +44,8 @@
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/",
-    "FORM_RECOGNIZER_TARGET_RESOURCE_ID": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/mariari-group/providers/Microsoft.CognitiveServices/accounts/mariari-fr-westcentralus",
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/",
+    "FORM_RECOGNIZER_TARGET_RESOURCE_ID": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/camaiaor-rg/providers/Microsoft.CognitiveServices/accounts/camaiaor-formrec-westcentralus",
     "FORM_RECOGNIZER_TARGET_RESOURCE_REGION": "westcentralus",
     "RandomSeed": "1610020911"
   }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/CopyModelErrorAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/FormTrainingClientLiveTests/CopyModelErrorAsync.json
@@ -1,16 +1,16 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0-preview/custom/models/00000000-0000-0000-0000-000000000000/copy",
+      "RequestUri": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/formrecognizer/v2.0/custom/models/00000000-0000-0000-0000-000000000000/copy",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Content-Length": "214",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "Request-Id": "|9b81193b-4d4c6dc7d67a1495.",
+        "traceparent": "00-294e4d152a36e8408565e1244fd57491-454291432cef7544-00",
         "User-Agent": [
-          "azsdk-net-AI.FormRecognizer/1.0.0-dev.20200610.1",
-          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.FormRecognizer/3.0.0-dev.20200817.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9a25eafa44fd73269c2faf1985a3defc",
         "x-ms-return-client-request-id": "true"
@@ -26,9 +26,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "a09ecd33-ab21-4a30-9947-73a462b88d74",
+        "apim-request-id": "845b15dc-4b2a-44cf-bdee-54b8a0394227",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 11 Jun 2020 03:45:54 GMT",
+        "Date": "Mon, 17 Aug 2020 16:45:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -44,8 +44,8 @@
   ],
   "Variables": {
     "FORM_RECOGNIZER_API_KEY": "Sanitized",
-    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-fr-westcentralus.cognitiveservices.azure.com/",
-    "FORM_RECOGNIZER_TARGET_RESOURCE_ID": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/mariari-group/providers/Microsoft.CognitiveServices/accounts/mariari-fr-westcentralus",
+    "FORM_RECOGNIZER_ENDPOINT": "https://camaiaor-formrec-westcentralus.cognitiveservices.azure.com/",
+    "FORM_RECOGNIZER_TARGET_RESOURCE_ID": "/subscriptions/faa080af-c1d8-40ad-9cce-e1a450ca5b57/resourceGroups/camaiaor-rg/providers/Microsoft.CognitiveServices/accounts/camaiaor-formrec-westcentralus",
     "FORM_RECOGNIZER_TARGET_RESOURCE_REGION": "westcentralus",
     "RandomSeed": "1135186625"
   }


### PR DESCRIPTION
After the latest Form Recognizer service deployment, some bugs have been fixed, which made it possible for us to re-enable some tests we had that were failing.

Partial: #12319