### PR TITLE
[Service Bus Client] Connection String SAS Support

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Authorization/SharedAccessSignatureCredential.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Authorization/SharedAccessSignatureCredential.cs
@@ -59,7 +59,11 @@ namespace Azure.Messaging.ServiceBus.Authorization
             TokenRequestContext requestContext,
             CancellationToken cancellationToken)
         {
-            if (SharedAccessSignature.SignatureExpiration <= DateTimeOffset.UtcNow.Add(SignatureRefreshBuffer))
+            // If the signature was derived from a shared key rather than being provided externally,
+            // determine if the expiration is approaching and attempt to extend the token.
+
+            if ((!string.IsNullOrEmpty(SharedAccessSignature.SharedAccessKey))
+                && (SharedAccessSignature.SignatureExpiration <= DateTimeOffset.UtcNow.Add(SignatureRefreshBuffer)))
             {
                 lock (SignatureSyncRoot)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ConnectionStringParser.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ConnectionStringParser.cs
@@ -33,6 +33,9 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <summary>The token that identifies the value of a shared access key.</summary>
         private const string SharedAccessKeyValueToken = "SharedAccessKey";
 
+        /// <summary>The token that identifies the value of a shared access signature.</summary>
+        private const string SharedAccessSignatureToken = "SharedAccessSignature";
+
         /// <summary>
         ///   Parses the specified Service Bus connection string into its component properties.
         /// </summary>
@@ -61,7 +64,8 @@ namespace Azure.Messaging.ServiceBus.Core
                 EndpointToken: default(UriBuilder),
                 EntityNameToken: default(string),
                 SharedAccessKeyNameToken: default(string),
-                SharedAccessKeyValueToken: default(string)
+                SharedAccessKeyValueToken: default(string),
+                SharedAccessSignatureToken: default(string)
             );
 
             while (currentPosition != -1)
@@ -131,6 +135,10 @@ namespace Azure.Messaging.ServiceBus.Core
                     {
                         parsedValues.SharedAccessKeyValueToken = value;
                     }
+                    else if (string.Compare(SharedAccessSignatureToken, token, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        parsedValues.SharedAccessSignatureToken = value;
+                    }
                 }
                 else if ((slice.Length != 1) || (slice[0] != TokenValuePairDelimiter))
                 {
@@ -149,7 +157,8 @@ namespace Azure.Messaging.ServiceBus.Core
                 parsedValues.EndpointToken?.Uri,
                 parsedValues.EntityNameToken,
                 parsedValues.SharedAccessKeyNameToken,
-                parsedValues.SharedAccessKeyValueToken
+                parsedValues.SharedAccessKeyValueToken,
+                parsedValues.SharedAccessSignatureToken
             );
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ConnectionStringProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ConnectionStringProperties.cs
@@ -41,6 +41,13 @@ namespace Azure.Messaging.ServiceBus.Core
         public string SharedAccessKey { get; }
 
         /// <summary>
+        ///   The value of the fully-formed shared access signature, either for the Service Bus
+        ///   namespace or the Service Bus entity.
+        /// </summary>
+        ///
+        public string SharedAccessSignature { get; }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="ConnectionStringProperties"/> structure.
         /// </summary>
         ///
@@ -48,17 +55,20 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="entityName">The name of the specific Service Bus entity under the namespace.</param>
         /// <param name="sharedAccessKeyName">The name of the shared access key, to use authorization.</param>
         /// <param name="sharedAccessKey">The shared access key to use for authorization.</param>
+        /// <param name="sharedAccessSignature">The precomputed shared access signature to use for authorization.</param>
         ///
         public ConnectionStringProperties(
             Uri endpoint,
             string entityName,
             string sharedAccessKeyName,
-            string sharedAccessKey)
+            string sharedAccessKey,
+            string sharedAccessSignature)
         {
             Endpoint = endpoint;
             EntityPath = entityName;
             SharedAccessKeyName = sharedAccessKeyName;
             SharedAccessKey = sharedAccessKey;
+            SharedAccessSignature = sharedAccessSignature;
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
@@ -83,33 +83,34 @@ namespace Azure.Messaging.ServiceBus
             ServiceBusClientOptions options)
         {
             Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-
             ValidateConnectionOptions(options);
-            ConnectionStringProperties connectionStringProperties = ConnectionStringParser.Parse(connectionString);
 
-            if (string.IsNullOrEmpty(connectionStringProperties.Endpoint?.Host)
-                || string.IsNullOrEmpty(connectionStringProperties.SharedAccessKeyName)
-                || string.IsNullOrEmpty(connectionStringProperties.SharedAccessKey))
-            {
-                throw new ArgumentException(Resources.MissingConnectionInformation, nameof(connectionString));
-            }
+            var connectionStringProperties = ConnectionStringParser.Parse(connectionString);
+            ValidateConnectionStringProperties(connectionStringProperties, nameof(connectionString));
 
             FullyQualifiedNamespace = connectionStringProperties.Endpoint.Host;
             TransportType = options.TransportType;
             EntityPath = connectionStringProperties.EntityPath;
             RetryOptions = options.RetryOptions;
 
-            var sharedAccessSignature = new SharedAccessSignature
-            (
-                 BuildAudienceResource(options.TransportType, FullyQualifiedNamespace, EntityPath),
-                 connectionStringProperties.SharedAccessKeyName,
-                 connectionStringProperties.SharedAccessKey
-            );
+            SharedAccessSignature sharedAccessSignature;
+
+            if (string.IsNullOrEmpty(connectionStringProperties.SharedAccessSignature))
+            {
+                sharedAccessSignature = new SharedAccessSignature(
+                     BuildConnectionResource(options.TransportType, FullyQualifiedNamespace, EntityPath),
+                     connectionStringProperties.SharedAccessKeyName,
+                     connectionStringProperties.SharedAccessKey);
+            }
+            else
+            {
+                sharedAccessSignature = new SharedAccessSignature(connectionStringProperties.SharedAccessSignature);
+            }
 
             var sharedCredential = new SharedAccessSignatureCredential(sharedAccessSignature);
             var tokenCredential = new ServiceBusTokenCredential(
                 sharedCredential,
-                BuildAudienceResource(TransportType, FullyQualifiedNamespace, EntityPath));
+                BuildConnectionResource(TransportType, FullyQualifiedNamespace, EntityPath));
 #pragma warning disable CA2214 // Do not call overridable methods in constructors. This internal method is virtual for testing purposes.
             _innerClient = CreateTransportClient(tokenCredential, options);
 #pragma warning restore CA2214 // Do not call overridable methods in constructors
