### PR TITLE
Add release preparation script

### DIFF
--- a/eng/scripts/Prepare-Release.ps1
+++ b/eng/scripts/Prepare-Release.ps1
@@ -27,7 +27,7 @@ foreach ($existingVersion in $existing.versions)
 $latestVersion = $existing.versions[$existing.versions.Count - 1];
 
 Write-Host
-Write-Host "Latest released version $latestVersion, library type $libraryType"
+Write-Host "Latest released version $latestVersion, library type $libraryType" -ForegroundColor Green
 
 $newVersion = Read-Host -Prompt 'Input the new version' 
 
@@ -51,10 +51,10 @@ elseif ($parsedNewVersion.IsPrerelease)
 }
 
 Write-Host
-Write-Host "Detected released type $releaseType"
+Write-Host "Detected released type $releaseType" -ForegroundColor Green
 
 Write-Host
-Write-Host "Updating versions"
+Write-Host "Updating versions" -ForegroundColor Green
 
 & "$repoRoot\eng\scripts\Update-PkgVersion.ps1" -ServiceDirectory $serviceDirectory -PackageName $package -NewVersionString $newVersion
 
@@ -65,7 +65,7 @@ if ($date.Day -gt 15)
     $month = $date.AddMonths(1).ToString("MMMM")
 }
 Write-Host
-Write-Host "Assuming release is in $month"
+Write-Host "Assuming release is in $month" -ForegroundColor Green
 
 $commonParameter = @("--organization", "https://dev.azure.com/azure-sdk", "-o", "json", "--only-show-errors")
 
@@ -94,7 +94,7 @@ $fields = @{
 }
 
 Write-Host
-Write-Host "Going to set the following fields:"
+Write-Host "Going to set the following fields:" -ForegroundColor Green
 
 foreach ($field in $fields.Keys)
 {
@@ -118,7 +118,7 @@ $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation "$packageDirectory/CHANG
 
 $githubAnchor = $changeLogEntry.ReleaseTitle.Replace("## ", "").Replace(".", "").Replace("(", "").Replace(")", "").Replace(" ", "-")
 Write-Host
-Write-Host "Snippet for the centralized CHANGELOG:"
+Write-Host "Snippet for the centralized CHANGELOG:" -ForegroundColor Green
 Write-Host "dotnet add package $package --version $newVersion"
 Write-Host "### $package [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/$serviceDirectory/$package/CHANGELOG.md#$githubAnchor)"
 $changeLogEntry.ReleaseContent | Write-Host 

--- a/eng/scripts/Prepare-Release.ps1
+++ b/eng/scripts/Prepare-Release.ps1
@@ -1,0 +1,105 @@
+param($package)
+
+$repoRoot = Resolve-Path "$PSScriptRoot/../..";
+
+$serviceDirectory = (Get-ChildItem "$repoRoot/sdk" -Directory -Recurse -Depth 2 -Filter $package).Parent.Name
+
+Write-Host "Source directory $serviceDirectory"
+
+$existing = Invoke-WebRequest "https://api.nuget.org/v3-flatcontainer/$($package.ToLower())/index.json" | ConvertFrom-Json;
+
+. ${repoRoot}\eng\common\scripts\SemVer.ps1
+
+$libraryType = "preview";
+$latestVersion = "unknown";
+foreach ($existingVersion in $existing.versions)
+{
+    $parsedVersion = [AzureEngSemanticVersion]::new($existingVersion)
+    if (!$packageOldSemVer.IsPrerelease)
+    {
+        $libraryType = "GA"
+    }
+    $latestVersion = $existingVersion;
+}
+
+$latestVersion = $existing.versions[$existing.versions.Count - 1];
+
+Write-Host "Latest released version $latestVersion, library type $libraryType"
+
+$newVersion = Read-Host -Prompt 'Input the new version' 
+
+$releaseType = "None";
+$parsedNewVersion = [AzureEngSemanticVersion]::new($newVersion)
+if ($parsedNewVersion.Major -ne $parsedVersion.Major)
+{
+    $releaseType = "Major"
+}
+elseif ($parsedNewVersion.Minor -ne $parsedVersion.Minor)
+{
+    $releaseType = "Minor"
+}
+elseif ($parsedNewVersion.Patch -ne $parsedVersion.Patch)
+{
+    $releaseType = "Bugfix"
+}
+elseif ($parsedNewVersion.IsPrerelease)
+{
+    $releaseType = "Bugfix"
+}
+
+Write-Host "Detected released type $releaseType"
+
+& "$repoRoot\eng\scripts\Update-PkgVersion.ps1" -ServiceDirectory $serviceDirectory -PackageName $package -NewVersionString $newVersion
+
+$date = Get-Date
+$month = $date.ToString("MMMM")
+if ($date.Day -gt 15)
+{
+    $month = $date.AddMonths(1).ToString("MMMM")
+}
+
+Write-Host "Assuming release is in $month"
+
+$commonParameter = @("--organization", "https://dev.azure.com/azure-sdk", "-o", "json", "--only-show-errors")
+
+$workItems = az boards query @commonParameter --project Release --wiql "SELECT [ID], [State], [Iteration Path], [Title] FROM WorkItems WHERE [State] <> 'Closed' AND [Iteration Path] under 'Release\2020\$month' AND [Title] contains '.NET'" | ConvertFrom-Json;
+
+$matchedWorkItems = @();
+
+Write-Host "The following issues exist:"
+foreach ($item in $workItems)
+{
+    $id = $item.fields."System.ID";
+    $title = $item.fields."System.Title";
+    $path = $item.fields."System.IterationPath";
+    Write-Host "$id - $path - $title" 
+}
+
+$issueId = Read-Host -Prompt 'Input the issue ID'
+
+$fields = @{
+    "Permalink usetag"="https://github.com/Azure/azure-sdk-for-net/sdk/$serviceDirectory/$package/README.md";
+    "Package Registry Permalink"="https://nuget.org/packages/$package/$newVersion";
+    "Library Type"=$libraryType;
+    "Release Type"=$releaseType;
+    "Version Number"=$newVersion;
+}
+
+Write-Host "Going to set the following fields:"
+
+foreach ($field in $fields.Keys)
+{
+    Write-Host "    $field $($fields[$field])"
+}
+
+$decision = $Host.UI.PromptForChoice('Updating work item', 'Are you sure you want to proceed?', @('&Yes'; '&No'), 0)
+
+if ($decision -eq 0)
+{
+    foreach ($field in $fields.Keys)
+    {
+        az boards work-item update @commonParameter --id $issueId -f "$field=$($fields[$field])" > $null
+    }
+
+    Write-Host "Updated https://dev.azure.com/azure-sdk/Release/_workitems/edit/$issueId"
+}

--- a/eng/scripts/Prepare-Release.ps1
+++ b/eng/scripts/Prepare-Release.ps1
@@ -1,5 +1,8 @@
-param($package)
-
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    $package
+)
 
 function Get-LevenshteinDistance {
     <#
@@ -71,13 +74,18 @@ function Get-LevenshteinDistance {
     }
 }
 
