### PR TITLE
Change prerelease versioning

### DIFF
--- a/doc/dev/Versioning.md
+++ b/doc/dev/Versioning.md
@@ -18,7 +18,7 @@ In the project file use the `Version` property to define the `MAJOR.MINOR.PATCH-
 By default builds will replace any prerelease identifier with a `alpha.yyyyMMdd.r` to ensure we have unique package versions for dev builds. The date will come from either
 today's date or a property named `OfficialBuildId` which we will pass as part of our build pipelines.
 
-If we need to produce a package that is not an dev package with an alpha version and has the version in the project (i.e. stable or beta) then the `SkipDevBuildNumber` should
+If we need to produce a package that is not a dev package with an alpha version and has the version in the project (i.e. stable or beta) then the `SkipDevBuildNumber` should
 be passed as `true` to the packaging command.
 
 ## Incrementing the version
@@ -61,4 +61,3 @@ The versioning scheme imposes the following limits on these version parts:
 | Parameter                  | Description                                                  |
 | -------------------------- | ------------------------------------------------------------ |
 | OfficialBuildId            | ID of current build. The accepted format is `yyyyMMdd.r`. Should be passed to build in YAML official build defintion. |
-

--- a/doc/dev/Versioning.md
+++ b/doc/dev/Versioning.md
@@ -9,16 +9,16 @@ Package version will look like:
 MAJOR.MINOR.PATCH-PRERELEASE
 ```
 
-In the project file use the `Version` property to define the `MAJOR.MINOR.PATCH-preview.X` part of the version.
+In the project file use the `Version` property to define the `MAJOR.MINOR.PATCH-beta.X` part of the version.
 
 ```
-<Version>1.0.0-preview.1</Version>
+<Version>1.0.0-beta.1</Version>
 ```
 
-By default builds will replace any prerelease identifier with a `dev.yyyyMMdd.r` to ensure we have unique package versions. The date will come from either
+By default builds will replace any prerelease identifier with a `alpha.yyyyMMdd.r` to ensure we have unique package versions for dev builds. The date will come from either
 today's date or a property named `OfficialBuildId` which we will pass as part of our build pipelines.
 
-If we need to produce a package that is not a dev version and has the version in the project (i.e. stable or preview) then the `SkipDevBuildNumber` should
+If we need to produce a package that is not an dev package with an alpha version and has the version in the project (i.e. stable or beta) then the `SkipDevBuildNumber` should
 be passed as `true` to the packaging command.
 
 ## Incrementing the version
@@ -26,8 +26,8 @@ be passed as `true` to the packaging command.
 See [Incrementing after release](https://github.com/Azure/azure-sdk/blob/master/docs/policies/releases.md#incrementing-after-release) for general guidance but at a
 high level we will do the following versioning changes:
 
-- After a preview release we bump the number after the preview. `1.0.0-preview.1` -> `1.0.0-preview.2`
-- After a GA release we bump the minor version and switch to preview 1. `1.0.0` -> `1.1.0-preview.1`
+- After a beta release we bump the number after the beta. `1.0.0-beta.1` -> `1.0.0-beta.2`
+- After a GA release we bump the minor version and switch to beta 1. `1.0.0` -> `1.1.0-beta.1`
 - Prior to a hot-fix release we bump the patch version. `1.0.0` -> `1.0.1`
 
 Versions are automatically bumped up in package project `.csproj` files as well as package changelog `CHANGELOG.md` as part of the release process. To increment a version locally make use of the `eng\scripts\Update-PkgVersion.ps1` script.

--- a/eng/Versioning.targets
+++ b/eng/Versioning.targets
@@ -4,7 +4,7 @@
     <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
     <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
     <HasReleaseVersion>true</HasReleaseVersion>
-    <HasReleaseVersion Condition="$(Version.Contains('preview'))">false</HasReleaseVersion>
+    <HasReleaseVersion Condition="$(Version.Contains('preview')) or $(Version.Contains('beta'))">false</HasReleaseVersion>
     <_VersionInProject>$(Version)</_VersionInProject>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
     <_PrereleaseIndex>$(Version.IndexOf('-'))</_PrereleaseIndex>
     <Version Condition="$(_PrereleaseIndex) &gt; 0">$(Version.SubString(0, $(_PrereleaseIndex)))</Version>
 
-    <Version>$(Version)-dev.$(_BuildNumber)</Version>
+    <Version>$(Version)-alpha.$(_BuildNumber)</Version>
   </PropertyGroup>
 
   <!--

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.3-beta.1 (2020-08-27)
+- Test new alpha beta versioning
+
 ## 1.0.2-preview.15 (2020-06-29)
 - Test release pipeline
 

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview.15</Version>
+    <Version>1.0.3-beta.1</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
- Use alpha instead of dev
- Use beta instead of preview

Updating versioning logic to match guideline update in https://github.com/Azure/azure-sdk/pull/1536. 

PTAL @AlexGhiondea  @pakrym @heaths 