### PR TITLE
Processor bug

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -358,6 +358,15 @@ namespace Azure.Messaging.ServiceBus {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The message processor is not currently running. It needs to be started before it can be stopped..
+        /// </summary>
+        internal static string MessageProcessorIsNotRunning {
+            get {
+                return ResourceManager.GetString("MessageProcessorIsNotRunning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The message (id:{0}, size:{1} bytes) is larger than is currently allowed ({2} bytes)..
         /// </summary>
         internal static string MessageSizeExceeded {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -294,4 +294,7 @@
   <data name="SendViaCannotBeUsedWithEntityInConnectionString" xml:space="preserve">
     <value>When sending via a different entity, an entity path is not allowed to specified in the connection string.</value>
   </data>
+  <data name="MessageProcessorIsNotRunning" xml:space="preserve">
+    <value>The message processor is not currently running. It needs to be started before it can be stopped.</value>
+  </data>
 </root>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -1303,11 +1303,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             }
 
             await processor.StartProcessingAsync();
-            var cts = new CancellationTokenSource();
-            cts.Cancel();
+            await processor.StopProcessingAsync();
+
             Assert.That(
-                async () => await processor.StopProcessingAsync(cts.Token),
-                Throws.InstanceOf<TaskCanceledException>());
+                async () => await processor.StopProcessingAsync(),
+                Throws.InstanceOf<InvalidOperationException>());
 
             mockLogger
                 .Verify(
@@ -1320,9 +1320,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                         processor.Identifier,
                         It.IsAny<string>()),
                 Times.Once);
-
-            // actually stop processing
-            await processor.StopProcessingAsync();
         }
 
         private Mock<ServiceBusConnection> GetMockConnection(Mock<TransportReceiver> mockTransportReceiver)


### PR DESCRIPTION
Previously, calling `StopProcessingAsync` simultaneously on multiple threads could result in a null ref exception. Now we avoid this, and explicitly throw an `InvalidOperationException` if `StopProcessingAsync` is called on an already stopped processor. This is consistent with how we handle calling `StartProcessingAsync` on an already started processor.