### PR TITLE
[Event Hubs Client] September Release Updates

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -18,9 +18,9 @@
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.0.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.0.1" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.1.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.0.1" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.2.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.2.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.2.0" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Update="Azure.Storage.Blobs.Batch" Version="12.1.1" />
     <PackageReference Update="Azure.Storage.Common" Version="12.1.1" />
     <PackageReference Update="Azure.Storage.Files.Shares" Version="12.0.1" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 5.2.0-preview.4 (Unreleased)
+## 5.3.0-beta.1 (Unreleased)
+
+## 5.2.0 (2020-09-08)
 
 ### Acknowledgments
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.2.0-preview.4</Version>
-    <ApiCompatVersion>5.1.0</ApiCompatVersion>
+    <Version>5.3.0-beta.1</Version>
+    <ApiCompatVersion>5.2.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0-preview.3" /> <!--Version override exists to bind to the preview; this will be removed when v5.2.0 is released for GA -->
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,8 @@
 ﻿# Release History
 
-## 5.2.0-preview.4 (Unreleased)
+## 5.3.0-beta.1 (Unreleased)
+
+## 5.2.0 (2020-09-08)
 
 ### Acknowledgments
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.2.0-preview.4</Version>
-    <ApiCompatVersion>5.1.0</ApiCompatVersion>
+    <Version>5.3.0-beta.1</Version>
+    <ApiCompatVersion>5.2.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to update versions and supporting assets to reflect the September release of the Event Hubs client packages.

# Last Upstream Rebase

Tuesday, September 8, 11:57am (EDT)