### PR TITLE
Fix a class name from media services to livevideoanalytics

### DIFF
--- a/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/CHANGELOG.md
+++ b/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/CHANGELOG.md
@@ -5,3 +5,9 @@
 ### New features
 
 - Initial preview of Microsoft.Azure.Media.LiveVideoAnalytics.Edge Client SDK
+
+## 1.0.0-preview.2 (2020-08-17)
+
+### Bug fixes
+
+- Change the factory class name from MediaServicesEdgeClientFactory to LiveVideoAnalyticsEdgeClientFactory to be consistent with product name.

--- a/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/src/LiveVideoAnalyticsEdgeClientFactory.cs
+++ b/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/src/LiveVideoAnalyticsEdgeClientFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Media.LiveVideoAnalytics.Edge
     /// <summary>
     /// Static factory for the client.
     /// </summary>
-    public static class MediaServicesEdgeClientFactory
+    public static class LiveVideoAnalyticsEdgeClientFactory
     {
         /// <summary>
         /// Creates an instance of the Azure Media Services Edge for local calls within the edge hub.

--- a/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/src/Microsoft.Azure.Media.LiveVideoAnalytics.Edge.csproj
+++ b/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/src/Microsoft.Azure.Media.LiveVideoAnalytics.Edge.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Media.LiveVideoAnalytics.Edge</PackageId>
     <Description>Provides developers with libraries for managing Live video analytics edge module using direct methods</Description>
-    <Version>1.0.0-preview.1</Version>
+    <Version>1.1.0-preview.1</Version>
     <AssemblyName>Microsoft.Azure.Media.LiveVideoAnalytics.Edge</AssemblyName>
     <PackageTags>Azure Media Live Video Analytics;Live Video Analytics;LVA;</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-        Release of Live video analytics V1 API
+        Fix the factory class name.
             ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/src/Microsoft.Azure.Media.LiveVideoAnalytics.Edge.csproj
+++ b/sdk/mediaservices/Microsoft.Azure.Media.LiveVideoAnalytics.Edge/src/Microsoft.Azure.Media.LiveVideoAnalytics.Edge.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Media.LiveVideoAnalytics.Edge</PackageId>
     <Description>Provides developers with libraries for managing Live video analytics edge module using direct methods</Description>
-    <Version>1.1.0-preview.1</Version>
+    <Version>1.0.0-preview.2</Version>
     <AssemblyName>Microsoft.Azure.Media.LiveVideoAnalytics.Edge</AssemblyName>
     <PackageTags>Azure Media Live Video Analytics;Live Video Analytics;LVA;</PackageTags>
     <PackageReleaseNotes>


### PR DESCRIPTION
We had a class name which is not following the project name. we want to get this change out before samples and documentation go out to public.