### PR TITLE
Fix #14408: [BUG] ChainedTokenCredential throws an exception when VisualStudioCodeCredential is present

### DIFF
--- a/sdk/identity/Azure.Identity/src/AuthenticationFailedException.cs
+++ b/sdk/identity/Azure.Identity/src/AuthenticationFailedException.cs
@@ -32,9 +32,27 @@ namespace Azure.Identity
         {
         }
 
-        internal static AuthenticationFailedException CreateAggregateException(string message, IList<Exception> innerExceptions)
+        internal static AuthenticationFailedException CreateAggregateException(string message, IList<Exception> exceptions)
         {
-            return new AuthenticationFailedException(message, new AggregateException("Multiple exceptions were encountered while attempting to authenticate.", innerExceptions.ToArray()));
+            // Build the credential unavailable message, this code is only reachable if all credentials throw AuthenticationFailedException
+            StringBuilder errorMsg = new StringBuilder(message);
+
+            bool allCredentialUnavailableException = true;
+            foreach (var exception in exceptions)
+            {
+                allCredentialUnavailableException &= exception is CredentialUnavailableException;
+                errorMsg.Append(Environment.NewLine).Append("- ").Append(exception.Message);
+            }
+
+            var innerException = exceptions.Count == 1
+                ? exceptions[0]
+                : new AggregateException("Multiple exceptions were encountered while attempting to authenticate.", exceptions);
+
+            // If all credentials have thrown CredentialUnavailableException, throw CredentialUnavailableException,
+            // otherwise throw AuthenticationFailedException
+            return allCredentialUnavailableException
+                ? new CredentialUnavailableException(errorMsg.ToString(), innerException)
+                : new AuthenticationFailedException(errorMsg.ToString(), innerException);
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/CredentialDiagnosticScope.cs
+++ b/sdk/identity/Azure.Identity/src/CredentialDiagnosticScope.cs
@@ -16,10 +16,10 @@ namespace Azure.Identity
         private readonly TokenRequestContext _context;
         private readonly IScopeHandler _scopeHandler;
 
-        public CredentialDiagnosticScope(string name, TokenRequestContext context, IScopeHandler scopeHandler)
+        public CredentialDiagnosticScope(ClientDiagnostics diagnostics, string name, TokenRequestContext context, IScopeHandler scopeHandler)
         {
             _name = name;
-            _scope = scopeHandler.CreateScope(name);
+            _scope = scopeHandler.CreateScope(diagnostics, name);
             _context = context;
             _scopeHandler = scopeHandler;
         }

--- a/sdk/identity/Azure.Identity/src/CredentialPipeline.cs
+++ b/sdk/identity/Azure.Identity/src/CredentialPipeline.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using Azure.Core;
 using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
@@ -12,12 +9,11 @@ using Microsoft.Identity.Client;
 
 namespace Azure.Identity
 {
-   internal class CredentialPipeline
+    internal class CredentialPipeline
     {
         private static readonly Lazy<CredentialPipeline> s_singleton = new Lazy<CredentialPipeline>(() => new CredentialPipeline(new TokenCredentialOptions()));
 
-        private readonly IScopeHandler _defaultScopeHandler;
-        private IScopeHandler _groupScopeHandler;
+        private static readonly IScopeHandler _defaultScopeHandler = new ScopeHandler();
 
         private CredentialPipeline(TokenCredentialOptions options)
         {
@@ -26,8 +22,6 @@ namespace Azure.Identity
             HttpPipeline = HttpPipelineBuilder.Build(options, Array.Empty<HttpPipelinePolicy>(), Array.Empty<HttpPipelinePolicy>(), new CredentialResponseClassifier());
 
             Diagnostics = new ClientDiagnostics(options);
-
-            _defaultScopeHandler = new ScopeHandler(Diagnostics);
         }
 
         public static CredentialPipeline GetInstance(TokenCredentialOptions options)
@@ -48,18 +42,18 @@ namespace Azure.Identity
 
         public CredentialDiagnosticScope StartGetTokenScope(string fullyQualifiedMethod, TokenRequestContext context)
         {
-            IScopeHandler scopeHandler = _groupScopeHandler ?? _defaultScopeHandler;
+            IScopeHandler scopeHandler = ScopeGroupHandler.Current ?? _defaultScopeHandler;
 
-            CredentialDiagnosticScope scope = new CredentialDiagnosticScope(fullyQualifiedMethod, context, scopeHandler);
+            CredentialDiagnosticScope scope = new CredentialDiagnosticScope(Diagnostics, fullyQualifiedMethod, context, scopeHandler);
             scope.Start();
             return scope;
         }
 
         public CredentialDiagnosticScope StartGetTokenScopeGroup(string fullyQualifiedMethod, TokenRequestContext context)
         {
-            var scopeHandler = new ScopeGroupHandler(this, fullyQualifiedMethod);
+            var scopeHandler = new ScopeGroupHandler(fullyQualifiedMethod);
 
-            CredentialDiagnosticScope scope = new CredentialDiagnosticScope(fullyQualifiedMethod, context, scopeHandler);
+            CredentialDiagnosticScope scope = new CredentialDiagnosticScope(Diagnostics, fullyQualifiedMethod, context, scopeHandler);
             scope.Start();
             return scope;
         }
@@ -74,123 +68,10 @@ namespace Azure.Identity
 
         private class ScopeHandler : IScopeHandler
         {
-            private readonly ClientDiagnostics _diagnostics;
-
-            public ScopeHandler(ClientDiagnostics diagnostics)
-            {
-                _diagnostics = diagnostics;
-            }
-
-            public DiagnosticScope CreateScope(string name) => _diagnostics.CreateScope(name);
+            public DiagnosticScope CreateScope(ClientDiagnostics diagnostics, string name) => diagnostics.CreateScope(name);
             public void Start(string name, in DiagnosticScope scope) => scope.Start();
             public void Dispose(string name, in DiagnosticScope scope) => scope.Dispose();
             public void Fail(string name, in DiagnosticScope scope, Exception exception) => scope.Failed(exception);
-        }
-
-        private class ScopeGroupHandler : IScopeHandler
-        {
-            private readonly CredentialPipeline _pipeline;
-            private readonly string _groupName;
-            private Dictionary<string, (DateTime StartDateTime, Exception Exception)> _childScopes;
-
-            public ScopeGroupHandler(CredentialPipeline pipeline, string groupName)
-            {
-                _pipeline = pipeline;
-                _groupName = groupName;
-            }
-
-            public DiagnosticScope CreateScope(string name)
-            {
-                if (IsGroup(name))
-                {
-                    _pipeline._groupScopeHandler = this;
-                    return _pipeline.Diagnostics.CreateScope(name);
-                }
-
-                _childScopes ??= new Dictionary<string, (DateTime startDateTime, Exception exception)>();
-                _childScopes[name] = default;
-                return default;
-            }
-
-            public void Start(string name, in DiagnosticScope scope)
-            {
-                if (IsGroup(name))
-                {
-                    scope.Start();
-                }
-                else
-                {
-                    _childScopes[name] = (DateTime.UtcNow, default);
-                }
-            }
-
-            public void Dispose(string name, in DiagnosticScope scope)
-            {
-                if (!IsGroup(name))
-                {
-                    return;
-                }
-
-                if (_childScopes != null)
-                {
-                    var succeededScope = _childScopes.LastOrDefault(kvp => kvp.Value.Exception == default);
-                    if (succeededScope.Key != default)
-                    {
-                        SucceedChildScope(succeededScope.Key, succeededScope.Value.StartDateTime);
-                    }
-                }
-
-                scope.Dispose();
-                _pipeline._groupScopeHandler = default;
-            }
-
-            public void Fail(string name, in DiagnosticScope scope, Exception exception)
-            {
-                if (_childScopes == default)
-                {
-                    scope.Failed(exception);
-                    return;
-                }
-
-                if (IsGroup(name))
-                {
-                    if (exception is OperationCanceledException)
-                    {
-                        var canceledScope = _childScopes.Last(kvp => kvp.Value.Exception == exception);
-                        FailChildScope(canceledScope.Key, canceledScope.Value.StartDateTime, canceledScope.Value.Exception);
-                    }
-                    else
-                    {
-                        foreach (var childScope in _childScopes)
-                        {
-                            FailChildScope(childScope.Key, childScope.Value.StartDateTime, childScope.Value.Exception);
-                        }
-                    }
-
-                    scope.Failed(exception);
-                }
-                else
-                {
-                    _childScopes[name] = (_childScopes[name].StartDateTime, exception);
-                }
-            }
-
-            private void SucceedChildScope(string name, DateTime dateTime)
-            {
-                using DiagnosticScope scope = _pipeline.Diagnostics.CreateScope(name);
-                scope.SetStartTime(dateTime);
-                scope.Start();
-            }
-
-            private void FailChildScope(string name, DateTime dateTime, Exception exception)
-            {
-                using DiagnosticScope scope = _pipeline.Diagnostics.CreateScope(name);
-                scope.SetStartTime(dateTime);
-                scope.Start();
-                scope.Failed(exception);
-            }
-
-            private bool IsGroup(string name) => string.Equals(name, _groupName, StringComparison.Ordinal);
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -33,7 +33,7 @@ namespace Azure.Identity
     public class DefaultAzureCredential : TokenCredential
     {
         private const string DefaultExceptionMessage = "DefaultAzureCredential failed to retrieve a token from the included credentials.";
-        private const string UnhandledExceptionMessage = "DefaultAzureCredential authentication failed.";
+        private const string UnhandledExceptionMessage = "DefaultAzureCredential authentication failed due to an unhandled exception: ";
         private static readonly TokenCredential[] s_defaultCredentialChain = GetDefaultAzureCredentialChain(new DefaultAzureCredentialFactory(null), new DefaultAzureCredentialOptions());
 
         private readonly CredentialPipeline _pipeline;
@@ -143,7 +143,7 @@ namespace Azure.Identity
 
         private static async ValueTask<(AccessToken, TokenCredential)> GetTokenFromSourcesAsync(TokenCredential[] sources, TokenRequestContext requestContext, bool async, CancellationToken cancellationToken)
         {
-            List<AuthenticationFailedException> exceptions = new List<AuthenticationFailedException>();
+            List<Exception> exceptions = new List<Exception>();
 
             for (var i = 0; i < sources.Length && sources[i] != null; i++)
             {
@@ -159,23 +159,14 @@ namespace Azure.Identity
                 {
                     exceptions.Add(e);
                 }
+                catch (Exception e) when (!(e is OperationCanceledException))
+                {
+                    exceptions.Add(e);
+                    throw AuthenticationFailedException.CreateAggregateException(UnhandledExceptionMessage + e.Message, exceptions);
+                }
             }
 
-            // Build the credential unavailable message, this code is only reachable if all credentials throw AuthenticationFailedException
-            StringBuilder errorMsg = new StringBuilder(DefaultExceptionMessage);
-
-            bool allCredentialUnavailableException = true;
-            foreach (AuthenticationFailedException ex in exceptions)
-            {
-                allCredentialUnavailableException &= ex is CredentialUnavailableException;
-                errorMsg.Append(Environment.NewLine).Append("- ").Append(ex.Message);
-            }
-
-            // If all credentials have thrown CredentialUnavailableException, throw CredentialUnavailableException,
-            // otherwise throw AuthenticationFailedException
-            throw allCredentialUnavailableException
-                ? new CredentialUnavailableException(errorMsg.ToString())
-                : new AuthenticationFailedException(errorMsg.ToString());
+            throw AuthenticationFailedException.CreateAggregateException(DefaultExceptionMessage, exceptions);
         }
 
         private static TokenCredential[] GetDefaultAzureCredentialChain(DefaultAzureCredentialFactory factory, DefaultAzureCredentialOptions options)

--- a/sdk/identity/Azure.Identity/src/IScopeHandler.cs
+++ b/sdk/identity/Azure.Identity/src/IScopeHandler.cs
@@ -8,7 +8,7 @@ namespace Azure.Identity
 {
     internal interface IScopeHandler
     {
-        DiagnosticScope CreateScope(string name);
+        DiagnosticScope CreateScope(ClientDiagnostics diagnostics, string name);
         void Start(string name, in DiagnosticScope scope);
         void Dispose(string name, in DiagnosticScope scope);
         void Fail(string name, in DiagnosticScope scope, Exception exception);

--- a/sdk/identity/Azure.Identity/src/ScopeGroupHandler.cs
+++ b/sdk/identity/Azure.Identity/src/ScopeGroupHandler.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Azure.Core.Pipeline;
+
+namespace Azure.Identity
+{
+    internal sealed class ScopeGroupHandler : IScopeHandler
+    {
+        private static readonly AsyncLocal<IScopeHandler> _currentAsyncLocal = new AsyncLocal<IScopeHandler>();
+        private readonly string _groupName;
+        private Dictionary<string, ChildScopeInfo> _childScopes;
+
+        public static IScopeHandler Current => _currentAsyncLocal.Value;
+
+        public ScopeGroupHandler(string groupName)
+        {
+            _groupName = groupName;
+            _currentAsyncLocal.Value = this;
+        }
+
+        public DiagnosticScope CreateScope(ClientDiagnostics diagnostics, string name)
+        {
+            if (IsGroup(name))
+            {
+                return diagnostics.CreateScope(name);
+            }
+
+            _childScopes ??= new Dictionary<string, ChildScopeInfo>();
+            _childScopes[name] = new ChildScopeInfo(diagnostics, name);
+            return default;
+        }
+
+        public void Start(string name, in DiagnosticScope scope)
+        {
+            if (IsGroup(name))
+            {
+                scope.Start();
+            }
+            else
+            {
+                _childScopes[name].StartDateTime = DateTime.UtcNow;
+            }
+        }
+
+        public void Dispose(string name, in DiagnosticScope scope)
+        {
+            if (!IsGroup(name))
+            {
+                return;
+            }
+
+            var succeededScope = _childScopes?.Values.LastOrDefault(i => i.Exception == default);
+            if (succeededScope != null)
+            {
+                SucceedChildScope(succeededScope);
+            }
+
+            scope.Dispose();
+            _currentAsyncLocal.Value = default;
+        }
+
+        public void Fail(string name, in DiagnosticScope scope, Exception exception)
+        {
+            if (_childScopes == default)
+            {
+                scope.Failed(exception);
+                return;
+            }
+
+            if (IsGroup(name))
+            {
+                if (exception is OperationCanceledException)
+                {
+                    var canceledScope = _childScopes.Values.Last(i => i.Exception == exception);
+                    FailChildScope(canceledScope);
+                }
+                else
+                {
+                    foreach (var childScope in _childScopes.Values)
+                    {
+                        FailChildScope(childScope);
+                    }
+                }
+
+                scope.Failed(exception);
+            }
+            else
+            {
+                _childScopes[name].Exception = exception;
+            }
+        }
+
+        private static void SucceedChildScope(ChildScopeInfo scopeInfo)
+        {
+            using DiagnosticScope scope = scopeInfo.Diagnostics.CreateScope(scopeInfo.Name);
+            scope.SetStartTime(scopeInfo.StartDateTime);
+            scope.Start();
+        }
+
+        private static void FailChildScope(ChildScopeInfo scopeInfo)
+        {
+            using DiagnosticScope scope = scopeInfo.Diagnostics.CreateScope(scopeInfo.Name);
+            scope.SetStartTime(scopeInfo.StartDateTime);
+            scope.Start();
+            scope.Failed(scopeInfo.Exception);
+        }
+
+        private bool IsGroup(string name) => string.Equals(name, _groupName, StringComparison.Ordinal);
+
+        private class ChildScopeInfo
+        {
+            public ClientDiagnostics Diagnostics { get; }
+            public string Name { get; }
+            public DateTime StartDateTime { get; set; }
+            public Exception Exception { get; set; }
+
+            public ChildScopeInfo(ClientDiagnostics diagnostics, string name)
+            {
+                Diagnostics = diagnostics;
+                Name = name;
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ChainedTokenCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ChainedTokenCredentialLiveTests.cs
@@ -1,0 +1,247 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Core.Tests;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class ChainedTokenCredentialLiveTests : RecordedTestBase<IdentityTestEnvironment>
+    {
+        private const string ExpectedServiceName = "VS Code Azure";
+
+        public ChainedTokenCredentialLiveTests(bool isAsync) : base(isAsync)
+        {
+            Matcher.ExcludeHeaders.Add("Content-Length");
+            Matcher.ExcludeHeaders.Add("client-request-id");
+            Matcher.ExcludeHeaders.Add("x-client-OS");
+            Matcher.ExcludeHeaders.Add("x-client-SKU");
+            Matcher.ExcludeHeaders.Add("x-client-CPU");
+
+            Sanitizer = new IdentityRecordedTestSanitizer();
+            TestDiagnostics = false;
+        }
+
+        [Test]
+        [RunOnlyOnPlatforms(Windows = true)] // VisualStudioCredential works only on Windows
+        public async Task ChainedTokenCredential_UseVisualStudioCredential()
+        {
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudio();
+            var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForVisualStudio();
+            var processService = new TestProcessService(new TestProcess { Output = processOutput });
+
+            var miCredential = new ManagedIdentityCredential(EnvironmentVariables.ClientId, pipeline);
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var credential = InstrumentClient(new ChainedTokenCredential(miCredential, vsCredential));
+
+            AccessToken token;
+            List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
+
+            using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
+            {
+                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+                scopes = diagnosticListener.Scopes;
+            }
+
+            Assert.AreEqual(token.Token, expectedToken);
+            Assert.AreEqual(token.ExpiresOn, expectedExpiresOn);
+
+            Assert.AreEqual(2, scopes.Count);
+            Assert.AreEqual($"{nameof(ChainedTokenCredential)}.{nameof(ChainedTokenCredential.GetToken)}", scopes[0].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCredential)}.{nameof(VisualStudioCredential.GetToken)}", scopes[1].Name);
+        }
+
+        [Test]
+        [RunOnlyOnPlatforms(Windows = true, OSX = true, ContainerNames = new[] { "ubuntu_netcore2_keyring" })]
+        public async Task ChainedTokenCredential_UseVisualStudioCodeCredential()
+        {
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var cloudName = Guid.NewGuid().ToString();
+            var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment, cloudName);
+            var processService = new TestProcessService(new TestProcess { Error = "Error" });
+
+            var miCredential = new ManagedIdentityCredential(EnvironmentVariables.ClientId, pipeline);
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var vscCredential = new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId }, pipeline, default, fileSystem, default);
+
+            var credential = InstrumentClient(new ChainedTokenCredential(miCredential, vsCredential, vscCredential));
+
+            AccessToken token;
+            List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
+
+            using (await CredentialTestHelpers.CreateRefreshTokenFixtureAsync(TestEnvironment, Mode, ExpectedServiceName, cloudName))
+            using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
+            {
+                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+                scopes = diagnosticListener.Scopes;
+            }
+
+            Assert.IsNotNull(token.Token);
+
+            Assert.AreEqual(2, scopes.Count);
+            Assert.AreEqual($"{nameof(ChainedTokenCredential)}.{nameof(ChainedTokenCredential.GetToken)}", scopes[0].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCodeCredential)}.{nameof(VisualStudioCodeCredential.GetToken)}", scopes[1].Name);
+        }
+
+        [Test]
+        [RunOnlyOnPlatforms(Windows = true, OSX = true, ContainerNames = new[] { "ubuntu_netcore2_keyring" })]
+        public async Task ChainedTokenCredential_UseVisualStudioCodeCredential_ParallelCalls()
+        {
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var cloudName = Guid.NewGuid().ToString();
+            var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment, cloudName);
+            var processService = new TestProcessService { CreateHandler = psi => new TestProcess { Error = "Error" }};
+
+            var miCredential = new ManagedIdentityCredential(EnvironmentVariables.ClientId, pipeline);
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var vscCredential = new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId }, pipeline, default, fileSystem, default);
+            var credential = InstrumentClient(new ChainedTokenCredential(miCredential, vsCredential, vscCredential));
+
+            var tasks = new List<Task<AccessToken>>();
+            using (await CredentialTestHelpers.CreateRefreshTokenFixtureAsync(TestEnvironment, Mode, ExpectedServiceName, cloudName))
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    tasks.Add(Task.Run(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None)));
+                }
+
+                await Task.WhenAll(tasks);
+            }
+
+            foreach (Task<AccessToken> task in tasks)
+            {
+                Assert.IsNotNull(task.Result.Token);
+            }
+        }
+
+        [Test]
+        public async Task ChainedTokenCredential_UseAzureCliCredential()
+        {
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
+            var processService = new TestProcessService(new TestProcess { Output = processOutput });
+
+            var miCredential = new ManagedIdentityCredential(EnvironmentVariables.ClientId, pipeline);
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var vscCredential = new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId }, pipeline, default, fileSystem, vscAdapter);
+            var azureCliCredential = new AzureCliCredential(pipeline, processService);
+
+            var credential = InstrumentClient(new ChainedTokenCredential(miCredential, vsCredential, vscCredential, azureCliCredential));
+
+            AccessToken token;
+            List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
+
+            using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
+            {
+                token = await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None);
+                scopes = diagnosticListener.Scopes;
+            }
+
+            Assert.AreEqual(token.Token, expectedToken);
+            Assert.AreEqual(token.ExpiresOn, expectedExpiresOn);
+
+            Assert.AreEqual(2, scopes.Count);
+            Assert.AreEqual($"{nameof(ChainedTokenCredential)}.{nameof(ChainedTokenCredential.GetToken)}", scopes[0].Name);
+            Assert.AreEqual($"{nameof(AzureCliCredential)}.{nameof(AzureCliCredential.GetToken)}", scopes[1].Name);
+        }
+
+        [Test]
+        public async Task ChainedTokenCredential_UseAzureCliCredential_ParallelCalls()
+        {
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
+            var processService = new TestProcessService(new TestProcess { Output = processOutput });
+
+            var miCredential = new ManagedIdentityCredential(EnvironmentVariables.ClientId, pipeline);
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var vscCredential = new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId }, pipeline, default, fileSystem, vscAdapter);
+            var azureCliCredential = new AzureCliCredential(pipeline, processService);
+
+            var credential = InstrumentClient(new ChainedTokenCredential(miCredential, vsCredential, vscCredential, azureCliCredential));
+
+            var tasks = new List<Task<AccessToken>>();
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(Task.Run(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None)));
+            }
+
+            await Task.WhenAll(tasks);
+
+            foreach (Task<AccessToken> task in tasks)
+            {
+                Assert.AreEqual(task.Result.Token, expectedToken);
+                Assert.AreEqual(task.Result.ExpiresOn, expectedExpiresOn);
+            }
+        }
+
+        [Test]
+        public void ChainedTokenCredential_AllCredentialsHaveFailed_CredentialUnavailableException()
+        {
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", "{}");
+
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var fileSystem = new TestFileSystemService();
+            var processService = new TestProcessService(new TestProcess { Error = "'az' is not recognized" });
+
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var vscCredential = new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId }, pipeline, default, fileSystem, vscAdapter);
+            var azureCliCredential = new AzureCliCredential(pipeline, processService);
+
+            var credential = InstrumentClient(new ChainedTokenCredential(vsCredential, vscCredential, azureCliCredential));
+
+            List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
+            using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
+            {
+                Assert.CatchAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+                scopes = diagnosticListener.Scopes;
+            }
+
+            Assert.AreEqual(4, scopes.Count);
+            Assert.AreEqual($"{nameof(ChainedTokenCredential)}.{nameof(ChainedTokenCredential.GetToken)}", scopes[0].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCredential)}.{nameof(VisualStudioCredential.GetToken)}", scopes[1].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCodeCredential)}.{nameof(VisualStudioCodeCredential.GetToken)}", scopes[2].Name);
+            Assert.AreEqual($"{nameof(AzureCliCredential)}.{nameof(AzureCliCredential.GetToken)}", scopes[3].Name);
+        }
+
+        [Test]
+        public void ChainedTokenCredential_AllCredentialsHaveFailed_AuthenticationFailedException()
+        {
+            var pipeline = CredentialPipeline.GetInstance(null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var fileSystem = new TestFileSystemService();
+            var processService = new TestProcessService(new TestProcess {Error = "Error"});
+
+            var miCredential = new ManagedIdentityCredential(EnvironmentVariables.ClientId, pipeline);
+            var vsCredential = new VisualStudioCredential(default, pipeline, fileSystem, processService);
+            var vscCredential = new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId }, pipeline, default, fileSystem, vscAdapter);
+            var azureCliCredential = new AzureCliCredential(pipeline, processService);
+
+            var credential = InstrumentClient(new ChainedTokenCredential(miCredential, vsCredential, vscCredential, azureCliCredential));
+
+            List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
+            using (ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure.Identity")))
+            {
+                Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {"https://vault.azure.net/.default"}), CancellationToken.None));
+                scopes = diagnosticListener.Scopes;
+            }
+
+            Assert.AreEqual(5, scopes.Count);
+            Assert.AreEqual($"{nameof(ChainedTokenCredential)}.{nameof(ChainedTokenCredential.GetToken)}", scopes[0].Name);
+            Assert.AreEqual($"{nameof(ManagedIdentityCredential)}.{nameof(ManagedIdentityCredential.GetToken)}", scopes[1].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCredential)}.{nameof(VisualStudioCredential.GetToken)}", scopes[2].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCodeCredential)}.{nameof(VisualStudioCodeCredential.GetToken)}", scopes[3].Name);
+            Assert.AreEqual($"{nameof(AzureCliCredential)}.{nameof(AzureCliCredential.GetToken)}", scopes[4].Name);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ChainedTokenCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ChainedTokenCredentialTests.cs
@@ -72,7 +72,7 @@ namespace Azure.Identity.Tests
         {
             Assert.Throws<ArgumentNullException>(() => new ChainedTokenCredential(null));
 
-            Assert.Throws<ArgumentException>(() => new ChainedTokenCredential());
+            Assert.Throws<ArgumentException>(() => new ChainedTokenCredential(Array.Empty<TokenCredential>()));
 
             Assert.Throws<ArgumentException>(() => new ChainedTokenCredential((TokenCredential)null));
 

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -438,29 +439,30 @@ namespace Azure.Identity.Tests
             var cred = new DefaultAzureCredential(credFactory, options);
 
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await cred.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var unhandledException = ex.InnerException is AggregateException ae ? ae.InnerExceptions.Last() : ex.InnerException;
 
             switch (exPossition)
             {
                 case 0:
-                    Assert.AreEqual(ex.InnerException.Message, "EnvironmentCredential unhandled exception");
+                    Assert.AreEqual("EnvironmentCredential unhandled exception", unhandledException.Message);
                     break;
                 case 1:
-                    Assert.AreEqual(ex.InnerException.Message, "ManagedIdentityCredential unhandled exception");
+                    Assert.AreEqual("ManagedIdentityCredential unhandled exception", unhandledException.Message);
                     break;
                 case 2:
-                    Assert.AreEqual(ex.InnerException.Message, "SharedTokenCacheCredential unhandled exception");
+                    Assert.AreEqual("SharedTokenCacheCredential unhandled exception", unhandledException.Message);
                     break;
                 case 3:
-                    Assert.AreEqual(ex.InnerException.Message, "VisualStudioCredential unhandled exception");
+                    Assert.AreEqual("VisualStudioCredential unhandled exception", unhandledException.Message);
                     break;
                 case 4:
-                    Assert.AreEqual(ex.InnerException.Message, "VisualStudioCodeCredential unhandled exception");
+                    Assert.AreEqual("VisualStudioCodeCredential unhandled exception", unhandledException.Message);
                     break;
                 case 5:
-                    Assert.AreEqual(ex.InnerException.Message, "CliCredential unhandled exception");
+                    Assert.AreEqual("CliCredential unhandled exception", unhandledException.Message);
                     break;
                 case 6:
-                    Assert.AreEqual(ex.InnerException.Message, "InteractiveBrowserCredential unhandled exception");
+                    Assert.AreEqual("InteractiveBrowserCredential unhandled exception", unhandledException.Message);
                     break;
                 default:
                     Assert.Fail();

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_AuthenticationFailedException.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_AuthenticationFailedException.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_AuthenticationFailedExceptionAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_AuthenticationFailedExceptionAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_CredentialUnavailableException.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_CredentialUnavailableException.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_CredentialUnavailableExceptionAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_AllCredentialsHaveFailed_CredentialUnavailableExceptionAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredential.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredential.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredentialAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredentialAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredential_ParallelCalls.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredential_ParallelCalls.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredential_ParallelCallsAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseAzureCliCredential_ParallelCallsAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredential.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredential.json
@@ -1,0 +1,153 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "dcda1317-9b93-4cf1-a6c3-6b7afb08ba19",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "6b8a6df8e9bb42376a88a3be1bfd167b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "dcda1317-9b93-4cf1-a6c3-6b7afb08ba19",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JY; expires=Sat, 03-Oct-2020 22:28:34 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "esctx=AQABAAAAAAAGV_bv21oQQ4ROqh0_1-tAYwTt_WVKOJbFBZwL987jL1SAYp3Y30KPZwPX8MjZ0Wh5yWccH5Mw1b3oBS010WbcQi9Y-mB1-n4i71N6w_ajv754J-b5wNd0U9dhMm6zjyEOcqb99R3Nq10VfuK1GRhG0_pMEn-VBPZowwHEPHF7kd7KyBSnCt3o7MVx8ODtcfEgAA; domain=.login.microsoftonline.com; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "3646c3ed-7468-466d-8023-794a7fb74700"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "dcda1317-9b93-4cf1-a6c3-6b7afb08ba19",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "1922dbb47a8de786256a9fa19a70bc1e",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "dcda1317-9b93-4cf1-a6c3-6b7afb08ba19",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,696.6398,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "d3798c0f-b1cd-4994-8638-2349a8954400"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTQsIm5iZiI6MTU5OTE3MTgxNCwiZXhwIjoxNTk5MTc1NzE0LCJhaW8iOiJBVFFBeS84UUFBQUFJbUNoelA5Wnp2dWNad3VyL3BMV1FGZEJ1bXBqYjFYZ2I4M3lXR3A5OGd3eUhMVTZaYXlIN3UyZVRpUytzcVBMIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IkQ0eDUwODJ4bEVtR09DTkpxSlZFQUEiLCJ2ZXIiOiIyLjAifQ.hS9XAX36AcSrA6OiWWAXPc8kEEl_zFyOFVweca-PfRN4M9d1zyw9jH6m5FCHTUsgjM98cED4ws90NM6Qv_NxF5kRbavvbly2Db1tQlnRU5cAGkDhxgUcXKkHnPwlTC57QsZUqlE7FK5QpCpyx8j4ecolwACiqOEIdyyvoZRKJgy6Tmu2K28WGCxrtyyxfoRtG-0c-nY_XOmQGz3TC1f-rsQqRczVEN3pVnXzIoftCHSjvvaqe33AoCMy5ttuyBYOUEJeKMkVkEu62xkRT5NQ27Bqdmr7mNTY1wMDev1SGQeC1MpsnaeY805pXtKbf1ObjuZX0IQ3SdHdhoR_H7SMXw",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "AZURE_IDENTITY_TEST_USERNAME": "identitytestuser@azuresdkplayground.onmicrosoft.com",
+    "RandomSeed": "1772237070",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredentialAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredentialAsync.json
@@ -1,0 +1,152 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "f0c9e7a7-f328-4d39-b979-b9ab62e2a3f8",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "a3608c890c1d3021ed0c07b1772aa6b2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "f0c9e7a7-f328-4d39-b979-b9ab62e2a3f8",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "1d348dc1-91c0-49ad-85f8-1a8cec474300"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "f0c9e7a7-f328-4d39-b979-b9ab62e2a3f8",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "ee5c0bba772ffa9b5de54dd92c076d73",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "f0c9e7a7-f328-4d39-b979-b9ab62e2a3f8",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,235.1976,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "3d8e53ce-3458-47cb-b7ae-827556775800"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUF6WjZtSjZDQlVlbHJoVHhRNjNxdFgrRGMwRnBzeUF4bGRLSHIwbWpoanE2c3ZQa2hXbnhBSk5QQU5JTXdRY0UxIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6InpsT09QVmcweTBlM3JvSjFWbmRZQUEiLCJ2ZXIiOiIyLjAifQ.FcCD67TX4MAhiGPOMvUMtQWi9FqW-HMYZzC_pHOFe_XCD2Y6coXuqaq6l-8vL0pHinAb6P1WkopNMsJa7l21r3A46VdyConqOnHnJ-E5u7HJ2KfU_YEXmVtGQLdljXy1JGAT75lIWF36BDJ00-ft9VmDPGFCIVujOjFDHigg2qdcwAys38LGA27zO0JHtt05-TYFbdnYNIDEPu2oZqU394mGQoRE6dBS3QPpQ9X1rECdgvZ7o7igDwt1ZvbCCCUWFazEGDRajww5BWk_2iZ_N_D-q3J1Z1lN16e6sVmJhuIqTfnZPs0P9BlomPai1txck_ur69emzAaBhIsAGsKBNg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "AZURE_IDENTITY_TEST_USERNAME": "identitytestuser@azuresdkplayground.onmicrosoft.com",
+    "RandomSeed": "1985071030",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredential_ParallelCalls.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredential_ParallelCalls.json
@@ -1,0 +1,1430 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "4192bda7-4fa5-45dd-8ec3-f4f932a7366d",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "7a1f5c439bcf8f1c7a1ade7e6c0283c8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "4192bda7-4fa5-45dd-8ec3-f4f932a7366d",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "8fc00fee-4e46-4181-8f34-843166a84f00"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "db4a1dd1-21e2-45d5-9d58-afb322eb7479",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "260153cffd3a5d01d88f246bbf436aee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "db4a1dd1-21e2-45d5-9d58-afb322eb7479",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "49455cb4-1640-429d-868c-4f28c0835000"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "c0a2080f-bb30-4308-9bda-d0f3c89d0616",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "e83259e649d74bf98ccf4fbbefd753e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "c0a2080f-bb30-4308-9bda-d0f3c89d0616",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "4aa11309-0024-44fb-9aa2-9b6c30ec1300"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "9f50d0fe-7179-42a9-9b0c-6180d1163bb8",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "215962d925ac3c6f2c18151c43fff615",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "9f50d0fe-7179-42a9-9b0c-6180d1163bb8",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "df6a57b8-5b84-407f-a3f1-fb1473505200"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "087d10ce-1347-4220-8370-57586b6e3f00",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "a22625ff69a1701c044d30d8c6b5f1e5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "087d10ce-1347-4220-8370-57586b6e3f00",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "f60f9fa3-a36a-4746-be69-dcdbb56a4b00"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "4d786a05-0974-4f18-84b6-8159d6d0461b",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "2900f5c7f0b9311ba3f5a20ea268049b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "4d786a05-0974-4f18-84b6-8159d6d0461b",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "b4e1dc70-7f65-4660-a2aa-ebb624324500"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "289274c7-669c-46d9-8787-f17f009cca9b",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "e9354c950eccfa3e62d4ee004c60a0a3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "289274c7-669c-46d9-8787-f17f009cca9b",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "45c28b43-e3e5-465b-b4d2-6090c1971000"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "6ac42abb-e005-435a-a241-61a46e004317",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "9348427eb5ac3db645c9a69146f0cf2a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "6ac42abb-e005-435a-a241-61a46e004317",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "d5884ca3-9dcf-49a8-b9b7-7d3b97e61400"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "be4bdd67-7d1f-41a9-b0be-3c87280bf38a",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "51ca0328a6f0a570300445d66b2f57fa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "be4bdd67-7d1f-41a9-b0be-3c87280bf38a",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "5201d638-f7bb-49f0-acb4-ae07e9cc4b00"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "d290ce78-2765-4d84-b56e-2dd18dbdd868",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "9fe5bd04b39e59aab581729d244604d5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "d290ce78-2765-4d84-b56e-2dd18dbdd868",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAQAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "ddfa899e-77cc-4ebe-9032-0073f52f0c00"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "4192bda7-4fa5-45dd-8ec3-f4f932a7366d",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "730836f6cab32baa016c79608104e5ec",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "4192bda7-4fa5-45dd-8ec3-f4f932a7366d",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,221.3215,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "d523b11a-307b-407b-bc74-692bc2c74800"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUFZUlUzMWc1NnRtcHYzNnJrUE1XU3B5WWRmRm5sSllxUmJHb2RkOW04N0cyMndLZHh3S1VlU3d6czQ3S0IvbFVvIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IkdyRWoxWHN3ZTBDOGRHa3J3c2RJQUEiLCJ2ZXIiOiIyLjAifQ.Oa3VcPJslykNeru4TDOxyOm_Hz9U7zropNaCeXbbnM41vj2qBnt2UzG2aTOJqGqqc5QTFBETybfSnlHNEEgNGeTH7kPibbh_OUVF9CcgcTpAvcMOak63uNum9KU9bUDHhCmBzaRdomHnX9k5G7Y4SWiq8TkjfGIyKf9-Dx0x5tniBp2KB20sffXSCUBAb0cHE2rWKIgMHhvFNmmUED24jat59M9mv9NZy8prlP8uMMoi5Gn07drxXk2h28-oGDSFlLZXqG48UZ9C3M7IlogpzAebKmXjznD0fhWMKDTeX8Ucot_HmunGEIJDF1Fsyb7R7LAI-HS-rDskq840XxNHfQ",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "db4a1dd1-21e2-45d5-9d58-afb322eb7479",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "cc02859b56743e8bd9eccb0b59f1a09c",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "db4a1dd1-21e2-45d5-9d58-afb322eb7479",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,328.0952,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "4f916a9d-f95a-45d1-bede-d1d02c921300"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUFuNzRScW9vaU1LN0h1TG40VGdZQ3M3NmVqZ2JaRVowZCtJeUw3MU9pL3puK21ENXlldjNBUW4zaEpOYTd0ZzVCIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6Im5XcVJUMXI1MFVXLTN0SFFMSklUQUEiLCJ2ZXIiOiIyLjAifQ.RWLFxN709gpFiueLCFCK3bZ7gXzV1JxJOMes8WGKN9KXUWMLFgq3C2A50FkdD1VcuzGfR8oHHtUwRyEOfoCn7QeBDUbUK26s0CcOEwJqwnANSjXeHYVqaTKSSr33qERacXGfOeQZk5tV5DojiHHrPvcuPj4CQvmaTPdGxH57g7n-5dWNt4WyMw4J3ol0Dyk_zqGjRbAWIR0VmCY0RgNBsMHv3mAhCFFVBMlO39sGbcJPK1Pd3lM1D6U6d4oiSmjJa9lB0f1Y-VF9Ys0r01LafgymAc5mh6wBWmxbi39fErqyRUqUle2NrTHz9Xpd6VPbllyNTn6T9igr1SsBYNUQiA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "6ac42abb-e005-435a-a241-61a46e004317",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "993a6d099ad4c53ac9a06c56ab6279ed",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "6ac42abb-e005-435a-a241-61a46e004317",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,352.2855,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "772787f5-3540-4bce-b4bc-64a432274200"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUFQU1NiQnREZkRZSnNVcjJHNHdwSTRVNVN0aGExK2UzZlh5alkxeHliNC9jRWY3QW1yQVlQMktRaitEMW9NeUJCIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IjlZY25kMEExemt1MHZHU2tNaWRDQUEiLCJ2ZXIiOiIyLjAifQ.M2CphI4q-s2n1IpR4EmIQS6y63NW_g1PfShbMofB7cleKfXnXEJ5KE7Iycdb_49jOlw1Nt5VAKHKUabij41OIu393zBA0oLTolVTw70BbtK7NgswODFbE1fN3dzqPbiUjjl6rUvg-28IGfgVPns87n8g-K4xWhsU_37kAfqN5JlIoMvdZvyk_x2khfWSCLVUatqH90qgSLEGAeOPoPws5YOF4meYQhyUG9qCz2VGDRIs-sV0sTSX0ZE73vckDIfVfBKBQziiMlLA8jLHFy1G7SanilFGFblSsCtGVM5BZDz5wSE_YxB24ordKhXUk_IFbdMfU0Q29Qac4J-c5M46lw",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "9f50d0fe-7179-42a9-9b0c-6180d1163bb8",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "89754f8bf63b3a3a12ba9e31394ad7b1",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "9f50d0fe-7179-42a9-9b0c-6180d1163bb8",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,331.9905,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "0d089dcc-dd95-4fbc-87c4-10883f8a4f00"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUE5dWVCT0IrRmY4T3h6Tk5CK3dmWDYzdVYxQURFYVlpdzlPWlJYNUtFU1pkWkFGVE14eU5aWUtKUkxra1JJTm5TIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6InpKMElEWlhkdkUtSHhCQ0lQNHBQQUEiLCJ2ZXIiOiIyLjAifQ.B43z3dXzsMASvIB0SBrJbDl8a_81u_0qfsC3YR-8j50I14aB8B4W_8RE2J5BGCUwsmzUuUfDh9CQEG3ZfW5Rtb6uNXZjMRq_27SxipV_qXcpC0vNS5KNQcAZT_iaHAGppxDGN9ye5eQRmZ64U-EouockfmfsE4b-V_MPKoNemrL6Om2N6TdHFw50C3aQYDF23S7S2lPzuuruyrR38tbCdKr49Gw1aWvEFnpfcl9roRTEnzWc0j1ZQaXRjv140b-hrCP33j7vjniy0ZC22o_E3ye7mrzMWLwnQmKgEXmZWLQAQ1CMazMUHinYNhuyFIB3G6e49at8LonuK7G963_sCg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "4d786a05-0974-4f18-84b6-8159d6d0461b",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "52ff0219a6744022d35eb0ddb9fb24ae",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "4d786a05-0974-4f18-84b6-8159d6d0461b",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,330.7468,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "ba7a62f7-4100-4629-9725-5d23bbcd4900"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUEwUERDcS9XZmRXS1hzcEVTSDFXcEsxSDQ3Q2lGY0xvOVlPQ3hjb0w5ZkNqV2pvNzNybE1jblZ3aldBbXZHQ0duIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IjkySjZ1Z0JCS1VhWEpWMGp1ODFKQUEiLCJ2ZXIiOiIyLjAifQ.tmucurV9rTsFH995Jo5o7sFMrhr01OgndXePxSzMIAmn6EfZ5eq6hkAOeSrV3XPjki2gz73kdYeGkYR115PlRL2Xj3-bLPlQSZYnWmLTTefYcHfz3idoEmOz7UlBqffUOLMw_mojcr-Q6LlOtxVGj78Vx_tR7JVvzTIePecy_wpzQW1x9uyZVyJ64NWev6nJiB_inCVxwAPsOTHEQ8uZ078KPOZD5xh2cXcWEW3Bt5SWX_33k-5MsHg2-wTcduW5AbQU6BqZ66-X38DVr-cWMdwTYAt7NH3itMlOgN5wxSOP21M7-Mj6bzC4flVcCecLpCtq_6PypaVuvGBjX5tudA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "be4bdd67-7d1f-41a9-b0be-3c87280bf38a",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "17757bb68f2b2ae99ddc3203bc3f7ac9",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "be4bdd67-7d1f-41a9-b0be-3c87280bf38a",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,336.9137,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "ddf367ea-fe8c-4177-a516-04b3f0311100"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUFSUi9PS0VNNDBoOEdKU1VZMHE2RU4rOVQ4U3Y1Wk5GeWtVdE9NazRzMXdxNW8wZ0FGTm9RMjNBdkdMaU8wYU9zIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IjZtZnozWXotZDBHbEZnU3o4REVSQUEiLCJ2ZXIiOiIyLjAifQ.QZKue1DxfPcPVuZIC6_GshbiFlzFv90XiRHxV-6ZeCoyqFYVfEjFcpnZOTPIBV3PUu6AyTt5IFA6kpppu0wIe-uutNdsmVZ4E6Qd-en50ZtGGos7_sp-9JYUJFPvDGhEHul3H6s9Osx1-pilDkvVJgVmbGlN3Ilr0aGlWpK6zh1bofsiR5uwxqRxAiOaDZHXOWvZ_kdqedku93N2aw_-PGwgqdl6xK8t5AfJMC77diGrnkVD0uMf7ZnfOVhJZAFYP08F9waBJIgz7yh_Ok4hWDEmmwXestNgs9d4hSX4iaVLDJ7CYuq6TCrX-NKzMU8Uw9xc5UQekqbPve9Bpk3oqg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "087d10ce-1347-4220-8370-57586b6e3f00",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "31d5e7325b8ea3b11c979c8f1a2ae25d",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "087d10ce-1347-4220-8370-57586b6e3f00",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,330.2012,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "78f6197f-ad6e-42a5-86fb-39d55a643c00"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUFtN1ludEwzMWg2MjRHb0JjeGgvUkZmY2l3c0w1NnpTWmJBOXNhWlBPNjdxRjk5bnM1UklycVpYKzRFbnRXRGNQIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6ImZ4bjJlRzZ0cFVLRy16blZXbVE4QUEiLCJ2ZXIiOiIyLjAifQ.UguWPJyzmjFATQfsWlau1aUspwqp4brb5RTT4zvBTWe80I561O5Md8ylisDyDUDRFQi07dDrUn_axjeTHeB50oqBpjprdkpmeVD6foDUo6JQlSTBlu3yWdCNQzj6EiqsIfCffyqwzqnn-14Sb7oc6LC2dEXAcFEOWiux9Gssd7a8J8fDqlbcI4NJ9jgecLxQJwRtt1CIUHPai1PabWNuJpbKS2CbF9Rz_Rhdr5-eG6xpV0q_oimS3WAs2t0Fz5iuV812ZKPR9k5Vgnn-qHvs1O01qZKM1lJiEn_Cff0h4s3xqeaT6IO2ctnvIk46D1RmMj-O5wmYUC7BdC-uOTKZSA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "d290ce78-2765-4d84-b56e-2dd18dbdd868",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "bc45001347f47f4bc83988d339cb9470",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "d290ce78-2765-4d84-b56e-2dd18dbdd868",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,346.1767,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "190d5705-5529-47ce-bc55-d9f52c241400"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUExbytEcUNndHV4NEZoTWJmVE43a1dDZXZydUFDM0F1NkpxeUg1TlNFQkVHNm56UVFxRTZpUnRFOFgwUmRVb254IiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IkJWY05HU2xWemtlOFZkbjFMQ1FVQUEiLCJ2ZXIiOiIyLjAifQ.gq-EXMS4mAOnx3eiZ_-apfEwwi-tRqvRIMwZ4iixF0bPQ47CTwR9aAdKLafgxjDjBWWZT3WLP8suhnkwwF_-PoKrmOuZsb9Pd2DtdhJGtR6CFt3mySvwVuCsrEBV28rt_Aok5D5BORVk-aZAuGAwtGyxlw3WTgcmBy2PJ04Zzh7tvSBKn8z9uM4y6AePbrAbfede0ybhguUGHRdnzXq0OXpOHb_nEYfd-jGYncHWytkLO95qJ0T-bux40Wrb0v5CFmispkjeq3WXo5mgbQC61UaX3djKKWNBDvuh9FBp8nHjtO8fWgPF4E4p-OoYwyZI8TgOj06yDppyl50IMZkzCQ",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "289274c7-669c-46d9-8787-f17f009cca9b",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "051dc0d06c62341dc437af4e2a2fe120",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "289274c7-669c-46d9-8787-f17f009cca9b",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,332.3269,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "af6a8ed2-0c7b-4d3d-8c51-4dce0cf14100"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUErbkhQUHRVS0dNVGdCWDlTRStVRXVTK3FteGZqRko0UWp4N3hNdzhFRDhpVnNsSWNXMUFvUXk0RmVMelpDUllLIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IjBvNXFyM3NNUFUyTVVVM09EUEZCQUEiLCJ2ZXIiOiIyLjAifQ.fHIeLnDmFhlQEUhsBFkWodRoYpuao-JuH_uoKdLyL5s-od4WMG2Z1iw3cxMXnxv6HNEBNU9qGpPoB-EpyRT_dBrNRloaNbCWgTRidzySbFOnVd3mxVQpPwp0klJHhW7oCMeFEMzfoqhuhWtgcluKK2yF4kaMsPdU_H4tj3eu7M_w1AF8vxYkuHqIv2r1tAeM4vxgRlJnoTuvtq49vkx9FmGz2ooxZ_LCS6zY_9MxmlYE05j7tmX46PxB4DTDV6Vm3lR2oWGjCBrl_8tkfPQqRC4_DVwn5haAo-eG92_fFXMyd_j8DD3q7Teq8uZEORzREVhmWsutwFmtpJvBHJOcQA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "c0a2080f-bb30-4308-9bda-d0f3c89d0616",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "aed1579ab8491c5ca8a871b98b643991",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "c0a2080f-bb30-4308-9bda-d0f3c89d0616",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:34 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAgAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:35 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,328.2325,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "d53123a7-f8ac-480d-9446-7cf2882d4f00"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTUsIm5iZiI6MTU5OTE3MTgxNSwiZXhwIjoxNTk5MTc1NzE1LCJhaW8iOiJBVFFBeS84UUFBQUFYcHIrRTFQMGpXSlVqSnpKRGgwUmRoUVlobzRWYlh6QVl0WTVPWkNCU0luTUdFTzhOcTl4b2xNaHRyNXoraHExIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6InB5TXgxYXo0RFVpVVJuenlpQzFQQUEiLCJ2ZXIiOiIyLjAifQ.POHMx3JgpFISY2vAM85lIcoiSps4fIA1mk-5OqV1yi_E3VvKIe7rhU5hk2lTUM2snhYhlzVExNxFDJZiKsrTezJHnd3eNXUaFiJujsOswWw0Of11oIql1BVKTWwjug6vbQRJvKduSB4Y-fBlY0bEJjcLkcPmc7pg0YZuELXRRgAWm0qbvUBCrNKkOkVjlZGxPRPlRPaffXtQJ6PpSkm4Enpp4OXZAO6_AnkQzIMlKKiyyUSiVu5cpUZmOEiwRptRA9zqSQUTkiOwET6ZkVUR9Ji1q7GWX3LNtpSWGMXVboxEtAg-N7hXnjPMXKHtBgEkwZdQFvwPKTU8KtNtNFk_Gg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "AZURE_IDENTITY_TEST_USERNAME": "identitytestuser@azuresdkplayground.onmicrosoft.com",
+    "RandomSeed": "629697818",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredential_ParallelCallsAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCodeCredential_ParallelCallsAsync.json
@@ -1,0 +1,1430 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "ff3263bf-4346-4769-a31a-8b3b0383b304",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "3fb120b080ff23d2a044e9dd66fb8f55",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "ff3263bf-4346-4769-a31a-8b3b0383b304",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "be12cf66-6419-437d-bc90-f215ecd64500"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "8285bac6-e701-44f2-a3db-ee91b937c91d",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "aaee65f17694fd916a2a99eb3fb79c12",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "8285bac6-e701-44f2-a3db-ee91b937c91d",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "abfbc364-50ef-44b5-9a7f-2b3f55154c00"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "360b1118-7afd-469f-a598-9d4b79d4f1e3",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "1b3b1e2de8cb2095a7ee916bf1825384",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "360b1118-7afd-469f-a598-9d4b79d4f1e3",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "190d5705-5529-47ce-bc55-d9f564241400"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "1b6c45da-124d-4f8e-8008-b6637363e1b2",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "1867bbee30c311b382dfa9de83949b4a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "1b6c45da-124d-4f8e-8008-b6637363e1b2",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "b4e1dc70-7f65-4660-a2aa-ebb642324500"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "fbf9414e-dc60-4b65-b384-c8bbc332537f",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "a8bd85f537522e6cc2f52ff4e95f65c8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "fbf9414e-dc60-4b65-b384-c8bbc332537f",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "7e690c1d-2c67-4a98-ac54-a54ed10d4500"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "27485bd9-8865-4e3f-ae2c-1017cdae6d45",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "1eec8baef0a6dfb665d426b75b5588d3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "27485bd9-8865-4e3f-ae2c-1017cdae6d45",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "772787f5-3540-4bce-b4bc-64a453274200"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "0874cc52-9ae8-4a3a-9744-9517df93ecb8",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "91d1f756f4e1c8408b919811ef67311d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "0874cc52-9ae8-4a3a-9744-9517df93ecb8",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "190d5705-5529-47ce-bc55-d9f565241400"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "1d630924-4d9d-4072-85df-0d8fa42267fa",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "fa144653c2b1f9a27b9f8c3298a2221a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "1d630924-4d9d-4072-85df-0d8fa42267fa",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "5c47a693-3f12-4f01-95a4-5ecf9cd61100"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "de1734ca-6058-41dc-8e40-6e501e498d5d",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "490255916d22017246e54cffaf1d100b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "de1734ca-6058-41dc-8e40-6e501e498d5d",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "4f34385a-d775-4af3-a5ba-894b65005200"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1\u0026authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fc54fac88-3dd3-461f-a7c4-8a368e0340b3%2Foauth2%2Fv2.0%2Fauthorize",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "client-request-id": "b68d5e86-6328-4aa1-b54c-d6fa33a18699",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "b33d7e077eca626c8f3494dc9bea9e26",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "max-age=86400, private",
+        "client-request-id": "b68d5e86-6328-4aa1-b54c-d6fa33a18699",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hAwAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "d523b11a-307b-407b-bc74-692beac74800"
+      },
+      "ResponseBody": {
+        "tenant_discovery_endpoint": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/v2.0/.well-known/openid-configuration",
+        "api-version": "1.1",
+        "metadata": [
+          {
+            "preferred_network": "login.microsoftonline.com",
+            "preferred_cache": "login.windows.net",
+            "aliases": [
+              "login.microsoftonline.com",
+              "login.windows.net",
+              "login.microsoft.com",
+              "sts.windows.net"
+            ]
+          },
+          {
+            "preferred_network": "login.partner.microsoftonline.cn",
+            "preferred_cache": "login.partner.microsoftonline.cn",
+            "aliases": [
+              "login.partner.microsoftonline.cn",
+              "login.chinacloudapi.cn"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.de",
+            "preferred_cache": "login.microsoftonline.de",
+            "aliases": [
+              "login.microsoftonline.de"
+            ]
+          },
+          {
+            "preferred_network": "login.microsoftonline.us",
+            "preferred_cache": "login.microsoftonline.us",
+            "aliases": [
+              "login.microsoftonline.us",
+              "login.usgovcloudapi.net"
+            ]
+          },
+          {
+            "preferred_network": "login-us.microsoftonline.com",
+            "preferred_cache": "login-us.microsoftonline.com",
+            "aliases": [
+              "login-us.microsoftonline.com"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "fbf9414e-dc60-4b65-b384-c8bbc332537f",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "b85a832bc5e41be47a21265042fc535d",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "fbf9414e-dc60-4b65-b384-c8bbc332537f",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,232.9172,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "0a9fe6c4-cf4e-4aa3-b874-c3b4fa684200"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUF4THJvREFYVlR6bkkzNEEyVlVGbTczYXJ6WUdKZGtZcjQ4TUlDTEx1UDZFTDRya2YxOXdLZ0FDdHo1NlJ6dHhIIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6InhPYWZDazdQbzBxNGRNTzAtbWhDQUEiLCJ2ZXIiOiIyLjAifQ.NCDSx6te3WRs2t2HrXZsryrihaiNkadqWAR6Mq1sqnWtbFeOoj2fEOicZbCzOTiEBGpf5on33nrJaFiK2ZiuEQGRGKo0qpgPCYq64-hgllN3xJV-nspF-WjMWtzNdOJTp8VsHWgw2uLiNoWRuTAiacrl0c3VUk7CCZ3ySKlYC7grc3MSHo29yLndyo7OyjUE03t8cEXpC7B6DK99re0wjW6OeG4DOUbVcSabPuWSmNbVutiUKBIf_Ig7WhS4aex1wzGSX3oWO-yMublSnzfaTTFpINU9kr67ZCo08-rGPWY4Bxxi698uTRDsbDGYB0qmIpdi7u6LQVx4bFdWKN8KTQ",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "ff3263bf-4346-4769-a31a-8b3b0383b304",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "123db91679e476c81fbe5bb0c1c2f606",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "ff3263bf-4346-4769-a31a-8b3b0383b304",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,223.7691,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "02038efa-c76f-496a-978a-e5d561833e00"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUFtN1ludEwzMWg2MjRHb0JjeGgvUkZlbzQyNUZENFpYVEI4WUdLdmk4VjhQU1J0ZDRuRTQrZExCd1dVSEgrN3BFIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6Ii1vNERBbV9IYWttWGl1WFZZWU0tQUEiLCJ2ZXIiOiIyLjAifQ.uFZQe6wJZWcjPgrY4Y-ig6urEMzmxJj_sRjmNsd9CCSs4YRWIrZZVzw8Axo-vU4oRjqwrdU_V1swhIWk894M5CtO2JdYphQA-5ETqJ4knKOWEjVySsmFylPV-C64zlm04lfrV9h3n05UYpvFkEoWEsGUBnnDQPCm36WXW8dUzdOwZ2FgcrG66bHmbs2Gy1QRlmfdUAGgRt72DJGQOyhFBQ6cZwU3f7miCB4LTbbu9UN8BU31f0f4F3Wiq_dAm5LWDt93RrBmZBNLM_GyuSrRRpFltZdYwQUZTgBGPTIB0M2HgVzBeVQttpfxD4yfqWUEcCb9sF2wyVO4UFZXDDP3CA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "27485bd9-8865-4e3f-ae2c-1017cdae6d45",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "14df4bb95521949cfa9c815b595a2d0c",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "27485bd9-8865-4e3f-ae2c-1017cdae6d45",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,229.1062,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "9c7a5f48-8331-423c-9b38-38a0ba5f4800"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUFRRWtCdEl2cGNDZFlaWnpTWXl0d1l6eFF6dlVoTk1MOXArMWFDUjVsaE9sQkUzOGYvZU1odllnUjFuNXBNVTdTIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IlNGOTZuREdEUEVLYk9EaWd1bDlJQUEiLCJ2ZXIiOiIyLjAifQ.1j57yxvcWKtIACnWhVWUSl5qrXHl0Z9Y7l3yZrhejjkKwxYxQMS1L-ZIc5n-ejEgpc5fNBRikxFn2UvzWDpNpbyRXN5TxwVMQn7ph3BQ-X8EACLC3tjihti9hjwWyxSDvUlgqqt52c-VsUx3PX1-DbIk0pvEMKnAExrErexwVFkOqT98V-fnhT_zQB3oODeJ6nvux3JnZ-MIL9OPIoyFppvyOwRZp0_4PnVDK0Fxkzxem44o0QzR34Os3qZhQ4w2VcSkMHh7rs1sUpQA6k-d5ntS4DHYvbwdRbCTkhWaYzMOeBgFeBSgUViXC8HxDO357SeFDH2goy0mQUs0mPkVgQ",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "360b1118-7afd-469f-a598-9d4b79d4f1e3",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "30dd095653228ee3b6c6930c23bba1cd",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "360b1118-7afd-469f-a598-9d4b79d4f1e3",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,225.5281,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "f78f9992-dfbe-4d8d-a932-3bd0fc291000"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUExMDhhUmNXcnovdjRwVDVkWldrTlRlMXhUNWt0Y2R1Y24vdFQ1MWVuNkkzSUZsMmVPMks4QWNJK1gxT0JoWGpQIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6ImtwbVA5NzdmalUycE1qdlFfQ2tRQUEiLCJ2ZXIiOiIyLjAifQ.h0O7zuy0kvM3OXLccrF8_gjgaCPsFApkuxJZOwuhYrlmTs_F0g4E0YF269h_Yai2Ufdm-pTi5QiDr1pdANAs2UBFWKF54GzdZPLIPFNoZIVWruKBtUbipbdAQSfAxWToWXSydU54UO8xS2FMhe5_As7VyIqsIR-roVMZXZSa36WGqvG_bqF_Wqr8FfeS_-dQ2_hTJje0lQu--Fzu7iH6NiHkO0Yejne-5BK_wyCI0RGpMTL8mEUF-PMWbJQaPuF3YtgFM3FDPBLoWLCbj63CvdYEqWA7az97Q8xmNUuDFUCnQRGNg6vZJr_Lkm6uBw_ThG9UJTF6v1IuzSudjTFuqg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "1b6c45da-124d-4f8e-8008-b6637363e1b2",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "3d6e8d3ec13b410eafc6f98960aad490",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "1b6c45da-124d-4f8e-8008-b6637363e1b2",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,225.0973,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "bd07bb78-1883-4938-bf0c-0794ea9d4d00"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUFBYjlJZHpCZFRja3AxbkwwR295bHRtSGFCRWNyVkhzZjNMRmN2Y0c2Y21hUjNiM2ZNai9FM2tIbHpHOWtkTkkwIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6ImVMc0h2WU1ZT0VtX0RBZVU2cDFOQUEiLCJ2ZXIiOiIyLjAifQ.EUMG6HnqcGkc8LhCwEUDRYc8W77H_Q7Hjvl_YO1-dcMPHcdT5FpJpdM5rbqRp8T8NqsTQ_Te9hd6IV7S5JZ42Uu9lz55ElQ7X7Pgsuna-j1mbnujCz_vDgpYB7aNGbuutNHiauEbwvidorkGhAouQhtEzv-Qn5nZKqvjWcbaX4oVWp1EMXcM7NG6c5pi5-fLqcKStm2UOW4WqoyQt0dTNGsKmmmItzKKMU6iBk1MeEMBFoZzryY553hzmvIzlkHuYWPyjNoEEd-ycCKm97W4_wg6RkBaZ8nvQVsLNrzZ_xyjI3Ai1TMZHZ0DVUQgoluCdr8qP6RAT5WxOVGBYO6aFg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "1d630924-4d9d-4072-85df-0d8fa42267fa",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "15cf9b73bfcbd56fe6c5bd484488c11f",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "1d630924-4d9d-4072-85df-0d8fa42267fa",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,234.8467,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "a951d795-9940-482b-bde5-d219884b5300"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUEzcHMycTk2RmpadlJxSlE2TGZQelNHZ3VlNFZOWVF4UnRPTlg0bWhWQTBzekt1VElNSVdUcXY1SEcwSzE5Z2EwIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6ImxkZFJxVUNaSzBpOTVkSVppRXRUQUEiLCJ2ZXIiOiIyLjAifQ.aSUarXj-rPETdIh-nt3UCCPzkDAGt1THeQCp7DLwC2uoqDi9eJo9iePoJCpWEf-wAWV0vftVN92RFogTp2GGbyczgmUGTVIc3hwyC1zokNFs5m_-WA4blyk_1onvVUmZW6v0uCCrWvliHf9NfMjd7VIVjYbZfeoWfLyToWUoY_J-PySmOrdl8BQ506WIFaUZkxM1DOW_ISPt5UqWeOKKwx0gPqpJPAftENCCwSFh3NdZBD4E7EarfnPQ-kk3ypos3JkA0NefkzVw_gOlc1F8K9ij8faWu6m-unF9O2lF63T01HRayLG9yw659BtO06d0Fn5A9LfzOSdungHFDaE5AA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "8285bac6-e701-44f2-a3db-ee91b937c91d",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "dcaf5e6ed5177609195b181da28f92d7",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "8285bac6-e701-44f2-a3db-ee91b937c91d",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,224.1527,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "f15c7471-0e64-4780-8793-b4a68f001400"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUFRY0kxaTFWWjVndnY2VFR1Nnp4aGl0d2FWTnl1ZnlYbkhoZmZESkhjRWtuOHZ0dDIyN1RKVWhpOU9aU0poSnV5IiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6ImNYUmM4V1FPZ0VlSGs3U21qd0FVQUEiLCJ2ZXIiOiIyLjAifQ.qdx8fyZYCsvqI-0e-4Hv-IGHxLPEnCqJaSU7JtCiItlZXwCJXHefRyRP0x9-7lqFIAohwaeg-I9pMsIRSPwqSzlzTUl5ZLQFqwhD43mqCfLMZ8LNtfpeRBpPhZ3TyhAPLueWIb8sU5E-sBv42i6wmumeD_6YF5aTyJ0n9kjxPEs2x4aPmkJ57bWODPG6yZibxm84NharaIQV5NSEa1rxr4IbdNDJh1g0SEWKkRghQNQEqmhbr-2lRfqCWJqJvjZC_pyRsK0Ll-sMfGGN5OWLbyqHe1r6Yi7m8Qsr2SSE9cxG3d5lENqmSxA3NXUWaKhMcdtq8u2haHX8NuO8apiCJw",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "b68d5e86-6328-4aa1-b54c-d6fa33a18699",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "bee8ce9d188a3340930bb99c2ba03520",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "b68d5e86-6328-4aa1-b54c-d6fa33a18699",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,248.0552,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "4a11ebdc-9955-4a8c-a59e-ff7fd1405200"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUFPK2NQQ3lvalpBOTEwQU1XUGVqdU9UNlJpTmxwTmZCOW1LeEc0Zi82d1ZoVFBxelA5cXpuc0hBeVhyZzdlZFIwIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IjNPc1JTbFdaakVxbG52OV8wVUJTQUEiLCJ2ZXIiOiIyLjAifQ.f4dGPyPuGkGXeD5uSkvSQ07VA25MlAVRFr-WNczkBD0mHeCAAyRbg4_alkID03j_XwbR2DhLnUTwJl9esZFB5UmiJ5L69j-B3xiMBeyiXcX6Fb80874OcdD-KJpe_0MJIu0XrCOzNvZQDs1KEcmDJUXTRwtpGsXicPClBSSoaBqYL4D_I0WC87oeq304p3PfRCBAMsr8WQitCTv0smZMJAJKazdifLkAC1xrEkBIVDMbtQebiq_1drN84AEmSughIppWNzgStvaiQje36fh7ttr4A06Agiz-fB8wm6Uzmh_dwlurr-a-LkTwQllwXSK9BsKVXe9Cc3z38mRiZ40euw",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "de1734ca-6058-41dc-8e40-6e501e498d5d",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "3f5d19f3b31bd0fc62656bce9182f93c",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "de1734ca-6058-41dc-8e40-6e501e498d5d",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:35 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,239.3944,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "190d5705-5529-47ce-bc55-d9f567241400"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUEzN1czeCtHTEtWc0R0TWhNUWFBZEg1Y3R3UjlZQ2s2RlpDWk9lRkN6bTNYK1Fibi9YNjM0Z2dTL05Gdm9BSW9KIiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6IkJWY05HU2xWemtlOFZkbjFaeVFVQUEiLCJ2ZXIiOiIyLjAifQ.rQzOULP2bGYvdJL_mPo8JILm_N7sWwv0hp4g6G4Tay32HXsD5-jCVodqEopOKzUyVBasHJFeV7wiXlPtVSyEo8H1r9Z1MdhNq6K8jFTKMdBz1slxh7EUjO7_iDziuyLRVVPd2dUwPKJZVn7_P47Qu8iKkLx01UGHbCAiC6H78TnQaTN4dliYIPFUj0hqMGhzf8Z154BZ1yE7RzPUzWEs_4kE056usHSLRCAV5NYCn9nyEN2g-TbpwZQp3k1EPWW4qqePGg3kfqX32TJ8uXId-pvVkwNSHclai7gVY67c8iZ1M5jx5ooh3Gsg1uBbxUe-rK7W48ReafEAyEn5wFpstA",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    },
+    {
+      "RequestUri": "https://login.microsoftonline.com/c54fac88-3dd3-461f-a7c4-8a368e0340b3/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "client-request-id": "0874cc52-9ae8-4a3a-9744-9517df93ecb8",
+        "Content-Length": "9",
+        "return-client-request-id": "true",
+        "User-Agent": [
+          "azsdk-net-Identity/1.3.0-dev.20200903.1",
+          "(.NET Core 4.6.28928.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-app-name": "UnknownClient",
+        "x-app-ver": "0.0.0.0",
+        "x-client-current-telemetry": "2|1001,0|",
+        "x-client-last-telemetry": "2|0|||",
+        "x-client-OS": "Microsoft Windows 10.0.19041 ",
+        "x-client-SKU": "MSAL.NetCore",
+        "x-client-Ver": "4.16.1.0",
+        "x-ms-client-request-id": "9fe102f2e96179e8a952c3199bbeffb2",
+        "x-ms-lib-capability": "retry-after, h429",
+        "x-ms-PKeyAuth": "1.0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "U2FuaXRpemVk",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-store, no-cache",
+        "client-request-id": "0874cc52-9ae8-4a3a-9744-9517df93ecb8",
+        "Content-Length": "1608",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 03 Sep 2020 22:28:36 GMT",
+        "Expires": "-1",
+        "P3P": "CP=\u0022DSP CUR OTPi IND OTRi ONL FIN\u0022",
+        "Pragma": "no-cache",
+        "Set-Cookie": [
+          "fpc=AswvsPMZMe1JkhLlyQmV7JboE88hBAAAABJl49YOAAAA; expires=Sat, 03-Oct-2020 22:28:36 GMT; path=/; secure; HttpOnly; SameSite=None",
+          "x-ms-gateway-slice=prod; path=/; secure; samesite=none; httponly",
+          "stsservicecookie=ests; path=/; secure; samesite=none; httponly"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-clitelem": "1,0,0,230.5494,",
+        "x-ms-ests-server": "2.1.10985.18 - EST ProdSlices",
+        "x-ms-request-id": "2fdb10cd-bd02-4a19-a2c8-7cbecfdd4300"
+      },
+      "ResponseBody": {
+        "token_type": "Bearer",
+        "scope": "https://vault.azure.net/user_impersonation https://vault.azure.net/.default",
+        "expires_in": 3599,
+        "ext_expires_in": 3599,
+        "access_token": "Sanitized",
+        "refresh_token": "Sanitized",
+        "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImppYk5ia0ZTU2JteFBZck45Q0ZxUms0SzRndyJ9.eyJhdWQiOiJhZWJjNjQ0My05OTZkLTQ1YzItOTBmMC0zODhmZjk2ZmFhNTYiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzL3YyLjAiLCJpYXQiOjE1OTkxNzE4MTYsIm5iZiI6MTU5OTE3MTgxNiwiZXhwIjoxNTk5MTc1NzE2LCJhaW8iOiJBVFFBeS84UUFBQUFhQnpCS3dxbXhGTVJqSHhWNnlQR2sxUm41WW93Z0FFa09mRFR1TDVoQ1pMRS8yaWRuZFQ3TGpFSjZWYUFtQjM4IiwibmFtZSI6IklkZW50aXR5IFRlc3QgVXNlciIsIm9pZCI6IjQyZDhlODg0LTI2NWEtNGNkNC05MDg5LTRjM2JjNDBhZjE4MyIsInByZWZlcnJlZF91c2VybmFtZSI6ImlkZW50aXR5dGVzdHVzZXJAYXp1cmVzZGtwbGF5Z3JvdW5kLm9ubWljcm9zb2Z0LmNvbSIsInJoIjoiMC5BQUFBaUt4UHhkTTlIMGFueElvMmpnTkFzME5rdks1dG1jSkZrUEE0al9sdnFsWXRBSWsuIiwic3ViIjoiV21sbnlVR0Y4U3lKdHh0MnMxNnZMZi1pYTBUT1NkQ05MUEdzdHpfVGxhVSIsInRpZCI6ImM1NGZhYzg4LTNkZDMtNDYxZi1hN2M0LThhMzY4ZTAzNDBiMyIsInV0aSI6InpSRGJMd0s5R1VxaXlIeS16OTFEQUEiLCJ2ZXIiOiIyLjAifQ.depK18USrR8zj2WYham2E2cVJnkFX6HrVv6HMxrZTUnAIYhnO1YESXT-s59JTlR2Z3MPyy1g6a5kYewhTf0MweAeif4IfoxUJE7tKLDFEC-M45wB5yCyKjTGgSUVEK5ah8Vd66BauUbUTZoR9A66eoYnYHXNn4SmVh-hK3tnO2LT-ruG2JpzwlWHwqKasb0o4EfgtIrNPUlCQkUpV21fa1YGFHDhHS7_JY1O1Kw2qvjd6gIzo_rUa43ZO_idylrJ83AFnT1O25qZWyTcqckDRt8CKyQmJrIA2VeJ0ZGfGAiQ1Yp08aofgjtY3F_jEdL47r8p_JfAlDqrM8EaBqWmjg",
+        "client_info": "eyJ1aWQiOiI0MmQ4ZTg4NC0yNjVhLTRjZDQtOTA4OS00YzNiYzQwYWYxODMiLCJ1dGlkIjoiYzU0ZmFjODgtM2RkMy00NjFmLWE3YzQtOGEzNjhlMDM0MGIzIn0"
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "AZURE_IDENTITY_TEST_USERNAME": "identitytestuser@azuresdkplayground.onmicrosoft.com",
+    "RandomSeed": "492282192",
+    "TENANT_ID": null
+  }
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCredential.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCredential.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCredentialAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/ChainedTokenCredentialLiveTests/ChainedTokenCredential_UseVisualStudioCredentialAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}


### PR DESCRIPTION
This commit unifies the way `DefaultAzureCredential` and `ChainedTokenCredential` handle exceptions