+$ErrorPreference = 'Stop'
 $repoRoot = Resolve-Path "$PSScriptRoot/../..";
+
+if (!(Get-Command az)) {
+  throw 'You must have the Azure CLI installed: https://aka.ms/azure-cli'
+}
 
 . ${repoRoot}\eng\common\scripts\SemVer.ps1
 . ${repoRoot}\eng\common\scripts\ChangeLog-Operations.ps1
 
 $packageDirectory = Get-ChildItem "$repoRoot/sdk" -Directory -Recurse -Depth 2 -Filter $package
-$serviceDirectory = ($packageDirectory).Parent.Name
+$serviceDirectory = $packageDirectory.Parent.Name
 
 Write-Host "Source directory $serviceDirectory"
 
@@ -170,11 +178,11 @@ if (!$issueId)
 }
 
 $fields = @{
-    "Permalink usetag"="https://github.com/Azure/azure-sdk-for-net/sdk/$serviceDirectory/$package/README.md";
-    "Package Registry Permalink"="https://nuget.org/packages/$package/$newVersion";
-    "Library Type"=$libraryType;
-    "Release Type"=$releaseType;
-    "Version Number"=$newVersion;
+    "Permalink usetag"="https://github.com/Azure/azure-sdk-for-net/sdk/$serviceDirectory/$package/README.md"
+    "Package Registry Permalink"="https://nuget.org/packages/$package/$newVersion"
+    "Library Type"=$libraryType
+    "Release Type"=$releaseType
+    "Version Number"=$newVersion
 }
 
 Write-Host

--- a/eng/scripts/Prepare-Release.ps1
+++ b/eng/scripts/Prepare-Release.ps1
@@ -1,5 +1,76 @@
 param($package)
 
