### PR TITLE
Fix the live test issue with the SDK pipelines

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/TestSettings.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/TestSettings.cs
@@ -16,6 +16,7 @@ namespace Azure.DigitalTwins.Core.Tests
     public class TestSettings
     {
         public const string AdtEnvironmentVariablesPrefix = "DIGITALTWINS";
+        public const string TestModeEnvVariable = "AZURE_DIGITALTWINS_TEST_MODE";
 
         // If these environment variables exist in the environment, their values will replace (supersede) config.json values.
 
@@ -42,7 +43,7 @@ namespace Azure.DigitalTwins.Core.Tests
 
             string userName = Environment.UserName;
 
-            // Initialize the settings related to DT instance and auth
+            // Initialize the settings related to DT instance and authentication
             var testSettingsConfigBuilder = new ConfigurationBuilder();
 
             string testSettingsCommonPath = Path.Combine(workingDirectory, "config", "common.config.json");
@@ -58,6 +59,15 @@ namespace Azure.DigitalTwins.Core.Tests
 
             Instance = config.Get<TestSettings>();
             Instance.WorkingDirectory = workingDirectory;
+
+            // Override the test mode if the test mode environment variable was specified.
+            string testModeEnvVariable = Environment.GetEnvironmentVariable(TestModeEnvVariable);
+            if (!string.IsNullOrEmpty(testModeEnvVariable))
+            {
+                Instance.TestMode = (RecordedTestMode)Enum.Parse(
+                    typeof(RecordedTestMode),
+                    testModeEnvVariable);
+            }
         }
     }
 }

--- a/sdk/digitaltwins/test-resources.json
+++ b/sdk/digitaltwins/test-resources.json
@@ -147,7 +147,7 @@
     }
   ],
   "outputs": {
-    "DIGITALTWINS_ADT_INSTANCE_ENDPOINT_URL": {
+    "DIGITALTWINS_URL": {
       "type": "string",
       "value": "[concat('https://', reference(variables('digitalTwinInstanceResourceId'), '2020-03-01-preview').hostName)]"
     }

--- a/sdk/digitaltwins/tests.yml
+++ b/sdk/digitaltwins/tests.yml
@@ -8,4 +8,4 @@ extends:
     SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
     EnvVars:
       # Runs live tests.
-      AZURE_IOT_TEST_MODE: Live
+      AZURE_DIGITALTWINS_TEST_MODE: Live

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/TestSettings.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/TestSettings.cs
@@ -17,6 +17,7 @@ namespace Azure.Iot.Hub.Service.Tests
     {
         public const string IotHubEnvironmentVariablesPrefix = "IOT";
         public const string IotHubConnectionString = "IOT_HUB_CONNECTION_STRING";
+        public const string TestModeEnvVariable = "AZURE_IOT_TEST_MODE";
 
         public static TestSettings Instance { get; private set; }
 
@@ -57,6 +58,16 @@ namespace Azure.Iot.Hub.Service.Tests
 
             // This will set the values from the above config files into the TestSettings Instance.
             Instance = config.Get<TestSettings>();
+
+            // Override the test mode if the test mode environment variable was specified.
+            string testModeEnvVariable = Environment.GetEnvironmentVariable(TestModeEnvVariable);
+            if (!string.IsNullOrEmpty(testModeEnvVariable))
+            {
+                Instance.TestMode = (RecordedTestMode)Enum.Parse(
+                    typeof(RecordedTestMode),
+                    testModeEnvVariable);
+            }
+
             Instance.WorkingDirectory = workingDirectory;
         }
     }


### PR DESCRIPTION
Fix Live test issue.
We have to make sure we load the test mode environment variable from the pipeline and override the common config to run the live tests.