### PR TITLE
Fixed bug where ShareClient.Delete() could not delete Share Snapshots…

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -73,6 +73,7 @@ namespace Azure.Storage
 
         public const string SnapshotParameterName = "snapshot";
         public const string VersionIdParameterName = "versionid";
+        public const string ShareSnapshotParameterName = "sharesnapshot";
 
         public const string Https = "https";
         public const string Http = "http";

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 12.4.0-preview.1 (Unreleased)
+- Fixed bug where ShareClient.Delete() could not delete Share Snapshots unless the includeSnapshots parameter was set to false.
 
 ## 12.3.1 (2020-08-18)
 - Bug in TaskExtensions.EnsureCompleted method that causes it to unconditionally throw an exception in the environments with synchronization context

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -1083,12 +1083,24 @@ namespace Azure.Storage.Files.Shares
                     $"{nameof(Uri)}: {Uri}");
                 try
                 {
+                    DeleteSnapshotsOptionType? deleteSnapshotsOption;
+
+                    // DeleteSnapshotsOptionType.Include is not valid when deleting a Snapshot Share.
+                    if (Uri.GetQueryParameters().ContainsKey(Constants.ShareSnapshotParameterName))
+                    {
+                        deleteSnapshotsOption = null;
+                    }
+                    else
+                    {
+                        deleteSnapshotsOption = includeSnapshots ? DeleteSnapshotsOptionType.Include : (DeleteSnapshotsOptionType?)null;
+                    }
+
                     return await FileRestClient.Share.DeleteAsync(
                         ClientDiagnostics,
                         Pipeline,
                         Uri,
                         version: Version.ToVersionString(),
-                        deleteSnapshots: includeSnapshots ? DeleteSnapshotsOptionType.Include : (DeleteSnapshotsOptionType?)null,
+                        deleteSnapshots: deleteSnapshotsOption,
                         async: async,
                         operationName: operationName ?? $"{nameof(ShareClient)}.{nameof(Delete)}",
                         cancellationToken: cancellationToken)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/DeleteAsync_SnapshotFailed.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/DeleteAsync_SnapshotFailed.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://seanmcccanary.file.core.windows.net/test-share-fbf45fc1-50fa-6132-2205-5fffaad1427a?restype=share",
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fbf45fc1-50fa-6132-2205-5fffaad1427a?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8b7509f8bbbeb7478b94b59865e95c7c-17435dd2974f4641-00",
+        "traceparent": "00-68c485790782fe47898c579e530598c4-5cc93656ee484145-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200625.1",
-          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+          "azsdk-net-Storage.Files.Shares/12.4.0-dev.20200825.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18362 )"
         ],
         "x-ms-client-request-id": "a5d4de22-9fe0-ab63-d343-58e59071e781",
-        "x-ms-date": "Fri, 26 Jun 2020 01:35:44 GMT",
+        "x-ms-date": "Tue, 25 Aug 2020 18:05:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-12-12"
       },
@@ -19,68 +19,67 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 26 Jun 2020 01:35:45 GMT",
-        "ETag": "\u00220x8D819713F26E9F0\u0022",
-        "Last-Modified": "Fri, 26 Jun 2020 01:35:45 GMT",
+        "Date": "Tue, 25 Aug 2020 18:05:37 GMT",
+        "ETag": "\u00220x8D84921783E30F0\u0022",
+        "Last-Modified": "Tue, 25 Aug 2020 18:05:37 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a5d4de22-9fe0-ab63-d343-58e59071e781",
-        "x-ms-request-id": "1a02607a-401a-0007-765a-4b21c3000000",
+        "x-ms-request-id": "623324d0-001a-004f-3e0a-7bce12000000",
         "x-ms-version": "2019-12-12"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seanmcccanary.file.core.windows.net/test-share-fbf45fc1-50fa-6132-2205-5fffaad1427a?sharesnapshot=2020-06-26T00:49:21.0000000Z\u0026restype=share",
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fbf45fc1-50fa-6132-2205-5fffaad1427a?sharesnapshot=2020-06-26T00:49:21.0000000Z\u0026restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e027191b0f80c24494edf7fa878437ca-e85a7ba2ae501648-00",
+        "traceparent": "00-e546af862970284fa80877952d1e0305-a82d92368091ac4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200625.1",
-          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+          "azsdk-net-Storage.Files.Shares/12.4.0-dev.20200825.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18362 )"
         ],
         "x-ms-client-request-id": "ccdd5855-9cfd-3799-b4ca-dde5409ae4a6",
