### PR TITLE
Add tests for multiple pages and resuming functionality

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -450,7 +450,7 @@ namespace Azure.DigitalTwins.Core
         /// <returns>The pageable list <see cref="AsyncPageable{T}"/> of application/json relationships belonging to the specified digital twin and the http response.</returns>
         /// <remarks>
         /// <para>
-        /// String relationships that are returned as part of the pageable list can always be deserialized into an instnace of <see cref="Serialization.BasicRelationship"/>.
+        /// String relationships that are returned as part of the pageable list can always be deserialized into an instance of <see cref="Serialization.BasicRelationship"/>.
         /// You may also deserialize the relationship into custom type that extend the <see cref="Serialization.BasicRelationship"/>.
         /// </para>
         /// <para>
@@ -1100,9 +1100,9 @@ namespace Azure.DigitalTwins.Core
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
         /// <para>
-        /// When a model is decomissioned, new digital twins will no longer be able to be defined by this model.
+        /// When a model is decommissioned, new digital twins will no longer be able to be defined by this model.
         /// However, existing digital twins may continue to use this model.
-        /// Once a model is decomissioned, it may not be recommissioned.
+        /// Once a model is decommissioned, it may not be recommissioned.
         /// </para>
         /// <para>
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
@@ -1123,7 +1123,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// catch (RequestFailedException ex)
         /// {
-        ///     FatalError($&quot;Failed to decommision model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to decommission model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1140,9 +1140,9 @@ namespace Azure.DigitalTwins.Core
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
         /// <para>
-        /// When a model is decomissioned, new digital twins will no longer be able to be defined by this model.
+        /// When a model is decommissioned, new digital twins will no longer be able to be defined by this model.
         /// However, existing digital twins may continue to use this model.
-        /// Once a model is decomissioned, it may not be recommissioned.
+        /// Once a model is decommissioned, it may not be recommissioned.
         /// </para>
         /// <para>
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
@@ -1339,7 +1339,7 @@ namespace Azure.DigitalTwins.Core
                 {
                     var querySpecification = new QuerySpecification
                     {
-                        Query = query
+                        Query = query,
                     };
                     Response<QueryResult> response = await _queryClient.QueryTwinsAsync(querySpecification, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Items, response.Value.ContinuationToken, response.GetRawResponse());

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
@@ -86,7 +86,7 @@ namespace Azure.DigitalTwins.Core.Tests
             string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
 
             int numberOfTwinsToCreate = 250;
-            IEnumerable<string> newTwinIds = getMultipleTwinIds(roomTwinId, numberOfTwinsToCreate);
+            IEnumerable<string> newTwinIds = GetMultipleTwinIds(roomTwinId, numberOfTwinsToCreate);
 
             try
             {
@@ -163,7 +163,7 @@ namespace Azure.DigitalTwins.Core.Tests
             }
         }
 
-        private IEnumerable<string> getMultipleTwinIds(string baseName, int count)
+        private IEnumerable<string> GetMultipleTwinIds(string baseName, int count)
         {
             var listOfTwinIds = new List<string>();
             for (int i = 0; i < count; i++)

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Azure.Core.TestFramework;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -25,6 +24,7 @@ namespace Azure.DigitalTwins.Core.Tests
 
             string floorModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.FloorModelIdPrefix).ConfigureAwait(false);
             string roomModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomModelIdPrefix).ConfigureAwait(false);
+            string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
 
             try
             {
@@ -35,7 +35,6 @@ namespace Azure.DigitalTwins.Core.Tests
                 await client.CreateModelsAsync(new List<string> { roomModel }).ConfigureAwait(false);
 
                 // Create a room twin, with property "IsOccupied": true
-                string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
                 string roomTwin = TestAssetsHelper.GetRoomTwinPayload(roomModelId);
                 await client.CreateDigitalTwinAsync(roomTwinId, roomTwin).ConfigureAwait(false);
 
@@ -61,12 +60,118 @@ namespace Azure.DigitalTwins.Core.Tests
                     {
                         await client.DeleteModelAsync(roomModelId).ConfigureAwait(false);
                     }
+
+                    if (!string.IsNullOrWhiteSpace(roomTwinId))
+                    {
+                        await client.DeleteDigitalTwinAsync(roomTwinId).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception ex)
                 {
                     Assert.Fail($"Test clean up failed: {ex.Message}");
                 }
             }
+        }
+
+        // TODO:azabbasi: Once you enable this test by removing the Ignore attribute, make sure to record and update session records.
+        [Test]
+        [Ignore("Waiting for Azure.Core to fix the issue with AsPages helper method")]
+        public async Task Query_MultiplePages_Resuming_Success()
+        {
+            DigitalTwinsClient client = GetClient();
+
+            string floorModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.FloorModelIdPrefix).ConfigureAwait(false);
+            string roomModelId = await GetUniqueModelIdAsync(client, TestAssetDefaults.RoomModelIdPrefix).ConfigureAwait(false);
+
+            string roomTwinId = await GetUniqueTwinIdAsync(client, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
+
+            int numberOfTwinsToCreate = 250;
+            IEnumerable<string> newTwinIds = getMultipleTwinIds(roomTwinId, numberOfTwinsToCreate);
+
+            try
+            {
+                //arrange
+
+                // Create room model
+                string roomModel = TestAssetsHelper.GetRoomModelPayload(roomModelId, floorModelId);
+                await client.CreateModelsAsync(new List<string> { roomModel }).ConfigureAwait(false);
+
+                // Create multiple room twins, with property "IsOccupied": true
+                // We do this to make sure the service is going to return multiple pages in the response.
+                List<Task> tasks = new List<Task>();
+
+                foreach (var twinName in newTwinIds)
+                {
+                    string roomTwin = TestAssetsHelper.GetRoomTwinPayload(roomModelId);
+                    tasks.Add(client.CreateDigitalTwinAsync(twinName, roomTwin));
+                }
+
+                Task.WaitAll(tasks.ToArray());
+
+                string queryString = "SELECT * FROM digitaltwins where IsOccupied = true";
+
+                // act
+                IAsyncEnumerable<Page<string>> asyncPageableResponse = client.QueryAsync(queryString).AsPages();
+                string continuationToken = null;
+
+                // Get the first page and store the continuation token.
+                await foreach (Page<string> page in asyncPageableResponse)
+                {
+                    Console.WriteLine(page.ContinuationToken);
+                    continuationToken = page.ContinuationToken;
+                    break;
+                }
+
+                // resume getting the query response by providing the continuation token.
+                IAsyncEnumerable<Page<string>> nextPages = client.QueryAsync(queryString).AsPages(continuationToken);
+                await foreach (Page<string> page in nextPages)
+                {
+                    // Make sure resume functionality works by comparing the new continuation token and the previously provided continuation token.
+                    Assert.AreNotEqual(
+                        continuationToken,
+                        page.ContinuationToken,
+                        "ContinuationToken should not remain the same when using resume functionality");
+
+                    break;
+                }
+            }
+            finally
+            {
+                //clean up
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(roomModelId))
+                    {
+                        await client.DeleteModelAsync(roomModelId).ConfigureAwait(false);
+                        if (!string.IsNullOrEmpty(roomTwinId))
+                        {
+                            List<Task> tasks = new List<Task>();
+
+                            foreach (string twinName in newTwinIds)
+                            {
+                                tasks.Add(client.DeleteDigitalTwinAsync(twinName));
+                            }
+
+                            Task.WaitAll(tasks.ToArray());
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Test clean up failed: {ex.Message}");
+                }
+            }
+        }
+
+        private IEnumerable<string> getMultipleTwinIds(string baseName, int count)
+        {
+            var listOfTwinIds = new List<string>();
+            for (int i = 0; i < count; i++)
+            {
+               listOfTwinIds.Add(baseName + $"random{i}");
+            }
+
+            return listOfTwinIds;
         }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_Success.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_Success.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b9ca1fd8ec40a90b8d26d9a58145dec3",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:35 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "53d8872f713948a15966c72f58e80f24",
         "x-ms-return-client-request-id": "true"
@@ -46,13 +46,41 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:35 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
           "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:room;180130729. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin286818603?api-version=2020-05-31-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d734488d2adade00bc15c4e97149195c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin286818603. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
@@ -65,10 +93,10 @@
         "Content-Length": "804",
         "Content-Type": "application/json; charset=utf-8",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "34488d2bdad7002adebc15c4e9714919",
+        "x-ms-client-request-id": "b993bcd49eed28ad70e7854479343eca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;180130729\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;17516826\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
@@ -76,49 +104,21 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:36 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;180130729\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-08-21T02:42:36.9045956\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;180130729\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-09-08T23:50:32.7390368\u002B00:00\u0022}]"
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin77902172?api-version=2020-05-31-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
-        ],
-        "x-ms-client-request-id": "b993bcd49eed28ad70e7854479343eca",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "269",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:36 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin77902172. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin77902172?api-version=2020-05-31-preview",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin286818603?api-version=2020-05-31-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "150",
         "Content-Type": "application/json; charset=utf-8",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "96b85680cb8f5d55d7757c5bdd5fe71d",
         "x-ms-return-client-request-id": "true"
@@ -126,15 +126,15 @@
       "RequestBody": "{  \u0022$metadata\u0022: {    \u0022$model\u0022: \u0022dtmi:example:room;180130729\u0022  },  \u0022Temperature\u0022: 80,  \u0022Humidity\u0022: 25,  \u0022IsOccupied\u0022: true,  \u0022EmployeeId\u0022: \u0022Employee1\u0022}",
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "658",
+        "Content-Length": "659",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:36 GMT",
-        "ETag": "W/\u0022a545749d-3182-4460-993a-ebe496816992\u0022",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "ETag": "W/\u0022b777c893-d416-47a9-a86f-da0751ee414c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin77902172",
-        "$etag": "W/\u0022a545749d-3182-4460-993a-ebe496816992\u0022",
+        "$dtId": "roomTwin286818603",
+        "$etag": "W/\u0022b777c893-d416-47a9-a86f-da0751ee414c\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -181,8 +181,8 @@
         "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2c84d3ad6b7cef3d9a0b66f2a4bc6488",
         "x-ms-return-client-request-id": "true"
