### PR TITLE
[Azure.Core TestFramework] Fix Required Optional Environment Variable

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -177,10 +177,6 @@ namespace Azure.Core.TestFramework
 
             string value = GetOptionalVariable(name);
 
-            var optionsInstance = new RecordedVariableOptions();
-            options?.Invoke(optionsInstance);
-            var sanitizedValue = optionsInstance.Apply(value);
-
             if (!Mode.HasValue)
             {
                 return value;
@@ -189,6 +185,17 @@ namespace Azure.Core.TestFramework
             if (_recording == null)
             {
                 throw new InvalidOperationException("Recorded value should not be set outside the test method invocation");
+            }
+
+            // If the value was populated, sanitize before recording it.
+
+            string sanitizedValue = value;
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                var optionsInstance = new RecordedVariableOptions();
+                options?.Invoke(optionsInstance);
+                sanitizedValue = optionsInstance.Apply(sanitizedValue);
             }
 
             _recording?.SetVariable(name, sanitizedValue);

--- a/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
+++ b/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
@@ -79,6 +79,23 @@ namespace Azure.Core.Tests
             Assert.AreEqual("endpoint=1;key=Sanitized", testRecording.GetVariable("ConnectionStringWithSecret", ""));
         }
 
+        [Test]
+        public void RecordedOptionalVariableNotSanitizedIfMissing()
+        {
+            var tempFile = Path.GetTempFileName();
+            var env = new MockTestEnvironment();
+            var testRecording = new TestRecording(RecordedTestMode.Record, tempFile, new RecordedTestSanitizer(), new RecordMatcher());
+            env.Mode = RecordedTestMode.Record;
+            env.SetRecording(testRecording);
+
+            Assert.IsNull(env.MissingOptionalSecret);
+
+            testRecording.Dispose();
+            testRecording = new TestRecording(RecordedTestMode.Playback, tempFile, new RecordedTestSanitizer(), new RecordMatcher());
+
+            Assert.IsNull(testRecording.GetVariable(nameof(env.MissingOptionalSecret), null));
+        }
+
         private class RecordedVariableMisuse : RecordedTestBase<MockTestEnvironment>
         {
             // To make NUnit happy
@@ -114,6 +131,7 @@ namespace Azure.Core.Tests
             public string Base64Secret => GetRecordedVariable("Base64Secret", option => option.IsSecret(SanitizedValue.Base64));
             public string DefaultSecret => GetRecordedVariable("DefaultSecret", option => option.IsSecret(SanitizedValue.Default));
             public string CustomSecret => GetRecordedVariable("CustomSecret", option => option.IsSecret("Custom"));
+            public string MissingOptionalSecret => GetRecordedOptionalVariable("MissingOptionalSecret", option => option.IsSecret("INVALID"));
             public string ConnectionStringWithSecret => GetRecordedVariable("ConnectionStringWithSecret", option => option.HasSecretConnectionStringParameter("key"));
 
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to bypass the attempt to sanitize an optional environment variable when no value was present.  Previously, if the variable was not read, sanitizing would result in an exception.

# Last Upstream Rebase

Friday, September 4, 10:39am (EDT)

# References and Related Issues

- [[Azure.Core] Test Environment Exception When Optional Environment Variable Not Set](https://github.com/Azure/azure-sdk-for-net/issues/14869) ([#14869](https://github.com/Azure/azure-sdk-for-net/issues/14869))