### PR TITLE
[Identity] Fix environment variable mismatch for live CI tests

### DIFF
--- a/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
@@ -29,6 +29,6 @@ namespace Azure.Identity.Tests
         public string ServicePrincipalClientSecret => GetOptionalVariable("IDENTITY_SP_CLIENT_SECRET") ?? "SANITIZED";
         public string ServicePrincipalCertificatePfxPath => GetOptionalVariable("IDENTITY_SP_CERT_PFX") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
         public string ServicePrincipalCertificatePemPath => GetOptionalVariable("IDENTITY_SP_CERT_PEM") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
-        public string ServicePrincipalSniCertificatePath => GetOptionalVariable("IDENTITY_SP_SNI_CERT") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
+        public string ServicePrincipalSniCertificatePath => GetOptionalVariable("IDENTITY_SP_CERT_SNI") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
     }
 }

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -8,7 +8,7 @@ extends:
       OSVmImage: "ubuntu-18.04"
       TestTargetFramework: netcoreapp2.1
       Container:
-        image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore2_keyring:523069'
+        image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:523386'
         endpoint: 'azsdkengsys'
         options: -ti --cap-add=IPC_LOCK
       PreSteps:

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -8,7 +8,7 @@ extends:
       OSVmImage: "ubuntu-18.04"
       TestTargetFramework: netcoreapp2.1
       Container:
-        image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore2_keyring:504600'
+        image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore2_keyring:523069'
         endpoint: 'azsdkengsys'
         options: -ti --cap-add=IPC_LOCK
       PreSteps:


### PR DESCRIPTION
Fixing variable name mismatch between code and tests.yml