### PR TITLE
[KeyVault] Use preview package version 

### DIFF
--- a/sdk/keyvault/Microsoft.Azure.Management.KeyVault/src/Microsoft.Azure.Management.KeyVault.csproj
+++ b/sdk/keyvault/Microsoft.Azure.Management.KeyVault/src/Microsoft.Azure.Management.KeyVault.csproj
@@ -11,7 +11,7 @@
 		</Description>
 		<AssemblyTitle>Microsoft Azure Key Vault Management</AssemblyTitle>
 		<AssemblyName>Microsoft.Azure.Management.KeyVault</AssemblyName>
-		<Version>3.1.0</Version>
+		<Version>3.1.0-preview.1</Version>
 		<PackageTags>Microsoft Azure key vault management;Key Vault;</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[


### PR DESCRIPTION
New features introduced in last PR #14569 was for preview only, so I added `-preview.1` suffix to the version.
(3.1.0 was not released, see https://www.nuget.org/packages/Microsoft.Azure.Management.KeyVault/)