### PR TITLE
[Messaging Clients] Microsoft.Azure.Amqp Package Update

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -32,7 +32,7 @@
     <PackageReference Update="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.5" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.6" />
     <PackageReference Update="Microsoft.Azure.Batch" Version="11.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.19.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to update the version of the `Microsoft.Azure.Amqp` package used by the messaging clients to v2.4.6, which was recently
released.  This new version contains a fix for a hard crash on .NET v5 and no other changes.  

# Last Upstream Rebase

Wednesday, September 9, 10:12am (EDT)

# References and Related Issues

- [`Microsoft.Azure.Amqp` Branch Commits](https://github.com/Azure/azure-amqp/commits/hotfix)
- [[BUG] Azure Service Bus Queue (RegisterMessageHandler) not working on .NET 5.0 Preview 7](https://github.com/Azure/azure-sdk-for-net/issues/13899#issuecomment-689227876)