### PR TITLE
Probe IMDS /metadata/instance endpoint during discovery in MsiAccessTokenProvider

### DIFF
--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/MsiAccessTokenProviderTests.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/MsiAccessTokenProviderTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 {
     /// <summary>
-    /// Test cases for MsiAccessTokenProvider class. MsiAccessTokenProvider is an internal class. 
+    /// Test cases for MsiAccessTokenProvider class. MsiAccessTokenProvider is an internal class.
     /// </summary>
     public class MsiAccessTokenProviderTests : IDisposable
     {
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 expectedAppId = Constants.TestAppId;
             }
 
-            // MockMsi is being asked to act like response from Azure VM MSI succeeded. 
+            // MockMsi is being asked to act like response from Azure VM MSI succeeded.
             MockMsi mockMsi = new MockMsi(msiTestType);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient, managedIdentityClientId: managedIdentityArgument);
@@ -56,18 +56,18 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             // Get token.
             var authResult = await msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
-            // Check if the principalused and type are as expected. 
+            // Check if the principalused and type are as expected.
             Validator.ValidateToken(authResult.AccessToken, msiAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, expectedAppId, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>
-        /// If json parse error when aquiring token, an exception should be thrown. 
+        /// If json parse error when aquiring token, an exception should be thrown.
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task ParseErrorMsiGetTokenTest()
         {
-            // MockMsi is being asked to act like response from Azure VM MSI suceeded. 
+            // MockMsi is being asked to act like response from Azure VM MSI suceeded.
             MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAppJsonParseFailure);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
@@ -80,13 +80,13 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        /// If MSI response if missing the token, an exception should be thrown. 
+        /// If MSI response if missing the token, an exception should be thrown.
         /// </summary>
         /// <returns></returns>
         [Fact]
         public async Task MsiResponseMissingTokenTest()
         {
-            // MockMsi is being asked to act like response from Azure VM MSI failed. 
+            // MockMsi is being asked to act like response from Azure VM MSI failed.
             MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiMissingToken);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         [InlineData(false)]
         public async Task GetTokenUsingManagedIdentityAppServices(bool specifyUserAssignedManagedIdentity)
         {
-            // Setup the environment variables that App Service MSI would setup. 
+            // Setup the environment variables that App Service MSI would setup.
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
 
@@ -125,19 +125,19 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 expectedAppId = Constants.TestAppId;
             }
 
-            // MockMsi is being asked to act like response from App Service MSI suceeded. 
+            // MockMsi is being asked to act like response from App Service MSI suceeded.
             MockMsi mockMsi = new MockMsi(msiTestType);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient, managedIdentityClientId: managedIdentityArgument);
 
-            // Get token. This confirms that the environment variables are being read. 
+            // Get token. This confirms that the environment variables are being read.
             var authResult = await msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
             Validator.ValidateToken(authResult.AccessToken, msiAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, expectedAppId, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>
-        /// Test response when IDENTITY_HEADER in AppServices MSI is invalid. 
+        /// Test response when IDENTITY_HEADER in AppServices MSI is invalid.
         /// </summary>
         /// <returns></returns>
         [Fact]
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
 
-            // MockMsi is being asked to act like response from App Service MSI failed (unauthorized). 
+            // MockMsi is being asked to act like response from App Service MSI failed (unauthorized).
             MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAppServicesUnauthorized);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        /// Test that response when MSI request is not valid is as expected. 
+        /// Test that response when MSI request is not valid is as expected.
         /// </summary>
         /// <returns></returns>
         [Fact]
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        /// If an unexpected http response has been received, ensure exception is thrown. 
+        /// If an unexpected http response has been received, ensure exception is thrown.
         /// </summary>
         /// <returns></returns>
         [Fact]
@@ -208,13 +208,13 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, null);
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, null);
 
-            MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAzureVmTimeout);
+            MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAzureVmImdsTimeout);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
             var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
-            Assert.Contains(AzureServiceTokenProviderException.MsiEndpointNotListening, exception.Message);
+            Assert.Contains(AzureServiceTokenProviderException.MetadataEndpointNotListening, exception.Message);
             Assert.DoesNotContain(AzureServiceTokenProviderException.RetryFailure, exception.Message);
         }
 
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         [InlineData(MockMsi.MsiTestType.MsiTransientServerError)]
         internal async Task TransientErrorRetryTest(MockMsi.MsiTestType testType)
         {
-            // To simplify tests, mock as MSI App Services to skip Azure VM IDMS probe request by 
+            // To simplify tests, mock as MSI App Services to skip Azure VM IDMS probe request by
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
 
@@ -254,12 +254,17 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             }
         }
 