@@ -192,14 +192,10727 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "37",
+        "Content-Length": "67381",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:36 GMT",
-        "query-charge": "2.79",
+        "Date": "Tue, 08 Sep 2020 23:50:33 GMT",
+        "query-charge": "25.86",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "items": [],
+        "items": [
+          {
+            "$dtId": "roomTwin1402882860",
+            "$etag": "W/\u00229d573bee-612b-4f21-aa62-9b9256e07665\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119099593",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1109090776",
+            "$etag": "W/\u00223d128102-d411-4612-ab12-623a9d74db01\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;112607543",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2138110373",
+            "$etag": "W/\u00224ad78fc7-2a79-4487-8ef1-c56e4e1280e4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;117001227",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin54248529",
+            "$etag": "W/\u0022f2493ae8-e187-4c19-8f99-d5e63ab7f7bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;177323580",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1259202816",
+            "$etag": "W/\u0022a743939a-e23b-49a3-830d-3cdac414f1f4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;177323580",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002254970a46-0a67-4cb8-b036-a586dd0cefe1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u0022d2899188-9c9b-45dc-8273-dcfc598a18d9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomWithWifiTwin474299538",
+            "$etag": "W/\u002227b97d1a-8204-4b77-aa77-94492e9bd0e0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "wifiAccessPoint": {
+              "RouterName": "Cisco1",
+              "Network": "Room1",
+              "$metadata": {
+                "RouterName": {
+                  "desiredValue": "Cisco1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                },
+                "Network": {
+                  "desiredValue": "Room1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                }
+              }
+            },
+            "$metadata": {
+              "$model": "dtmi:example:wifiroom;14907",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin783776230",
+            "$etag": "W/\u0022ca7909a5-90fa-4b6c-9d4b-5f90b88bb623\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;110454602",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2074187830",
+            "$etag": "W/\u00227955c8fe-8c91-4439-85b7-f3e8c95532c5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120670516",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1402305145",
+            "$etag": "W/\u00228b39b064-b47f-4396-9312-1c42ff1da699\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120615932",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random6",
+            "$etag": "W/\u00220e8b5247-8fc6-41c8-983a-675c1cbc7c19\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random8",
+            "$etag": "W/\u0022cc922dbd-7cc6-4917-bc3a-2affdd5a75df\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random4",
+            "$etag": "W/\u00226d343169-dbaa-4def-ad4d-6ca770a0abc4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random5",
+            "$etag": "W/\u0022bf970d0d-1179-4666-9d50-5397b082e333\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random7",
+            "$etag": "W/\u0022cc7307ba-9d77-4c81-9990-b228e19c7c2f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random12",
+            "$etag": "W/\u002209bb6816-f5f8-4178-bdf1-dd4be0c57fee\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random13",
+            "$etag": "W/\u0022045b0783-f518-4013-9fb3-9cab69ec7198\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random14",
+            "$etag": "W/\u00222ac0dd90-0eb2-4995-90e6-9bbde17df18c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random18",
+            "$etag": "W/\u002207241852-c4d9-4b69-9fd7-e9da28bc414f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random21",
+            "$etag": "W/\u0022151839f1-e292-4eb7-b42d-c6cf61b1bbea\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random22",
+            "$etag": "W/\u00226aacca73-8ce6-4282-8269-48d1f233363f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random23",
+            "$etag": "W/\u00225e4f3ba0-04a9-412a-8c43-520efa6e3b5c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random24",
+            "$etag": "W/\u002261bfd3fb-60cf-445b-9cec-5ab8448d0d00\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random28",
+            "$etag": "W/\u002279d58a4a-4afc-4629-9aad-9da93dcaaf2e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random31",
+            "$etag": "W/\u00226df4f860-047c-45f9-9812-33b4ed79abe4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random32",
+            "$etag": "W/\u0022a4e733d2-d5e1-4718-bd29-cf1d4c09b93d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random34",
+            "$etag": "W/\u002213dc8a1a-ec25-4918-87ca-6be0e799ba16\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random36",
+            "$etag": "W/\u0022e2c9963b-1c46-4a10-b03c-5af29ffa4e1a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random37",
+            "$etag": "W/\u0022ae2c8fe8-34f6-4fc1-af57-7a63d8c22c17\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random44",
+            "$etag": "W/\u002271b1b856-6dcd-4e75-a32f-7a0b104b9dd1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random45",
+            "$etag": "W/\u00221fdf5f6c-0c81-4c4a-aeeb-be140a94aec4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random46",
+            "$etag": "W/\u0022aba54bf1-5666-4ae4-875f-71b47e0b0ffe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random47",
+            "$etag": "W/\u0022806a871b-eb40-44a3-a9a1-d9691e5aa3be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random50",
+            "$etag": "W/\u00221b69d8d9-7637-4a15-a45f-5b016492de6d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random51",
+            "$etag": "W/\u0022f914c127-4bc5-4598-90c1-fa900e3c342e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random52",
+            "$etag": "W/\u0022b073e810-06d4-43ea-b0f5-8a82e7e8a5b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random56",
+            "$etag": "W/\u002248616b1c-0ec6-467f-bb45-ed5511f8896f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random57",
+            "$etag": "W/\u00227ffdc5c8-b2c3-4af2-8aee-1002923e5929\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random58",
+            "$etag": "W/\u002289d0fe31-7fa6-474e-9a7d-4b99b4dcde0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random60",
+            "$etag": "W/\u00223559d97a-770e-4e0b-9d21-87d25eb7ffea\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random61",
+            "$etag": "W/\u0022f2fbd307-12d4-4e20-8d04-782b13715a24\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random62",
+            "$etag": "W/\u00222dcb2862-3ca3-4a33-aa37-0df787e9f921\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random67",
+            "$etag": "W/\u0022082b246a-4822-450c-8292-c61a1ec3d501\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random68",
+            "$etag": "W/\u002240bde673-12a1-4a8e-824d-7bc6c3a369bd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random70",
+            "$etag": "W/\u0022f5682c8f-1027-462f-a950-5c11f4e89497\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random71",
+            "$etag": "W/\u002237962897-f8ce-418d-af20-1dfe3cee6e65\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random76",
+            "$etag": "W/\u0022b1182327-4b5e-4147-899d-1474f7cc706d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random78",
+            "$etag": "W/\u0022498189d1-4cde-463f-a4bc-4c1aa54be349\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random82",
+            "$etag": "W/\u00226a17303d-d129-4cae-8f11-855cd0374c2a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random83",
+            "$etag": "W/\u002264c15d5a-6c89-4205-b31a-9c2cdded6fb6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random85",
+            "$etag": "W/\u002243fbe576-c2eb-4774-b9b2-c38827403b26\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random87",
+            "$etag": "W/\u0022942b82db-6031-47ff-a60d-e962f36edc85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random88",
+            "$etag": "W/\u002217909da2-25fb-41bf-9f28-b6a8cf4dc989\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random90",
+            "$etag": "W/\u0022c322c1c9-d9d1-4677-9ffd-d0f9534bdde1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random91",
+            "$etag": "W/\u0022159917d2-c213-4ea5-b3e4-815e23c501d8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random93",
+            "$etag": "W/\u002296c4a70e-35e6-4946-8f96-3b80c1107c53\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random94",
+            "$etag": "W/\u002221760ef3-0d11-4d48-8182-ae0fab6c3aa0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random98",
+            "$etag": "W/\u0022fdcb28ce-f6b7-41db-83d0-f04c3684ec8b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random99",
+            "$etag": "W/\u0022533a2df6-ad2e-41ea-846d-dac101995058\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random101",
+            "$etag": "W/\u0022f649b914-6663-4594-b19c-ac696a6e7042\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random102",
+            "$etag": "W/\u00226027afab-d85b-4034-9105-75efa9b66d03\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random106",
+            "$etag": "W/\u00225b900ab8-8edc-4d7f-bd6b-07ef1d989e12\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random111",
+            "$etag": "W/\u002245f1dc82-e7f3-46a4-b4bc-bcb98655bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random117",
+            "$etag": "W/\u0022bdcf52f8-8a09-4b13-8296-a8eb870805ed\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random119",
+            "$etag": "W/\u002289f3b6bc-a9b5-4ce3-b8b5-cff48002a540\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random120",
+            "$etag": "W/\u002289e485a4-d88f-4c4c-9fef-5e171b804a3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random121",
+            "$etag": "W/\u00222c552298-e2b9-497c-9d09-2503400aad9a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random123",
+            "$etag": "W/\u0022f4344cca-9e37-42f2-8ef3-0ae53b2e77a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random125",
+            "$etag": "W/\u00223766d3b2-a29a-44ef-b6bb-690509a19c51\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random129",
+            "$etag": "W/\u002246138a2b-e6c1-46c3-ad72-82128e82d15b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random130",
+            "$etag": "W/\u00221244fcec-9728-44ba-9c14-c51c548458c9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random131",
+            "$etag": "W/\u0022154c21a1-e6b4-45d8-aa7b-7a7fa70f5b18\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random132",
+            "$etag": "W/\u002276cb5ffa-32b2-4ec8-8dce-3abfd8cdb280\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random135",
+            "$etag": "W/\u00221e59c7a2-ea39-4122-90b0-3a962c7215e3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random136",
+            "$etag": "W/\u0022da0d1c42-19c9-47b9-ba04-511b837b0c94\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random139",
+            "$etag": "W/\u00222089e178-ba20-4573-9dcd-72340b84a716\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random140",
+            "$etag": "W/\u0022a59cc326-efa1-4e1c-957f-691f36f8fd31\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random142",
+            "$etag": "W/\u00223f126193-fcc1-45d0-b3a9-99a1a0f96d08\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random143",
+            "$etag": "W/\u0022f32f8f80-90af-4f46-863c-2188aaf6b389\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random145",
+            "$etag": "W/\u002251601ae7-6ec5-4398-8848-9d5a8249d954\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random147",
+            "$etag": "W/\u002222e41cde-defb-4372-a063-263b79fda486\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random150",
+            "$etag": "W/\u0022dd831905-f185-469f-9020-994b70be1c5f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random151",
+            "$etag": "W/\u0022e00db56a-0243-4d9f-84dd-87a4747a7aac\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random153",
+            "$etag": "W/\u00222ae4e503-742d-49b1-bc32-2be5c2baaba6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random156",
+            "$etag": "W/\u0022de569fd2-71b0-4f0b-880f-526c5a8aeeb6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random157",
+            "$etag": "W/\u0022440dc0b2-99e8-45f9-86a2-cb26deab7822\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random158",
+            "$etag": "W/\u0022821569a4-194c-468c-b0f7-a7f75b02ab35\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random159",
+            "$etag": "W/\u00221d300851-391b-4e3e-bcff-b7eb1fc85ae1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random164",
+            "$etag": "W/\u0022de352d6b-5e77-48f4-b6b7-92b0cf789198\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random165",
+            "$etag": "W/\u0022712962c4-ee74-44d9-bf45-8bad29079d84\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random171",
+            "$etag": "W/\u0022e9eed66c-4cbb-41dd-8371-21298c285815\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random174",
+            "$etag": "W/\u0022990d3f5d-e475-44de-83d0-f531accf1f84\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random175",
+            "$etag": "W/\u00223e6817f9-2579-4c51-a22b-ef50719368bd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random177",
+            "$etag": "W/\u002244830686-8328-44a6-9874-6d30166ae1b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random178",
+            "$etag": "W/\u00220af70c5b-d8ee-405f-ade7-0d435b1e311d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random181",
+            "$etag": "W/\u00228a773751-0c6b-4ec9-8ef5-c2489fa6e802\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random182",
+            "$etag": "W/\u00228005036e-f67d-4188-b459-a846741c2ffe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random183",
+            "$etag": "W/\u002205716c9a-63e5-4df1-a283-a76988b35555\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random186",
+            "$etag": "W/\u0022afa6c27a-419b-4269-845e-344632abf482\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqReAQAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AV4BAAAAAAAAfgEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-05-31-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "416",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1a68fad7839009cc6735e17821524b11",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqReAQAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AV4BAAAAAAAAfgEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "72037",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 08 Sep 2020 23:50:33 GMT",
+        "query-charge": "29.589999999999996",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "$dtId": "roomTwin617148482random188",
+            "$etag": "W/\u0022133b2ea2-6991-4f80-9ae0-7b4abdbe7924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random189",
+            "$etag": "W/\u00229e919296-f7c4-4acc-b3e0-fde95f6a75b5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random190",
+            "$etag": "W/\u00223866dac5-2ac8-4dad-b462-88b1bf22baf2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random191",
+            "$etag": "W/\u002274af214e-8f6a-46ba-a494-e1dbb29ca55a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random194",
+            "$etag": "W/\u0022a9cddf78-f5bf-4108-a100-6f7a1e084b00\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random196",
+            "$etag": "W/\u00220010bbec-1492-4124-86cd-9d144edc8737\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random197",
+            "$etag": "W/\u0022fb96f9e3-ecc7-4a95-839f-505ceae76245\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random198",
+            "$etag": "W/\u002201666f3b-2a6b-449d-81fe-39cfeec2d083\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random200",
+            "$etag": "W/\u002209614d4c-38f3-4ae1-9903-935d26b81ccb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random202",
+            "$etag": "W/\u0022cd29be13-1286-41b9-bbed-aa4372485205\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random206",
+            "$etag": "W/\u0022a071d98b-ff79-4856-8b8a-65080c08f00c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random209",
+            "$etag": "W/\u0022e886b481-9943-4ff2-91ae-4b047685526e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random210",
+            "$etag": "W/\u0022bd5233e0-b395-4d44-8118-7f1849b2b78c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random212",
+            "$etag": "W/\u0022beb4459e-8b43-495c-8f74-646e60e70f1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random213",
+            "$etag": "W/\u0022cc55d2ce-b6f6-4f6f-b378-f9dd185ce593\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random214",
+            "$etag": "W/\u002222438199-48e7-484a-b86d-03174090e28d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random215",
+            "$etag": "W/\u002271e8faaa-6906-4f4d-90ef-40e5de0b92f4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random216",
+            "$etag": "W/\u0022a4a640e8-d35b-4301-a8c8-4d5f35123caf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random218",
+            "$etag": "W/\u002244ffb034-1871-45a8-821d-598776734186\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random219",
+            "$etag": "W/\u0022c6aa29a8-9b42-4023-9934-996f6af80f58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random220",
+            "$etag": "W/\u00226044a052-889c-42c3-951a-b33f3a12020e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random225",
+            "$etag": "W/\u0022025b9cb0-19cd-4c71-a5ec-b62dfddcd15a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random229",
+            "$etag": "W/\u002288cf0681-1c44-4b8a-90a7-18d55f1238d3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random230",
+            "$etag": "W/\u00224f2375a6-1d13-44d0-84cb-6928b0a50aeb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random234",
+            "$etag": "W/\u0022edee499e-f62e-4835-a736-d17f106a676a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random237",
+            "$etag": "W/\u002215ec8040-11c4-4912-8e87-a23846a7cb0b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random240",
+            "$etag": "W/\u002256845622-5742-4566-bd15-7f65787cb64c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random243",
+            "$etag": "W/\u0022a2e96a08-e425-4e62-b993-03e4bcab9e67\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random244",
+            "$etag": "W/\u00228d6a2320-9a3c-49b9-a563-7c38db547f05\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random246",
+            "$etag": "W/\u00229eb832ac-654f-441f-8dcc-0d013249ee95\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random248",
+            "$etag": "W/\u002260014ed3-dcb4-4478-a43a-0589a221c66f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random249",
+            "$etag": "W/\u0022c0a217b7-b7e0-4421-9292-eabdc6203b39\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2013649222",
+            "$etag": "W/\u0022c25b8183-8b0e-4553-829c-4b4019d83530\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;187060801",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1823984986",
+            "$etag": "W/\u00225c41a39e-43ea-4382-ab92-abdd1f180391\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;15155852",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin129896917",
+            "$etag": "W/\u0022cd5f8a13-7005-4a1b-aa98-85ba26454036\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;117001227",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u00221d4bdb84-0306-442d-bc7e-ea3c93c27ad1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2008572996",
+            "$etag": "W/\u0022af515f36-a229-4fbf-b492-d4d51269fe76\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;117898422",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1917345053",
+            "$etag": "W/\u0022558eff3f-88f9-4bec-863c-0eed6cc4791f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115056348",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u00229168c38d-385d-42fc-99e4-de129f18e3aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u00227233c708-a75c-4d50-bb5f-d4243208ff9c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "RoomTwin",
+            "$etag": "W/\u0022e2c607fb-00e1-4d6f-a971-d12b9fb6db8b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "wifiAccessPoint": {
+              "RouterName": "Cisco1",
+              "Network": "Room1",
+              "$metadata": {
+                "RouterName": {
+                  "desiredValue": "Cisco1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                },
+                "Network": {
+                  "desiredValue": "Room1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                }
+              }
+            },
+            "$metadata": {
+              "$model": "dtmi:samples:Room;1",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1436994705",
+            "$etag": "W/\u0022d560344f-0281-4494-a5f5-28cf276e9f9e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;110946152",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1956725720",
+            "$etag": "W/\u002216ca7223-38b5-42c0-adef-1974cb0774bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119969462",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random2",
+            "$etag": "W/\u0022f96297e7-446a-4ab4-81ac-64e7d0d9c8f9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random1",
+            "$etag": "W/\u0022b21c95b3-0dd5-458b-9d81-8c788c9799a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random9",
+            "$etag": "W/\u002218decdd8-a20d-4627-be1a-5d9b90f6207b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random0",
+            "$etag": "W/\u002232a9b6a6-388b-4e06-bf9f-599f4f54463d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random3",
+            "$etag": "W/\u0022d5459bfa-8549-4525-9309-63e60a87a408\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random10",
+            "$etag": "W/\u00224d272ad0-ddf5-4426-b2f0-07f86edf1b4d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random11",
+            "$etag": "W/\u0022141b8c78-f857-4f3a-9a0d-711573ec7834\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random15",
+            "$etag": "W/\u002269bbd4af-5595-409d-ab65-46b9706debf6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random16",
+            "$etag": "W/\u0022546be82c-a070-4909-8b11-799439db0262\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random17",
+            "$etag": "W/\u00228a7dec81-73ad-4cef-a040-5e097cb928fe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random19",
+            "$etag": "W/\u00225c134802-27c6-4f78-9ecf-d39e797a4c87\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random20",
+            "$etag": "W/\u0022dae9ab9e-248e-4f37-8352-6c8277398181\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random25",
+            "$etag": "W/\u0022a2778e16-288e-4a97-8542-8c2486f7c2f7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random26",
+            "$etag": "W/\u0022aba01caf-14ac-4092-b5ea-c3089bc0fc9b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random27",
+            "$etag": "W/\u00226684cc84-550e-42fd-8094-24cd286ad07f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random29",
+            "$etag": "W/\u00221e1fcda9-21f7-47ba-90ba-34abd2e4e1ba\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random30",
+            "$etag": "W/\u0022ff2fcbf8-490a-4d4b-aee7-4c01e61d90b9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random33",
+            "$etag": "W/\u00228554c137-b840-4a51-8962-28c3c495e7c1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random35",
+            "$etag": "W/\u00220a85e34d-1a48-406c-8f39-57f49949d9aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random38",
+            "$etag": "W/\u00224ad947a5-d52f-4bbb-9aee-ec41d714b0de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random39",
+            "$etag": "W/\u0022a2feb89a-6779-4151-b358-1a8e1b24da2a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random40",
+            "$etag": "W/\u002265b7293f-85b7-476f-b237-5042c5771f22\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random41",
+            "$etag": "W/\u0022848048a3-0774-4f54-a830-e3d1e3c57d5d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random42",
+            "$etag": "W/\u00223c694f8e-2bf7-40cd-84f2-a53dc20a6ec1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random43",
+            "$etag": "W/\u002201ff8dd5-600b-46bc-bef3-3c89647c90c6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random48",
+            "$etag": "W/\u00225f8f4268-a1f6-4b03-a1f8-716c161e69d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random49",
+            "$etag": "W/\u0022d3bc31da-be3a-472e-bb1e-771bd4af491a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random53",
+            "$etag": "W/\u0022ef837608-ce8e-4049-828a-c99a975aabf3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random54",
+            "$etag": "W/\u00222fd6f7c5-b1f0-48b8-87a8-ded3b66e6f6f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random55",
+            "$etag": "W/\u0022d8b215f3-b224-4681-a3ce-86729cd08258\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random59",
+            "$etag": "W/\u0022d389125f-a463-48bc-863b-8fb13b2706ae\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random63",
+            "$etag": "W/\u00227b50cc1f-12e9-462d-8873-948afad4acee\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random64",
+            "$etag": "W/\u0022c2fe4e74-2afc-483b-b0d8-681cc01e6870\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random65",
+            "$etag": "W/\u0022650f90ee-2475-43d1-bf10-c61248597996\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random66",
+            "$etag": "W/\u0022c9443ceb-7085-4ec4-9bb6-b7491d343894\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random69",
+            "$etag": "W/\u00225e42c69b-5454-48be-976f-584d1475c819\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random72",
+            "$etag": "W/\u00220fe9d9bc-e443-4ab0-8fc2-257e39425cad\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random73",
+            "$etag": "W/\u0022f3208b5e-d868-477d-adc8-955330a406cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random74",
+            "$etag": "W/\u002256605118-3fc8-415f-904a-1f4494c46e8e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random75",
+            "$etag": "W/\u00228081e4e4-632b-41be-8973-75acb469c488\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random77",
+            "$etag": "W/\u0022df62cf9d-02cc-4c47-835c-9b3786c4f460\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random79",
+            "$etag": "W/\u0022a09c8de5-b851-49a8-8392-88f3fae36a1b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random80",
+            "$etag": "W/\u0022301d795c-06ba-45e4-8946-fbaa14347e56\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random81",
+            "$etag": "W/\u0022397b7389-8ba2-424d-a13e-936a620c18a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random84",
+            "$etag": "W/\u0022f11ca50f-3e1f-42d7-9eac-c716e2510637\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random86",
+            "$etag": "W/\u00226ab54979-4b17-4bbe-bf23-a0766e563fca\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random89",
+            "$etag": "W/\u0022abaebb84-920b-42e3-aff4-a8f12e163df0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random92",
+            "$etag": "W/\u0022eefaab9e-6338-4295-afa3-67ebd817b750\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random95",
+            "$etag": "W/\u002263102413-3e92-4c8f-9218-c23528fd97ab\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random96",
+            "$etag": "W/\u00222d7fea08-81a8-49f4-9d24-f742e3312d4f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random97",
+            "$etag": "W/\u0022d940eb75-b54a-41d9-a960-5219ec9b8eff\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random100",
+            "$etag": "W/\u0022e0a5726c-50e9-47f1-af55-e4ec329bbd91\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random103",
+            "$etag": "W/\u0022759f036e-6c3f-4bf7-843a-001e64a54061\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random104",
+            "$etag": "W/\u002253e2176c-d99b-41aa-ac33-1b3c9a598607\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random105",
+            "$etag": "W/\u0022b7e07188-6344-411b-8b65-8ed3cf4e7eb5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random107",
+            "$etag": "W/\u0022f95b45e7-b69e-4ef7-97a7-27833962757c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random108",
+            "$etag": "W/\u0022e55a247f-f4d6-4ff9-9b8a-7dcae9a084ca\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random109",
+            "$etag": "W/\u002271d97392-c8fd-4936-86e8-adcad8d16803\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random110",
+            "$etag": "W/\u00221d8190c5-efa4-4fdb-94d5-526e355f3a7e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random112",
+            "$etag": "W/\u00227a94859c-fcc8-4cfb-a487-7af16cc7a352\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random113",
+            "$etag": "W/\u002224dae20f-330d-4a8c-a50f-6c9ed325fdbe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random114",
+            "$etag": "W/\u00221052cf61-4be6-4fa8-a85f-cb6558ec491e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random115",
+            "$etag": "W/\u00221e22619d-9d38-4c7b-8742-eb19deafddef\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random116",
+            "$etag": "W/\u00226fd71e8a-4f3f-443a-a4e5-fde64c65ef4e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqR5AQAAAAAACA==#RT:3#TRC:75#ISV:2#IEO:65551#FPC:AXkBAAAAAAAIugEAAAAAAAg=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-05-31-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "417",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a69667ff12b0154d19c9fc836462b81b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqR5AQAAAAAACA==#RT:3#TRC:75#ISV:2#IEO:65551#FPC:AXkBAAAAAAAIugEAAAAAAAg=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "43521",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 08 Sep 2020 23:50:33 GMT",
+        "query-charge": "17.72",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "$dtId": "roomTwin617148482random118",
+            "$etag": "W/\u002297299934-2941-4065-a249-c6c785b1e8de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random122",
+            "$etag": "W/\u00226e8a4984-68ea-4d36-91c6-6b45fb4595e6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random124",
+            "$etag": "W/\u00220dc6527e-5244-4ad4-a8e7-6a34707eeafc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random126",
+            "$etag": "W/\u0022adb454b2-e10a-4bd5-b827-cb576e080413\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random127",
+            "$etag": "W/\u00223c55e031-287f-40cf-aab8-affd922ce8e6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random128",
+            "$etag": "W/\u00220346ed64-4a86-46fe-94db-464d39ce4b8f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random133",
+            "$etag": "W/\u0022479023b3-a63f-41e0-8dc1-c13179629cdd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random134",
+            "$etag": "W/\u00225b0a393b-6d0e-4ec4-bdd5-dd1cfc639347\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random137",
+            "$etag": "W/\u00226cb380fb-a089-4896-b64e-0df03d755881\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random138",
+            "$etag": "W/\u0022e28d8a9f-3a93-4401-974c-7df7117649ff\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random141",
+            "$etag": "W/\u0022f8f52223-5fb2-4fb1-8936-e34b0a367e1e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random144",
+            "$etag": "W/\u0022afddb3b8-29c4-4977-8443-87f2e303c10d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random146",
+            "$etag": "W/\u0022c7e9cb17-1855-4205-94a3-a1c68466cbe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random148",
+            "$etag": "W/\u0022c9e10048-ae79-49c7-9279-c1591c193979\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random149",
+            "$etag": "W/\u0022a2ae38dc-fdeb-43e2-bf4d-01e2d63d72fc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random152",
+            "$etag": "W/\u0022af1e389b-68de-462f-a602-bf889bef96af\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random154",
+            "$etag": "W/\u0022e36fb80d-36f6-47b7-b17c-1027c209b77b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random155",
+            "$etag": "W/\u00229c53a23e-205c-44d1-a025-11d41a5f9b58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random160",
+            "$etag": "W/\u0022c1672fbf-910d-47a2-8b26-142897681c09\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random161",
+            "$etag": "W/\u002268421b96-27af-444e-ac63-a7913145b049\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random162",
+            "$etag": "W/\u0022214cfd7d-2bcf-4144-b348-705729db2303\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random163",
+            "$etag": "W/\u0022e02563b5-0d6c-49bd-b290-37dbdd7c0380\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random166",
+            "$etag": "W/\u00224774b4d0-da5c-46b5-bf5f-6465785acbbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random167",
+            "$etag": "W/\u0022dcd9c24f-ffad-4375-a12d-36fb36e337f5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random168",
+            "$etag": "W/\u002252d528fa-824a-4b2d-bbc0-263676b08254\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random169",
+            "$etag": "W/\u0022c7bd55cc-50f2-4bec-b047-009948b80769\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random170",
+            "$etag": "W/\u0022fd0d60b6-8517-40ed-b5bc-2c56933ba15d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random172",
+            "$etag": "W/\u0022f49b3c34-5ffb-46e5-81e0-6b4aa769db17\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random173",
+            "$etag": "W/\u00225b71ea38-30e6-4876-b4cf-bd330851d903\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random176",
+            "$etag": "W/\u002228798da1-2103-4e45-908b-86d1039a49da\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random179",
+            "$etag": "W/\u00226e499d91-bdab-4c3b-93cd-f068a014ff71\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random180",
+            "$etag": "W/\u00225e2ace13-eef0-4762-858e-c69a9bfb1b63\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random184",
+            "$etag": "W/\u002279207ac9-0c7f-456b-85a4-588ff8941475\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random185",
+            "$etag": "W/\u0022191aedbe-3e1f-41c9-a475-6404b2b5a2b3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random187",
+            "$etag": "W/\u00221b21ed24-1600-4e85-9ce1-68630067b7b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random192",
+            "$etag": "W/\u0022d254b00e-64f8-412e-9ff0-62d1b585be17\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random193",
+            "$etag": "W/\u002218c65b5e-a797-4e9b-9b7e-62e0192465b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random195",
+            "$etag": "W/\u0022e1abb9e2-a0a4-42c5-9803-b3ca4a42e1aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random199",
+            "$etag": "W/\u0022d9600ba5-9960-4bde-acc6-a2979f7204d3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random201",
+            "$etag": "W/\u00223014e54f-28c9-416f-b5e2-6e7311d48b10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random203",
+            "$etag": "W/\u0022623d6d80-6505-4079-aa46-58539b13db55\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random204",
+            "$etag": "W/\u002232efca2b-8107-4d55-9171-ff120da50be7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random205",
+            "$etag": "W/\u002237fff783-90f1-4031-953f-eb9fd07a38b9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random207",
+            "$etag": "W/\u00220d93e9b5-b7e1-4e49-a053-ecd8da16408f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random208",
+            "$etag": "W/\u00222771151f-a9cc-42e5-950f-aa8dad1fa258\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random211",
+            "$etag": "W/\u00220f66f210-baee-4565-b3ed-4e50ec0cbc52\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random217",
+            "$etag": "W/\u0022c3725c1f-8321-4f02-85e7-5f72deac1cfc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random221",
+            "$etag": "W/\u0022d1939576-b174-433a-8c55-80fe9cf2a2cd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random222",
+            "$etag": "W/\u0022e7109590-ea84-4c9f-85f4-7500e21adc08\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random223",
+            "$etag": "W/\u002294b162a2-7d87-4499-8db9-012c7c8d7a5a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random224",
+            "$etag": "W/\u002291daefca-b44c-4063-ae59-8cb6c435bb9f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random226",
+            "$etag": "W/\u002247f7e095-3f6b-450d-bad8-5feafd7b558d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random227",
+            "$etag": "W/\u002216069d80-1c24-46c2-9a92-8389776a70d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random228",
+            "$etag": "W/\u002273ac0c3a-4a36-4558-8066-ec5e950d6c39\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random231",
+            "$etag": "W/\u002267282cb1-1609-45e7-bfaa-f470040e98cb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random232",
+            "$etag": "W/\u0022589e71ca-7512-4288-8d53-6f0875fa71e8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random233",
+            "$etag": "W/\u0022699df15f-cc94-4803-b7af-a9807d76ec8e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random235",
+            "$etag": "W/\u0022e13277af-1e54-4a28-b1c4-e444a6c2c7e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random236",
+            "$etag": "W/\u00227d930100-21a1-4ec9-aa0f-c4efe2e9684f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random238",
+            "$etag": "W/\u0022fd0ac9e5-0025-4560-8289-49f6a99414f5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random239",
+            "$etag": "W/\u0022cf406335-636b-441e-8d29-aed57f5cb7b2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random241",
+            "$etag": "W/\u0022e2c1923a-8e71-419d-9c13-4dd0df33a506\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random242",
+            "$etag": "W/\u0022d5df815e-4783-4d5b-b93e-02c91516e557\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random245",
+            "$etag": "W/\u002274c2aac3-d324-4c02-bef6-f3c627880686\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random247",
+            "$etag": "W/\u0022b0f55240-a0ea-407f-ad06-089bbb1cdd04\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          }
+        ],
         "continuationToken": null
       }
     },
@@ -210,17 +10923,39 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "1a68fad7839009cc6735e17821524b11",
+        "x-ms-client-request-id": "e383f410ccf72a8d067ac44689c5cd47",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 21 Aug 2020 02:42:36 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:33 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin286818603?api-version=2020-05-31-preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3cf355bfbe25c5d7ac5201c78648a405",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 08 Sep 2020 23:50:33 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_SuccessAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_SuccessAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fa97b3e673c1795cb4d508fd78961ec8",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:36 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4a164ce3e3b36b015cbff77b83d297fd",
         "x-ms-return-client-request-id": "true"
@@ -46,13 +46,41 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:37 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
           "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:room;123439021. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1761111288?api-version=2020-05-31-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "00d5f4d0d0f763f248c4fd82796841fd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 08 Sep 2020 23:50:31 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1761111288. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
@@ -65,10 +93,10 @@
         "Content-Length": "804",
         "Content-Type": "application/json; charset=utf-8",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d5f4d0f8f700f2d06348c4fd82796841",
+        "x-ms-client-request-id": "33de3ee132da95cf8e65b364fd310370",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;123439021\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;12337958\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
@@ -76,49 +104,21 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:37 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;123439021\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-08-21T02:42:37.8722364\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;123439021\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-09-08T23:50:32.6966624\u002B00:00\u0022}]"
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1982570493?api-version=2020-05-31-preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
-        ],
-        "x-ms-client-request-id": "33de3ee132da95cf8e65b364fd310370",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:37 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1982570493. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1982570493?api-version=2020-05-31-preview",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1761111288?api-version=2020-05-31-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "150",
         "Content-Type": "application/json; charset=utf-8",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2ac67fffc5f37cec23e76b1f04e9e256",
         "x-ms-return-client-request-id": "true"