-        "x-ms-date": "Fri, 26 Jun 2020 01:35:44 GMT",
-        "x-ms-delete-snapshots": "include",
+        "x-ms-date": "Tue, 25 Aug 2020 18:05:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-12-12"
       },
       "RequestBody": null,
-      "StatusCode": 400,
+      "StatusCode": 404,
       "ResponseHeaders": {
-        "Content-Length": "518",
+        "Content-Length": "233",
         "Content-Type": "application/xml",
-        "Date": "Fri, 26 Jun 2020 01:35:45 GMT",
+        "Date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ccdd5855-9cfd-3799-b4ca-dde5409ae4a6",
-        "x-ms-error-code": "InvalidQueryParameterValue",
-        "x-ms-request-id": "1a02607d-401a-0007-775a-4b21c3000000",
+        "x-ms-error-code": "ShareSnapshotNotFound",
+        "x-ms-request-id": "623324d4-001a-004f-3f0a-7bce12000000",
         "x-ms-version": "2019-12-12"
       },
       "ResponseBody": [
-        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EInvalidQueryParameterValue\u003C/Code\u003E\u003CMessage\u003EValue for one of the query parameters specified in the request URI is invalid.\n",
-        "RequestId:1a02607d-401a-0007-775a-4b21c3000000\n",
-        "Time:2020-06-26T01:35:45.5219455Z\u003C/Message\u003E\u003CQueryParameterName\u003Esharesnapshot\u003C/QueryParameterName\u003E\u003CQueryParameterValue\u003E2020-06-26T00:49:21.0000000Z\u003C/QueryParameterValue\u003E\u003CReason\u003EThis operation is only allowed on the base share. ShareSnapshot query parameter should not be provided.\u003C/Reason\u003E\u003C/Error\u003E"
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EShareSnapshotNotFound\u003C/Code\u003E\u003CMessage\u003EThe specified share snapshot was not found.\n",
+        "RequestId:623324d4-001a-004f-3f0a-7bce12000000\n",
+        "Time:2020-08-25T18:05:37.3935930Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://seanmcccanary.file.core.windows.net/test-share-fbf45fc1-50fa-6132-2205-5fffaad1427a?restype=share",
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-fbf45fc1-50fa-6132-2205-5fffaad1427a?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6a6b28df655f4b4c90b29aa033a2ced7-2eba31f1cc21b246-00",
+        "traceparent": "00-3c1a7c8ec9b9c94aaed7923ba253219b-8378d3cb2dc0c24c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200625.1",
-          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+          "azsdk-net-Storage.Files.Shares/12.4.0-dev.20200825.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18362 )"
         ],
         "x-ms-client-request-id": "38904e29-1b94-0084-a5f1-3f404f84e845",
-        "x-ms-date": "Fri, 26 Jun 2020 01:35:45 GMT",
+        "x-ms-date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-12-12"
@@ -89,13 +88,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 26 Jun 2020 01:35:45 GMT",
+        "Date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "38904e29-1b94-0084-a5f1-3f404f84e845",
-        "x-ms-request-id": "1a02607e-401a-0007-785a-4b21c3000000",
+        "x-ms-request-id": "623324d5-001a-004f-400a-7bce12000000",
         "x-ms-version": "2019-12-12"
       },
       "ResponseBody": []
@@ -103,6 +102,6 @@
   ],
   "Variables": {
     "RandomSeed": "141367655",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary\nU2FuaXRpemVk\nhttps://seanmcccanary.blob.core.windows.net\nhttps://seanmcccanary.file.core.windows.net\nhttps://seanmcccanary.queue.core.windows.net\nhttps://seanmcccanary.table.core.windows.net\n\n\n\n\nhttps://seanmcccanary-secondary.blob.core.windows.net\nhttps://seanmcccanary-secondary.file.core.windows.net\nhttps://seanmcccanary-secondary.queue.core.windows.net\nhttps://seanmcccanary-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanary.blob.core.windows.net/;QueueEndpoint=https://seanmcccanary.queue.core.windows.net/;FileEndpoint=https://seanmcccanary.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanary-secondary.file.core.windows.net/;AccountName=seanmcccanary;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/DeleteAsync_SnapshotFailedAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/DeleteAsync_SnapshotFailedAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://seanmcccanary.file.core.windows.net/test-share-3ee857d2-0f4a-a0aa-54b7-a30e3a48b6e0?restype=share",
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-3ee857d2-0f4a-a0aa-54b7-a30e3a48b6e0?restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-48a43dc71f81cd42bf8d4d7b2a48e300-5cb5e951f5e4af44-00",
+        "traceparent": "00-28404a0971c6e748af7de703d7b527a1-e2f13af7db7a7448-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200625.1",
-          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+          "azsdk-net-Storage.Files.Shares/12.4.0-dev.20200825.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18362 )"
         ],
         "x-ms-client-request-id": "1fddaa7e-839b-19b3-c4b6-f213e18ca1ad",
