### PR TITLE
Fix starvation issue with session processor when MaxCallsPerSession > 1

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -182,6 +182,10 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int SendLinkClosedEvent = 100;
         internal const int ManagementLinkClosedEvent = 101;
 
+        internal const int ProcessorMessageHandlerStartEvent = 102;
+        internal const int ProcessorMessageHandlerCompleteEvent = 103;
+        internal const int ProcessorMessageHandlerExceptionEvent = 104;
+
         #endregion
         // add new event numbers here incrementing from previous
 
@@ -743,6 +747,33 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
+        [Event(ProcessorMessageHandlerStartEvent, Level = EventLevel.Informational, Message = "{0}: User message handler start: Message: SequenceNumber: {1}")]
+        public void ProcessorMessageHandlerStart(string identifier, long sequenceNumber)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorMessageHandlerStartEvent, identifier, sequenceNumber);
+            }
+        }
+
+        [Event(ProcessorMessageHandlerCompleteEvent, Level = EventLevel.Informational, Message = "{0}: User message handler complete: Message: SequenceNumber: {1}")]
+        public void ProcessorMessageHandlerComplete(string identifier, long sequenceNumber)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorMessageHandlerCompleteEvent, identifier, sequenceNumber);
+            }
+        }
+
+        [Event(ProcessorMessageHandlerExceptionEvent, Level = EventLevel.Error, Message = "{0}: User message handler complete: Message: SequenceNumber: {1}, Exception: {2}")]
+        public void ProcessorMessageHandlerException(string identifier, long sequenceNumber, string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorMessageHandlerExceptionEvent, identifier, sequenceNumber, exception);
+            }
+        }
+
         #endregion region
 
         #region Rule management
@@ -992,12 +1023,12 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
 
-        [Event(CreateReceiveLinkCompleteEvent, Level = EventLevel.Informational, Message = "Receive link created for Identifier: {0}.")]
-        public virtual void CreateReceiveLinkComplete(string identifier)
+        [Event(CreateReceiveLinkCompleteEvent, Level = EventLevel.Informational, Message = "Receive link created for Identifier: {0}. Session Id: {1}")]
+        public virtual void CreateReceiveLinkComplete(string identifier, string sessionId)
         {
             if (IsEnabled())
             {
-                WriteEvent(CreateReceiveLinkCompleteEvent, identifier);
+                WriteEvent(CreateReceiveLinkCompleteEvent, identifier, sessionId);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -170,7 +170,17 @@ namespace Azure.Messaging.ServiceBus
 
                 errorSource = ServiceBusErrorSource.UserCallback;
 
-                await OnMessageHandler(message, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    ServiceBusEventSource.Log.ProcessorMessageHandlerStart(_identifier, message.SequenceNumber);
+                    await OnMessageHandler(message, cancellationToken).ConfigureAwait(false);
+                    ServiceBusEventSource.Log.ProcessorMessageHandlerComplete(_identifier, message.SequenceNumber);
+                }
+                catch (Exception ex)
+                {
+                    ServiceBusEventSource.Log.ProcessorMessageHandlerException(_identifier, message.SequenceNumber, ex.ToString());
+                    throw;
+                }
 
                 if (Receiver.ReceiveMode == ReceiveMode.PeekLock &&
                     _processorOptions.AutoComplete &&

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/SessionReceiverManager.cs
@@ -82,14 +82,16 @@ namespace Azure.Messaging.ServiceBus
             {
                 await WaitSemaphore(cancellationToken).ConfigureAwait(false);
                 releaseSemaphore = true;
+
+                // If a receive call timed out for this session, avoid adding more threads
+                // if we don't intend to leave the receiver open on receive timeouts. This
+                // will help ensure other sessions get a chance to be processed.
                 if (_threadCount >= _maxCallsPerSession ||
-                    // If a receive call timed out for this session, avoid adding more threads
-                    // if we don't intend to leave the receiver open on receive timeouts. This
-                    // will help ensure other sessions get a chance to be processed.
                     (_receiveTimeout && !_keepOpenOnReceiveTimeout))
                 {
                     return false;
                 }
+
                 if (_receiver == null)
                 {
                     await CreateAndInitializeSessionReceiver(cancellationToken).ConfigureAwait(false);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -1486,7 +1486,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [TestCase(10, 10, 1)]
         [TestCase(10, 5, 2)]
         [TestCase(10, 20, 5)]
-        [Timeout(60 * 1000 * 15)]
         public async Task MaxCallsPerSessionRespected(int numSessions, int maxConcurrentSessions, int maxCallsPerSession)
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/14938

The heuristic we use to determine when a session should be closed when using the `ServiceBusSessionProcessor` in the round-robin case (i.e. when no specific sessions are listed in the `ServiceBusSessionProcesserOptions`) is the following: a receive call times out and there are no other threads processing the session. If `MaxCallsPerSession` is more than 1, the session processor can end up leaving sessions open for a long time even when there are no messages for the session, as new threads will keep getting assigned to the session. To fix this, we avoid adding new threads to a session when a receive call has already timed out. This issue manifested in the `MaxCallsPerSessionRespected` test timing out occasionally.

Also, updated logging to include `SessionId` when opening a receive link, consolidated the session open logic, and added additional logging for processor event handlers.