### PR TITLE
Fix warning during Search docs publishing

### DIFF
--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -129,7 +129,7 @@ foreach (SearchResult<SearchDocument> result in response.GetResults())
 ```
 
 You can paste that into a new console app,
-[install the Azure.Search.Documents package](#Install-the-package), add a
+[install the Azure.Search.Documents package](#install-the-package), add a
 `using Azure.Search.Documents;` statement, and then hit F5 to run.
 
 ## Key concepts


### PR DESCRIPTION
Fixes a warning on Azure/azure-docs-sdk-dotnet#1290