### PR TITLE
Retire Net core installer

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -30,10 +30,10 @@ jobs:
           RootFolder: '.'
           BuildSHA: $(Build.SourceVersion)
           RepoId: 'Azure/azure-sdk-for-net'
-      - task: UseDotNet@2
-        displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
-        inputs:
-          version: "$(DotNetCoreSDKVersion)"
+      - pwsh: |
+          dotnet --list-sdks
+          dotnet --list-runtimes
+        displayName: View Dotnet Versions installed
       - script: >-
           dotnet pack eng/service.proj -o $(Build.ArtifactStagingDirectory) -warnaserror /p:ServiceDirectory=${{parameters.ServiceToBuild}}
           /p:PublicSign=false $(VersioningProperties) /p:Configuration=$(BuildConfiguration) /p:CommitSHA=$(Build.SourceVersion)
@@ -74,15 +74,10 @@ jobs:
           pip install doc-warden==$(DocWardenVersion)
           ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
         displayName: "Verify Readmes"
-      - task: UseDotNet@2
-        displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
-        inputs:
-          version: "$(DotNetCoreSDKVersion)"
-      - task: UseDotNet@2
-        displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
-        inputs:
-          packageType: runtime
-          version: "$(DotNetCoreRuntimeVersion)"
+      - pwsh: |
+          dotnet --list-sdks
+          dotnet --list-runtimes
+        displayName: View Dotnet Versions installed
       - task: DownloadPipelineArtifact@2
         displayName: "Download Build Artifacts"
         condition: succeededOrFailed()
@@ -149,16 +144,10 @@ jobs:
       vmImage: "$(OSVmImage)"
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-      - task: DotNetCoreInstaller@2
-        displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
-        inputs:
-          packageType: runtime
-          version: "$(DotNetCoreRuntimeVersion)"
-      - task: DotNetCoreInstaller@2
-        displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
-        inputs:
-          packageType: sdk
-          version: "$(DotNetCoreSDKVersion)"
+      - pwsh: |
+          dotnet --list-sdks
+          dotnet --list-runtimes
+        displayName: View Dotnet Versions installed
       - script: >-
           dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption) /p:CollectCoverage=$(CollectCoverage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -30,10 +30,6 @@ jobs:
           RootFolder: '.'
           BuildSHA: $(Build.SourceVersion)
           RepoId: 'Azure/azure-sdk-for-net'
-      - pwsh: |
-          dotnet --list-sdks
-          dotnet --list-runtimes
-        displayName: View Dotnet Versions installed
       - script: >-
           dotnet pack eng/service.proj -o $(Build.ArtifactStagingDirectory) -warnaserror /p:ServiceDirectory=${{parameters.ServiceToBuild}}
           /p:PublicSign=false $(VersioningProperties) /p:Configuration=$(BuildConfiguration) /p:CommitSHA=$(Build.SourceVersion)
@@ -74,10 +70,6 @@ jobs:
           pip install doc-warden==$(DocWardenVersion)
           ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
         displayName: "Verify Readmes"
-      - pwsh: |
-          dotnet --list-sdks
-          dotnet --list-runtimes
-        displayName: View Dotnet Versions installed
       - task: DownloadPipelineArtifact@2
         displayName: "Download Build Artifacts"
         condition: succeededOrFailed()
@@ -144,10 +136,6 @@ jobs:
       vmImage: "$(OSVmImage)"
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-      - pwsh: |
-          dotnet --list-sdks
-          dotnet --list-runtimes
-        displayName: View Dotnet Versions installed
       - script: >-
           dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption) /p:CollectCoverage=$(CollectCoverage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -70,13 +70,11 @@ jobs:
           pip install doc-warden==$(DocWardenVersion)
           ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
         displayName: "Verify Readmes"
-      - task: DownloadPipelineArtifact@2
-        displayName: "Download Build Artifacts"
-        condition: succeededOrFailed()
+      - task: UseDotNet@2
+        displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
         inputs:
-          artifact: packages
-          path: $(Pipeline.Workspace)/packages
-          patterns: "*.nupkg"
+          packageType: runtime
+          version: "$(DotNetCoreRuntimeVersion)"
       - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
         parameters:
           SourceDirectory: $(Build.SourcesDirectory)
@@ -136,6 +134,11 @@ jobs:
       vmImage: "$(OSVmImage)"
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+      - task: UseDotNet@2
+        displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
+        inputs:
+          packageType: runtime
+          version: "$(DotNetCoreRuntimeVersion)"
       - script: >-
           dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption) /p:CollectCoverage=$(CollectCoverage)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -55,18 +55,6 @@ jobs:
 
         - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
-        - task: UseDotNet@2
-          displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
-          inputs:
-            packageType: runtime
-            version: "$(DotNetCoreRuntimeVersion)"
-
-        - task: UseDotNet@2
-          displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
-          inputs:
-            packageType: sdk
-            version: "$(DotNetCoreSDKVersion)"
-
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:
             Location: ${{ parameters.Location }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -55,6 +55,12 @@ jobs:
 
         - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
+        - task: UseDotNet@2
+          displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
+          inputs:
+            packageType: runtime
+            version: "$(DotNetCoreRuntimeVersion)"
+
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:
             Location: ${{ parameters.Location }}

--- a/eng/pipelines/templates/steps/archetype-sdk-docs.yml
+++ b/eng/pipelines/templates/steps/archetype-sdk-docs.yml
@@ -1,8 +1,4 @@
 steps:
-  - task: UseDotNet@2
-    displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
-    inputs:
-      version: $(DotNetCoreSDKVersion)
   - pwsh: |
       # Download and Extract or restore Packages required for Doc Generation
       Write-Host "Download and Extract mdoc to Build.BinariesDirectory/mdoc"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,9 @@
 {
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "1.0.45"
+  },
+  "sdk": {
+    "version": "3.1.301",
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
Retiring `UseDotNet@2` task.
Specify sdk version `3.1.301` in global.json. Version is already installed on the build agents.

Runtime version `2.1.10` is also already installed on the agent. So am guessing we also don't need the task to download it.