### PR TITLE
[Identity] Add IdentityModelFactory to facilitate mocking

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Restoring Application Authentication APIs from 1.2.0-preview.6
 - Added `IncludeX5CClaimHeader` to `ClientCertificateCredentialOptions` to enable subject name / issuer authentication with the `ClientCertificateCredential`.
 - Added `RedirectUri` to `InteractiveBrowserCredentialOptions` to enable authentication with user specified application with a custom redirect url.
+- Added `IdentityModelFactory` to enable constructing models from the Azure.Identity library for mocking.
 
 ### Fixes and improvements
 - Fixed issue with non GUID Client Ids (Issue [#14585](https://github.com/Azure/azure-sdk-for-net/issues/14585))

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -157,6 +157,11 @@ namespace Azure.Identity
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    public static partial class IdentityModelFactory
+    {
+        public static Azure.Identity.AuthenticationRecord AuthenticationRecord(string username, string authority, string homeAccountId, string tenantId, string clientId) { throw null; }
+        public static Azure.Identity.DeviceCodeInfo DeviceCodeInfo(string userCode, string deviceCode, System.Uri verificationUri, System.DateTimeOffset expiresOn, string message, string clientId, System.Collections.Generic.IReadOnlyCollection<string> scopes) { throw null; }
+    }
     public partial class InteractiveBrowserCredential : Azure.Core.TokenCredential
     {
         public InteractiveBrowserCredential() { }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeInfo.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeInfo.cs
@@ -4,6 +4,7 @@
 using Microsoft.Identity.Client;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Text;
 
 namespace Azure.Identity
@@ -14,14 +15,19 @@ namespace Azure.Identity
     public struct DeviceCodeInfo
     {
         internal DeviceCodeInfo(DeviceCodeResult deviceCode)
+            : this(deviceCode.UserCode, deviceCode.DeviceCode, new Uri(deviceCode.VerificationUrl), deviceCode.ExpiresOn, deviceCode.Message, deviceCode.ClientId, deviceCode.Scopes)
         {
-            UserCode = deviceCode.UserCode;
-            DeviceCode = deviceCode.DeviceCode;
-            VerificationUri = new Uri(deviceCode.VerificationUrl);
-            ExpiresOn = deviceCode.ExpiresOn;
-            Message = deviceCode.Message;
-            ClientId = deviceCode.ClientId;
-            Scopes = deviceCode.Scopes;
+        }
+
+        internal DeviceCodeInfo(string userCode, string deviceCode, Uri verificationUri, DateTimeOffset expiresOn, string message, string clientId, IReadOnlyCollection<string> scopes)
+        {
+            UserCode = userCode;
+            DeviceCode = deviceCode;
+            VerificationUri = verificationUri;
+            ExpiresOn = expiresOn;
+            Message = message;
+            ClientId = clientId;
+            Scopes = scopes;
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/DeviceCodeInfo.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeInfo.cs
@@ -4,8 +4,6 @@
 using Microsoft.Identity.Client;
 using System;
 using System.Collections.Generic;
-using System.Security;
-using System.Text;
 
 namespace Azure.Identity
 {

--- a/sdk/identity/Azure.Identity/src/IdentityModelFactory.cs
+++ b/sdk/identity/Azure.Identity/src/IdentityModelFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Azure.Identity
+{
+
+    /// <summary>
+    /// Model factory that enables mocking for the Azure Identity library.
+    /// </summary>
+    public static class IdentityModelFactory
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationRecord"/> class for mocking purposes.
+        /// </summary>
+        /// <param name="username">Sets the <see cref="AuthenticationRecord.Username"/>.</param>
+        /// <param name="authority">Sets the <see cref="AuthenticationRecord.Authority"/>.</param>
+        /// <param name="homeAccountId">Sets the <see cref="AuthenticationRecord.HomeAccountId"/>.</param>
+        /// <param name="tenantId">Sets the <see cref="AuthenticationRecord.TenantId"/>.</param>
+        /// <param name="clientId">Sets the <see cref="AuthenticationRecord.ClientId"/>.</param>
+        /// <returns>A new instance of the <see cref="AuthenticationRecord"/> for mocking purposes.</returns>
+        public static AuthenticationRecord AuthenticationRecord(string username, string authority, string homeAccountId, string tenantId, string clientId)
+            => new AuthenticationRecord(username, authority, homeAccountId, tenantId, clientId);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceCodeInfo"/> class for mocking purposes.
+        /// </summary>
+        /// <param name="userCode">Sets the <see cref="DeviceCodeInfo.UserCode"/>.</param>
+        /// <param name="deviceCode">Sets the <see cref="DeviceCodeInfo.DeviceCode"/>.</param>
+        /// <param name="verificationUri">Sets the <see cref="DeviceCodeInfo.VerificationUri"/>.</param>
+        /// <param name="expiresOn">Sets the <see cref="DeviceCodeInfo.ExpiresOn"/>.</param>
+        /// <param name="message">Sets the <see cref="DeviceCodeInfo.Message"/>.</param>
+        /// <param name="clientId">Sets the <see cref="DeviceCodeInfo.ClientId"/>.</param>
+        /// <param name="scopes">Sets the <see cref="DeviceCodeInfo.Scopes"/>.</param>
+        /// <returns>A new instance of the <see cref="DeviceCodeInfo"/> for mocking purposes.</returns>
+        public static DeviceCodeInfo DeviceCodeInfo(string userCode, string deviceCode, Uri verificationUri, DateTimeOffset expiresOn, string message, string clientId, IReadOnlyCollection<string> scopes)
+            => new DeviceCodeInfo(userCode, deviceCode, verificationUri, expiresOn, message, clientId, scopes);
+    }
+}

--- a/sdk/identity/Azure.Identity/src/IdentityModelFactory.cs
+++ b/sdk/identity/Azure.Identity/src/IdentityModelFactory.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace Azure.Identity
 {


### PR DESCRIPTION
Added `IdentityModelFactory` to enable constructing `AuthenticationRecord` and `DeviceCodeInfo` for mocking support, as detailed in the .NET Design Guidelines here: https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-mocking-factory-builder

Fixes #13828