-        [Fact]
-        private async Task MsiRetryTimeoutTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        private async Task MsiRetryTimeoutTest(bool isAppServices)
         {
-            // To simplify tests, mock as MSI App Services to skip Azure VM IDMS probe request
-            Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
-            Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
+            if (isAppServices)
+            {
+                // To simplify tests, mock as MSI App Services to skip Azure VM IDMS probe request
+                Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
+                Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
+            }
 
             int timeoutInSeconds = (new Random()).Next(1, 4);
 
@@ -291,11 +296,11 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 // ensure thread culture is NOT using en-US culture (App Services MSI endpoint always uses en-US DateTime format)
                 Thread.CurrentThread.CurrentCulture = new CultureInfo("en-GB");
 
-                // Setup the environment variables that App Service MSI would setup. 
+                // Setup the environment variables that App Service MSI would setup.
                 Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
                 Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
 
-                // MockMsi is being asked to act like response from App Service MSI suceeded. 
+                // MockMsi is being asked to act like response from App Service MSI suceeded.
                 MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAppServicesSuccess);
                 HttpClient httpClient = new HttpClient(mockMsi);
                 MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/MsiAccessTokenProviderTests.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/MsiAccessTokenProviderTests.cs
@@ -257,11 +257,11 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        private async Task MsiRetryTimeoutTest(bool isAppServices)
+        internal async Task MsiRetryTimeoutTest(bool isAppServices)
         {
             if (isAppServices)
             {
-                // To simplify tests, mock as MSI App Services to skip Azure VM IDMS probe request
+                // Mock as MSI App Services to skip Azure VM IDMS probe request
                 Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, Constants.MsiEndpoint);
                 Environment.SetEnvironmentVariable(Constants.MsiAppServiceHeaderEnv, Constants.ClientSecret);
             }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
     public class TokenHelper
     {
         /// <summary>
-        /// The hardcoded user token has expiry replaced by [exp], so we can replace it with some value to test functionality. 
+        /// The hardcoded user token has expiry replaced by [exp], so we can replace it with some value to test functionality.
         /// </summary>
         /// <param name="accessToken"></param>
         /// <param name="secondsFromCurrent"></param>
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
         internal static string GetUserToken()
         {
-            // Gets a user token that will expire in 10 seconds from now. 
+            // Gets a user token that will expire in 10 seconds from now.
             return GetUserToken(10);
         }
 
@@ -61,6 +61,16 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             }
 
             return tokenResult;
+        }
+
+        /// <summary>
+        /// Sample IMDS /instance response
+        /// </summary>
+        /// <returns></returns>
+        internal static string GetInstanceMetadataResponse()
+        {
+            return
+                "{\"compute\":{\"location\":\"westus\",\"name\":\"TestBedVm\",\"resourceGroupName\":\"testbed\",\"subscriptionId\":\"bdd789f3-d9d1-4bea-ac14-30a39ed66d33\"}}";
         }
 
         /// <summary>
@@ -128,7 +138,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        ///  The response has claims as expected from Client Credentials flow response. 
+        ///  The response has claims as expected from Client Credentials flow response.
         /// </summary>
         /// <returns></returns>
         internal static string GetAppToken()