-        "x-ms-date": "Fri, 26 Jun 2020 01:35:47 GMT",
+        "x-ms-date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-12-12"
       },
@@ -19,68 +19,67 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 26 Jun 2020 01:35:47 GMT",
-        "ETag": "\u00220x8D8197140FFDCC3\u0022",
-        "Last-Modified": "Fri, 26 Jun 2020 01:35:48 GMT",
+        "Date": "Tue, 25 Aug 2020 18:05:37 GMT",
+        "ETag": "\u00220x8D849217891A975\u0022",
+        "Last-Modified": "Tue, 25 Aug 2020 18:05:37 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1fddaa7e-839b-19b3-c4b6-f213e18ca1ad",
-        "x-ms-request-id": "03cf4ddd-101a-0025-235a-4be4dc000000",
+        "x-ms-request-id": "79ad2577-f01a-0015-240a-7bc893000000",
         "x-ms-version": "2019-12-12"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://seanmcccanary.file.core.windows.net/test-share-3ee857d2-0f4a-a0aa-54b7-a30e3a48b6e0?sharesnapshot=2020-06-26T00:49:21.0000000Z\u0026restype=share",
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-3ee857d2-0f4a-a0aa-54b7-a30e3a48b6e0?sharesnapshot=2020-06-26T00:49:21.0000000Z\u0026restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3fc19b18c899fc4787130574ad7da334-66e60e38c0388a40-00",
+        "traceparent": "00-eec811fc3a91c347859f64647c1c2192-6cd818f8bf53954e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200625.1",
-          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+          "azsdk-net-Storage.Files.Shares/12.4.0-dev.20200825.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18362 )"
         ],
         "x-ms-client-request-id": "8f90c9e3-976a-fa44-f666-f9867aeec1d9",
-        "x-ms-date": "Fri, 26 Jun 2020 01:35:48 GMT",
-        "x-ms-delete-snapshots": "include",
+        "x-ms-date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-12-12"
       },
       "RequestBody": null,
-      "StatusCode": 400,
+      "StatusCode": 404,
       "ResponseHeaders": {
-        "Content-Length": "518",
+        "Content-Length": "233",
         "Content-Type": "application/xml",
-        "Date": "Fri, 26 Jun 2020 01:35:47 GMT",
+        "Date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8f90c9e3-976a-fa44-f666-f9867aeec1d9",
-        "x-ms-error-code": "InvalidQueryParameterValue",
-        "x-ms-request-id": "03cf4de0-101a-0025-245a-4be4dc000000",
+        "x-ms-error-code": "ShareSnapshotNotFound",
+        "x-ms-request-id": "79ad257f-f01a-0015-270a-7bc893000000",
         "x-ms-version": "2019-12-12"
       },
       "ResponseBody": [
-        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EInvalidQueryParameterValue\u003C/Code\u003E\u003CMessage\u003EValue for one of the query parameters specified in the request URI is invalid.\n",
-        "RequestId:03cf4de0-101a-0025-245a-4be4dc000000\n",
-        "Time:2020-06-26T01:35:48.6194592Z\u003C/Message\u003E\u003CQueryParameterName\u003Esharesnapshot\u003C/QueryParameterName\u003E\u003CQueryParameterValue\u003E2020-06-26T00:49:21.0000000Z\u003C/QueryParameterValue\u003E\u003CReason\u003EThis operation is only allowed on the base share. ShareSnapshot query parameter should not be provided.\u003C/Reason\u003E\u003C/Error\u003E"
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EShareSnapshotNotFound\u003C/Code\u003E\u003CMessage\u003EThe specified share snapshot was not found.\n",
+        "RequestId:79ad257f-f01a-0015-270a-7bc893000000\n",
+        "Time:2020-08-25T18:05:37.9426294Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://seanmcccanary.file.core.windows.net/test-share-3ee857d2-0f4a-a0aa-54b7-a30e3a48b6e0?restype=share",
+      "RequestUri": "https://seandevtest.file.core.windows.net/test-share-3ee857d2-0f4a-a0aa-54b7-a30e3a48b6e0?restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e9eecac83c4b75408e4cace7af860925-0e486a5dd72a5240-00",
+        "traceparent": "00-08fb99e6fe3c5c42bf04d409eddf7ca7-d801048ac01ed141-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200625.1",
-          "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.18362 )"
+          "azsdk-net-Storage.Files.Shares/12.4.0-dev.20200825.1",
+          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18362 )"
         ],
         "x-ms-client-request-id": "1830dd32-11fc-3242-929f-c518a335ea66",
