### PR TITLE
Identity work around for issue with non GUID Client Ids

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 - Restoring Application Authentication APIs from 1.2.0-preview.6
 
+### Fixes and improvements
+- Fixed issue with non GUID Client Ids (Issue [#14585](https://github.com/Azure/azure-sdk-for-net/issues/14585))
+
+
 ## 1.2.2 (2020-08-20)
 
 ### Fixes and improvements

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -60,9 +60,13 @@ namespace Azure.Identity
 
             if (EnablePersistentCache)
             {
+                // we are creating the MsalCacheHelper with a random guid based clientId to work around issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98
+                // This does not impact the functionality of the cacheHelper as the ClientId is only used to iterate accounts in the cache not for authentication purposes.
+                string msalCacheClientId = Guid.NewGuid().ToString();
+
                 MsalCacheHelper cacheHelper;
 
-                StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, ClientId)
+                StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, msalCacheClientId)
                     .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
                     .WithLinuxKeyring(Constants.DefaultMsalTokenCacheKeyringSchema, Constants.DefaultMsalTokenCacheKeyringCollection, Constants.DefaultMsalTokenCacheKeyringLabel, Constants.DefaultMsaltokenCacheKeyringAttribute1, Constants.DefaultMsaltokenCacheKeyringAttribute2)
                     .Build();
@@ -77,7 +81,7 @@ namespace Azure.Identity
                 {
                     if (AllowUnencryptedCache)
                     {
-                        storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, ClientId)
+                        storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, msalCacheClientId)
                             .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
                             .WithLinuxUnprotectedFile()
                             .Build();

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -12,6 +12,10 @@ namespace Azure.Identity
     internal abstract class MsalClientBase<TClient>
         where TClient : IClientApplicationBase
     {
+        // we are creating the MsalCacheHelper with a random guid based clientId to work around issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98
+        // This does not impact the functionality of the cacheHelper as the ClientId is only used to iterate accounts in the cache not for authentication purposes.
+        private static readonly string s_msalCacheClientId = Guid.NewGuid().ToString();
+
         private readonly AsyncLockWithValue<TClient> _clientAsyncLock;
 
         /// <summary>
@@ -60,13 +64,9 @@ namespace Azure.Identity
 
             if (EnablePersistentCache)
             {
-                // we are creating the MsalCacheHelper with a random guid based clientId to work around issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98
-                // This does not impact the functionality of the cacheHelper as the ClientId is only used to iterate accounts in the cache not for authentication purposes.
-                string msalCacheClientId = Guid.NewGuid().ToString();
-
                 MsalCacheHelper cacheHelper;
 
-                StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, msalCacheClientId)
+                StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
                     .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
                     .WithLinuxKeyring(Constants.DefaultMsalTokenCacheKeyringSchema, Constants.DefaultMsalTokenCacheKeyringCollection, Constants.DefaultMsalTokenCacheKeyringLabel, Constants.DefaultMsaltokenCacheKeyringAttribute1, Constants.DefaultMsaltokenCacheKeyringAttribute2)
                     .Build();
@@ -81,7 +81,7 @@ namespace Azure.Identity
                 {
                     if (AllowUnencryptedCache)
                     {
-                        storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, msalCacheClientId)
+                        storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
                             .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
                             .WithLinuxUnprotectedFile()
                             .Build();


### PR DESCRIPTION
This is a work around for issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98 in the .NET Msal Extension library. Currently constructing the `MsalCacheHelper` from this library when a non-GUID client id is used. This work around uses a random GUID for the Client Id to work around this issue. The random Client Id does not affect authentication in any way. MsalCacheHelper only uses the Client to create a `PublicClientApplication`  to enumerate accounts in the cache.

Fixes #14585
