### PR TITLE
fix(iot): Fix iot hub service client to not implement BearerTokenAuthenticationPolicy

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SasTokenAuthenticationPolicy.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Authentication/SasTokenAuthenticationPolicy.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Iot.Hub.Service.Authentication
+{
+    /// <summary>
+    /// The shared access signature based HTTP pipeline policy.
+    /// This authentication policy injects the sas token into the HTTP authentication header for each HTTP request made.
+    /// </summary>
+    internal class SasTokenAuthenticationPolicy : HttpPipelinePolicy
+    {
+        private readonly TimeSpan _getTokenTimeout = TimeSpan.FromSeconds(30);
+        private readonly TokenCredential _credential;
+
+        internal SasTokenAuthenticationPolicy(TokenCredential credential)
+        {
+            _credential = credential;
+        }
+
+        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            ProcessAsync(message, pipeline, false).EnsureCompleted();
+        }
+
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            return ProcessAsync(message, pipeline, true);
+        }
+
+        private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
+        {
+            if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new InvalidOperationException("Token authentication is not permitted for non TLS protected (https) endpoints.");
+            }
+
+            await AddHeaders(message, async).ConfigureAwait(false);
+
+            if (async)
+            {
+                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+            }
+            else
+            {
+                ProcessNext(message, pipeline);
+            }
+        }
+
+        private async Task AddHeaders(HttpMessage message, bool async)
+        {
+            using var cts = new CancellationTokenSource(_getTokenTimeout);
+
+            AccessToken token = async
+                ? await _credential.GetTokenAsync(new TokenRequestContext(), cts.Token).ConfigureAwait(false)
+                : _credential.GetToken(new TokenRequestContext(), cts.Token);
+
+            message.Request.Headers.Add(HttpHeader.Names.Authorization, token.Token);
+        }
+    }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/IotHubServiceClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/IotHubServiceClient.cs
@@ -22,10 +22,6 @@ namespace Azure.Iot.Hub.Service
         private readonly StatisticsRestClient _statisticsRestClient;
         private readonly ConfigurationRestClient _configurationRestClient;
 
-        // IoT Hub service currently does not support OAuth tokens, so they do not have their authorization scopes defined.
-        // This value will need to be correctly populated once OAuth token support is available.
-        private static readonly string[] s_authorizationScopes = new[] { "" };
-
         /// <summary>
         /// place holder for Devices.
         /// </summary>
@@ -139,7 +135,7 @@ namespace Azure.Iot.Hub.Service
             options ??= new IotHubServiceClientOptions();
             _clientDiagnostics = new ClientDiagnostics(options);
 
-            options.AddPolicy(new BearerTokenAuthenticationPolicy(credential, s_authorizationScopes), HttpPipelinePosition.PerCall);
+            options.AddPolicy(new SasTokenAuthenticationPolicy(credential), HttpPipelinePosition.PerCall);
             _httpPipeline = HttpPipelineBuilder.Build(options);
 
             _devicesRestClient = new DevicesRestClient(_clientDiagnostics, _httpPipeline, credential.Endpoint, options.GetVersionString());


### PR DESCRIPTION
The `Azure.Core` provided `BearerTokenAuthenticationPolicy` that the IoT hub service client had taken a dependency on (recently) was adding a `Bearer` token into the authorization header (as the name signifies). IoT Hub service, however, does not accept bearer tokens, so we were getting 400 Bad Request response codes.

Client library was sending:
`Authorization: Bearer SharedAccessSignature sr=vinageshtrack2iothub.azure-devices.net&sig=<signature>&se=1597690907&skn=iothubowner`

Where, it should have been:
`Authorization: SharedAccessSignature sr=vinageshtrack2iothub.azure-devices.net&sig=<signature>&se=1597690686&skn=iothubowner`

As a result, we cannot use `BearerTokenAuthenticationPolicy`, but will have to use our previously implemented custom authentication policy instead.

There is one more change that will come to the auth code -> our custom auth type `IotHubSasCredential` currently implements `TokenCredential`; however, the SDK board does not recommend adding custom authentication types that implement `TokenCredential`, since a customer could unknowingly use this credential type in a different library unintentionally (since the constructors take `TokenCredential`).
I will send out a separate PR to address that issue; this PR is being sent out first so that others can get unblocked in the meanwhile.