### PR TITLE
[Event Hubs Client] September Release Preparation (Processor)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.2.0-preview.4 (Unreleased)
+## 5.2.0 (2020-09-08)
 
 ### Acknowledgments
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.2.0-preview.4</Version>
+    <Version>5.2.0</Version>
     <ApiCompatVersion>5.1.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -12,9 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0-preview.3" /> <!--Version override exists to bind to the preview; this will be removed when v5.2.0 is released for GA -->
-
-    <!-- Version override is specific to the v5.2.0 release from the branch; this will be removed and the package properties updated when merged to master -->
+    <!-- Version overrides are specific to the v5.2.0 release from the branch; this will be removed and the package properties updated when merged to master -->
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0" /> 
     <PackageReference Include="Azure.Storage.Blobs" VersionOverride="12.6.0"/>
     <!-- END v5.2.0 SPECIFIC OVERRIDES -->
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ﻿# Release History
 
+## 5.3.0-beta.1 (Unreleased)
+
 ## 5.2.0 (2020-09-08)
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.2.0</Version>
-    <ApiCompatVersion>5.1.0</ApiCompatVersion>
+    <Version>5.3.0-beta.1</Version>
+    <ApiCompatVersion>5.2.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the `Azure.Messaging.EventHubs.Processor` library for its September release and update the version information for the `Azure.Messaging.EventHubs` library.

# Last Upstream Rebase

Tuesday, September 8, 8:48am (EDT)