@@ -128,13 +128,13 @@
       "ResponseHeaders": {
         "Content-Length": "660",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:37 GMT",
-        "ETag": "W/\u00228d8485c8-ffa9-41b6-ac33-23d951a1cfdd\u0022",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "ETag": "W/\u0022f3dd2c7f-2b01-45d6-8fea-ddac0e30d401\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1982570493",
-        "$etag": "W/\u00228d8485c8-ffa9-41b6-ac33-23d951a1cfdd\u0022",
+        "$dtId": "roomTwin1761111288",
+        "$etag": "W/\u0022f3dd2c7f-2b01-45d6-8fea-ddac0e30d401\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -181,8 +181,8 @@
         "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "93a27db5c9b89d1e244071921c8d6517",
         "x-ms-return-client-request-id": "true"
@@ -192,14 +192,10727 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "37",
+        "Content-Length": "67381",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 21 Aug 2020 02:42:38 GMT",
-        "query-charge": "2.79",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "query-charge": "25.86",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "items": [],
+        "items": [
+          {
+            "$dtId": "roomTwin1402882860",
+            "$etag": "W/\u00229d573bee-612b-4f21-aa62-9b9256e07665\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119099593",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1109090776",
+            "$etag": "W/\u00223d128102-d411-4612-ab12-623a9d74db01\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;112607543",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2138110373",
+            "$etag": "W/\u00224ad78fc7-2a79-4487-8ef1-c56e4e1280e4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;117001227",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin54248529",
+            "$etag": "W/\u0022f2493ae8-e187-4c19-8f99-d5e63ab7f7bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;177323580",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1259202816",
+            "$etag": "W/\u0022a743939a-e23b-49a3-830d-3cdac414f1f4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;177323580",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002254970a46-0a67-4cb8-b036-a586dd0cefe1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u0022d2899188-9c9b-45dc-8273-dcfc598a18d9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomWithWifiTwin474299538",
+            "$etag": "W/\u002227b97d1a-8204-4b77-aa77-94492e9bd0e0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "wifiAccessPoint": {
+              "RouterName": "Cisco1",
+              "Network": "Room1",
+              "$metadata": {
+                "RouterName": {
+                  "desiredValue": "Cisco1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                },
+                "Network": {
+                  "desiredValue": "Room1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                }
+              }
+            },
+            "$metadata": {
+              "$model": "dtmi:example:wifiroom;14907",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin783776230",
+            "$etag": "W/\u0022ca7909a5-90fa-4b6c-9d4b-5f90b88bb623\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;110454602",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2074187830",
+            "$etag": "W/\u00227955c8fe-8c91-4439-85b7-f3e8c95532c5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120670516",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1402305145",
+            "$etag": "W/\u00228b39b064-b47f-4396-9312-1c42ff1da699\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120615932",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random6",
+            "$etag": "W/\u00220e8b5247-8fc6-41c8-983a-675c1cbc7c19\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random8",
+            "$etag": "W/\u0022cc922dbd-7cc6-4917-bc3a-2affdd5a75df\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random4",
+            "$etag": "W/\u00226d343169-dbaa-4def-ad4d-6ca770a0abc4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random5",
+            "$etag": "W/\u0022bf970d0d-1179-4666-9d50-5397b082e333\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random7",
+            "$etag": "W/\u0022cc7307ba-9d77-4c81-9990-b228e19c7c2f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random12",
+            "$etag": "W/\u002209bb6816-f5f8-4178-bdf1-dd4be0c57fee\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random13",
+            "$etag": "W/\u0022045b0783-f518-4013-9fb3-9cab69ec7198\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random14",
+            "$etag": "W/\u00222ac0dd90-0eb2-4995-90e6-9bbde17df18c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random18",
+            "$etag": "W/\u002207241852-c4d9-4b69-9fd7-e9da28bc414f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random21",
+            "$etag": "W/\u0022151839f1-e292-4eb7-b42d-c6cf61b1bbea\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random22",
+            "$etag": "W/\u00226aacca73-8ce6-4282-8269-48d1f233363f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random23",
+            "$etag": "W/\u00225e4f3ba0-04a9-412a-8c43-520efa6e3b5c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random24",
+            "$etag": "W/\u002261bfd3fb-60cf-445b-9cec-5ab8448d0d00\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random28",
+            "$etag": "W/\u002279d58a4a-4afc-4629-9aad-9da93dcaaf2e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random31",
+            "$etag": "W/\u00226df4f860-047c-45f9-9812-33b4ed79abe4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random32",
+            "$etag": "W/\u0022a4e733d2-d5e1-4718-bd29-cf1d4c09b93d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random34",
+            "$etag": "W/\u002213dc8a1a-ec25-4918-87ca-6be0e799ba16\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random36",
+            "$etag": "W/\u0022e2c9963b-1c46-4a10-b03c-5af29ffa4e1a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random37",
+            "$etag": "W/\u0022ae2c8fe8-34f6-4fc1-af57-7a63d8c22c17\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random44",
+            "$etag": "W/\u002271b1b856-6dcd-4e75-a32f-7a0b104b9dd1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random45",
+            "$etag": "W/\u00221fdf5f6c-0c81-4c4a-aeeb-be140a94aec4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random46",
+            "$etag": "W/\u0022aba54bf1-5666-4ae4-875f-71b47e0b0ffe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random47",
+            "$etag": "W/\u0022806a871b-eb40-44a3-a9a1-d9691e5aa3be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random50",
+            "$etag": "W/\u00221b69d8d9-7637-4a15-a45f-5b016492de6d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random51",
+            "$etag": "W/\u0022f914c127-4bc5-4598-90c1-fa900e3c342e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random52",
+            "$etag": "W/\u0022b073e810-06d4-43ea-b0f5-8a82e7e8a5b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random56",
+            "$etag": "W/\u002248616b1c-0ec6-467f-bb45-ed5511f8896f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random57",
+            "$etag": "W/\u00227ffdc5c8-b2c3-4af2-8aee-1002923e5929\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random58",
+            "$etag": "W/\u002289d0fe31-7fa6-474e-9a7d-4b99b4dcde0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random60",
+            "$etag": "W/\u00223559d97a-770e-4e0b-9d21-87d25eb7ffea\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random61",
+            "$etag": "W/\u0022f2fbd307-12d4-4e20-8d04-782b13715a24\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random62",
+            "$etag": "W/\u00222dcb2862-3ca3-4a33-aa37-0df787e9f921\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random67",
+            "$etag": "W/\u0022082b246a-4822-450c-8292-c61a1ec3d501\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random68",
+            "$etag": "W/\u002240bde673-12a1-4a8e-824d-7bc6c3a369bd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random70",
+            "$etag": "W/\u0022f5682c8f-1027-462f-a950-5c11f4e89497\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random71",
+            "$etag": "W/\u002237962897-f8ce-418d-af20-1dfe3cee6e65\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random76",
+            "$etag": "W/\u0022b1182327-4b5e-4147-899d-1474f7cc706d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random78",
+            "$etag": "W/\u0022498189d1-4cde-463f-a4bc-4c1aa54be349\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random82",
+            "$etag": "W/\u00226a17303d-d129-4cae-8f11-855cd0374c2a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random83",
+            "$etag": "W/\u002264c15d5a-6c89-4205-b31a-9c2cdded6fb6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random85",
+            "$etag": "W/\u002243fbe576-c2eb-4774-b9b2-c38827403b26\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random87",
+            "$etag": "W/\u0022942b82db-6031-47ff-a60d-e962f36edc85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random88",
+            "$etag": "W/\u002217909da2-25fb-41bf-9f28-b6a8cf4dc989\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random90",
+            "$etag": "W/\u0022c322c1c9-d9d1-4677-9ffd-d0f9534bdde1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random91",
+            "$etag": "W/\u0022159917d2-c213-4ea5-b3e4-815e23c501d8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random93",
+            "$etag": "W/\u002296c4a70e-35e6-4946-8f96-3b80c1107c53\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random94",
+            "$etag": "W/\u002221760ef3-0d11-4d48-8182-ae0fab6c3aa0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random98",
+            "$etag": "W/\u0022fdcb28ce-f6b7-41db-83d0-f04c3684ec8b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random99",
+            "$etag": "W/\u0022533a2df6-ad2e-41ea-846d-dac101995058\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random101",
+            "$etag": "W/\u0022f649b914-6663-4594-b19c-ac696a6e7042\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random102",
+            "$etag": "W/\u00226027afab-d85b-4034-9105-75efa9b66d03\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random106",
+            "$etag": "W/\u00225b900ab8-8edc-4d7f-bd6b-07ef1d989e12\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random111",
+            "$etag": "W/\u002245f1dc82-e7f3-46a4-b4bc-bcb98655bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random117",
+            "$etag": "W/\u0022bdcf52f8-8a09-4b13-8296-a8eb870805ed\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random119",
+            "$etag": "W/\u002289f3b6bc-a9b5-4ce3-b8b5-cff48002a540\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random120",
+            "$etag": "W/\u002289e485a4-d88f-4c4c-9fef-5e171b804a3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random121",
+            "$etag": "W/\u00222c552298-e2b9-497c-9d09-2503400aad9a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random123",
+            "$etag": "W/\u0022f4344cca-9e37-42f2-8ef3-0ae53b2e77a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random125",
+            "$etag": "W/\u00223766d3b2-a29a-44ef-b6bb-690509a19c51\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random129",
+            "$etag": "W/\u002246138a2b-e6c1-46c3-ad72-82128e82d15b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random130",
+            "$etag": "W/\u00221244fcec-9728-44ba-9c14-c51c548458c9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random131",
+            "$etag": "W/\u0022154c21a1-e6b4-45d8-aa7b-7a7fa70f5b18\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random132",
+            "$etag": "W/\u002276cb5ffa-32b2-4ec8-8dce-3abfd8cdb280\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random135",
+            "$etag": "W/\u00221e59c7a2-ea39-4122-90b0-3a962c7215e3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random136",
+            "$etag": "W/\u0022da0d1c42-19c9-47b9-ba04-511b837b0c94\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random139",
+            "$etag": "W/\u00222089e178-ba20-4573-9dcd-72340b84a716\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random140",
+            "$etag": "W/\u0022a59cc326-efa1-4e1c-957f-691f36f8fd31\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random142",
+            "$etag": "W/\u00223f126193-fcc1-45d0-b3a9-99a1a0f96d08\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random143",
+            "$etag": "W/\u0022f32f8f80-90af-4f46-863c-2188aaf6b389\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random145",
+            "$etag": "W/\u002251601ae7-6ec5-4398-8848-9d5a8249d954\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random147",
+            "$etag": "W/\u002222e41cde-defb-4372-a063-263b79fda486\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random150",
+            "$etag": "W/\u0022dd831905-f185-469f-9020-994b70be1c5f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random151",
+            "$etag": "W/\u0022e00db56a-0243-4d9f-84dd-87a4747a7aac\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random153",
+            "$etag": "W/\u00222ae4e503-742d-49b1-bc32-2be5c2baaba6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random156",
+            "$etag": "W/\u0022de569fd2-71b0-4f0b-880f-526c5a8aeeb6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random157",
+            "$etag": "W/\u0022440dc0b2-99e8-45f9-86a2-cb26deab7822\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random158",
+            "$etag": "W/\u0022821569a4-194c-468c-b0f7-a7f75b02ab35\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random159",
+            "$etag": "W/\u00221d300851-391b-4e3e-bcff-b7eb1fc85ae1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random164",
+            "$etag": "W/\u0022de352d6b-5e77-48f4-b6b7-92b0cf789198\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random165",
+            "$etag": "W/\u0022712962c4-ee74-44d9-bf45-8bad29079d84\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random171",
+            "$etag": "W/\u0022e9eed66c-4cbb-41dd-8371-21298c285815\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random174",
+            "$etag": "W/\u0022990d3f5d-e475-44de-83d0-f531accf1f84\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random175",
+            "$etag": "W/\u00223e6817f9-2579-4c51-a22b-ef50719368bd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random177",
+            "$etag": "W/\u002244830686-8328-44a6-9874-6d30166ae1b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random178",
+            "$etag": "W/\u00220af70c5b-d8ee-405f-ade7-0d435b1e311d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random181",
+            "$etag": "W/\u00228a773751-0c6b-4ec9-8ef5-c2489fa6e802\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random182",
+            "$etag": "W/\u00228005036e-f67d-4188-b459-a846741c2ffe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random183",
+            "$etag": "W/\u002205716c9a-63e5-4df1-a283-a76988b35555\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random186",
+            "$etag": "W/\u0022afa6c27a-419b-4269-845e-344632abf482\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqReAQAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AV4BAAAAAAAAfgEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-05-31-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "416",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "fa828cc117a21b0a52620ff2c7b091a4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqReAQAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AV4BAAAAAAAAfgEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "72037",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "query-charge": "29.589999999999996",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "$dtId": "roomTwin617148482random188",
+            "$etag": "W/\u0022133b2ea2-6991-4f80-9ae0-7b4abdbe7924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random189",
+            "$etag": "W/\u00229e919296-f7c4-4acc-b3e0-fde95f6a75b5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random190",
+            "$etag": "W/\u00223866dac5-2ac8-4dad-b462-88b1bf22baf2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random191",
+            "$etag": "W/\u002274af214e-8f6a-46ba-a494-e1dbb29ca55a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random194",
+            "$etag": "W/\u0022a9cddf78-f5bf-4108-a100-6f7a1e084b00\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random196",
+            "$etag": "W/\u00220010bbec-1492-4124-86cd-9d144edc8737\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random197",
+            "$etag": "W/\u0022fb96f9e3-ecc7-4a95-839f-505ceae76245\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random198",
+            "$etag": "W/\u002201666f3b-2a6b-449d-81fe-39cfeec2d083\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random200",
+            "$etag": "W/\u002209614d4c-38f3-4ae1-9903-935d26b81ccb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random202",
+            "$etag": "W/\u0022cd29be13-1286-41b9-bbed-aa4372485205\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random206",
+            "$etag": "W/\u0022a071d98b-ff79-4856-8b8a-65080c08f00c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random209",
+            "$etag": "W/\u0022e886b481-9943-4ff2-91ae-4b047685526e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random210",
+            "$etag": "W/\u0022bd5233e0-b395-4d44-8118-7f1849b2b78c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random212",
+            "$etag": "W/\u0022beb4459e-8b43-495c-8f74-646e60e70f1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random213",
+            "$etag": "W/\u0022cc55d2ce-b6f6-4f6f-b378-f9dd185ce593\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random214",
+            "$etag": "W/\u002222438199-48e7-484a-b86d-03174090e28d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random215",
+            "$etag": "W/\u002271e8faaa-6906-4f4d-90ef-40e5de0b92f4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random216",
+            "$etag": "W/\u0022a4a640e8-d35b-4301-a8c8-4d5f35123caf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random218",
+            "$etag": "W/\u002244ffb034-1871-45a8-821d-598776734186\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random219",
+            "$etag": "W/\u0022c6aa29a8-9b42-4023-9934-996f6af80f58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random220",
+            "$etag": "W/\u00226044a052-889c-42c3-951a-b33f3a12020e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random225",
+            "$etag": "W/\u0022025b9cb0-19cd-4c71-a5ec-b62dfddcd15a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random229",
+            "$etag": "W/\u002288cf0681-1c44-4b8a-90a7-18d55f1238d3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random230",
+            "$etag": "W/\u00224f2375a6-1d13-44d0-84cb-6928b0a50aeb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random234",
+            "$etag": "W/\u0022edee499e-f62e-4835-a736-d17f106a676a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random237",
+            "$etag": "W/\u002215ec8040-11c4-4912-8e87-a23846a7cb0b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random240",
+            "$etag": "W/\u002256845622-5742-4566-bd15-7f65787cb64c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random243",
+            "$etag": "W/\u0022a2e96a08-e425-4e62-b993-03e4bcab9e67\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random244",
+            "$etag": "W/\u00228d6a2320-9a3c-49b9-a563-7c38db547f05\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random246",
+            "$etag": "W/\u00229eb832ac-654f-441f-8dcc-0d013249ee95\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random248",
+            "$etag": "W/\u002260014ed3-dcb4-4478-a43a-0589a221c66f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random249",
+            "$etag": "W/\u0022c0a217b7-b7e0-4421-9292-eabdc6203b39\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2013649222",
+            "$etag": "W/\u0022c25b8183-8b0e-4553-829c-4b4019d83530\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;187060801",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1823984986",
+            "$etag": "W/\u00225c41a39e-43ea-4382-ab92-abdd1f180391\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;15155852",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin129896917",
+            "$etag": "W/\u0022cd5f8a13-7005-4a1b-aa98-85ba26454036\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;117001227",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u00221d4bdb84-0306-442d-bc7e-ea3c93c27ad1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2008572996",
+            "$etag": "W/\u0022af515f36-a229-4fbf-b492-d4d51269fe76\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;117898422",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1917345053",
+            "$etag": "W/\u0022558eff3f-88f9-4bec-863c-0eed6cc4791f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115056348",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u00229168c38d-385d-42fc-99e4-de129f18e3aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u00227233c708-a75c-4d50-bb5f-d4243208ff9c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "RoomTwin",
+            "$etag": "W/\u0022e2c607fb-00e1-4d6f-a971-d12b9fb6db8b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "wifiAccessPoint": {
+              "RouterName": "Cisco1",
+              "Network": "Room1",
+              "$metadata": {
+                "RouterName": {
+                  "desiredValue": "Cisco1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                },
+                "Network": {
+                  "desiredValue": "Room1",
+                  "desiredVersion": 1,
+                  "ackVersion": 1,
+                  "ackCode": 200,
+                  "ackDescription": "Auto-Sync"
+                }
+              }
+            },
+            "$metadata": {
+              "$model": "dtmi:samples:Room;1",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1436994705",
+            "$etag": "W/\u0022d560344f-0281-4494-a5f5-28cf276e9f9e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;110946152",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1956725720",
+            "$etag": "W/\u002216ca7223-38b5-42c0-adef-1974cb0774bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119969462",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random2",
+            "$etag": "W/\u0022f96297e7-446a-4ab4-81ac-64e7d0d9c8f9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random1",
+            "$etag": "W/\u0022b21c95b3-0dd5-458b-9d81-8c788c9799a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random9",
+            "$etag": "W/\u002218decdd8-a20d-4627-be1a-5d9b90f6207b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random0",
+            "$etag": "W/\u002232a9b6a6-388b-4e06-bf9f-599f4f54463d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random3",
+            "$etag": "W/\u0022d5459bfa-8549-4525-9309-63e60a87a408\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random10",
+            "$etag": "W/\u00224d272ad0-ddf5-4426-b2f0-07f86edf1b4d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random11",
+            "$etag": "W/\u0022141b8c78-f857-4f3a-9a0d-711573ec7834\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random15",
+            "$etag": "W/\u002269bbd4af-5595-409d-ab65-46b9706debf6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random16",
+            "$etag": "W/\u0022546be82c-a070-4909-8b11-799439db0262\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random17",
+            "$etag": "W/\u00228a7dec81-73ad-4cef-a040-5e097cb928fe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random19",
+            "$etag": "W/\u00225c134802-27c6-4f78-9ecf-d39e797a4c87\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random20",
+            "$etag": "W/\u0022dae9ab9e-248e-4f37-8352-6c8277398181\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random25",
+            "$etag": "W/\u0022a2778e16-288e-4a97-8542-8c2486f7c2f7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random26",
+            "$etag": "W/\u0022aba01caf-14ac-4092-b5ea-c3089bc0fc9b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random27",
+            "$etag": "W/\u00226684cc84-550e-42fd-8094-24cd286ad07f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random29",
+            "$etag": "W/\u00221e1fcda9-21f7-47ba-90ba-34abd2e4e1ba\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random30",
+            "$etag": "W/\u0022ff2fcbf8-490a-4d4b-aee7-4c01e61d90b9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random33",
+            "$etag": "W/\u00228554c137-b840-4a51-8962-28c3c495e7c1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random35",
+            "$etag": "W/\u00220a85e34d-1a48-406c-8f39-57f49949d9aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random38",
+            "$etag": "W/\u00224ad947a5-d52f-4bbb-9aee-ec41d714b0de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random39",
+            "$etag": "W/\u0022a2feb89a-6779-4151-b358-1a8e1b24da2a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random40",
+            "$etag": "W/\u002265b7293f-85b7-476f-b237-5042c5771f22\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random41",
+            "$etag": "W/\u0022848048a3-0774-4f54-a830-e3d1e3c57d5d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random42",
+            "$etag": "W/\u00223c694f8e-2bf7-40cd-84f2-a53dc20a6ec1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random43",
+            "$etag": "W/\u002201ff8dd5-600b-46bc-bef3-3c89647c90c6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random48",
+            "$etag": "W/\u00225f8f4268-a1f6-4b03-a1f8-716c161e69d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random49",
+            "$etag": "W/\u0022d3bc31da-be3a-472e-bb1e-771bd4af491a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random53",
+            "$etag": "W/\u0022ef837608-ce8e-4049-828a-c99a975aabf3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random54",
+            "$etag": "W/\u00222fd6f7c5-b1f0-48b8-87a8-ded3b66e6f6f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random55",
+            "$etag": "W/\u0022d8b215f3-b224-4681-a3ce-86729cd08258\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random59",
+            "$etag": "W/\u0022d389125f-a463-48bc-863b-8fb13b2706ae\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random63",
+            "$etag": "W/\u00227b50cc1f-12e9-462d-8873-948afad4acee\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random64",
+            "$etag": "W/\u0022c2fe4e74-2afc-483b-b0d8-681cc01e6870\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random65",
+            "$etag": "W/\u0022650f90ee-2475-43d1-bf10-c61248597996\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random66",
+            "$etag": "W/\u0022c9443ceb-7085-4ec4-9bb6-b7491d343894\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random69",
+            "$etag": "W/\u00225e42c69b-5454-48be-976f-584d1475c819\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random72",
+            "$etag": "W/\u00220fe9d9bc-e443-4ab0-8fc2-257e39425cad\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random73",
+            "$etag": "W/\u0022f3208b5e-d868-477d-adc8-955330a406cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random74",
+            "$etag": "W/\u002256605118-3fc8-415f-904a-1f4494c46e8e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random75",
+            "$etag": "W/\u00228081e4e4-632b-41be-8973-75acb469c488\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random77",
+            "$etag": "W/\u0022df62cf9d-02cc-4c47-835c-9b3786c4f460\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random79",
+            "$etag": "W/\u0022a09c8de5-b851-49a8-8392-88f3fae36a1b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random80",
+            "$etag": "W/\u0022301d795c-06ba-45e4-8946-fbaa14347e56\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random81",
+            "$etag": "W/\u0022397b7389-8ba2-424d-a13e-936a620c18a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random84",
+            "$etag": "W/\u0022f11ca50f-3e1f-42d7-9eac-c716e2510637\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random86",
+            "$etag": "W/\u00226ab54979-4b17-4bbe-bf23-a0766e563fca\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random89",
+            "$etag": "W/\u0022abaebb84-920b-42e3-aff4-a8f12e163df0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random92",
+            "$etag": "W/\u0022eefaab9e-6338-4295-afa3-67ebd817b750\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random95",
+            "$etag": "W/\u002263102413-3e92-4c8f-9218-c23528fd97ab\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random96",
+            "$etag": "W/\u00222d7fea08-81a8-49f4-9d24-f742e3312d4f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random97",
+            "$etag": "W/\u0022d940eb75-b54a-41d9-a960-5219ec9b8eff\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random100",
+            "$etag": "W/\u0022e0a5726c-50e9-47f1-af55-e4ec329bbd91\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random103",
+            "$etag": "W/\u0022759f036e-6c3f-4bf7-843a-001e64a54061\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random104",
+            "$etag": "W/\u002253e2176c-d99b-41aa-ac33-1b3c9a598607\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random105",
+            "$etag": "W/\u0022b7e07188-6344-411b-8b65-8ed3cf4e7eb5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random107",
+            "$etag": "W/\u0022f95b45e7-b69e-4ef7-97a7-27833962757c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random108",
+            "$etag": "W/\u0022e55a247f-f4d6-4ff9-9b8a-7dcae9a084ca\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random109",
+            "$etag": "W/\u002271d97392-c8fd-4936-86e8-adcad8d16803\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random110",
+            "$etag": "W/\u00221d8190c5-efa4-4fdb-94d5-526e355f3a7e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random112",
+            "$etag": "W/\u00227a94859c-fcc8-4cfb-a487-7af16cc7a352\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random113",
+            "$etag": "W/\u002224dae20f-330d-4a8c-a50f-6c9ed325fdbe\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random114",
+            "$etag": "W/\u00221052cf61-4be6-4fa8-a85f-cb6558ec491e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random115",
+            "$etag": "W/\u00221e22619d-9d38-4c7b-8742-eb19deafddef\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random116",
+            "$etag": "W/\u00226fd71e8a-4f3f-443a-a4e5-fde64c65ef4e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqR5AQAAAAAACA==#RT:3#TRC:75#ISV:2#IEO:65551#FPC:AXkBAAAAAAAIugEAAAAAAAg=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-05-31-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "417",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "80ae5d836f8e35b8612805b3535a6096",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAMiSVqR5AQAAAAAACA==#RT:3#TRC:75#ISV:2#IEO:65551#FPC:AXkBAAAAAAAIugEAAAAAAAg=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u002205C1DFFFFFFFFC\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "43521",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "query-charge": "17.72",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "$dtId": "roomTwin617148482random118",
+            "$etag": "W/\u002297299934-2941-4065-a249-c6c785b1e8de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random122",
+            "$etag": "W/\u00226e8a4984-68ea-4d36-91c6-6b45fb4595e6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random124",
+            "$etag": "W/\u00220dc6527e-5244-4ad4-a8e7-6a34707eeafc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random126",
+            "$etag": "W/\u0022adb454b2-e10a-4bd5-b827-cb576e080413\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random127",
+            "$etag": "W/\u00223c55e031-287f-40cf-aab8-affd922ce8e6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random128",
+            "$etag": "W/\u00220346ed64-4a86-46fe-94db-464d39ce4b8f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random133",
+            "$etag": "W/\u0022479023b3-a63f-41e0-8dc1-c13179629cdd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random134",
+            "$etag": "W/\u00225b0a393b-6d0e-4ec4-bdd5-dd1cfc639347\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random137",
+            "$etag": "W/\u00226cb380fb-a089-4896-b64e-0df03d755881\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random138",
+            "$etag": "W/\u0022e28d8a9f-3a93-4401-974c-7df7117649ff\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random141",
+            "$etag": "W/\u0022f8f52223-5fb2-4fb1-8936-e34b0a367e1e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random144",
+            "$etag": "W/\u0022afddb3b8-29c4-4977-8443-87f2e303c10d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random146",
+            "$etag": "W/\u0022c7e9cb17-1855-4205-94a3-a1c68466cbe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random148",
+            "$etag": "W/\u0022c9e10048-ae79-49c7-9279-c1591c193979\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random149",
+            "$etag": "W/\u0022a2ae38dc-fdeb-43e2-bf4d-01e2d63d72fc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random152",
+            "$etag": "W/\u0022af1e389b-68de-462f-a602-bf889bef96af\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random154",
+            "$etag": "W/\u0022e36fb80d-36f6-47b7-b17c-1027c209b77b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random155",
+            "$etag": "W/\u00229c53a23e-205c-44d1-a025-11d41a5f9b58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random160",
+            "$etag": "W/\u0022c1672fbf-910d-47a2-8b26-142897681c09\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random161",
+            "$etag": "W/\u002268421b96-27af-444e-ac63-a7913145b049\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random162",
+            "$etag": "W/\u0022214cfd7d-2bcf-4144-b348-705729db2303\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random163",
+            "$etag": "W/\u0022e02563b5-0d6c-49bd-b290-37dbdd7c0380\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random166",
+            "$etag": "W/\u00224774b4d0-da5c-46b5-bf5f-6465785acbbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random167",
+            "$etag": "W/\u0022dcd9c24f-ffad-4375-a12d-36fb36e337f5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random168",
+            "$etag": "W/\u002252d528fa-824a-4b2d-bbc0-263676b08254\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random169",
+            "$etag": "W/\u0022c7bd55cc-50f2-4bec-b047-009948b80769\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random170",
+            "$etag": "W/\u0022fd0d60b6-8517-40ed-b5bc-2c56933ba15d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random172",
+            "$etag": "W/\u0022f49b3c34-5ffb-46e5-81e0-6b4aa769db17\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random173",
+            "$etag": "W/\u00225b71ea38-30e6-4876-b4cf-bd330851d903\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random176",
+            "$etag": "W/\u002228798da1-2103-4e45-908b-86d1039a49da\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random179",
+            "$etag": "W/\u00226e499d91-bdab-4c3b-93cd-f068a014ff71\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random180",
+            "$etag": "W/\u00225e2ace13-eef0-4762-858e-c69a9bfb1b63\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random184",
+            "$etag": "W/\u002279207ac9-0c7f-456b-85a4-588ff8941475\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random185",
+            "$etag": "W/\u0022191aedbe-3e1f-41c9-a475-6404b2b5a2b3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random187",
+            "$etag": "W/\u00221b21ed24-1600-4e85-9ce1-68630067b7b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random192",
+            "$etag": "W/\u0022d254b00e-64f8-412e-9ff0-62d1b585be17\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random193",
+            "$etag": "W/\u002218c65b5e-a797-4e9b-9b7e-62e0192465b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random195",
+            "$etag": "W/\u0022e1abb9e2-a0a4-42c5-9803-b3ca4a42e1aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random199",
+            "$etag": "W/\u0022d9600ba5-9960-4bde-acc6-a2979f7204d3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random201",
+            "$etag": "W/\u00223014e54f-28c9-416f-b5e2-6e7311d48b10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random203",
+            "$etag": "W/\u0022623d6d80-6505-4079-aa46-58539b13db55\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random204",
+            "$etag": "W/\u002232efca2b-8107-4d55-9171-ff120da50be7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random205",
+            "$etag": "W/\u002237fff783-90f1-4031-953f-eb9fd07a38b9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random207",
+            "$etag": "W/\u00220d93e9b5-b7e1-4e49-a053-ecd8da16408f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random208",
+            "$etag": "W/\u00222771151f-a9cc-42e5-950f-aa8dad1fa258\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random211",
+            "$etag": "W/\u00220f66f210-baee-4565-b3ed-4e50ec0cbc52\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random217",
+            "$etag": "W/\u0022c3725c1f-8321-4f02-85e7-5f72deac1cfc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random221",
+            "$etag": "W/\u0022d1939576-b174-433a-8c55-80fe9cf2a2cd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random222",
+            "$etag": "W/\u0022e7109590-ea84-4c9f-85f4-7500e21adc08\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random223",
+            "$etag": "W/\u002294b162a2-7d87-4499-8db9-012c7c8d7a5a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random224",
+            "$etag": "W/\u002291daefca-b44c-4063-ae59-8cb6c435bb9f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random226",
+            "$etag": "W/\u002247f7e095-3f6b-450d-bad8-5feafd7b558d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random227",
+            "$etag": "W/\u002216069d80-1c24-46c2-9a92-8389776a70d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random228",
+            "$etag": "W/\u002273ac0c3a-4a36-4558-8066-ec5e950d6c39\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random231",
+            "$etag": "W/\u002267282cb1-1609-45e7-bfaa-f470040e98cb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random232",
+            "$etag": "W/\u0022589e71ca-7512-4288-8d53-6f0875fa71e8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random233",
+            "$etag": "W/\u0022699df15f-cc94-4803-b7af-a9807d76ec8e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random235",
+            "$etag": "W/\u0022e13277af-1e54-4a28-b1c4-e444a6c2c7e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random236",
+            "$etag": "W/\u00227d930100-21a1-4ec9-aa0f-c4efe2e9684f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random238",
+            "$etag": "W/\u0022fd0ac9e5-0025-4560-8289-49f6a99414f5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random239",
+            "$etag": "W/\u0022cf406335-636b-441e-8d29-aed57f5cb7b2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random241",
+            "$etag": "W/\u0022e2c1923a-8e71-419d-9c13-4dd0df33a506\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random242",
+            "$etag": "W/\u0022d5df815e-4783-4d5b-b93e-02c91516e557\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random245",
+            "$etag": "W/\u002274c2aac3-d324-4c02-bef6-f3c627880686\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin617148482random247",
+            "$etag": "W/\u0022b0f55240-a0ea-407f-ad06-089bbb1cdd04\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;121051489",
+              "Temperature": {
+                "desiredValue": 80,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "Humidity": {
+                "desiredValue": 25,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "IsOccupied": {
+                "desiredValue": true,
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              },
+              "EmployeeId": {
+                "desiredValue": "Employee1",
+                "desiredVersion": 1,
+                "ackVersion": 1,
+                "ackCode": 200,
+                "ackDescription": "Auto-Sync"
+              }
+            }
+          }
+        ],
         "continuationToken": null
       }
     },
@@ -210,17 +10923,39 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-dev.20200820.8",
-          "(.NET Core 4.6.27514.02; Microsoft Windows 10.0.17763 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "fa828cc117a21b0a52620ff2c7b091a4",
+        "x-ms-client-request-id": "775e5381e8679eb373864156b92bd674",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 21 Aug 2020 02:42:38 GMT",
+        "Date": "Tue, 08 Sep 2020 23:50:32 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1761111288?api-version=2020-05-31-preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20200908.1",
+          "(.NET Core 4.6.29130.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "be0fcdaee5de5188d44c997a1157c8f7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Tue, 08 Sep 2020 23:50:33 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/identity/Azure.Identity/src/AuthenticationRecord.cs
+++ b/sdk/identity/Azure.Identity/src/AuthenticationRecord.cs
@@ -45,10 +45,9 @@ namespace Azure.Identity
 
         internal AuthenticationRecord(string username, string authority, string homeAccountId, string tenantId, string clientId)
         {
-
             Username = username;
             Authority = authority;
-            AccountId = new AccountId(homeAccountId);
+            AccountId = BuildAccountIdFromString(homeAccountId);
             TenantId = tenantId;
             ClientId = clientId;
         }
@@ -176,7 +175,7 @@ namespace Azure.Identity
                         authProfile.Authority = prop.Value.GetString();
                         break;
                     case HomeAccountIdPropertyName:
-                        authProfile.AccountId = new AccountId(prop.Value.GetString());
+                        authProfile.AccountId = BuildAccountIdFromString(prop.Value.GetString());
                         break;
                     case TenantIdPropertyName:
                         authProfile.TenantId = prop.Value.GetString();
@@ -188,6 +187,23 @@ namespace Azure.Identity
             }
 
             return authProfile;
+        }
+
+        private static AccountId BuildAccountIdFromString(string homeAccountId)
+        {
+            //For the Microsoft identity platform (formerly named Azure AD v2.0), the identifier is the concatenation of
+            // Microsoft.Identity.Client.AccountId.ObjectId and Microsoft.Identity.Client.AccountId.TenantId separated by a dot.
+            var homeAccountSegments = homeAccountId.Split('.');
+            AccountId accountId;
+            if (homeAccountSegments.Length == 2)
+            {
+                accountId = new AccountId(homeAccountId, homeAccountSegments[0], homeAccountSegments[1]);
+            }
+            else
+            {
+                accountId = new AccountId(homeAccountId);
+            }
+            return accountId;
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AuthenticationRecordTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AuthenticationRecordTests.cs
@@ -6,6 +6,9 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Identity.Client;
+
 using NUnit.Framework;
 
 namespace Azure.Identity.Tests
@@ -13,6 +16,20 @@ namespace Azure.Identity.Tests
     public class AuthenticationRecordTests
     {
         private const int TestBufferSize = 512;
+
+        [Test]
+        public void AuthenticationRecordConstructor()
+        {
+            var record = new AuthenticationRecord(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(),
+                $"{Guid.NewGuid()}.{Guid.NewGuid()}", Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+
+            IAccount account = (AuthenticationAccount)record;
+            Assert.NotNull(account.Username);
+            Assert.NotNull(account.Environment);
+            Assert.NotNull(account.HomeAccountId.Identifier);
+            Assert.NotNull(account.HomeAccountId.ObjectId);
+            Assert.NotNull(account.HomeAccountId.TenantId);
+        }
 
         [Test]
         public void SerializeDeserializeInputChecks()
@@ -28,23 +45,31 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task SerializeDeserializeAsync()
         {
-            var expRecord = new AuthenticationRecord(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            var expRecord = new AuthenticationRecord(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), $"{Guid.NewGuid()}.{Guid.NewGuid()}", Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
             byte[] buff = new byte[TestBufferSize];
 
             var stream = new MemoryStream(buff);
 
             await expRecord.SerializeAsync(stream);
+            IAccount expAccount = (AuthenticationAccount)expRecord;
 
             stream = new MemoryStream(buff, 0, (int)stream.Position);
 
             var actRecord = await AuthenticationRecord.DeserializeAsync(stream);
+            IAccount actAccount = (AuthenticationAccount)actRecord;
 
             Assert.AreEqual(expRecord.Username, actRecord.Username);
             Assert.AreEqual(expRecord.Authority, actRecord.Authority);
             Assert.AreEqual(expRecord.HomeAccountId, actRecord.HomeAccountId);
             Assert.AreEqual(expRecord.TenantId, actRecord.TenantId);
             Assert.AreEqual(expRecord.ClientId, actRecord.ClientId);
+
+            Assert.AreEqual(expAccount.Username, actAccount.Username);
+            Assert.AreEqual(expAccount.Environment, actAccount.Environment);
+            Assert.AreEqual(expAccount.HomeAccountId.Identifier, actAccount.HomeAccountId.Identifier);
+            Assert.AreEqual(expAccount.HomeAccountId.ObjectId, actAccount.HomeAccountId.ObjectId);
+            Assert.AreEqual(expAccount.HomeAccountId.TenantId, actAccount.HomeAccountId.TenantId);
         }
 
         [Test]


### PR DESCRIPTION
I investigated a customer issue where the customer would like to use the resuming functionality in the QueryAsync API.
Azure.Core has a bug where this functionality is broken (see the issue here:  https://github.com/Azure/autorest.csharp/issues/890 and the fix here: https://github.com/Azure/autorest.csharp/pull/891)

The test is ignored for now, but once the regeneration process happens (automatically) we can enable this test)