+
+function Get-LevenshteinDistance {
+    <#
+        .SYNOPSIS
+            Get the Levenshtein distance between two strings.
+        .DESCRIPTION
+            The Levenshtein Distance is a way of quantifying how dissimilar two strings (e.g., words) are to one another by counting the minimum number of operations required to transform one string into the other.
+        .EXAMPLE
+            Get-LevenshteinDistance 'kitten' 'sitting'
+        .LINK
+            http://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C.23
+            http://en.wikipedia.org/wiki/Edit_distance
+            https://communary.wordpress.com/
+            https://github.com/gravejester/Communary.PASM
+        .NOTES
+            Author: Ã˜yvind Kallstad
+            Date: 07.11.2014
+            Version: 1.0
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [string]$String1,
+
+        [Parameter(Position = 1)]
+        [string]$String2,
+
+        # Makes matches case-sensitive. By default, matches are not case-sensitive.
+        [Parameter()]
+        [switch] $CaseSensitive,
+
+        # A normalized output will fall in the range 0 (perfect match) to 1 (no match).
+        [Parameter()]
+        [switch] $NormalizeOutput
+    )
+
+    if (-not($CaseSensitive)) {
+        $String1 = $String1.ToLowerInvariant()
+        $String2 = $String2.ToLowerInvariant()
+    }
+
+    $d = New-Object 'Int[,]' ($String1.Length + 1), ($String2.Length + 1)
+    for ($i = 0; $i -le $d.GetUpperBound(0); $i++) {
+        $d[$i,0] = $i
+    }
+
+    for ($i = 0; $i -le $d.GetUpperBound(1); $i++) {
+        $d[0,$i] = $i
+    }
+
+    for ($i = 1; $i -le $d.GetUpperBound(0); $i++) {
+        for ($j = 1; $j -le $d.GetUpperBound(1); $j++) {
+            $cost = [Convert]::ToInt32((-not($String1[$i–1] -ceq $String2[$j–1])))
+            $min1 = $d[($i–1),$j] + 1
+            $min2 = $d[$i,($j–1)] + 1
+            $min3 = $d[($i–1),($j–1)] + $cost
+            $d[$i,$j] = [Math]::Min([Math]::Min($min1,$min2),$min3)
+        }
+    }
+
+    $distance = ($d[$d.GetUpperBound(0),$d.GetUpperBound(1)])
+
+    if ($NormalizeOutput) {
+        return (1 – ($distance) / ([Math]::Max($String1.Length,$String2.Length)))
+    }
+
+    else {
+        return $distance
+    }
+}
+
 $repoRoot = Resolve-Path "$PSScriptRoot/../..";
 
 . ${repoRoot}\eng\common\scripts\SemVer.ps1
@@ -12,24 +83,30 @@ Write-Host "Source directory $serviceDirectory"
 
 $existing = Invoke-WebRequest "https://api.nuget.org/v3-flatcontainer/$($package.ToLower())/index.json" | ConvertFrom-Json;
 
-$libraryType = "preview";
+$libraryType = "Preview";
 $latestVersion = "unknown";
 foreach ($existingVersion in $existing.versions)
 {
     $parsedVersion = [AzureEngSemanticVersion]::new($existingVersion)
-    if (!$packageOldSemVer.IsPrerelease)
+    if (!$parsedVersion.IsPrerelease)
     {
         $libraryType = "GA"
     }
+
     $latestVersion = $existingVersion;
 }
 
-$latestVersion = $existing.versions[$existing.versions.Count - 1];
+$currentProjectVersion = ([xml](Get-Content "$packageDirectory/src/*.csproj")).Project.PropertyGroup.Version
 
 Write-Host
 Write-Host "Latest released version $latestVersion, library type $libraryType" -ForegroundColor Green
 
-$newVersion = Read-Host -Prompt 'Input the new version' 
+$newVersion = Read-Host -Prompt "Input the new version or press Enter to use use current project version '$currentProjectVersion'"
+
+if (!$newVersion)
+{
+    $newVersion = $currentProjectVersion;
+}
 
 $releaseType = "None";
 $parsedNewVersion = [AzureEngSemanticVersion]::new($newVersion)
