### PR TITLE
Update known_presence_issues to clear CI break

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -119,6 +119,7 @@ known_presence_issues:
   - ['sdk/search/Microsoft.Azure.Search.Service/CHANGELOG.md','#5499']
   - ['sdk/template/Azure.Template/CHANGELOG.md','#5499']
   - ['sdk/attestation/Microsoft.Azure.Attestation','#5499']
+  - ['sdk/monitor/OpenTelemetry.Exporter.AzureMonitor','#5499']
 
 known_content_issues:
   - ['README.md','Root readme']


### PR DESCRIPTION
Adding to OpenTelemetry.Exporter.AzureMonitor package path known_presence_issues to fix CI failure