@@ -137,11 +138,11 @@ namespace Azure.Messaging.ServiceBus
                     break;
 
                 case ServiceBusSharedKeyCredential sharedKeyCredential:
-                    credential = sharedKeyCredential.AsSharedAccessSignatureCredential(BuildAudienceResource(options.TransportType, fullyQualifiedNamespace, EntityPath));
+                    credential = sharedKeyCredential.AsSharedAccessSignatureCredential(BuildConnectionResource(options.TransportType, fullyQualifiedNamespace, EntityPath));
                     break;
             }
 
-            var tokenCredential = new ServiceBusTokenCredential(credential, BuildAudienceResource(options.TransportType, fullyQualifiedNamespace, EntityPath));
+            var tokenCredential = new ServiceBusTokenCredential(credential, BuildConnectionResource(options.TransportType, fullyQualifiedNamespace, EntityPath));
 
             FullyQualifiedNamespace = fullyQualifiedNamespace;
             TransportType = options.TransportType;
@@ -265,7 +266,7 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        ///   Builds the audience for use in the signature.
+        ///   Builds the audience of the connection for use in the signature.
         /// </summary>
         ///
         /// <param name="transportType">The type of protocol and transport that will be used for communicating with the Service Bus service.</param>
@@ -274,7 +275,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>The value to use as the audience of the signature.</returns>
         ///
