### PR TITLE
[Event Hubs Client] September Release Preparation (Core)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -13,7 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0-preview.3" /> <!--Version override exists to bind to the preview; this will be removed when v5.2.0 is released for GA -->
-    <PackageReference Include="Azure.Storage.Blobs" />
+
+    <!-- Version override is specific to the v5.2.0 release from the branch; this will be removed and the package properties updated when merged to master -->
+    <PackageReference Include="Azure.Storage.Blobs" VersionOverride="12.6.0"/>
+    <!-- END v5.2.0 SPECIFIC OVERRIDES -->
+
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
@@ -54,5 +58,29 @@
   </ItemGroup>
 
   <!-- Import the Azure.Core reference -->
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
+  <!-- <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" /> -->
+
+  <!-- 
+    THIS SECTION IS SPECIFIC TO THE v5.2.0 RELEASE 
+
+    These are normally set via the above reference to Azure.Core.props, but have been included here
+    to allow a specific override to the Azure.Core version for Event Hubs only; when merged back to 
+    master, this section should be removed and the above import restored.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" VersionOverride="1.5.0" />
+  </ItemGroup>
+
+  <!-- Nullability -->
+  <PropertyGroup>
+    <!-- Visual Studio 2019 version 16.1 shipped a version of .NET Core that used older 'NullableContextOptions' -->
+    <Nullable Condition="'$(Nullable)'==''">$(NullableContextOptions)</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Nullable)'=='enable' Or '$(UseAzureCoreNullableAttributes)'=='true'">
+    <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(Nullable)'=='enable' Or '$(UseAzureCoreNullableAttributes)'=='true'">
+    <Compile Include="$(AzureCoreSharedSources)NullableAttributes.cs" />
+  </ItemGroup>
+  <!-- END v5.2.0 SPECIFIC OVERRIDES -->
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -61,5 +61,29 @@
   </ItemGroup>
 
   <!-- Import the Azure.Core reference -->
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
+  <!-- <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" /> -->
+
+  <!--
+    THIS SECTION IS SPECIFIC TO THE v5.2.0 RELEASE
+
+    These are normally set via the above reference to Azure.Core.props, but have been included here
+    to allow a specific override to the Azure.Core version for Event Hubs only; when merged back to
+    master, this section should be removed and the above import restored.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" VersionOverride="1.5.0" />
+  </ItemGroup>
+
+  <!-- Nullability -->
+  <PropertyGroup>
+    <!-- Visual Studio 2019 version 16.1 shipped a version of .NET Core that used older 'NullableContextOptions' -->
+    <Nullable Condition="'$(Nullable)'==''">$(NullableContextOptions)</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Nullable)'=='enable' Or '$(UseAzureCoreNullableAttributes)'=='true'">
+    <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(Nullable)'=='enable' Or '$(UseAzureCoreNullableAttributes)'=='true'">
+    <Compile Include="$(AzureCoreSharedSources)NullableAttributes.cs" />
+  </ItemGroup>
+  <!-- END v5.2.0 SPECIFIC OVERRIDES -->
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Release History
 
-## 5.2.0-preview.4 (Unreleased)
+## 5.2.0 (2020-09-08)
 
 ### Acknowledgments
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.2.0-preview.4</Version>
+    <Version>5.2.0</Version>
     <ApiCompatVersion>5.1.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -55,5 +55,29 @@
   </ItemGroup>
 
   <!-- Import the Azure.Core reference -->
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
+  <!-- Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" /> -->
+
+  <!-- 
+    THIS SECTION IS SPECIFIC TO THE v5.2.0 RELEASE 
+
+    These are normally set via the above reference to Azure.Core.props, but have been included here
+    to allow a specific override to the Azure.Core version for Event Hubs only; when merged back to 
+    master, this section should be removed and the above import restored.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" VersionOverride="1.5.0" />
+  </ItemGroup>
+
+  <!-- Nullability -->
+  <PropertyGroup>
+    <!-- Visual Studio 2019 version 16.1 shipped a version of .NET Core that used older 'NullableContextOptions' -->
+    <Nullable Condition="'$(Nullable)'==''">$(NullableContextOptions)</Nullable>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Nullable)'=='enable' Or '$(UseAzureCoreNullableAttributes)'=='true'">
+    <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(Nullable)'=='enable' Or '$(UseAzureCoreNullableAttributes)'=='true'">
+    <Compile Include="$(AzureCoreSharedSources)NullableAttributes.cs" />
+  </ItemGroup>
+  <!-- END v5.2.0 SPECIFIC OVERRIDES -->
 </Project>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the core `Azure.Messaging.EventHubs` library for its September release.

# Last Upstream Rebase

Saturday, September 5, 10:02am (EDT)