-        "x-ms-date": "Fri, 26 Jun 2020 01:35:48 GMT",
+        "x-ms-date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "x-ms-delete-snapshots": "include",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2019-12-12"
@@ -89,13 +88,13 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 26 Jun 2020 01:35:47 GMT",
+        "Date": "Tue, 25 Aug 2020 18:05:37 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "1830dd32-11fc-3242-929f-c518a335ea66",
-        "x-ms-request-id": "03cf4de1-101a-0025-255a-4be4dc000000",
+        "x-ms-request-id": "79ad2580-f01a-0015-280a-7bc893000000",
         "x-ms-version": "2019-12-12"
       },
       "ResponseBody": []
@@ -103,6 +102,6 @@
   ],
   "Variables": {
     "RandomSeed": "187399296",
-    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary\nU2FuaXRpemVk\nhttps://seanmcccanary.blob.core.windows.net\nhttps://seanmcccanary.file.core.windows.net\nhttps://seanmcccanary.queue.core.windows.net\nhttps://seanmcccanary.table.core.windows.net\n\n\n\n\nhttps://seanmcccanary-secondary.blob.core.windows.net\nhttps://seanmcccanary-secondary.file.core.windows.net\nhttps://seanmcccanary-secondary.queue.core.windows.net\nhttps://seanmcccanary-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seanmcccanary.blob.core.windows.net/;QueueEndpoint=https://seanmcccanary.queue.core.windows.net/;FileEndpoint=https://seanmcccanary.file.core.windows.net/;BlobSecondaryEndpoint=https://seanmcccanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seanmcccanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seanmcccanary-secondary.file.core.windows.net/;AccountName=seanmcccanary;AccountKey=Sanitized\nseanscope1"
+    "Storage_TestConfigDefault": "ProductionTenant\nseandevtest\nU2FuaXRpemVk\nhttps://seandevtest.blob.core.windows.net\nhttps://seandevtest.file.core.windows.net\nhttps://seandevtest.queue.core.windows.net\nhttps://seandevtest.table.core.windows.net\n\n\n\n\nhttps://seandevtest-secondary.blob.core.windows.net\nhttps://seandevtest-secondary.file.core.windows.net\nhttps://seandevtest-secondary.queue.core.windows.net\nhttps://seandevtest-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://seandevtest.blob.core.windows.net/;QueueEndpoint=https://seandevtest.queue.core.windows.net/;FileEndpoint=https://seandevtest.file.core.windows.net/;BlobSecondaryEndpoint=https://seandevtest-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://seandevtest-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://seandevtest-secondary.file.core.windows.net/;AccountName=seandevtest;AccountKey=Kg==;\nseanscope1"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -890,7 +890,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient snapshotShareClient = share.WithSnapshot(response.Value.Snapshot);
 
             // Act
-            await snapshotShareClient.DeleteAsync(false);
+            await snapshotShareClient.DeleteAsync();
 
             // Assert
             Response<bool> shareExistsResponse = await share.ExistsAsync();
@@ -915,7 +915,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
                snapshotShareClient.DeleteAsync(),
-               e => Assert.AreEqual(ShareErrorCode.InvalidQueryParameterValue.ToString(), e.ErrorCode));
+               e => Assert.AreEqual("ShareSnapshotNotFound", e.ErrorCode));
         }
 
         [Test]


### PR DESCRIPTION
… unless includeSnapshots was set to false.