@@ -71,10 +148,8 @@ $commonParameter = @("--organization", "https://dev.azure.com/azure-sdk", "-o", 
 
 $workItems = az boards query @commonParameter --project Release --wiql "SELECT [ID], [State], [Iteration Path], [Title] FROM WorkItems WHERE [State] <> 'Closed' AND [Iteration Path] under 'Release\2020\$month' AND [Title] contains '.NET'" | ConvertFrom-Json;
 
-$matchedWorkItems = @();
-
 Write-Host
-Write-Host "The following issues exist:"
+Write-Host "The following work items exist:"
 foreach ($item in $workItems)
 {
     $id = $item.fields."System.ID";
@@ -83,7 +158,16 @@ foreach ($item in $workItems)
     Write-Host "$id - $path - $title" 
 }
 
-$issueId = Read-Host -Prompt 'Input the issue ID'
+# Sort using fuzzy match
+$workItems = $workItems | Sort-Object -property @{Expression = { Get-LevenshteinDistance $_.fields."System.Title" $package -NormalizeOutput }}
+$mostProbable = $workItems | Select-Object -Last 1
+
+$issueId = Read-Host -Prompt "Input the work item ID or press Enter to use '$($mostProbable.fields."System.ID") - $($mostProbable.fields."System.Title")'"
+
+if (!$issueId)
+{
+    $issueId = $mostProbable.fields."System.ID"
+}
 
 $fields = @{
     "Permalink usetag"="https://github.com/Azure/azure-sdk-for-net/sdk/$serviceDirectory/$package/README.md";
@@ -101,7 +185,7 @@ foreach ($field in $fields.Keys)
     Write-Host "    $field = $($fields[$field])"
 }
 
-$decision = $Host.UI.PromptForChoice('Updating work item', 'Are you sure you want to proceed?', @('&Yes'; '&No'), 0)
+$decision = $Host.UI.PromptForChoice("Updating work item https://dev.azure.com/azure-sdk/Release/_workitems/edit/$issueId", 'Are you sure you want to proceed?', @('&Yes'; '&No'), 0)
 
 if ($decision -eq 0)
 {
@@ -110,8 +194,6 @@ if ($decision -eq 0)
     {
         az boards work-item update @commonParameter --id $issueId -f "$field=$($fields[$field])" > $null
     }
-
-    Write-Host "Updated https://dev.azure.com/azure-sdk/Release/_workitems/edit/$issueId"
 }
 
 $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation "$packageDirectory/CHANGELOG.md" -VersionString $newVersion


### PR DESCRIPTION
Sample run:

```
 .\eng\scripts\Prepare-Release.ps1 Azure.Core
Source directory core

Latest released version 1.4.1, library type GA
Input the new version: 1.5.0

Detected released type Minor

Updating versions
Current Version: 1.5.0
Current Version title: ## 1.5.0 (2020-08-28)
No change is required in change log. Version is already present.
New Version: 1.5.0

Assuming release is in September

The following issues exist:
1131 - Release\2020\September - .NET EventGrid-Client
1139 - Release\2020\September - .NET Storage-Queue
1144 - Release\2020\September - .NET Storage-FileShare
1149 - Release\2020\September - .NET Storage-DataLake
1154 - Release\2020\September - .NET Storage-BlobCryptography
1157 - Release\2020\September - .NET Storage-BlobBatch
1160 - Release\2020\September - .NET Storage-Blob
1165 - Release\2020\September - .NET Storage-Common
1168 - Release\2020\September - .NET Storage-BlobChangefeed
1174 - Release\2020\September - .NET EventHubs-CheckpointStore (Blob)
1180 - Release\2020\September - .NET EventHubs-Client
1187 - Release\2020\September - .NET Cosmos-Client
1193 - Release\2020\September - .NET AppConfig-Client
1199 - Release\2020\September\Out-of-band - .NET TextAnalytics-Client
1204 - Release\2020\September - .NET Identity-Client
1210 - Release\2020\September - .NET Search-Client
1216 - Release\2020\September - .NET ServiceBus-Client
1222 - Release\2020\September - .NET FormRecognizer-Client
1228 - Release\2020\September - .NET Extensions-DataProtection.Keys
1229 - Release\2020\September - .NET Extensions-Configuration.Secrets
1230 - Release\2020\September - .NET Extensions-DataProtection.Blobs
1240 - Release\2020\September - .NET Core-HTTP
1262 - Release\2020\September - .NET Core Serializer - Newtonsoft.Json
1271 - Release\2020\September - .NET KeyVault-Keys
1277 - Release\2020\September - .NET KeyVault-Secrets
1283 - Release\2020\September - .NET KeyVault-Certificates
1288 - Release\2020\September - .NET Table-Client
1336 - Release\2020\September - .NET Core-Experimental
1338 - Release\2020\September - .NET KeyVault-Administration
Input the issue ID: 1240

Going to set the following fields:
    Release Type = Minor
    Library Type = GA
    Package Registry Permalink = https://nuget.org/packages/Azure.Core/1.5.0
    Permalink usetag = https://github.com/Azure/azure-sdk-for-net/sdk/core/Azure.Core/README.md
    Version Number = 1.5.0

Updating work item
Are you sure you want to proceed?
[Y] Yes  [N] No  [?] Help (default is "Y"): n

Snippet for the centralized CHANGELOG:
dotnet add package Azure.Core --version 1.5.0
### Azure.Core [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/CHANGELOG.md#150-2020-08-28)

### Changed
- `ETag` now supports weak ETags and implements an overload for `ToString` that accepts a format string.

### Added
- HttpWebRequest-based transport implementation. Enabled by-default on .NET Framework. Can be disabled using `AZURE_CORE_DISABLE_HTTPWEBREQUESTTRANSPORT` environment variable or `Azure.Core.Pipeline.DisableHttpWebRequestTransport` AppContext switch. To use the app context switch add the following snippet to your `.csproj`:

``xml
 <ItemGroup>
    <RuntimeHostConfigurationOption Include="Azure.Core.Pipeline.DisableHttpWebRequestTransport" Value="true" />
  </ItemGroup>
``

When the environment variable or the switch are set the `HttpClientTransport` would be used by default instead.
```