### PR TITLE
Fix bug when sanitizing empty body

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestSanitizer.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestSanitizer.cs
@@ -66,7 +66,7 @@ namespace Azure.Core.TestFramework
 
         public virtual void SanitizeBody(RecordEntryMessage message)
         {
-            if (message.Body != null)
+            if (message.Body?.Length > 0)
             {
                 message.TryGetContentType(out string contentType);
 

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestSanitizer.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestSanitizer.cs
@@ -66,7 +66,7 @@ namespace Azure.Core.TestFramework
 
         public virtual void SanitizeBody(RecordEntryMessage message)
         {
-            if (message.Body?.Length > 0)
+            if (message.Body != null)
             {
                 message.TryGetContentType(out string contentType);
 
@@ -93,7 +93,10 @@ namespace Azure.Core.TestFramework
 
             SanitizeHeaders(entry.Response.Headers);
 
-            SanitizeBody(entry.Response);
+            if (entry.RequestMethod != RequestMethod.Head)
+            {
+                SanitizeBody(entry.Response);
+            }
         }
 
         public virtual void Sanitize(RecordSession session)

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -410,9 +410,18 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void ContentLengthUpdatedCorrectlyOnEmptyBody(bool isHeadRequest)
+        public void ContentLengthNotChangedOnHeadRequestWithEmptyBody()
+        {
+            ContentLengthUpdatedCorrectlyOnEmptyBody(isHeadRequest: true);
+        }
+
+        [Test]
+        public void ContentLengthResetToZeroOnGetRequestWithEmptyBody()
+        {
+            ContentLengthUpdatedCorrectlyOnEmptyBody(isHeadRequest: false);
+        }
+
+        private void ContentLengthUpdatedCorrectlyOnEmptyBody(bool isHeadRequest)
         {
             var sanitizer = new RecordedTestSanitizer();
             var entry = new RecordEntry()

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -412,13 +412,13 @@ namespace Azure.Core.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public void ContentLengthUpdatedCorrectlyOnEmptyBody(bool headRequest)
+        public void ContentLengthUpdatedCorrectlyOnEmptyBody(bool isHeadRequest)
         {
             var sanitizer = new RecordedTestSanitizer();
             var entry = new RecordEntry()
             {
                 RequestUri = "http://localhost/",
-                RequestMethod = headRequest ? RequestMethod.Head : RequestMethod.Get,
+                RequestMethod = isHeadRequest ? RequestMethod.Head : RequestMethod.Get,
                 Response =
                 {
                     Headers =
@@ -432,7 +432,7 @@ namespace Azure.Core.Tests
             };
             sanitizer.Sanitize(entry);
 
-            if (headRequest)
+            if (isHeadRequest)
             {
                 Assert.AreEqual(new[] { "41" }, entry.Response.Headers["Content-Length"]);
             }


### PR DESCRIPTION
Sanitizing response from a HEAD request should not result in resetting content-length to 0.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/13510