### PR TITLE
Properly segment StorageEndpointSuffix and CosmosEndpointSuffix

### DIFF
--- a/sdk/tables/Azure.Data.Tables/tests/TablesTestEnvironment.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TablesTestEnvironment.cs
@@ -12,15 +12,15 @@ namespace Azure.Data.Tables.Tests
         }
 
         // Storage Tables
-        public const string DefaultStorageSuffix = ".table.core.windows.net";
+        public const string DefaultStorageSuffix = "core.windows.net";
         public string PrimaryStorageAccountKey => GetRecordedVariable("TABLES_PRIMARY_STORAGE_ACCOUNT_KEY", options => options.IsSecret(SanitizedValue.Base64));
         public string StorageAccountName => GetRecordedVariable("TABLES_STORAGE_ACCOUNT_NAME");
-        public string StorageUri => $"https://{StorageAccountName}{StorageEndpointSuffix ?? DefaultStorageSuffix}";
+        public string StorageUri => $"https://{StorageAccountName}.table.{StorageEndpointSuffix ?? DefaultStorageSuffix}";
 
         // Cosmos Tables
-        public string CosmosEndpointSuffix => GetRecordedOptionalVariable("COSMOS_TABLES_ENDPOINT_SUFFIX") ?? ".table.cosmos.azure.com";
+        public string CosmosEndpointSuffix => GetRecordedOptionalVariable("COSMOS_TABLES_ENDPOINT_SUFFIX") ?? "cosmos.azure.com";
         public string PrimaryCosmosAccountKey => GetRecordedVariable("TABLES_PRIMARY_COSMOS_ACCOUNT_KEY", options => options.IsSecret(SanitizedValue.Base64));
         public string CosmosAccountName => GetRecordedVariable("TABLES_COSMOS_ACCOUNT_NAME");
-        public string CosmosUri => $"https://{CosmosAccountName}{CosmosEndpointSuffix}";
+        public string CosmosUri => $"https://{CosmosAccountName}.table.{CosmosEndpointSuffix}";
     }
 }


### PR DESCRIPTION
Nightly tests were failing because `STORAGE_ENDPOINT_SUFFIX` started getting populated with `core.windows.net` on the test server. `TablesTestEnvironment ` was incorrectly using it.