### PR TITLE
AutoRest generates type IDictionary<string, string> correctly

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -92,8 +92,8 @@ namespace Azure.DigitalTwins.Core
     {
         internal ModelData() { }
         public bool? Decommissioned { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, string> Description { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, string> DisplayName { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Description { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> DisplayName { get { throw null; } }
         public string Id { get { throw null; } }
         public string Model { get { throw null; } }
         public System.DateTimeOffset? UploadTime { get { throw null; } }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/ModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/ModelData.cs
@@ -11,41 +11,13 @@ namespace Azure.DigitalTwins.Core
     public partial class ModelData
     {
         // This class declaration makes the generated class of the same name declare Model as a **string** rather than an **object**.
-        // It also changes displayName and description from objects (per swagger) to dictionaries (per swagger comment).
         // It also changes the namespace.
         // Do not remove.
-
-        /// <summary> Initializes a new instance of ModelData. </summary>
-        /// <param name="displayName"> A language map that contains the localized display names as specified in the model definition. </param>
-        /// <param name="description"> A language map that contains the localized descriptions as specified in the model definition. </param>
-        /// <param name="id"> The id of the model as specified in the model definition. </param>
-        /// <param name="uploadTime"> The time the model was uploaded to the service. </param>
-        /// <param name="decommissioned"> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </param>
-        /// <param name="model"> The model definition. </param>
-        internal ModelData(IDictionary<string, string> displayName, IDictionary<string, string> description, string id, DateTimeOffset? uploadTime, bool? decommissioned, string model)
-        {
-            DisplayName = displayName;
-            Description = description;
-            Id = id;
-            UploadTime = uploadTime;
-            Decommissioned = decommissioned;
-            Model = model;
-        }
 
         /// <summary>
         /// The model definition.
         /// </summary>
         public string Model { get; }
-
-        /// <summary>
-        /// A language map that contains the localized display names as specified in the model definition.
-        /// </summary>
-        public IDictionary<string, string> DisplayName { get; }
-
-        /// <summary>
-        /// A language map that contains the localized descriptions as specified in the model definition.
-        /// </summary>
-        public IDictionary<string, string> Description { get; }
 
         #region null overrides
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/ModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/ModelData.cs
@@ -14,6 +14,28 @@ namespace Azure.DigitalTwins.Core
     /// <summary> A model definition and metadata for that model. </summary>
     public partial class ModelData
     {
+
+        /// <summary> Initializes a new instance of ModelData. </summary>
+        /// <param name="displayName"> A language map that contains the localized display names as specified in the model definition. </param>
+        /// <param name="description"> A language map that contains the localized descriptions as specified in the model definition. </param>
+        /// <param name="id"> The id of the model as specified in the model definition. </param>
+        /// <param name="uploadTime"> The time the model was uploaded to the service. </param>
+        /// <param name="decommissioned"> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </param>
+        /// <param name="model"> The model definition. </param>
+        internal ModelData(IReadOnlyDictionary<string, string> displayName, IReadOnlyDictionary<string, string> description, string id, DateTimeOffset? uploadTime, bool? decommissioned, string model)
+        {
+            DisplayName = displayName;
+            Description = description;
+            Id = id;
+            UploadTime = uploadTime;
+            Decommissioned = decommissioned;
+            Model = model;
+        }
+
+        /// <summary> A language map that contains the localized display names as specified in the model definition. </summary>
+        public IReadOnlyDictionary<string, string> DisplayName { get; }
+        /// <summary> A language map that contains the localized descriptions as specified in the model definition. </summary>
+        public IReadOnlyDictionary<string, string> Description { get; }
         /// <summary> The id of the model as specified in the model definition. </summary>
         public string Id { get; }
         /// <summary> The time the model was uploaded to the service. </summary>


### PR DESCRIPTION
Remove the customized code for DisplayName and Description properties.