@@ -139,7 +149,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        ///  Invalid AppToken. 
+        ///  Invalid AppToken.
         /// </summary>
         /// <returns></returns>
         internal static string GetInvalidAppToken()

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
@@ -9,7 +9,7 @@ using System.Runtime.Serialization;
 namespace Microsoft.Azure.Services.AppAuthentication
 {
     /// <summary>
-    /// Instance of this exception is thrown if access token cannot be acquired. 
+    /// Instance of this exception is thrown if access token cannot be acquired.
     /// </summary>
 #if FullNetFx || NETSTANDARD2_0
     [Serializable]
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
     public class AzureServiceTokenProviderException : Exception
     {
+        internal const string MetadataEndpointNotListening = "Unable to connect to the Instance Metadata Service (IMDS). Skipping request to the Managed Service Identity (MSI) token endpoint.";
+
         internal const string MsiEndpointNotListening = "Unable to connect to the Managed Service Identity (MSI) endpoint. Please check that you are running on an Azure resource that has MSI setup.";
 
         internal const string UnableToParseMsiTokenResponse = "A successful response was received from Managed Service Identity, but it could not be parsed.";
@@ -42,7 +44,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         internal const string NonRetryableError = "Received a non-retryable error.";
 
         /// <summary>
-        /// Creates an instance of AzureServiceTokenProviderException. 
+        /// Creates an instance of AzureServiceTokenProviderException.
         /// </summary>
         /// <param name="connectionString">Connection string used.</param>
         /// <param name="resource">Resource for which token was expected.</param>

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Azure.Services.AppAuthentication
 {
     /// <summary>
-    /// Gets a token using Azure VM or App Services MSI. 
+    /// Gets a token using Azure VM or App Services MSI.
     /// https://docs.microsoft.com/en-us/azure/active-directory/msi-overview
     /// </summary>
     internal class MsiAccessTokenProvider : NonInteractiveAzureServiceTokenProviderBase
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         // This client ID can be specified in the constructor to specify a specific managed identity to use (e.g. user-assigned identity)
         private readonly string _managedIdentityClientId;
 
-        // HttpClient is intended to be instantiated once and re-used throughout the life of an application. 
+        // HttpClient is intended to be instantiated once and re-used throughout the life of an application.
 #if NETSTANDARD1_4 || net452 || net461
         private static readonly HttpClient DefaultHttpClient = new HttpClient();
 #else
@@ -29,10 +29,14 @@ namespace Microsoft.Azure.Services.AppAuthentication
 #endif
 
         // Azure Instance Metadata Service (IMDS) endpoint
-        private const string AzureVmImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+        private const string AzureVmImdsEndpoint = "http://169.254.169.254";
+        private const string ImdsInstanceRoute = "/metadata/instance";
+        private const string ImdsTokenRoute = "/metadata/identity/oauth2/token";
+        private const string ImdsInstanceApiVersion = "2020-06-01";
+        private const string ImdsTokenApiVersion = "2019-11-01";
 
         // Timeout for Azure IMDS probe request
-        internal const int AzureVmImdsProbeTimeoutInSeconds = 2;
+        internal const int AzureVmImdsProbeTimeoutInSeconds = 3;
         internal readonly TimeSpan AzureVmImdsProbeTimeout = TimeSpan.FromSeconds(AzureVmImdsProbeTimeoutInSeconds);
 
         // Configurable timeout for MSI retry logic
@@ -61,12 +65,12 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority,
             CancellationToken cancellationToken = default)
         {
-            // Use the httpClient specified in the constructor. If it was not specified in the constructor, use the default httpClient. 
+            // Use the httpClient specified in the constructor. If it was not specified in the constructor, use the default httpClient.
             HttpClient httpClient = _httpClient ?? DefaultHttpClient;
 
             try
             {
-                // Check if App Services MSI is available. If both these environment variables are set, then it is. 
+                // Check if App Services MSI is available. If both these environment variables are set, then it is.
                 string msiEndpoint = Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT");
                 string msiHeader = Environment.GetEnvironmentVariable("IDENTITY_HEADER");
                 var isAppServicesMsiAvailable = !string.IsNullOrWhiteSpace(msiEndpoint) && !string.IsNullOrWhiteSpace(msiHeader);
@@ -77,7 +81,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     using (var internalTokenSource = new CancellationTokenSource())
                     using (var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(internalTokenSource.Token, cancellationToken))
                     {
-                        HttpRequestMessage imdsProbeRequest = new HttpRequestMessage(HttpMethod.Get, AzureVmImdsEndpoint);
+                        string probeRequestUrl = $"{AzureVmImdsEndpoint}{ImdsInstanceRoute}?api-version={ImdsInstanceApiVersion}";
+                        HttpRequestMessage imdsProbeRequest = new HttpRequestMessage(HttpMethod.Get, probeRequestUrl);
 
                         try
                         {
@@ -90,7 +95,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                             if (internalTokenSource.Token.IsCancellationRequested)
                             {
                                 throw new AzureServiceTokenProviderException(ConnectionString, resource, authority,
-                                    $"{AzureServiceTokenProviderException.ManagedServiceIdentityUsed} {AzureServiceTokenProviderException.MsiEndpointNotListening}");
+                                    $"{AzureServiceTokenProviderException.ManagedServiceIdentityUsed} {AzureServiceTokenProviderException.MetadataEndpointNotListening}");
                             }
 
                             throw;
@@ -106,7 +111,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 // Craft request as per the MSI protocol
                 var requestUrl = isAppServicesMsiAvailable
                     ? $"{msiEndpoint}?resource={resource}{clientIdParameter}&api-version=2019-08-01"
-                    : $"{AzureVmImdsEndpoint}?resource={resource}{clientIdParameter}&api-version=2018-02-01";
+                    : $"{AzureVmImdsEndpoint}{ImdsTokenRoute}?resource={resource}{clientIdParameter}" +
+                        $"&api-version={ImdsTokenApiVersion}";
 
                 Func<HttpRequestMessage> getRequestMessage = () =>
                 {
@@ -153,7 +159,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                         PrincipalUsed.AppId = token.AppId;
                         PrincipalUsed.TenantId = token.TenantId;
                     }
-                    
+
                     return AppAuthenticationResult.Create(tokenResponse);
                 }
 

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -111,8 +111,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 // Craft request as per the MSI protocol
                 var requestUrl = isAppServicesMsiAvailable
                     ? $"{msiEndpoint}?resource={resource}{clientIdParameter}&api-version=2019-08-01"
-                    : $"{AzureVmImdsEndpoint}{ImdsTokenRoute}?resource={resource}{clientIdParameter}" +
-                        $"&api-version={ImdsTokenApiVersion}";
+                    : $"{AzureVmImdsEndpoint}{ImdsTokenRoute}?resource={resource}{clientIdParameter}&api-version={ImdsTokenApiVersion}";
 
                 Func<HttpRequestMessage> getRequestMessage = () =>
                 {


### PR DESCRIPTION
The way the probe is currently being made to the token endpoint, the request is always going to return a 400. This is causing noise in the monitoring and logging for the Identity Plugin in IMDS and is creating additional confusion on the customer side of things both because of the inaccurate error description and the extra unexpected web traffic.

If the goal is to see if IMDS exists, the probe should go to the main instance endpoint and reflect the availability of IMDS as a whole, rather than the /token endpoint.

Extending the timeout as well, because we've seen additional support issues pop up where the call is occasionally taking slightly more than the two seconds to reach IMDS in the first place and timing out before the request even appears in the log trace.