### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@
 
 # PRLabel: %Storage
 /sdk/storage/                                   @tg-msft
-/sdk/storage/Azure.Storage.*/                   @amishra-dev @seanmcc-msft @amnguye @kasobol-msft
+/sdk/storage/Azure.Storage.*/                   @amishra-dev @seanmcc-msft @amnguye @kasobol-msft @tg-msft
 
 # PRLabel: %Tables
 /sdk/tables/                                    @christothes


### PR DESCRIPTION
From observation. Looks like nesting is winning and @tg-msft is no longer added to our PRs. Fixing that here.