-        private static string BuildAudienceResource(
+        internal static string BuildConnectionResource(
             ServiceBusTransportType transportType,
             string fullyQualifiedNamespace,
             string entityName)
@@ -296,6 +297,12 @@ namespace Azure.Messaging.ServiceBus
 
             return builder.Uri.AbsoluteUri.ToLowerInvariant();
         }
+
+        /// <summary>
+        /// Throw an ObjectDisposedException if the object is Closing.
+        /// </summary>
+        internal virtual void ThrowIfClosed() =>
+            Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusConnection));
 
         /// <summary>
         ///   Performs the actions needed to validate the <see cref="ServiceBusClientOptions" /> associated
@@ -327,13 +334,36 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        /// Throw an ObjectDisposedException if the object is Closing.
+        ///   Performs the actions needed to validate the set of connection string properties for connecting to the
+        ///   Service Bus service.
         /// </summary>
-        internal virtual void ThrowIfClosed()
+        ///
+        /// <param name="connectionStringProperties">The set of connection string properties to validate.</param>
+        /// <param name="connectionStringArgumentName">The name of the argument associated with the connection string; to be used when raising <see cref="ArgumentException" /> variants.</param>
+        ///
+        /// <exception cref="ArgumentException">In the case that the properties violate an invariant or otherwise represent a combination that is not permissible, an appropriate exception will be thrown.</exception>
+        ///
+        private static void ValidateConnectionStringProperties(
+            ConnectionStringProperties connectionStringProperties,
+            string connectionStringArgumentName)
         {
-            if (IsClosed)
+            var hasSharedKey = ((!string.IsNullOrEmpty(connectionStringProperties.SharedAccessKeyName)) && (!string.IsNullOrEmpty(connectionStringProperties.SharedAccessKey)));
+            var hasSharedSignature = (!string.IsNullOrEmpty(connectionStringProperties.SharedAccessSignature));
+
+            // Ensure that each of the needed components are present for connecting.
+
+            if ((string.IsNullOrEmpty(connectionStringProperties.Endpoint?.Host))
+                || ((!hasSharedKey) && (!hasSharedSignature)))
             {
-                throw new ObjectDisposedException($"{nameof(ServiceBusConnection)} has already been closed. Please create a new instance");
+                throw new ArgumentException(Resources.MissingConnectionInformation, connectionStringArgumentName);
+            }
+
+            // The connection string may contain a precomputed shared access signature OR a shared key name and value,
+            // but not both.
+
+            if (hasSharedKey && hasSharedSignature)
+            {
+                throw new ArgumentException(Resources.OnlyOneSharedAccessAuthorizationMayBeSpecified, connectionStringArgumentName);
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -599,5 +599,16 @@ namespace Azure.Messaging.ServiceBus {
                 return ResourceManager.GetString("UnsupportedTransportEventType", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The authorization for a connection string may specifiy a shared key or precomputed shared access signature, but not both.  Please verify that your connection string does not have the `SharedAccessSignature` token if you are passing the  `SharedKeyName` and `SharedKey`..
+        /// </summary>
+        internal static string OnlyOneSharedAccessAuthorizationMayBeSpecified
+        {
+            get
+            {
+                return ResourceManager.GetString("OnlyOneSharedAccessAuthorizationMayBeSpecified", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -256,7 +256,7 @@
     <value>The message (id:{0}, size:{1} bytes) is larger than is currently allowed ({2} bytes).</value>
   </data>
   <data name="MissingConnectionInformation" xml:space="preserve">
-    <value>The connection string used for an Service Bus entity client must specify the Service Bus namespace host, and a Shared Access Signature (both the name and value) to be valid. The path to an Service Bus entity must be included in the connection string or specified separately.</value>
+    <value>The connection string used for an Service Bus client must specify the Service Bus namespace host and either a Shared Access Key (both the name and value) OR a Shard Access Signature to be valid.</value>
   </data>
   <data name="OnlyOneEntityNameMayBeSpecified" xml:space="preserve">
     <value>The path to an Service Bus entity may be specified as part of the connection string or as a separate value, but not both.</value>
@@ -296,5 +296,8 @@
   </data>
   <data name="MessageProcessorIsNotRunning" xml:space="preserve">
     <value>The message processor is not currently running. It needs to be started before it can be stopped.</value>
+  </data>
+  <data name="OnlyOneSharedAccessAuthorizationMayBeSpecified" xml:space="preserve">
+    <value>The authorization for a connection string may specifiy a shared key or precomputed shared access signature, but not both.  Please verify that your connection string does not have the `SharedAccessSignature` token if you are passing the `SharedKeyName` and `SharedKey`.</value>
   </data>
 </root>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -12,6 +12,40 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
 {
     public class ServiceBusClientLiveTests : ServiceBusLiveTestBase
     {
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConnection" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientCanConnectUsingSharedAccessSignatureConnectionString()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: true, enableSession: false))
+            {
+                var options = new ServiceBusClientOptions();
+                var audience = ServiceBusConnection.BuildConnectionResource(options.TransportType, TestEnvironment.FullyQualifiedNamespace, scope.QueueName);
+                var connectionString = TestEnvironment.BuildConnectionStringWithSharedAccessSignature(scope.QueueName, audience);
+
+                await using (var client = new ServiceBusClient(connectionString, options))
+                {
+                    Assert.That(async () =>
+                    {
+                        ServiceBusReceiver receiver = null;
+
+                        try
+                        {
+                            receiver = client.CreateReceiver(scope.QueueName);
+                        }
+                        finally
+                        {
+                            await (receiver?.DisposeAsync() ?? new ValueTask());
+                        }
+
+                    }, Throws.Nothing);
+                }
+            }
+        }
+
         [Test]
         [TestCase(true)]
         [TestCase(false)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -119,9 +119,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         [TestCase("SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]")]
         [TestCase("Endpoint=value.com;SharedAccessKey=[value];EntityPath=[value]")]
         [TestCase("Endpoint=value.com;SharedAccessKeyName=[value];EntityPath=[value]")]
-        public void ConstructorValidatesConnectionString(string connectionString)
+        [TestCase("HostName=value.azure-devices.net;SharedAccessKeyName=[value];SharedAccessKey=[value]")]
+        [TestCase("HostName=value.azure-devices.net;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]")]
+        [TestCase("HostName=value.azure-devices.net;SharedAccessKeyName=[value];SharedAccessSignature=[sas];EntityPath=[value]")]
+        [TestCase("HostName=value.azure-devices.net;SharedAccessKey=[value];SharedAccessSignature=[sas];EntityPath=[value]")]
+        public void ConstructorValidatesConnectionStringForMissingInformation(string connectionString)
         {
-            Assert.That(() => new ServiceBusClient(connectionString), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new ServiceBusClient(connectionString), Throws.ArgumentException.And.Message.StartsWith(Resources.MissingConnectionInformation));
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="ServiceBusClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+
+        [TestCase("Endpoint=value.azure-devices.net;SharedAccessKeyName=[value];SharedAccessKey=[value];SharedAccessSignature=[sas]")]
+        public void ConstructorValidatesConnectionStringForDuplicateAuthorization(string connectionString)
+        {
+            Assert.That(() => new ServiceBusClient(connectionString), Throws.ArgumentException.And.Message.StartsWith(Resources.OnlyOneSharedAccessAuthorizationMayBeSpecified));
         }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ConnectionStringParserTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Core/ConnectionStringParserTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Azure.Messaging.ServiceBus.Core;
 using NUnit.Framework;
 
-namespace Azure.Messaging.ServiceBus.Tests.Client
+namespace Azure.Messaging.ServiceBus.Tests.Core
 {
     public class ConnectionStringParserTests
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestEnvironment.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestEnvironment.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
+using Azure.Messaging.ServiceBus.Authorization;
 using Azure.Messaging.ServiceBus.Core;
 
 namespace Azure.Messaging.ServiceBus.Tests
@@ -143,6 +144,25 @@ namespace Azure.Messaging.ServiceBus.Tests
         /// <returns>The connection string to the requested Service Bus namespace and entity.</returns>
         ///
         public string BuildConnectionStringForEntity(string entityName) => $"{ ServiceBusConnectionString };EntityPath={ entityName }";
+
+        /// <summary>
+        ///   Builds a connection string for the Service Bus namespace used for Live tests, creating a shared access signature
+        ///   in place of the shared key.
+        /// </summary>
+        ///
+        /// <param name="entityName">The name of the entity for which the connection string is being built.</param>
+        /// <param name="signatureAudience">The audience to use for the shared access signature.</param>
+        /// <param name="validDurationMinutes">The duration, in minutes, that the signature should be considered valid for.</param>
+        ///
+        /// <returns>The namespace connection string with a shared access signature based on the shared key of the current scope.</value>
+        ///
+        public string BuildConnectionStringWithSharedAccessSignature(string entityName,
+                                                                     string signatureAudience,
+                                                                     int validDurationMinutes = 30)
+        {
+            var signature = new SharedAccessSignature(signatureAudience, SharedAccessKeyName, SharedAccessKey, TimeSpan.FromMinutes(validDurationMinutes));
+            return $"Endpoint={ ParsedConnectionString.Value.Endpoint };EntityPath={ entityName };SharedAccessSignature={ signature.Value }";
+        }
 
         /// <summary>
         ///   Ensures that a Service Bus namespace is available.  If the <see cref="OverrideServiceBusConnectionString"/> override was set for the environment,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -15,11 +15,47 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
     public class ReceiverLiveTests : ServiceBusLiveTestBase
     {
         [Test]
-        public async Task Peek()
+        public async Task PeekUsingConnectionStringWithSharedKey()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var messageCt = 10;
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+                IEnumerable<ServiceBusMessage> sentMessages = AddMessages(batch, messageCt).AsEnumerable<ServiceBusMessage>();
+
+                await sender.SendMessagesAsync(batch);
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                var messageEnum = sentMessages.GetEnumerator();
+
+                var ct = 0;
+                while (ct < messageCt)
+                {
+                    foreach (ServiceBusReceivedMessage peekedMessage in await receiver.PeekMessagesAsync(
+                    maxMessages: messageCt))
+                    {
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, peekedMessage.MessageId);
+                        ct++;
+                    }
+                }
+                Assert.AreEqual(messageCt, ct);
+            }
+        }
+
+        [Test]
+        public async Task PeekUsingConnectionStringWithSisgnature()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var options = new ServiceBusClientOptions();
+                var audience = ServiceBusConnection.BuildConnectionResource(options.TransportType, TestEnvironment.FullyQualifiedNamespace, scope.QueueName);
+                var connectionString = TestEnvironment.BuildConnectionStringWithSharedAccessSignature(scope.QueueName, audience);
+
+                await using var client = new ServiceBusClient(connectionString, options);
                 var messageCt = 10;
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -15,11 +15,25 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
     public class SenderLiveTests : ServiceBusLiveTestBase
     {
         [Test]
-        public async Task SendConnString()
+        public async Task SendConnStringWithSharedKey()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
+                await sender.SendMessageAsync(GetMessage());
+            }
+        }
+
+        [Test]
+        public async Task SendConnStringWithSignature()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var options = new ServiceBusClientOptions();
+                var audience = ServiceBusConnection.BuildConnectionResource(options.TransportType, TestEnvironment.FullyQualifiedNamespace, scope.QueueName);
+                var connectionString = TestEnvironment.BuildConnectionStringWithSharedAccessSignature(scope.QueueName, audience);
+
+                await using var sender = new ServiceBusClient(connectionString, options).CreateSender(scope.QueueName);
                 await sender.SendMessageAsync(GetMessage());
             }
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to add support for a precomputed shared
access signature token to be used as part of the connection string.

# Last Upstream Rebase

Wednesday, September 2, 1:12pm (EDT)

# References and Related Issues

- [Shared Access Signature Connection String Support](https://github.com/Azure/azure-sdk-for-net/issues/14712) ([#14712](https://github.com/Azure/azure-sdk-for-net/issues/14712))