### PR TITLE
[TA] Add flags enum for Opinion mining

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -1,9 +1,15 @@
 namespace Azure.AI.TextAnalytics
 {
+    [System.FlagsAttribute]
+    public enum AdditionalSentimentAnalyses
+    {
+        None = 0,
+        OpinionMining = 1,
+    }
     public partial class AnalyzeSentimentOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
     {
         public AnalyzeSentimentOptions() { }
-        public Azure.AI.TextAnalytics.AnalyzeSentimentType IncludeAnalysis { get { throw null; } set { } }
+        public Azure.AI.TextAnalytics.AdditionalSentimentAnalyses AdditionalSentimentAnalyses { get { throw null; } set { } }
     }
     public partial class AnalyzeSentimentResult : Azure.AI.TextAnalytics.TextAnalyticsResult
     {
@@ -15,12 +21,6 @@ namespace Azure.AI.TextAnalytics
         internal AnalyzeSentimentResultCollection() : base (default(System.Collections.Generic.IList<Azure.AI.TextAnalytics.AnalyzeSentimentResult>)) { }
         public string ModelVersion { get { throw null; } }
         public Azure.AI.TextAnalytics.TextDocumentBatchStatistics Statistics { get { throw null; } }
-    }
-    [System.FlagsAttribute]
-    public enum AnalyzeSentimentType
-    {
-        None = 0,
-        OpinionMining = 1,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AspectSentiment

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -3,7 +3,7 @@ namespace Azure.AI.TextAnalytics
     public partial class AnalyzeSentimentOptions : Azure.AI.TextAnalytics.TextAnalyticsRequestOptions
     {
         public AnalyzeSentimentOptions() { }
-        public bool IncludeOpinionMining { get { throw null; } set { } }
+        public Azure.AI.TextAnalytics.AnalyzeSentimentType IncludeAnalysis { get { throw null; } set { } }
     }
     public partial class AnalyzeSentimentResult : Azure.AI.TextAnalytics.TextAnalyticsResult
     {
@@ -15,6 +15,12 @@ namespace Azure.AI.TextAnalytics
         internal AnalyzeSentimentResultCollection() : base (default(System.Collections.Generic.IList<Azure.AI.TextAnalytics.AnalyzeSentimentResult>)) { }
         public string ModelVersion { get { throw null; } }
         public Azure.AI.TextAnalytics.TextDocumentBatchStatistics Statistics { get { throw null; } }
+    }
+    [System.FlagsAttribute]
+    public enum AnalyzeSentimentType
+    {
+        None = 0,
+        OpinionMining = 1,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AspectSentiment

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AdditionalSentimentAnalyses.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AdditionalSentimentAnalyses.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿ // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,13 +6,14 @@ using System;
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
-    /// Specialized types of Sentiment Analysis, like for example Opinion Mining.
+    /// Additional types of Sentiment Analysis to be applied to the
+    /// AnalyzeSentiment method, like for example Opinion Mining.
     /// </summary>
     [Flags]
-    public enum AnalyzeSentimentType
+    public enum AdditionalSentimentAnalyses
     {
         /// <summary>
-        /// Sentiment analysis for documents and its sentences.
+        /// Use standard sentiment analysis for documents and its sentences.
         /// </summary>
         None = 0,
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
@@ -23,9 +23,9 @@ namespace Azure.AI.TextAnalytics
         }
 
         /// <summary>
-        /// Specifies the types of analysis to apply, like for example,
-        /// Opinion mining.
+        /// Additional types of Sentiment Analysis to be applied to the
+        /// AnalyzeSentiment method, like for example Opinion Mining.
         /// </summary>
-        public AnalyzeSentimentType IncludeAnalysis { get; set; }
+        public AdditionalSentimentAnalyses AdditionalSentimentAnalyses { get; set; }
 }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentOptions.cs
@@ -23,9 +23,9 @@ namespace Azure.AI.TextAnalytics
         }
 
         /// <summary>
-        /// If set to true, response will contain Opinion Mining sentiment analysis results.
-        /// Only available for Text Analytics Service version v3.1-preview.1 and above.
+        /// Specifies the types of analysis to apply, like for example,
+        /// Opinion mining.
         /// </summary>
-        public bool IncludeOpinionMining { get; set; } = false;
-    }
+        public AnalyzeSentimentType IncludeAnalysis { get; set; }
+}
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentType.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentType.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Specialized types of Sentiment Analysis, like for example Opinion Mining.
+    /// </summary>
+    [Flags]
+    public enum AnalyzeSentimentType
+    {
+        /// <summary>
+        /// Sentiment analysis for documents and its sentences.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Sentiment analysis results with Opinion Mining,
+        /// also known as Aspect-based Sentiment Analysis.
+        /// Only available for Text Analytics Service version v3.1-preview.1 and above.
+        /// </summary>
+        OpinionMining = 1,
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
@@ -57,7 +57,7 @@ namespace Azure.AI.TextAnalytics
 
         /// <summary>
         /// Gets the mined opinions of a sentence. This is only returned if
-        /// <see cref="AnalyzeSentimentType.OpinionMining"/> is set in <see cref="AnalyzeSentimentOptions.IncludeAnalysis"/>.
+        /// <see cref="AdditionalSentimentAnalyses.OpinionMining"/> is set in <see cref="AnalyzeSentimentOptions.AdditionalSentimentAnalyses"/>.
         /// </summary>
         public IReadOnlyCollection<MinedOpinion> MinedOpinions { get; }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
@@ -57,7 +57,7 @@ namespace Azure.AI.TextAnalytics
 
         /// <summary>
         /// Gets the mined opinions of a sentence. This is only returned if
-        /// <see cref="AnalyzeSentimentOptions.IncludeOpinionMining"/> is set to true.
+        /// <see cref="AnalyzeSentimentType.OpinionMining"/> is set in <see cref="AnalyzeSentimentOptions.IncludeAnalysis"/>.
         /// </summary>
         public IReadOnlyCollection<MinedOpinion> MinedOpinions { get; }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -788,11 +788,12 @@ namespace Azure.AI.TextAnalytics
             try
             {
                 var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
+                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
                 Response<SentimentResponse> result = await _serviceRestClient.SentimentAsync(
                     new MultiLanguageBatchInput(documents),
                     options.ModelVersion,
                     options.IncludeStatistics,
-                    options.IncludeOpinionMining,
+                    opinionMining,
                     _stringCodeUnit,
                     cancellationToken).ConfigureAwait(false);
                 Response response = result.GetRawResponse();
@@ -848,11 +849,12 @@ namespace Azure.AI.TextAnalytics
             try
             {
                 var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
+                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
                 Response<SentimentResponse> result = _serviceRestClient.Sentiment(
                     new MultiLanguageBatchInput(documents),
                     options.ModelVersion,
                     options.IncludeStatistics,
-                    options.IncludeOpinionMining,
+                    opinionMining,
                     _stringCodeUnit,
                     cancellationToken);
                 Response response = result.GetRawResponse();
@@ -1126,11 +1128,12 @@ namespace Azure.AI.TextAnalytics
 
             try
             {
+                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
                 Response<SentimentResponse> result = await _serviceRestClient.SentimentAsync(
                     batchInput,
                     options.ModelVersion,
                     options.IncludeStatistics,
-                    options.IncludeOpinionMining,
+                    opinionMining,
                     _stringCodeUnit,
                     cancellationToken).ConfigureAwait(false);
                 var response = result.GetRawResponse();
@@ -1153,10 +1156,12 @@ namespace Azure.AI.TextAnalytics
 
             try
             {
-                Response<SentimentResponse> result = _serviceRestClient.Sentiment(batchInput,
+                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
+                Response<SentimentResponse> result = _serviceRestClient.Sentiment(
+                    batchInput,
                     options.ModelVersion,
                     options.IncludeStatistics,
-                    options.IncludeOpinionMining,
+                    opinionMining,
                     _stringCodeUnit,
                     cancellationToken);
                 var response = result.GetRawResponse();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -788,7 +788,7 @@ namespace Azure.AI.TextAnalytics
             try
             {
                 var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
+                bool opinionMining = options.AdditionalSentimentAnalyses.HasFlag(AdditionalSentimentAnalyses.OpinionMining);
                 Response<SentimentResponse> result = await _serviceRestClient.SentimentAsync(
                     new MultiLanguageBatchInput(documents),
                     options.ModelVersion,
@@ -849,7 +849,7 @@ namespace Azure.AI.TextAnalytics
             try
             {
                 var documents = new List<MultiLanguageInput>() { ConvertToMultiLanguageInput(document, language) };
-                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
+                bool opinionMining = options.AdditionalSentimentAnalyses.HasFlag(AdditionalSentimentAnalyses.OpinionMining);
                 Response<SentimentResponse> result = _serviceRestClient.Sentiment(
                     new MultiLanguageBatchInput(documents),
                     options.ModelVersion,
@@ -1128,7 +1128,7 @@ namespace Azure.AI.TextAnalytics
 
             try
             {
-                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
+                bool opinionMining = options.AdditionalSentimentAnalyses.HasFlag(AdditionalSentimentAnalyses.OpinionMining);
                 Response<SentimentResponse> result = await _serviceRestClient.SentimentAsync(
                     batchInput,
                     options.ModelVersion,
@@ -1156,7 +1156,7 @@ namespace Azure.AI.TextAnalytics
 
             try
             {
-                bool opinionMining = options.IncludeAnalysis.HasFlag(AnalyzeSentimentType.OpinionMining) ? true : false;
+                bool opinionMining = options.AdditionalSentimentAnalyses.HasFlag(AdditionalSentimentAnalyses.OpinionMining);
                 Response<SentimentResponse> result = _serviceRestClient.Sentiment(
                     batchInput,
                     options.ModelVersion,

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
@@ -65,7 +65,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "The park was clean and pretty. The bathrooms and restaurant were not clean.";
 
-            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document, options: new AnalyzeSentimentOptions() { AdditionalSentimentAnalyses = AdditionalSentimentAnalyses.OpinionMining });
 
             CheckAnalyzeSentimentProperties(docSentiment, opinionMining: true);
             Assert.AreEqual("Mixed", docSentiment.Sentiment.ToString());
@@ -77,7 +77,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = singleEnglish;
 
-            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document, "en", new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document, "en", new AnalyzeSentimentOptions() { AdditionalSentimentAnalyses = AdditionalSentimentAnalyses.OpinionMining });
 
             CheckAnalyzeSentimentProperties(docSentiment);
             Assert.AreEqual("Positive", docSentiment.Sentiment.ToString());
@@ -89,7 +89,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "The bathrooms are not clean.";
 
-            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document, options: new AnalyzeSentimentOptions() { AdditionalSentimentAnalyses = AdditionalSentimentAnalyses.OpinionMining });
 
             CheckAnalyzeSentimentProperties(docSentiment, opinionMining: true);
             MinedOpinion minedOpinion = docSentiment.Sentences.FirstOrDefault().MinedOpinions.FirstOrDefault();
@@ -151,7 +151,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 "The food and service is not good."
             };
 
-            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(documents, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(documents, options: new AnalyzeSentimentOptions() { AdditionalSentimentAnalyses = AdditionalSentimentAnalyses.OpinionMining });
 
             foreach (AnalyzeSentimentResult docs in results)
             {
@@ -334,7 +334,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 }
             };
 
-            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(documents, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(documents, options: new AnalyzeSentimentOptions() { AdditionalSentimentAnalyses = AdditionalSentimentAnalyses.OpinionMining });
 
             foreach (AnalyzeSentimentResult docs in results)
             {


### PR DESCRIPTION
Last feedback from Arch board meeting. 
> Consider making IncludeOpinionMining an enum flag like https://apiview.dev/Assemblies/Review/a17b6175b93847db83a99c7fcfeca9ab#Azure.Storage.Blobs.Models.BlobStates.

After looking into other types of analysis that could be applied and confirming with the services that a user could ask for different type analysis for one document, I decided to change the property `IncludeOpinionMining` to `AnalyzeSentimentType.OpinionMining`.

Here is a proposal for .NET [API View](https://apiview.dev/Assemblies/Review/b196a5e53fa2441f92e3b1accefa35e7/0a7669f90b7249ddad28d589bdb1fed2#Azure.AI.TextAnalytics.TextAnalyticsClient.AnalyzeSentiment(System.String,%20System.String))

Before the change:
```
await client.AnalyzeSentimentAsync(document, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
```

After the change:
```
await client.AnalyzeSentimentAsync(document, options: new AnalyzeSentimentOptions() { IncludeAnalysis = AnalyzeSentimentType.OpinionMining });
```

Once other types of analysis are supported by the service, the user will be able to do something like this to request for multiple analysis in one single document:
```
IncludeAnalysis = AnalyzeSentimentType.OpinionMining | AnalyzeSentimentType.EmotionBased
```

**Note:** This change will only happen in .NET

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/13359