### PR TITLE
Test Runtime Version Framework

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -70,11 +70,6 @@ jobs:
           pip install doc-warden==$(DocWardenVersion)
           ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
         displayName: "Verify Readmes"
-      - task: UseDotNet@2
-        displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
-        inputs:
-          packageType: runtime
-          version: "$(DotNetCoreRuntimeVersion)"
       - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
         parameters:
           SourceDirectory: $(Build.SourcesDirectory)
@@ -134,14 +129,11 @@ jobs:
       vmImage: "$(OSVmImage)"
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-      - task: UseDotNet@2
-        displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
-        inputs:
-          packageType: runtime
-          version: "$(DotNetCoreRuntimeVersion)"
       - script: >-
-          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
-          /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption) /p:CollectCoverage=$(CollectCoverage)
+          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework)
+          --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
+          /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false
+          /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption) /p:CollectCoverage=$(CollectCoverage)
         displayName: "Build & Test ($(TestTargetFramework))"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -55,12 +55,6 @@ jobs:
 
         - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
-        - task: UseDotNet@2
-          displayName: "Use .NET Core runtime $(DotNetCoreRuntimeVersion)"
-          inputs:
-            packageType: runtime
-            version: "$(DotNetCoreRuntimeVersion)"
-
         - template: /eng/common/TestResources/deploy-test-resources.yml
           parameters:
             Location: ${{ parameters.Location }}

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
   },
   "sdk": {
     "version": "3.1.301",
-    "rollForward": "disable"
+    "rollForward": "feature"
   }
 }


### PR DESCRIPTION
Remove `UseDotNet@2` task. 
Allow `rollForward` while specifying sdk version.