### PR TITLE
Update test resources script to print the environment values set.

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/setup.ps1
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/setup.ps1
@@ -103,12 +103,12 @@ az deployment group create --resource-group $ResourceGroup --name $($DigitalTwin
 # and we have to use that casing in order to get them from the deployment outputs.
 $dtHostName = az deployment group show -g $ResourceGroup -n $($DigitalTwinName.ToLower()) --query 'properties.outputs.digitaltwinS_ADT_INSTANCE_ENDPOINT_URL.value' --output tsv
 
-Write-Host("Set a new client secret for $appId`n")
+Write-Host("`nSet a new client secret for $appId`n")
 $appSecret = az ad app credential reset --id $appId --years 2 --query 'password' --output tsv
 
 $user = $env:UserName
 $fileName = "$user.config.json"
-Write-Host("Writing user config file - $fileName`n")
+Write-Host("`nWriting user config file - $fileName`n")
 
 $config = @"
 {
@@ -134,12 +134,12 @@ $environmentText = @"
 }
 "@
 
-Write-Host "Environment variables set, this will now be encrypted. Copy these values for future reference."
-Write-Host $environmentText
+Write-Host "`nEnvironment variables set, this will now be encrypted. Copy these values for future reference.`n"
+Write-Host "`n$environmentText`n"
 
 $bytes = ([System.Text.Encoding]::UTF8).GetBytes($environmentText)
 $protectedBytes = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
 Set-Content $outputFile -Value $protectedBytes -AsByteStream -Force
-Write-Host "Test environment settings stored into encrypted $outputFile"
+Write-Host "`nTest environment settings stored into encrypted $outputFile`n"
 
 Write-Host "Done!"

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/setup.ps1
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/setup.ps1
@@ -134,6 +134,9 @@ $environmentText = @"
 }
 "@
 
+Write-Host "Environment variables set, this will now be encrypted. Copy these values for future reference."
+Write-Host $environmentText
+
 $bytes = ([System.Text.Encoding]::UTF8).GetBytes($environmentText)
 $protectedBytes = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
 Set-Content $outputFile -Value $protectedBytes -AsByteStream -Force


### PR DESCRIPTION
The env variables being generated by the script is encrypted and stored. This makes retrieving the values difficult.
We now print the values as a part of the resources script.