### PR TITLE
Identity fix regression in InteractiveBrowserCredential from invalid redirectUrl

### DIFF
--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
@@ -77,7 +77,7 @@ namespace Azure.Identity
 
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
 
-            _client = client ?? new MsalPublicClient(_pipeline, tenantId, clientId, null, options as ITokenCacheOptions);
+            _client = client ?? new MsalPublicClient(_pipeline, tenantId, clientId, "http://localhost", options as ITokenCacheOptions);
         }
 
         /// <summary>


### PR DESCRIPTION
A regression was introduced in the `InteractiveBrowserCredential` when refactoring MSAL client usage in [this commit](https://github.com/Azure/azure-sdk-for-net/commit/30b3da9518dd8bd363eae56eecbe70cfd8396043#diff-5cc13e152977a6894d78d38f5e681a91). Previously the `InteractiveBrowserCredential` was using the hard-coded redirectUrl "http://localhost/". This was erroneously updated to `null` in the aforementioned change. 

Fixes: #13940