### PR TITLE
[Event Hubs Client] Idempotent Producer Client

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -78,7 +78,7 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to A producer created for a specific partition cannot send events using a partition key. This producer is associated with partition &apos;{0}&apos;..
+        ///   Looks up a localized string similar to An event cannot be published using both a partition key and a partition identifier.  This operation specified partition key `{0}` and partition id `{1}`..
         /// </summary>
         internal static string CannotSendWithPartitionIdAndPartitionKey
         {
@@ -701,6 +701,28 @@ namespace Azure.Messaging.EventHubs
             get
             {
                 return ResourceManager.GetString("OnlyOneSharedAccessAuthorizationMayBeSpecified", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The producer was configured to use features that require publishing to a specific partition.  Publishing with automatic routing or using a partition key is not supported by this producer..
+        /// </summary>
+        internal static string CannotPublishToGateway
+        {
+            get
+            {
+                return ResourceManager.GetString("CannotPublishToGateway", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to These events have already been successfully published.  When idempotent publishing is enabled, events that were acknowledged by the Event Hubs service may not be published again..
+        /// </summary>
+        internal static string IdempotentAlreadyPublished
+        {
+            get
+            {
+                return ResourceManager.GetString("IdempotentAlreadyPublished", resourceCulture);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -172,7 +172,7 @@
     <value>The requested transport type, '{0}' is not supported.</value>
   </data>
   <data name="CannotSendWithPartitionIdAndPartitionKey" xml:space="preserve">
-    <value>A producer created for a specific partition cannot send events using a partition key. This producer is associated with partition '{0}'.</value>
+    <value>An event cannot be published using both a partition key and a partition identifier.  This operation specified partition key `{0}` and partition id `{1}`.</value>
   </data>
   <data name="UnsupportedCredential" xml:space="preserve">
     <value>The credential is not a known and supported credential type. Please use a JWT credential or shared key credential.</value>
@@ -289,6 +289,12 @@
     <value>One or more exceptions occured during event processing.  Please see the inner exceptions for more detail.</value>
   </data>
   <data name="OnlyOneSharedAccessAuthorizationMayBeSpecified" xml:space="preserve">
-    <value>The authorization for a connection string may specifiy a shared key or precomputed shared access signature, but not both.  Please verify that your connection string does not have the `SharedAccessSignature` token if you are passing the `SharedKeyName` and `SharedKey`.</value>
+    <value>The authorization for a connection string may specify a shared key or pre-computed shared access signature, but not both.  Please verify that your connection string does not have the `SharedAccessSignature` token if you are passing the `SharedKeyName` and `SharedKey`.</value>
+  </data>
+  <data name="CannotPublishToGateway" xml:space="preserve">
+    <value>The producer was configured to use features that require publishing to a specific partition.  Publishing with automatic routing or using a partition key is not supported by this producer.</value>
+  </data>
+  <data name="IdempotentAlreadyPublished" xml:space="preserve">
+    <value>These events have already been successfully published.  When idempotent publishing is enabled, events that were acknowledged by the Event Hubs service may not be published again.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -465,7 +465,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public virtual System.Threading.Tasks.Task<string[]> GetPartitionIdsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.PartitionProperties> GetPartitionPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(Azure.Messaging.EventHubs.Producer.EventDataBatch eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, Azure.Messaging.EventHubs.Producer.SendEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventSet, Azure.Messaging.EventHubs.Producer.SendEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
@@ -495,9 +495,9 @@ namespace Azure.Messaging.EventHubs.Producer
     {
         protected internal PartitionPublishingProperties(bool isIdempotentPublishingEnabled, long? producerGroupId, short? ownerLevel, int? lastPublishedSequenceNumber) { }
         public bool IsIdempotentPublishingEnabled { get { throw null; } }
-        public int? LastPublishedSequenceNumber { get { throw null; } set { } }
-        public short? OwnerLevel { get { throw null; } set { } }
-        public long? ProducerGroupId { get { throw null; } set { } }
+        public int? LastPublishedSequenceNumber { get { throw null; } }
+        public short? OwnerLevel { get { throw null; } }
+        public long? ProducerGroupId { get { throw null; } }
     }
     public partial class SendEventOptions
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -13,6 +13,7 @@ using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
+using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Azure.Amqp;
 
 namespace Azure.Messaging.EventHubs.Amqp
@@ -374,11 +375,15 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
+        /// <param name="requestedFeatures">The flags specifying the set of special transport features that should be opted-into.</param>
+        /// <param name="partitionOptions">The set of options, if any, that should be considered when initializing the producer.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         public override TransportProducer CreateProducer(string partitionId,
+                                                         TransportProducerFeatures requestedFeatures,
+                                                         PartitionPublishingOptions partitionOptions,
                                                          EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));
@@ -389,7 +394,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                 partitionId,
                 ConnectionScope,
                 MessageConverter,
-                retryPolicy
+                retryPolicy,
+                requestedFeatures,
+                partitionOptions
             );
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Producer;
 
 namespace Azure.Messaging.EventHubs.Core
 {
@@ -67,11 +68,15 @@ namespace Azure.Messaging.EventHubs.Core
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
+        /// <param name="requestedFeatures">The flags specifying the set of special transport features that should be opted-into.</param>
+        /// <param name="partitionOptions">The set of options, if any, that should be considered when initializing the producer.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         public abstract TransportProducer CreateProducer(string partitionId,
+                                                         TransportProducerFeatures requestedFeatures,
+                                                         PartitionPublishingOptions partitionOptions,
                                                          EventHubsRetryPolicy retryPolicy);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
@@ -72,6 +72,21 @@ namespace Azure.Messaging.EventHubs.Core
                                                                         CancellationToken cancellationToken);
 
         /// <summary>
+        ///   Reads the set of partition publishing properties active for this producer at the time it was initialized.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The cancellation token to consider when creating the link.</param>
+        ///
+        /// <returns>The set of <see cref="PartitionPublishingProperties" /> observed when the producer was initialized.</returns>
+        ///
+        /// <remarks>
+        ///   It is important to note that these properties are a snapshot of the service state at the time when the
+        ///   producer was initialized; they do not necessarily represent the current state of the service.
+        /// </remarks>
+        ///
+        public abstract ValueTask<PartitionPublishingProperties> ReadInitializationPublishingPropertiesAsync(CancellationToken cancellationToken);
+
+        /// <summary>
         ///   Closes the connection to the transport producer instance.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducerFeatures.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducerFeatures.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   The set of special transport features specific to a <see cref="TransportProducer" /> which
+    ///   require opting-into.
+    /// </summary>
+    ///
+    [Flags]
+    internal enum TransportProducerFeatures : byte
+    {
+        /// <summary>No transport features were requested.</summary>
+        None = 0,
+
+        /// <summary>The idempotent publishing feature is requested.</summary>
+        IdempotentPublishing = 1
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducerPool.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducerPool.cs
@@ -21,13 +21,6 @@ namespace Azure.Messaging.EventHubs.Core
         private static readonly TimeSpan DefaultPerformExpirationPeriod = TimeSpan.FromMinutes(10);
 
         /// <summary>
-        ///   The set of active Event Hub transport-specific producers specific to a given partition;
-        ///   intended to perform delegated operations.
-        /// </summary>
-        ///
-        private ConcurrentDictionary<string, PoolItem> Pool { get; }
-
-        /// <summary>
         ///   An abstracted Event Hub transport-specific producer that is associated with the
         ///   Event Hub gateway rather than a specific partition; intended to perform delegated operations.
         /// </summary>
@@ -35,17 +28,11 @@ namespace Azure.Messaging.EventHubs.Core
         public TransportProducer EventHubProducer { get; }
 
         /// <summary>
-        ///   The active connection to the Azure Event Hubs service, enabling client communications for metadata
-        ///   about the associated Event Hub and access to a transport-aware producer.
+        ///   The set of active Event Hub transport-specific producers specific to a given partition;
+        ///   intended to perform delegated operations.
         /// </summary>
         ///
-        private EventHubConnection Connection { get; }
-
-        /// <summary>
-        ///   The policy to use for determining retry behavior for when an operation fails.
-        /// </summary>
-        ///
-        private EventHubsRetryPolicy RetryPolicy { get; }
+        private ConcurrentDictionary<string, PoolItem> Pool { get; }
 
         /// <summary>
         ///   A reference to a <see cref="Timer" /> periodically checking every <see cref="DefaultPerformExpirationPeriod" />
@@ -55,39 +42,39 @@ namespace Azure.Messaging.EventHubs.Core
         private Timer ExpirationTimer { get; }
 
         /// <summary>
+        ///   A factory method for spawning a <see cref="TransportProducer" /> for a given partition.
+        /// </summary>
+        ///
+        private Func<string, TransportProducer> TransportProducerFactory { get; }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="TransportProducerPool" /> class.
         /// </summary>
         ///
-        internal TransportProducerPool()
+        /// <param name="transportProducerFactory">A factory method for spawning a <see cref="TransportProducer" /> for a given partition.</param>
+        /// <param name="pool">The pool of <see cref="PoolItem" /> that is going to be used to store the partition specific <see cref="TransportProducer" />.</param>
+        /// <param name="performExpirationPeriod">The period after which <see cref="CreateExpirationTimerCallback" /> is run. Overrides <see cref="DefaultPerformExpirationPeriod" />.</param>
+        /// <param name="eventHubProducer">An abstracted Event Hub transport-specific producer that is associated with the Event Hub gateway rather than a specific partition.</param>
+        ///
+        public TransportProducerPool(Func<string, TransportProducer> transportProducerFactory,
+                                     ConcurrentDictionary<string, PoolItem> pool = default,
+                                     TimeSpan? performExpirationPeriod = default,
+                                     TransportProducer eventHubProducer = default)
         {
+            performExpirationPeriod ??= DefaultPerformExpirationPeriod;
+
+            Pool = pool ?? new ConcurrentDictionary<string, PoolItem>();
+            EventHubProducer = eventHubProducer ?? transportProducerFactory(null);
+            TransportProducerFactory = transportProducerFactory;
+            ExpirationTimer = new Timer(CreateExpirationTimerCallback(), null, performExpirationPeriod.Value, performExpirationPeriod.Value);
         }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="TransportProducerPool" /> class.
         /// </summary>
         ///
-        /// <param name="connection">The <see cref="EventHubConnection" /> connection to use for communication with the Event Hubs service.</param>
-        /// <param name="retryPolicy">The policy to use for determining retry behavior for when an operation fails.</param>
-        /// <param name="pool">The pool of <see cref="PoolItem" /> that is going to be used to store the partition specific <see cref="TransportProducer" />.</param>
-        /// <param name="performExpirationPeriod">The period after which <see cref="CreateExpirationTimerCallback" /> is run. Overrides <see cref="DefaultPerformExpirationPeriod" />.</param>
-        /// <param name="eventHubProducer">An abstracted Event Hub transport-specific producer that is associated with the Event Hub gateway rather than a specific partition.</param>
-        ///
-        public TransportProducerPool(EventHubConnection connection,
-                                     EventHubsRetryPolicy retryPolicy,
-                                     ConcurrentDictionary<string, PoolItem> pool = default,
-                                     TimeSpan? performExpirationPeriod = default,
-                                     TransportProducer eventHubProducer = default)
+        internal TransportProducerPool()
         {
-            Connection = connection;
-            RetryPolicy = retryPolicy;
-            Pool = pool ?? new ConcurrentDictionary<string, PoolItem>();
-            performExpirationPeriod ??= DefaultPerformExpirationPeriod;
-            EventHubProducer = eventHubProducer ?? connection.CreateTransportProducer(null, retryPolicy);
-
-            ExpirationTimer = new Timer(CreateExpirationTimerCallback(),
-                                        null,
-                                        performExpirationPeriod.Value,
-                                        performExpirationPeriod.Value);
         }
 
         /// <summary>
@@ -114,8 +101,7 @@ namespace Azure.Messaging.EventHubs.Core
             }
 
             var identifier = Guid.NewGuid().ToString();
-
-            var item = Pool.GetOrAdd(partitionId, id => new PoolItem(partitionId, Connection.CreateTransportProducer(id, RetryPolicy), removeAfterDuration));
+            var item = Pool.GetOrAdd(partitionId, id => new PoolItem(partitionId, TransportProducerFactory(id), removeAfterDuration));
 
             // A race condition at this point may end with CloseAsync called on
             // the returned PoolItem if it had expired. The probability is very low and
@@ -124,7 +110,7 @@ namespace Azure.Messaging.EventHubs.Core
             if (item.PartitionProducer.IsClosed || !item.ActiveInstances.TryAdd(identifier, 0))
             {
                 identifier = Guid.NewGuid().ToString();
-                item = Pool.GetOrAdd(partitionId, id => new PoolItem(partitionId, Connection.CreateTransportProducer(id, RetryPolicy), removeAfterDuration));
+                item = Pool.GetOrAdd(partitionId, id => new PoolItem(partitionId, TransportProducerFactory(id), removeAfterDuration));
                 item.ActiveInstances.TryAdd(identifier, 0);
             }
 
@@ -141,7 +127,7 @@ namespace Azure.Messaging.EventHubs.Core
 
                 // If TryRemove returned false the PoolItem would not be closed deterministically
                 // and the ExpirationTimer callback would eventually remove it from the
-                // Pool leaving to the Garbage Collector the responsability of closing
+                // Pool leaving to the Garbage Collector the responsibility of closing
                 // the TransportProducer and the AMQP link.
 
                 item.ActiveInstances.TryRemove(identifier, out _);
@@ -200,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Core
         {
             return _ =>
             {
-                // Capture the timestamp to use a consistent value.
+                // Capture the time stamp to use a consistent value.
                 var now = DateTimeOffset.UtcNow;
 
                 foreach (var key in Pool.Keys.ToList())

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -923,6 +923,158 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that the idempotent publishing of events has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        ///
+        [Event(46, Level = EventLevel.Informational, Message = "Impotently publishing events for Event Hub: {0} (Partition Id: '{1}').")]
+        public virtual void IdempotentPublishStart(string eventHubName,
+                                                   string partitionId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(46, eventHubName ?? string.Empty, partitionId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the idempotent publishing of events has acquired the synchronization primitive.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        ///
+        [Event(47, Level = EventLevel.Verbose, Message = "Impotently publishing for Event Hub: {0} (Partition Id: '{1}') has acquired the partition synchronization primitive.")]
+        public virtual void IdempotentSynchronizationAcquire(string eventHubName,
+                                                             string partitionId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(47, eventHubName ?? string.Empty, partitionId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the idempotent publishing of events has released the synchronization primitive.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        ///
+        [Event(48, Level = EventLevel.Verbose, Message = "Impotently publishing for Event Hub: {0} (Partition Id: '{1}') has released the partition synchronization primitive.")]
+        public virtual void IdempotentSynchronizationRelease(string eventHubName,
+                                                             string partitionId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(48, eventHubName ?? string.Empty, partitionId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the idempotent publishing of events has released the synchronization primitive.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        /// <param name="startSequenceNumber">The starting sequence number used for publishing.</param>
+        /// <param name="endSequenceNumber">The ending sequence number of partition state used for publishing.</param>
+        ///
+        [Event(49, Level = EventLevel.Verbose, Message = "Impotently publishing for Event Hub: {0} (Partition Id: '{1}') is publishing events with the sequence number range from '{2}` to '{3}'.")]
+        public virtual void IdempotentSequencePublish(string eventHubName,
+                                                      string partitionId,
+                                                      long startSequenceNumber,
+                                                      long endSequenceNumber)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(49, eventHubName ?? string.Empty, partitionId ?? string.Empty, startSequenceNumber, endSequenceNumber);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the idempotent publishing of events has released the synchronization primitive.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        /// <param name="oldSequenceNumber">The sequence number of partition state before the update.</param>
+        /// <param name="newSequenceNumber">The sequence number of partition state after the update.</param>
+        ///
+        [Event(50, Level = EventLevel.Verbose, Message = "Impotently publishing for Event Hub: {0} (Partition Id: '{1}') has updated the tracked sequence number from '{2}` to '{3}'.")]
+        public virtual void IdempotentSequenceUpdate(string eventHubName,
+                                                     string partitionId,
+                                                     long oldSequenceNumber,
+                                                     long newSequenceNumber)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(50, eventHubName ?? string.Empty, partitionId ?? string.Empty, oldSequenceNumber, newSequenceNumber);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the idempotent publishing of events has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        ///
+        [Event(51, Level = EventLevel.Informational, Message = "Completed idempotent publishing events for Event Hub: {0} (Partition Id: '{1}').")]
+        public virtual void IdempotentPublishComplete(string eventHubName,
+                                                      string partitionId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(51, eventHubName ?? string.Empty, partitionId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while idempotent publishing events.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(52, Level = EventLevel.Error, Message = "An exception occurred while idempotent publishing events for Event Hub: {0} (Partition Id: '{1}'). Error Message: '{2}'")]
+        public virtual void IdempotentPublishError(string eventHubName,
+                                                   string partitionId,
+                                                   string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(52, eventHubName ?? string.Empty, partitionId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the idempotent publishing state for a partition has been initialized.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionId">The identifier of a partition used for idempotent publishing.</param>
+        /// <param name="producerGroupId">The identifier of the producer group associated with the partition.</param>
+        /// <param name="ownerLevel">The owner level associated with the partition.</param>
+        /// <param name="lastPublishedSequence">The sequence number last published to the partition for the producer group.</param>
+        ///
+        [Event(53, Level = EventLevel.Informational, Message = "Initializing idempotent publishing state for Event Hub: {0} (Partition Id: '{1}'). Producer Group Id: '{2}', Owner Level: '{3}', Last Published Sequence: '{4}'.")]
+        public virtual void IdempotentPublishInitializeState(string eventHubName,
+                                                             string partitionId,
+                                                             long producerGroupId,
+                                                             short ownerLevel,
+                                                             long lastPublishedSequence)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(53, eventHubName ?? string.Empty, partitionId ?? string.Empty, producerGroupId, ownerLevel, lastPublishedSequence);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that an exception was encountered in an unexpected code path, not directly associated with
         ///   an Event Hubs operation.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using Azure.Core;
 using Azure.Messaging.EventHubs.Consumer;
 
 namespace Azure.Messaging.EventHubs
@@ -17,9 +16,6 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventData
     {
-        /// <summary>The sequence number associated with publishing of the event.</summary>
-        private int? _publishedSequenceNumber = null;
-
         /// <summary>
         ///   The data associated with the event.
         /// </summary>
@@ -104,20 +100,7 @@ namespace Azure.Messaging.EventHubs
         ///   of the producer are enabled.  For example, it is used by idempotent publishing.
         /// </remarks>
         ///
-        public int? PublishedSequenceNumber
-        {
-            get => _publishedSequenceNumber;
-
-            internal set
-            {
-                if (value.HasValue)
-                {
-                    Argument.AssertAtLeast(value.Value, 0, nameof(PublishedSequenceNumber));
-                }
-
-                _publishedSequenceNumber = value;
-            }
-        }
+        public int? PublishedSequenceNumber { get; private set; }
 
         /// <summary>
         ///   The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.
@@ -161,6 +144,24 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         public string PartitionKey { get; }
+
+        /// <summary>
+        ///   The publishing sequence number assigned to the event as part of a publishing operation.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The sequence number that was assigned during publishing, if the event was successfully
+        ///   published by a sequence-aware producer.  If the producer was not configured to apply
+        ///   sequence numbering or if the event has not yet been successfully published, this member
+        ///   will be <c>null</c>.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   The published sequence number is only populated and relevant when certain features
+        ///   of the producer are enabled.  For example, it is used by idempotent publishing.
+        /// </remarks>
+        ///
+        internal int? PendingPublishSequenceNumber { get; set; }
 
         /// <summary>
         ///   The sequence number of the event that was last enqueued into the Event Hub partition from which this
@@ -235,6 +236,8 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastPartitionOffset">The offset that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionEnqueuedTime">The date and time, in UTC, of the event that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionPropertiesRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the service.</param>
+        /// <param name="publishedSequenceNumber">The publishing sequence number assigned to the event at the time it was successfully published.</param>
+        /// <param name="pendingPublishSequenceNumber">The publishing sequence number assigned to the event as part of a publishing operation.</param>
         ///
         internal EventData(ReadOnlyMemory<byte> eventBody,
                            IDictionary<string, object> properties = null,
@@ -246,7 +249,9 @@ namespace Azure.Messaging.EventHubs
                            long? lastPartitionSequenceNumber = null,
                            long? lastPartitionOffset = null,
                            DateTimeOffset? lastPartitionEnqueuedTime = null,
-                           DateTimeOffset? lastPartitionPropertiesRetrievalTime = null)
+                           DateTimeOffset? lastPartitionPropertiesRetrievalTime = null,
+                           int? publishedSequenceNumber = null,
+                           int? pendingPublishSequenceNumber = null)
         {
             Body = eventBody;
             Properties = properties ?? new Dictionary<string, object>();
@@ -255,10 +260,12 @@ namespace Azure.Messaging.EventHubs
             Offset = offset;
             EnqueuedTime = enqueuedTime;
             PartitionKey = partitionKey;
+            PendingPublishSequenceNumber = pendingPublishSequenceNumber;
             LastPartitionSequenceNumber = lastPartitionSequenceNumber;
             LastPartitionOffset = lastPartitionOffset;
             LastPartitionEnqueuedTime = lastPartitionEnqueuedTime;
             LastPartitionPropertiesRetrievalTime = lastPartitionPropertiesRetrievalTime;
+            PublishedSequenceNumber = publishedSequenceNumber;
         }
 
         /// <summary>
@@ -313,6 +320,16 @@ namespace Azure.Messaging.EventHubs
         public override string ToString() => base.ToString();
 
         /// <summary>
+        ///   Transitions the pending publishing sequence number to the published sequence number.
+        /// </summary>
+        ///
+        internal void CommitPublishingSequenceNumber()
+        {
+            PublishedSequenceNumber = PendingPublishSequenceNumber;
+            PendingPublishSequenceNumber = default;
+        }
+
+        /// <summary>
         ///   Creates a new copy of the current <see cref="EventData" />, cloning its attributes into a new instance.
         /// </summary>
         ///
@@ -331,7 +348,9 @@ namespace Azure.Messaging.EventHubs
                 LastPartitionSequenceNumber,
                 LastPartitionOffset,
                 LastPartitionEnqueuedTime,
-                LastPartitionPropertiesRetrievalTime
+                LastPartitionPropertiesRetrievalTime,
+                PublishedSequenceNumber,
+                PendingPublishSequenceNumber
             );
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -12,6 +12,7 @@ using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
+using Azure.Messaging.EventHubs.Producer;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -354,15 +355,19 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
+        /// <param name="requestedFeatures">The flags specifying the set of special transport features that should be opted-into.</param>
+        /// <param name="partitionOptions">The set of options, if any, that should be considered when initializing the producer.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         internal virtual TransportProducer CreateTransportProducer(string partitionId,
+                                                                   TransportProducerFeatures requestedFeatures,
+                                                                   PartitionPublishingOptions partitionOptions,
                                                                    EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
-            return InnerClient.CreateProducer(partitionId, retryPolicy);
+            return InnerClient.CreateProducer(partitionId, requestedFeatures, partitionOptions, retryPolicy);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -61,16 +61,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public int? StartingPublishedSequenceNumber
         {
             get => InnerBatch.StartingPublishedSequenceNumber;
-
-            internal set
-            {
-                if (value.HasValue)
-                {
-                    Argument.AssertAtLeast(value.Value, 0, nameof(StartingPublishedSequenceNumber));
-                }
-
-                InnerBatch.StartingPublishedSequenceNumber = value;
-            }
+            internal set => InnerBatch.StartingPublishedSequenceNumber = value;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -92,6 +94,12 @@ namespace Azure.Messaging.EventHubs.Producer
         private EventHubsRetryPolicy RetryPolicy { get; }
 
         /// <summary>
+        ///   The set of options to use with the <see cref="EventHubProducerClient" />  instance.
+        /// </summary>
+        ///
+        private EventHubProducerClientOptions Options { get; }
+
+        /// <summary>
         ///   The active connection to the Azure Event Hubs service, enabling client communications for metadata
         ///   about the associated Event Hub and access to a transport-aware producer.
         /// </summary>
@@ -103,6 +111,17 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </summary>
         ///
         private TransportProducerPool PartitionProducerPool { get; }
+
+        /// <summary>
+        ///   The publishing-related state associated with partitions.
+        /// </summary>
+        ///
+        /// <value>
+        ///   Created if the producer has been configured with one or more features which requires
+        ///   publishing to partitions in a stateful manner; otherwise, <c>null</c>.
+        /// </value>
+        ///
+        private ConcurrentDictionary<string, PartitionPublishingState> PartitionState { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventHubProducerClient" /> class.
@@ -194,7 +213,19 @@ namespace Azure.Messaging.EventHubs.Producer
             OwnsConnection = true;
             Connection = new EventHubConnection(connectionString, eventHubName, clientOptions.ConnectionOptions);
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
-            PartitionProducerPool = new TransportProducerPool(Connection, RetryPolicy);
+            Options = clientOptions;
+
+            PartitionProducerPool = new TransportProducerPool(partitionId =>
+                Connection.CreateTransportProducer(
+                    partitionId,
+                    clientOptions.CreateFeatureFlags(),
+                    Options.GetPublishingOptionsOrDefaultForPartition(partitionId),
+                    RetryPolicy));
+
+            if (RequiresStatefulPartitions(clientOptions))
+            {
+                PartitionState = new ConcurrentDictionary<string, PartitionPublishingState>();
+            }
         }
 
         /// <summary>
@@ -219,8 +250,20 @@ namespace Azure.Messaging.EventHubs.Producer
 
             OwnsConnection = true;
             Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, clientOptions.ConnectionOptions);
+            Options = clientOptions;
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
-            PartitionProducerPool = new TransportProducerPool(Connection, RetryPolicy);
+
+            PartitionProducerPool = new TransportProducerPool(partitionId =>
+                Connection.CreateTransportProducer(
+                    partitionId,
+                    clientOptions.CreateFeatureFlags(),
+                    Options.GetPublishingOptionsOrDefaultForPartition(partitionId),
+                    RetryPolicy));
+
+            if (RequiresStatefulPartitions(clientOptions))
+            {
+                PartitionState = new ConcurrentDictionary<string, PartitionPublishingState>();
+            }
         }
 
         /// <summary>
@@ -239,7 +282,19 @@ namespace Azure.Messaging.EventHubs.Producer
             OwnsConnection = false;
             Connection = connection;
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
-            PartitionProducerPool = new TransportProducerPool(Connection, RetryPolicy);
+            Options = clientOptions;
+
+            PartitionProducerPool = new TransportProducerPool(partitionId =>
+                Connection.CreateTransportProducer(
+                    partitionId,
+                    clientOptions.CreateFeatureFlags(),
+                    Options.GetPublishingOptionsOrDefaultForPartition(partitionId),
+                    RetryPolicy));
+
+            if (RequiresStatefulPartitions(clientOptions))
+            {
+                PartitionState = new ConcurrentDictionary<string, PartitionPublishingState>();
+            }
         }
 
         /// <summary>
@@ -265,7 +320,13 @@ namespace Azure.Messaging.EventHubs.Producer
             OwnsConnection = false;
             Connection = connection;
             RetryPolicy = new EventHubsRetryOptions().ToRetryPolicy();
-            PartitionProducerPool = partitionProducerPool ?? new TransportProducerPool(Connection, RetryPolicy, eventHubProducer: transportProducer);
+            Options = new EventHubProducerClientOptions();
+            PartitionProducerPool = partitionProducerPool ?? new TransportProducerPool(partitionId => transportProducer);
+
+            if (RequiresStatefulPartitions(Options))
+            {
+                PartitionState = new ConcurrentDictionary<string, PartitionPublishingState>();
+            }
         }
 
         /// <summary>
@@ -403,7 +464,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   validated until this method is invoked.  The call will fail if the size of the specified set of events exceeds the maximum allowable size of a single batch.
         /// </summary>
         ///
-        /// <param name="eventBatch">The set of event data to send.</param>
+        /// <param name="eventSet">The set of event data to send.</param>
         /// <param name="options">The set of options to consider when sending this batch.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
         ///
@@ -418,62 +479,31 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
         ///
-        public virtual async Task SendAsync(IEnumerable<EventData> eventBatch,
+        public virtual async Task SendAsync(IEnumerable<EventData> eventSet,
                                             SendEventOptions options,
                                             CancellationToken cancellationToken = default)
         {
             options ??= DefaultSendOptions;
 
-            Argument.AssertNotNull(eventBatch, nameof(eventBatch));
+            Argument.AssertNotNull(eventSet, nameof(eventSet));
             AssertSinglePartitionReference(options.PartitionId, options.PartitionKey);
 
-            int attempts = 0;
-
-            eventBatch = (eventBatch as IList<EventData>) ?? eventBatch.ToList();
-            InstrumentMessages(eventBatch);
-
-            var diagnosticIdentifiers = new List<string>();
-
-            foreach (var eventData in eventBatch)
+            var events = eventSet switch
             {
-                if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out var identifier))
-                {
-                    diagnosticIdentifiers.Add(identifier);
-                }
+               IReadOnlyList<EventData> eventList => eventList,
+               _ => eventSet.ToList()
+            };
+
+            if (events.Count == 0)
+            {
+                return;
             }
 
-            using DiagnosticScope scope = CreateDiagnosticScope(diagnosticIdentifiers);
+            var sendTask = (Options.EnableIdempotentPartitions)
+                ? SendIdempotentAsync(events, options, cancellationToken)
+                : SendInternalAsync(events, options, cancellationToken);
 
-            var pooledProducer = PartitionProducerPool.GetPooledProducer(options.PartitionId, PartitionProducerLifespan);
-
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    await using var _ = pooledProducer.ConfigureAwait(false);
-                    await pooledProducer.TransportProducer.SendAsync(eventBatch, options, cancellationToken).ConfigureAwait(false);
-
-                    return;
-                }
-                catch (EventHubsException eventHubException)
-                    when (eventHubException.Reason == EventHubsException.FailureReason.ClientClosed && ShouldRecreateProducer(pooledProducer.TransportProducer, options.PartitionId))
-                {
-                    if (++attempts >= MaximumCreateProducerAttempts)
-                    {
-                        scope.Failed(eventHubException);
-                        throw;
-                    }
-
-                    pooledProducer = PartitionProducerPool.GetPooledProducer(options.PartitionId, PartitionProducerLifespan);
-                }
-                catch (Exception ex)
-                {
-                    scope.Failed(ex);
-                    throw;
-                }
-            }
-
-            throw new TaskCanceledException();
+            await sendTask.ConfigureAwait(false);
         }
 
         /// <summary>
@@ -493,45 +523,16 @@ namespace Azure.Messaging.EventHubs.Producer
             Argument.AssertNotNull(eventBatch, nameof(eventBatch));
             AssertSinglePartitionReference(eventBatch.SendOptions.PartitionId, eventBatch.SendOptions.PartitionKey);
 
-            using DiagnosticScope scope = CreateDiagnosticScope(eventBatch.GetEventDiagnosticIdentifiers());
-
-            var attempts = 0;
-            var pooledProducer = PartitionProducerPool.GetPooledProducer(eventBatch.SendOptions.PartitionId, PartitionProducerLifespan);
-
-            while (!cancellationToken.IsCancellationRequested)
+            if (eventBatch.Count == 0)
             {
-                try
-                {
-                    await using var _ = pooledProducer.ConfigureAwait(false);
-
-                    eventBatch.Lock();
-                    await pooledProducer.TransportProducer.SendAsync(eventBatch, cancellationToken).ConfigureAwait(false);
-
-                    return;
-                }
-                catch (EventHubsException eventHubException)
-                    when (eventHubException.Reason == EventHubsException.FailureReason.ClientClosed && ShouldRecreateProducer(pooledProducer.TransportProducer, eventBatch.SendOptions.PartitionId))
-                {
-                    if (++attempts >= MaximumCreateProducerAttempts)
-                    {
-                        scope.Failed(eventHubException);
-                        throw;
-                    }
-
-                    pooledProducer = PartitionProducerPool.GetPooledProducer(eventBatch.SendOptions.PartitionId, PartitionProducerLifespan);
-                }
-                catch (Exception ex)
-                {
-                    scope.Failed(ex);
-                    throw;
-                }
-                finally
-                {
-                    eventBatch.Unlock();
-                }
+                return;
             }
 
-            throw new TaskCanceledException();
+            var sendTask = (!Options.EnableIdempotentPartitions)
+                ? SendInternalAsync(eventBatch, cancellationToken)
+                : SendIdempotentAsync(eventBatch, cancellationToken);
+
+            await sendTask.ConfigureAwait(false);
         }
 
         /// <summary>
@@ -685,6 +686,354 @@ namespace Azure.Messaging.EventHubs.Producer
         public override string ToString() => base.ToString();
 
         /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  Because the batch is implicitly created, the size of the event set is not
+        ///   validated until this method is invoked.  The call will fail if the size of the specified set of events exceeds the maximum allowable size of a single batch.
+        /// </summary>
+        ///
+        /// <param name="events">The set of event data to send.</param>
+        /// <param name="options">The set of options to consider when sending this batch.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        ///
+        private async Task SendInternalAsync(IReadOnlyList<EventData> events,
+                                             SendEventOptions options,
+                                             CancellationToken cancellationToken = default)
+        {
+            var attempts = 0;
+            var diagnosticIdentifiers = new List<string>();
+
+            InstrumentMessages(events);
+
+            foreach (var eventData in events)
+            {
+                if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out var identifier))
+                {
+                    diagnosticIdentifiers.Add(identifier);
+                }
+            }
+
+            using DiagnosticScope scope = CreateDiagnosticScope(diagnosticIdentifiers);
+
+            var pooledProducer = PartitionProducerPool.GetPooledProducer(options.PartitionId, PartitionProducerLifespan);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await using var _ = pooledProducer.ConfigureAwait(false);
+                    await pooledProducer.TransportProducer.SendAsync(events, options, cancellationToken).ConfigureAwait(false);
+
+                    return;
+                }
+                catch (EventHubsException eventHubException)
+                    when (eventHubException.Reason == EventHubsException.FailureReason.ClientClosed && ShouldRecreateProducer(pooledProducer.TransportProducer, options.PartitionId))
+                {
+                    if (++attempts >= MaximumCreateProducerAttempts)
+                    {
+                        scope.Failed(eventHubException);
+                        throw;
+                    }
+
+                    pooledProducer = PartitionProducerPool.GetPooledProducer(options.PartitionId, PartitionProducerLifespan);
+                }
+                catch (Exception ex)
+                {
+                    scope.Failed(ex);
+                    throw;
+                }
+            }
+
+            throw new TaskCanceledException();
+        }
+
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.
+        /// </summary>
+        ///
+        /// <param name="eventBatch">The set of event data to send. A batch may be created using <see cref="CreateBatchAsync(CancellationToken)" />.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        ///
+        private async Task SendInternalAsync(EventDataBatch eventBatch,
+                                             CancellationToken cancellationToken = default)
+        {
+            using DiagnosticScope scope = CreateDiagnosticScope(eventBatch.GetEventDiagnosticIdentifiers());
+
+            var attempts = 0;
+            var pooledProducer = PartitionProducerPool.GetPooledProducer(eventBatch.SendOptions.PartitionId, PartitionProducerLifespan);
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await using var _ = pooledProducer.ConfigureAwait(false);
+
+                        eventBatch.Lock();
+                        await pooledProducer.TransportProducer.SendAsync(eventBatch, cancellationToken).ConfigureAwait(false);
+
+                        return;
+                    }
+                    catch (EventHubsException eventHubException)
+                        when (eventHubException.Reason == EventHubsException.FailureReason.ClientClosed && ShouldRecreateProducer(pooledProducer.TransportProducer, eventBatch.SendOptions.PartitionId))
+                    {
+                        if (++attempts >= MaximumCreateProducerAttempts)
+                        {
+                            scope.Failed(eventHubException);
+                            throw;
+                        }
+
+                        pooledProducer = PartitionProducerPool.GetPooledProducer(eventBatch.SendOptions.PartitionId, PartitionProducerLifespan);
+                    }
+                    catch (Exception ex)
+                    {
+                        scope.Failed(ex);
+                        throw;
+                    }
+                }
+            }
+            finally
+            {
+                eventBatch.Unlock();
+            }
+
+            throw new TaskCanceledException();
+        }
+
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  Because the batch is implicitly created, the size of the event set is not
+        ///   validated until this method is invoked.  The call will fail if the size of the specified set of events exceeds the maximum allowable size of a single batch.
+        /// </summary>
+        ///
+        /// <param name="eventSet">The set of event data to send.</param>
+        /// <param name="options">The set of options to consider when sending this batch.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        ///
+        private async Task SendIdempotentAsync(IReadOnlyList<EventData> eventSet,
+                                               SendEventOptions options,
+                                               CancellationToken cancellationToken = default)
+        {
+            AssertPartitionIsReferenced(options.PartitionId);
+            AssertIdempotentEventsNotPublished(eventSet);
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                EventHubsEventSource.Log.IdempotentPublishStart(EventHubName, options.PartitionId);
+
+                var partitionState = PartitionState.GetOrAdd(options.PartitionId, new PartitionPublishingState(options.PartitionId));
+
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                    await partitionState.PublishingGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    EventHubsEventSource.Log.IdempotentSynchronizationAcquire(EventHubName, options.PartitionId);
+
+                    // Ensure that the partition state has been initialized.
+
+                    if (!partitionState.IsInitialized)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                        await InitializePartitionStateAsync(partitionState, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Sequence the events for publishing.
+
+                    var lastSequence = partitionState.LastPublishedSequenceNumber.Value;
+                    var firstSequence = lastSequence;
+
+                    foreach (var eventData in eventSet)
+                    {
+                        lastSequence = NextSequence(lastSequence);
+                        eventData.PendingPublishSequenceNumber = lastSequence;
+                    }
+
+                    // Publish the events.
+
+                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                    EventHubsEventSource.Log.IdempotentSequencePublish(EventHubName, options.PartitionId, firstSequence, lastSequence);
+                    await SendInternalAsync(eventSet, options, cancellationToken).ConfigureAwait(false);
+
+                    // Update state and commit the sequencing.
+
+                    EventHubsEventSource.Log.IdempotentSequenceUpdate(EventHubName, options.PartitionId, partitionState.LastPublishedSequenceNumber.Value, lastSequence);
+                    partitionState.LastPublishedSequenceNumber = lastSequence;
+
+                    foreach (var eventData in eventSet)
+                    {
+                        eventData.CommitPublishingSequenceNumber();
+                    }
+                }
+                catch
+                {
+                    // Clear the pending sequence numbers in the face of an exception.
+
+                    foreach (var eventData in eventSet)
+                    {
+                        eventData.PendingPublishSequenceNumber = null;
+                    }
+
+                    throw;
+                }
+                finally
+                {
+                    partitionState.PublishingGuard.Release();
+                    EventHubsEventSource.Log.IdempotentSynchronizationRelease(EventHubName, options.PartitionId);
+                }
+            }
+            catch (Exception ex)
+            {
+                EventHubsEventSource.Log.IdempotentPublishError(EventHubName, options.PartitionId, ex.Message);
+                throw;
+            }
+            finally
+            {
+                EventHubsEventSource.Log.IdempotentPublishComplete(EventHubName, options.PartitionId);
+            }
+        }
+
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.
+        /// </summary>
+        ///
+        /// <param name="eventBatch">The set of event data to send. A batch may be created using <see cref="CreateBatchAsync(CancellationToken)" />.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        ///
+        private async Task SendIdempotentAsync(EventDataBatch eventBatch,
+                                               CancellationToken cancellationToken = default)
+        {
+            var options = eventBatch.SendOptions;
+
+            AssertPartitionIsReferenced(options.PartitionId);
+            AssertIdempotentBatchNotPublished(eventBatch);
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                EventHubsEventSource.Log.IdempotentPublishStart(EventHubName, options.PartitionId);
+
+                var partitionState = PartitionState.GetOrAdd(options.PartitionId, new PartitionPublishingState(options.PartitionId));
+
+                var eventSet = eventBatch.AsEnumerable<EventData>() switch
+                {
+                    IReadOnlyList<EventData> eventList => eventList,
+                    IEnumerable<EventData> eventEnumerable => eventEnumerable.ToList()
+                };
+
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                    await partitionState.PublishingGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    EventHubsEventSource.Log.IdempotentSynchronizationAcquire(EventHubName, options.PartitionId);
+
+                    // Ensure that the partition state has been initialized.
+
+                    if (!partitionState.IsInitialized)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                        await InitializePartitionStateAsync(partitionState, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Sequence the events for publishing.
+
+                    var lastSequence = partitionState.LastPublishedSequenceNumber.Value;
+                    var firstSequence = NextSequence(lastSequence);
+
+                    foreach (var eventData in eventSet)
+                    {
+                        lastSequence = NextSequence(lastSequence);
+                        eventData.PendingPublishSequenceNumber = lastSequence;
+                    }
+
+                    // Publish the events.
+
+                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                    EventHubsEventSource.Log.IdempotentSequencePublish(EventHubName, options.PartitionId, firstSequence, lastSequence);
+                    await SendInternalAsync(eventBatch, cancellationToken).ConfigureAwait(false);
+
+                    // Update state and commit the sequencing.  This needs only to happen at the batch level, as the contained
+                    // events are not accessible by callers.
+
+                    EventHubsEventSource.Log.IdempotentSequenceUpdate(EventHubName, options.PartitionId, partitionState.LastPublishedSequenceNumber.Value, lastSequence);
+                    partitionState.LastPublishedSequenceNumber = lastSequence;
+                    eventBatch.StartingPublishedSequenceNumber = firstSequence;
+                }
+                catch
+                {
+                    // Clear the pending sequence numbers in the face of an exception.
+
+                    foreach (var eventData in eventSet)
+                    {
+                        eventData.PendingPublishSequenceNumber = null;
+                    }
+
+                    throw;
+                }
+                finally
+                {
+                    partitionState.PublishingGuard.Release();
+                    EventHubsEventSource.Log.IdempotentSynchronizationRelease(EventHubName, options.PartitionId);
+                }
+            }
+            catch (Exception ex)
+            {
+                EventHubsEventSource.Log.IdempotentPublishError(EventHubName, options.PartitionId, ex.Message);
+                throw;
+            }
+            finally
+            {
+
+                EventHubsEventSource.Log.IdempotentPublishComplete(EventHubName, options.PartitionId);
+            }
+        }
+
+        /// <summary>
+        ///   Initializes state instance for a given partition.
+        /// </summary>
+        ///
+        /// <param name="partitionState">The state of the partition to be initialized.  This parameter will be mutated by this call.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <remarks>
+        ///   The <paramref name="partitionState"/> parameter will be mutated by this call.  To avoid duplicate initialization or state corruption, this
+        ///   method should only be called while the <see cref="PartitionPublishingState.PublishingGuard" /> primitive of the state instance is held.
+        /// </remarks>
+        ///
+        private async Task InitializePartitionStateAsync(PartitionPublishingState partitionState,
+                                                         CancellationToken cancellationToken = default)
+        {
+            if (partitionState.IsInitialized)
+            {
+                return;
+            }
+
+            var producer = PartitionProducerPool.GetPooledProducer(partitionState.PartitionId, PartitionProducerLifespan);
+            var properties = await producer.TransportProducer.ReadInitializationPublishingPropertiesAsync(cancellationToken).ConfigureAwait(false);
+
+            partitionState.ProducerGroupId = properties.ProducerGroupId;
+            partitionState.OwnerLevel = properties.OwnerLevel;
+            partitionState.LastPublishedSequenceNumber = properties.LastPublishedSequenceNumber;
+
+            // If the state was not initialized and no exception has occurred, then the service is behaving
+            // unexpectedly and the client should be considered invalid.
+
+            if (!partitionState.IsInitialized)
+            {
+                throw new EventHubsException(false, EventHubName, EventHubsException.FailureReason.InvalidClientState);
+            }
+
+            EventHubsEventSource.Log.IdempotentPublishInitializeState(
+                EventHubName,
+                partitionState.PartitionId,
+                partitionState.ProducerGroupId.Value,
+                partitionState.OwnerLevel.Value,
+                partitionState.LastPublishedSequenceNumber.Value);
+        }
+
+        /// <summary>
         ///   Creates and configures a diagnostics scope to be used for instrumenting
         ///   events.
         /// </summary>
@@ -729,22 +1078,6 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
-        ///   Ensures that no more than a single partition reference is active.
-        /// </summary>
-        ///
-        /// <param name="partitionId">The identifier of the partition to which the producer is bound.</param>
-        /// <param name="partitionKey">The hash key for partition routing that was requested for a publish operation.</param>
-        ///
-        private static void AssertSinglePartitionReference(string partitionId,
-                                                           string partitionKey)
-        {
-            if ((!string.IsNullOrEmpty(partitionId)) && (!string.IsNullOrEmpty(partitionKey)))
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.CannotSendWithPartitionIdAndPartitionKey, partitionId));
-            }
-        }
-
-        /// <summary>
         ///   Checks if the <see cref="TransportProducer" /> returned by the <see cref="TransportProducerPool" /> is still open.
         /// </summary>
         ///
@@ -758,5 +1091,100 @@ namespace Azure.Messaging.EventHubs.Producer
                                                                    && producer.IsClosed
                                                                    && !IsClosed
                                                                    && !Connection.IsClosed;
+
+        /// <summary>
+        ///   Ensures that no more than a single partition reference is active.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition to which the producer is bound.</param>
+        /// <param name="partitionKey">The hash key for partition routing that was requested for a publish operation.</param>
+        ///
+        private static void AssertSinglePartitionReference(string partitionId,
+                                                           string partitionKey)
+        {
+            if ((!string.IsNullOrEmpty(partitionId)) && (!string.IsNullOrEmpty(partitionKey)))
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.CannotSendWithPartitionIdAndPartitionKey, partitionKey, partitionId));
+            }
+        }
+
+        /// <summary>
+        ///   Ensures that a partition reference is active and the request is not for publishing
+        ///   to the Event Hubs gateway.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition to which the producer is bound.</param>
+        ///
+        private static void AssertPartitionIsReferenced(string partitionId)
+        {
+            if (string.IsNullOrEmpty(partitionId))
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.CannotPublishToGateway, partitionId));
+            }
+        }
+
+        /// <summary>
+        ///   Ensures that a batch of events has not been previously acknowledged by the Event Hubs
+        ///   service as having been successfully published.
+        /// </summary>
+        ///
+        /// <param name="batch">The <see cref="EventDataBatch" /> to consider.</param>
+        ///
+        private static void AssertIdempotentBatchNotPublished(EventDataBatch batch)
+        {
+            if ((batch.StartingPublishedSequenceNumber.HasValue)
+                || (batch.AsEnumerable<EventData>().Any(eventData => eventData.PublishedSequenceNumber.HasValue)))
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.IdempotentAlreadyPublished));
+            }
+        }
+
+        /// <summary>
+        ///   Ensures that a batch of events has not been previously acknowledged by the Event Hubs
+        ///   service as having been successfully published.
+        /// </summary>
+        ///
+        /// <param name="eventSet">The set of <see cref="EventData" /> to consider.</param>
+        ///
+        private static void AssertIdempotentEventsNotPublished(IEnumerable<EventData> eventSet)
+        {
+            foreach (var eventData in eventSet)
+            {
+                if (eventData.PublishedSequenceNumber.HasValue)
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.IdempotentAlreadyPublished));
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Calculates the next sequence number based on the current sequence number.
+        /// </summary>
+        ///
+        /// <param name="currentSequence">The current sequence number to consider.</param>
+        ///
+        /// <returns>The next sequence number, in proper order.</returns>
+        ///
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int NextSequence(int currentSequence)
+        {
+            if (unchecked(++currentSequence) < 0)
+            {
+                currentSequence = 0;
+            }
+
+            return currentSequence;
+        }
+
+        /// <summary>
+        ///   Indicates whether publishing requires stateful partitions.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for making the determination.</param>
+        ///
+        /// <returns><c>true</c> if publishing is stateful; otherwise, <c>false</c>.</returns>
+        ///
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool RequiresStatefulPartitions(EventHubProducerClientOptions options) => options.EnableIdempotentPartitions;
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
@@ -127,5 +127,44 @@ namespace Azure.Messaging.EventHubs.Producer
 
             return copiedOptions;
         }
+
+        /// <summary>
+        ///   Creates the set of flags that represents the features requested by these options.
+        /// </summary>
+        ///
+        /// <returns>The set of features that were requested for the <see cref="EventHubProducerClient" />.</returns>
+        ///
+        internal TransportProducerFeatures CreateFeatureFlags()
+        {
+            var features = TransportProducerFeatures.None;
+
+            if (EnableIdempotentPartitions)
+            {
+                features |= TransportProducerFeatures.IdempotentPublishing;
+            }
+
+            return features;
+        }
+
+        /// <summary>
+        ///   Attempts to retrieve the publishing options for a given partition, returning a
+        ///   default in the case that no partition was specified or there were no available options
+        ///   for that partition.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition for which options are requested.</param>
+        ///
+        /// <returns><c>null</c> in the event that there was no partition specified or no options for the partition; otherwise, the publishing options.</returns>
+        ///
+        internal PartitionPublishingOptions GetPublishingOptionsOrDefaultForPartition(string partitionId)
+        {
+            if (string.IsNullOrEmpty(partitionId))
+            {
+                return default;
+            }
+
+            PartitionOptions.TryGetValue(partitionId, out var options);
+            return options;
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Messaging.EventHubs.Core;
+
 namespace Azure.Messaging.EventHubs.Producer
 {
     /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
@@ -21,20 +21,20 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   The identifier of the producer group for which this producer is publishing to the associated partition.
         /// </summary>
         ///
-        public long? ProducerGroupId  { get; set; }
+        public long? ProducerGroupId  { get; }
 
         /// <summary>
-        ///   The owner level of this producer for publishing to the associated partition.
+        ///   The owner level of the producer publishing to the associated partition.
         /// </summary>
         ///
-        public short? OwnerLevel { get; set; }
+        public short? OwnerLevel { get; }
 
         /// <summary>
         ///   The sequence number assigned to the event that was most recently published to the associated partition
         ///   successfully.
         /// </summary>
         ///
-        public int? LastPublishedSequenceNumber   { get; set; }
+        public int? LastPublishedSequenceNumber { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingState.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingState.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+
+namespace Azure.Messaging.EventHubs.Producer
+{
+    /// <summary>
+    ///   The set of state associated with stateful publishing to a partition, such as when
+    ///   idempotency is enabled.
+    /// </summary>
+    ///
+    internal class PartitionPublishingState
+    {
+        /// <summary>
+        ///   The identifier of the partition whose state is represented.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   This class is not intended to be used with its <see cref="PublishingGuard" />
+        ///   for synchronizing access; it does not provide any inherent thread safety guarantees.
+        /// </remarks>
+        ///
+        public string PartitionId { get; }
+
+        /// <summary>
+        ///   Indicates whether or not the state has been initialized.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if this instance is initialized; otherwise, <c>false</c>.</value>
+        ///
+        public bool IsInitialized => (ProducerGroupId.HasValue && OwnerLevel.HasValue && LastPublishedSequenceNumber.HasValue);
+
+        /// <summary>
+        ///   The primitive for synchronizing access for publishing to the partition.
+        /// </summary>
+        ///
+        public SemaphoreSlim PublishingGuard { get; } = new SemaphoreSlim(1, 1);
+
+        /// <summary>
+        ///   The identifier of the producer group for which publishing is being performed.
+        /// </summary>
+        ///
+        public long? ProducerGroupId  { get; set; }
+
+        /// <summary>
+        ///   The owner level for which publishing is being performed.
+        /// </summary>
+        ///
+        public short? OwnerLevel { get; set; }
+
+        /// <summary>
+        ///   The sequence number assigned to the event that was most recently published to the associated partition
+        ///   successfully.
+        /// </summary>
+        ///
+        public int? LastPublishedSequenceNumber { get; set; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PartitionPublishingState"/> class.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition whose state is represented.</param>
+        ///
+        public PartitionPublishingState(string partitionId) => PartitionId = partitionId;
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -717,7 +717,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateProducer(null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(() => client.CreateProducer(null, TransportProducerFeatures.None, null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -572,13 +572,18 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportClient = new ObservableTransportClientMock();
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { MaximumRetries = 6, TryTimeout = TimeSpan.FromMinutes(4) } };
+            var options = new EventHubProducerClientOptions { EnableIdempotentPartitions = true, RetryOptions = new EventHubsRetryOptions { MaximumRetries = 6, TryTimeout = TimeSpan.FromMinutes(4) } };
+            var expectedFeatures = options.CreateFeatureFlags();
+            var expectedPartitionOptions = new PartitionPublishingOptions { ProducerGroupId = 123 };
             var expectedRetry = options.RetryOptions.ToRetryPolicy();
 
-            client.CreateTransportProducer(null, expectedRetry);
+            client.CreateTransportProducer(null, expectedFeatures, expectedPartitionOptions, expectedRetry);
 
             Assert.That(transportClient.CreateProducerCalledWith, Is.Not.Null, "The producer options should have been set.");
             Assert.That(transportClient.CreateProducerCalledWith.PartitionId, Is.Null, "There should have been no partition specified.");
+            Assert.That(transportClient.CreateProducerCalledWith.Features, Is.EqualTo(expectedFeatures), "The features should match.");
+            Assert.That(transportClient.CreateProducerCalledWith.PartitionOptions, Is.Not.Null, "The partition options should have been specified.");
+            Assert.That(transportClient.CreateProducerCalledWith.PartitionOptions, Is.SameAs(expectedPartitionOptions), "The partition options should match.");
             Assert.That(transportClient.CreateProducerCalledWith.RetryPolicy, Is.Not.Null, "The retry policy should have been specified.");
             Assert.That(transportClient.CreateProducerCalledWith.RetryPolicy, Is.SameAs(expectedRetry), "The retry policies should match.");
         }
@@ -802,7 +807,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private class ObservableTransportClientMock : TransportClient
         {
             public (string ConsumerGroup, string Partition, EventPosition Position, EventHubsRetryPolicy RetryPolicy, bool TrackLastEnqueued, long? OwnerLevel, uint? Prefetch) CreateConsumerCalledWith;
-            public (string PartitionId, EventHubsRetryPolicy RetryPolicy) CreateProducerCalledWith;
+            public (string PartitionId, TransportProducerFeatures Features, PartitionPublishingOptions PartitionOptions, EventHubsRetryPolicy RetryPolicy) CreateProducerCalledWith;
             public string GetPartitionPropertiesCalledForId;
             public bool WasGetPropertiesCalled;
             public bool WasCloseCalled;
@@ -823,9 +828,11 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             public override TransportProducer CreateProducer(string partitionId,
+                                                             TransportProducerFeatures requestedFeatures,
+                                                             PartitionPublishingOptions partitionOptions,
                                                              EventHubsRetryPolicy retryPolicy)
             {
-                CreateProducerCalledWith = (partitionId, retryPolicy);
+                CreateProducerCalledWith = (partitionId, requestedFeatures, partitionOptions, retryPolicy);
                 return default;
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -55,38 +55,26 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventData.PublishedSequenceNumber "/>
+        ///   Verifies functionality of the <see cref="EventData.CommitPublishingSequenceNumber "/>
         ///   property.
         /// </summary>
         ///
         [Test]
-        [TestCase(-1)]
-        [TestCase(-10)]
-        [TestCase(-100)]
-        public void PublishedSequenceNumberValidatesOnSet(int value)
+        public void CommitPublishingSequenceNumberTransitionsState()
         {
-            var eventData = new EventData(Array.Empty<byte>());
-            Assert.That(() => eventData.PublishedSequenceNumber = value, Throws.InstanceOf<ArgumentException>(), "Negative values should not be allowed.");
-        }
+            var expectedSequence = 8675309;
 
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventData.PublishedSequenceNumber "/>
-        ///   property.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(null)]
-        [TestCase(0)]
-        [TestCase(1)]
-        [TestCase(10)]
-        [TestCase(100)]
-        [TestCase(32768)]
-        public void PublishedSequenceNumberAllowsValidValues(int? value)
-        {
-            var eventData = new EventData(Array.Empty<byte>());
-            eventData.PublishedSequenceNumber = value;
+            var eventData = new EventData(Array.Empty<byte>())
+            {
+                PendingPublishSequenceNumber = expectedSequence
+            };
 
-            Assert.That(eventData.PublishedSequenceNumber, Is.EqualTo(value), "The value should have been accepted.");
+            Assert.That(eventData.PendingPublishSequenceNumber, Is.EqualTo(expectedSequence), "The pending sequence number should have been set.");
+
+            eventData.CommitPublishingSequenceNumber();
+
+            Assert.That(eventData.PublishedSequenceNumber, Is.EqualTo(expectedSequence), "The published sequence number should have been set.");
+            Assert.That(eventData.PendingPublishSequenceNumber, Is.EqualTo(default(int?)), "The pending sequence number should have been cleared.");
         }
 
         /// <summary>
@@ -108,7 +96,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 111222,
                 999888,
                 DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
-                DateTimeOffset.Parse("2003-09-27T15:00:00Z"));
+                DateTimeOffset.Parse("2003-09-27T15:00:00Z"),
+                787878,
+                987654);
 
             var clone = sourceEvent.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
@@ -136,7 +126,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 111222,
                 999888,
                 DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
-                DateTimeOffset.Parse("2003-09-27T15:00:00Z"));
+                DateTimeOffset.Parse("2003-09-27T15:00:00Z"),
+                787878,
+                987654);
 
             var clone = sourceEvent.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -98,7 +98,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var fakeConnection = new MockConnection(endpoint, eventHubName);
             var batchTransportMock = new Mock<TransportEventBatch>();
 
-
             batchTransportMock
                 .Setup(m => m.TryAdd(It.IsAny<EventData>()))
                 .Callback<EventData>(addedEvent => batchEvent = addedEvent)
@@ -107,6 +106,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     eventCount++;
                     return eventCount <= 1;
                 });
+
+            batchTransportMock
+                .Setup(m => m.Count)
+                .Returns(1);
 
             var transportMock = new Mock<TransportProducer>();
 
@@ -122,7 +125,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var eventData = new EventData(ReadOnlyMemory<byte>.Empty);
             var batch = await producer.CreateBatchAsync();
-            Assert.True(batch.TryAdd(eventData));
+            Assert.That(batch.TryAdd(eventData), Is.True);
 
             await producer.SendAsync(batch);
             activity.Stop();
@@ -306,6 +309,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     }
                     return hasSpace;
                 });
+
+            batchTransportMock
+                .Setup(m => m.Count)
+                .Returns(2);
 
             transportMock
                 .Setup(m => m.CreateBatchAsync(It.IsAny<CreateBatchOptions>(), It.IsAny<CancellationToken>()))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -100,44 +100,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies property accessors for the <see cref="EventDataBatch" />
-        ///   class.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(-1)]
-        [TestCase(-10)]
-        [TestCase(-100)]
-        public void StartingPublishedSequenceNumberValidatesOnSet(int value)
-        {
-            var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
-
-            Assert.That(() => batch.StartingPublishedSequenceNumber = value, Throws.InstanceOf<ArgumentException>(), "Negative values should not be allowed.");
-        }
-
-        // <summary>
-        ///   Verifies property accessors for the <see cref="EventDataBatch" />
-        ///   class.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(null)]
-        [TestCase(0)]
-        [TestCase(1)]
-        [TestCase(10)]
-        [TestCase(100)]
-        [TestCase(32768)]
-        public void StartingPublishedSequenceNumberValidatesAllowsValidValues(int? value)
-        {
-            var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
-
-            batch.StartingPublishedSequenceNumber = value;
-            Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(value), "The value should have been accepted.");
-        }
-
-        /// <summary>
         ///   Verifies property accessors for the <see cref="EventDataBatch.TryAdd" />
         ///   method.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientOptionsTests.cs
@@ -82,5 +82,76 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             Assert.That(() => new EventHubProducerClientOptions { RetryOptions = null }, Throws.ArgumentNullException);
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.CreateFeatureFlags" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateFeatureFlagsDetectsWhenNoFeaturesWereRequested()
+        {
+            var options = new EventHubProducerClientOptions { EnableIdempotentPartitions = false };
+            Assert.That(options.CreateFeatureFlags(), Is.EqualTo(TransportProducerFeatures.None));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.CreateFeatureFlags" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateFeatureFlagsDetectsIdempotentPublishing()
+        {
+            var options = new EventHubProducerClientOptions { EnableIdempotentPartitions = true };
+            Assert.That(options.CreateFeatureFlags(), Is.EqualTo(TransportProducerFeatures.IdempotentPublishing));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.GetPublishingOptionsOrDefaultForPartition" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void GetPublishingOptionsOrDefaultForPartitionDefaultsWhenNoPartitionIsSpecified(string partitionId)
+        {
+            var options = new EventHubProducerClientOptions();
+            options.PartitionOptions.Add("1", new PartitionPublishingOptions{ ProducerGroupId = 1 });
+
+            Assert.That(options.GetPublishingOptionsOrDefaultForPartition(partitionId), Is.EqualTo(default(PartitionPublishingOptions)));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.GetPublishingOptionsOrDefaultForPartition" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void GetPublishingOptionsOrDefaultForPartitionDefaultsWhenNoPartitionIsFound()
+        {
+            var options = new EventHubProducerClientOptions();
+            options.PartitionOptions.Add("1", new PartitionPublishingOptions{ ProducerGroupId = 1 });
+
+            Assert.That(options.GetPublishingOptionsOrDefaultForPartition("0"), Is.EqualTo(default(PartitionPublishingOptions)));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.GetPublishingOptionsOrDefaultForPartition" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void GetPublishingOptionsOrDefaultForPartitionReturnsTheOptionsWhenThePartitionIsFound()
+        {
+            var partitionId = "12";
+            var expectedPartitionOptions = new PartitionPublishingOptions{ ProducerGroupId = 1 };
+
+            var options = new EventHubProducerClientOptions();
+            options.PartitionOptions.Add(partitionId, expectedPartitionOptions);
+
+            Assert.That(options.GetPublishingOptionsOrDefaultForPartition(partitionId), Is.SameAs(expectedPartitionOptions));
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -12,6 +13,7 @@ using Azure.Core;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
+using Microsoft.Azure.Amqp;
 using Moq;
 using NUnit.Framework;
 
@@ -487,7 +489,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendWithoutOptionsInvokesTheTransportProducer()
         {
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -507,7 +509,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendInvokesTheTransportProducer()
         {
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var options = new SendEventOptions();
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
@@ -529,12 +531,1066 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendInvokesTheTransportProducerWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.SendAsync(batch);
             Assert.That(transportProducer.SendBatchCalledWith, Is.SameAs(batch), "The batch should be the same instance.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentRequiresThePartition()
+        {
+
+            var events = EventGenerator.CreateEvents(5);
+            var transportProducer = new ObservableTransportProducerMock();
+            var connection = new MockConnection(() => transportProducer);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            var sendOptions = new SendEventOptions();
+            Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.InstanceOf<InvalidOperationException>(), "Automatic routing cannot be used with idempotent publishing.");
+
+            sendOptions.PartitionKey = "Still not allowed";
+            Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.InstanceOf<InvalidOperationException>(), "A partition key cannot be used with idempotent publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentDoesNotAllowResending()
+        {
+            var transportProducer = new ObservableTransportProducerMock();
+            var connection = new MockConnection(() => transportProducer);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            var events = EventGenerator.CreateEvents(5).Select(item =>
+            {
+               item.PendingPublishSequenceNumber = 5;
+               item.CommitPublishingSequenceNumber();
+
+               return item;
+            });
+
+            var sendOptions = new SendEventOptions { PartitionId = "0" };
+            Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.InstanceOf<InvalidOperationException>(), "Resending of events cannot be done with idempotent publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentCreatesTheTransportWithTheCorrectOptions()
+        {
+            var expectedPartition = "5";
+            var eventCount = 1;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
+            var expectedLastSequence = expectedProperties.LastPublishedSequenceNumber + eventCount;
+            var expectedOptions = new PartitionPublishingOptions();
+            var requestedOptions = default(PartitionPublishingOptions);
+            var requestedFeatures = TransportProducerFeatures.None;
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var events = EventGenerator.CreateEvents(eventCount);
+            var mockTransport = new Mock<TransportProducer>();
+
+            expectedOptions.ProducerGroupId = expectedProperties.ProducerGroupId;
+            expectedOptions.OwnerLevel = expectedProperties.OwnerLevel;
+            expectedOptions.StartingSequenceNumber = expectedOptions.StartingSequenceNumber;
+
+            var clientOptions = new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            };
+
+            clientOptions.PartitionOptions.Add(expectedPartition, expectedOptions);
+            clientOptions.PartitionOptions.Add("0", new PartitionPublishingOptions());
+            clientOptions.PartitionOptions.Add("1", new PartitionPublishingOptions());
+
+            var connection = new MockConnection((partition, feature, options, retry) =>
+            {
+                requestedFeatures = feature;
+                requestedOptions = options;
+
+                return mockTransport.Object;
+            });
+
+            var producer = new EventHubProducerClient(connection, clientOptions);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            await producer.SendAsync(events, sendOptions);
+
+            Assert.That(requestedFeatures, Is.EqualTo(TransportProducerFeatures.IdempotentPublishing), "The idempotent feature should have been requested.");
+            Assert.That(requestedOptions.ProducerGroupId, Is.EqualTo(expectedOptions.ProducerGroupId), "The wrong producer group option was used to create the transport client.");
+            Assert.That(requestedOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The wrong owner level option was used to create the transport client.");
+            Assert.That(requestedOptions.StartingSequenceNumber, Is.EqualTo(expectedOptions.StartingSequenceNumber), "The wrong sequence number option was used to create the transport client.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentInitializesPartitionState()
+        {
+            var expectedPartition = "5";
+            var eventCount = 1;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
+            var expectedLastSequence = expectedProperties.LastPublishedSequenceNumber + eventCount;
+            var events = EventGenerator.CreateEvents(eventCount);
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var clientOptions = new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            };
+
+            clientOptions.PartitionOptions.Add("0", new PartitionPublishingOptions());
+            clientOptions.PartitionOptions.Add("1", new PartitionPublishingOptions());
+
+            clientOptions.PartitionOptions.Add(expectedPartition, new PartitionPublishingOptions
+            {
+               ProducerGroupId = 999,
+               OwnerLevel = 999,
+               StartingSequenceNumber = 999
+            });
+
+            var producer = new EventHubProducerClient(connection, clientOptions);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            await producer.SendAsync(events, sendOptions);
+
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.ProducerGroupId, Is.EqualTo(expectedProperties.ProducerGroupId), "The producer group should match.");
+            Assert.That(partitionState.OwnerLevel, Is.EqualTo(expectedProperties.OwnerLevel), "The owner level should match.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(expectedLastSequence), "The sequence number should match.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentFailsIfPartitionStateCannotBeInitialized()
+        {
+            var expectedPartition = "5";
+            var expectedProperties = new PartitionPublishingProperties(true, null, null, null);
+            var events = EventGenerator.CreateEvents(1);
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            Assert.That(async () => await producer.SendAsync(events, sendOptions),
+                Throws.InstanceOf<EventHubsException>().With.Property("Reason").EqualTo(EventHubsException.FailureReason.InvalidClientState),
+                "The client should not allow an uninitialized partition state.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentHonorsCancellationIfSetWhenCalled()
+        {
+            var expectedPartition = "5";
+            var events = EventGenerator.CreateEvents(1);
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Assert.That(async () => await producer.SendAsync(events, sendOptions, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentHonorsCancellationIfSetWhenInitializingPartitionState()
+        {
+            var expectedPartition = "5";
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
+            var events = EventGenerator.CreateEvents(1);
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => cancellationSource.Cancel())
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            Assert.That(async () => await producer.SendAsync(events, sendOptions, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentAppliesSequenceNumbers()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var events = EventGenerator.CreateEvents(eventCount).ToArray();
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable("The events should have been sent using the transport producer.");
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await producer.SendAsync(events, sendOptions);
+
+            for (var index = 0; index < events.Length; ++index)
+            {
+                Assert.That(events[index].PublishedSequenceNumber, Is.EqualTo(startingSequence + 1 + index), $"The event in position `{ index }` was not in the proper sequence.");
+                Assert.That(events[index].PendingPublishSequenceNumber, Is.Null, $"The event in position `{ index }` should not have a pending sequence number remaining.");
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence + events.Length), "The sequence number for partition state should have been updated.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentRollsOverSequenceNumbersToZero()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = int.MaxValue;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var events = EventGenerator.CreateEvents(eventCount).ToArray();
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable("The events should have been sent using the transport producer.");
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await producer.SendAsync(events, sendOptions);
+
+            for (var index = 0; index < events.Length; ++index)
+            {
+                Assert.That(events[index].PublishedSequenceNumber, Is.EqualTo(index), $"The event in position `{ index }` was not in the proper sequence.");
+                Assert.That(events[index].PendingPublishSequenceNumber, Is.Null, $"The event in position `{ index }` should not have a pending sequence number remaining.");
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(events.Length - 1), "The sequence number for partition state should have been updated.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentRollsBackSequenceNumbersOnFailure()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var events = EventGenerator.CreateEvents(eventCount).ToArray();
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new OverflowException()));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.Exception, "The send operation should have failed.");
+
+            for (var index = 0; index < events.Length; ++index)
+            {
+                Assert.That(events[index].PublishedSequenceNumber, Is.Null, $"The event in position `{ index }`should not have a sequence number.");
+                Assert.That(events[index].PendingPublishSequenceNumber, Is.Null, $"The event in position `{ index }` should not have a pending sequence number remaining.");
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence), "The sequence number for partition state should have been rolled back.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentOrdersConcurrentRequests()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var events = new[]
+            {
+                EventGenerator.CreateEvents(eventCount).ToArray(),
+                EventGenerator.CreateEvents(eventCount).ToArray(),
+                EventGenerator.CreateEvents(eventCount).ToArray()
+            };
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            // Each send operation will wait less time before completing to give later operations an
+            // advantage to complete first if synchronization does not take place properly.
+
+            var sendCountdown = events.Length;
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await Task.WhenAll(events.Select(batch => producer.SendAsync(batch, sendOptions)));
+
+            var eventPosition = 0;
+
+            foreach (var batch in events)
+            {
+                for (var index = 0; index < batch.Length; ++index)
+                {
+                    ++eventPosition;
+
+                    Assert.That(batch[index].PublishedSequenceNumber, Is.EqualTo(startingSequence + eventPosition), $"The event in position `{ eventPosition }` was not in the proper sequence.");
+                    Assert.That(batch[index].PendingPublishSequenceNumber, Is.Null, $"The event in position `{ eventPosition }` should not have a pending sequence number remaining.");
+                }
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence + (events.Length * eventCount)), "The sequence number for partition state should have been updated.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentAllowsConcurrentRequestsToDifferentPartitions()
+        {
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var events = new[]
+            {
+                EventGenerator.CreateEvents(eventCount).ToArray(),
+                EventGenerator.CreateEvents(eventCount).ToArray(),
+                EventGenerator.CreateEvents(eventCount).ToArray()
+            };
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            // Each send operation will wait less time before completing to give later operations an
+            // advantage to complete first if synchronization does not take place properly.
+
+            var sendCountdown = events.Length;
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partition = 0L;
+            await Task.WhenAll(events.Select(batch => producer.SendAsync(batch, new SendEventOptions { PartitionId = Interlocked.Increment(ref partition).ToString() })));
+
+            for (var batchIndex = 0; batchIndex < events.Length; ++batchIndex)
+            {
+                var batch = events[batchIndex];
+
+                for (var index = 0; index < batch.Length; ++index)
+                {
+                    Assert.That(batch[index].PublishedSequenceNumber, Is.EqualTo(startingSequence + 1 + index), $"The event in batch `{ batchIndex }` position `{ index }` was not in the proper sequence.");
+                }
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            foreach (var stateKey in partitionStateCollection.Keys)
+            {
+                Assert.That(partitionStateCollection.TryGetValue(stateKey, out var partitionState), Is.True, $"The state collection should have an entry for the partition `{ stateKey }`.");
+                Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence + eventCount), $"The sequence number for partition `{ stateKey }` state should have been updated.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentRequiresThePartitionWithABatch()
+        {
+            var transportProducer = new ObservableTransportProducerMock();
+            var connection = new MockConnection(() => transportProducer);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", new CreateBatchOptions());
+            Assert.That(async () => await producer.SendAsync(batch), Throws.InstanceOf<InvalidOperationException>(), "Automatic routing cannot be used with idempotent publishing.");
+
+            var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
+            batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
+            Assert.That(async () => await producer.SendAsync(batch), Throws.InstanceOf<InvalidOperationException>(), "A partition key cannot be used with idempotent publishing.");;
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentDoesNotAllowResendingWithAPublishedBatch()
+        {
+            var transportProducer = new ObservableTransportProducerMock();
+            var connection = new MockConnection(() => transportProducer);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            var events = EventGenerator.CreateEvents(5);
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new CreateBatchOptions { PartitionId = "0" });
+            events.ToList().ForEach(item => batch.TryAdd(item));
+
+            batch.StartingPublishedSequenceNumber = 0;
+            Assert.That(async () => await producer.SendAsync(batch), Throws.InstanceOf<InvalidOperationException>(), "Resending of events cannot be done with idempotent publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentDoesNotAllowResendingWithABatchContainingPublishedEvents()
+        {
+            var transportProducer = new ObservableTransportProducerMock();
+            var connection = new MockConnection(() => transportProducer);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            var events = EventGenerator.CreateEvents(5).Skip(4).Select(item =>
+            {
+               item.PendingPublishSequenceNumber = 5;
+               item.CommitPublishingSequenceNumber();
+
+               return item;
+            });
+
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new CreateBatchOptions { PartitionId = "0" });
+            events.ToList().ForEach(item => batch.TryAdd(item));
+
+            Assert.That(async () => await producer.SendAsync(batch), Throws.InstanceOf<InvalidOperationException>(), "Resending of events cannot be done with idempotent publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentCreatesTheTransportWithTheCorrectOptionsWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 1;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
+            var expectedLastSequence = expectedProperties.LastPublishedSequenceNumber + eventCount;
+            var expectedOptions = new PartitionPublishingOptions();
+            var requestedOptions = default(PartitionPublishingOptions);
+            var requestedFeatures = TransportProducerFeatures.None;
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+            var mockTransport = new Mock<TransportProducer>();
+
+            expectedOptions.ProducerGroupId = expectedProperties.ProducerGroupId;
+            expectedOptions.OwnerLevel = expectedProperties.OwnerLevel;
+            expectedOptions.StartingSequenceNumber = expectedOptions.StartingSequenceNumber;
+
+            var clientOptions = new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            };
+
+            clientOptions.PartitionOptions.Add(expectedPartition, expectedOptions);
+            clientOptions.PartitionOptions.Add("0", new PartitionPublishingOptions());
+            clientOptions.PartitionOptions.Add("1", new PartitionPublishingOptions());
+
+            var connection = new MockConnection((partition, feature, options, retry) =>
+            {
+                requestedFeatures = feature;
+                requestedOptions = options;
+
+                return mockTransport.Object;
+            });
+
+            var producer = new EventHubProducerClient(connection, clientOptions);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            await producer.SendAsync(batch);
+
+            Assert.That(requestedFeatures, Is.EqualTo(TransportProducerFeatures.IdempotentPublishing), "The idempotent feature should have been requested.");
+            Assert.That(requestedOptions.ProducerGroupId, Is.EqualTo(expectedOptions.ProducerGroupId), "The wrong producer group option was used to create the transport client.");
+            Assert.That(requestedOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The wrong owner level option was used to create the transport client.");
+            Assert.That(requestedOptions.StartingSequenceNumber, Is.EqualTo(expectedOptions.StartingSequenceNumber), "The wrong sequence number option was used to create the transport client.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentInitializesPartitionStateWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 1;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
+            var expectedLastSequence = expectedProperties.LastPublishedSequenceNumber + eventCount;
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+
+            var clientOptions = new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            };
+
+            clientOptions.PartitionOptions.Add("0", new PartitionPublishingOptions());
+            clientOptions.PartitionOptions.Add("1", new PartitionPublishingOptions());
+
+            clientOptions.PartitionOptions.Add(expectedPartition, new PartitionPublishingOptions
+            {
+               ProducerGroupId = 999,
+               OwnerLevel = 999,
+               StartingSequenceNumber = 999
+            });
+
+            var producer = new EventHubProducerClient(connection, clientOptions);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            await producer.SendAsync(batch);
+
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.ProducerGroupId, Is.EqualTo(expectedProperties.ProducerGroupId), "The producer group should match.");
+            Assert.That(partitionState.OwnerLevel, Is.EqualTo(expectedProperties.OwnerLevel), "The owner level should match.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(expectedLastSequence), "The sequence number should match.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentFailsIfPartitionStateCannotBeInitializedWithABatch()
+        {
+            var expectedPartition = "5";
+            var expectedProperties = new PartitionPublishingProperties(true, null, null, null);
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            Assert.That(async () => await producer.SendAsync(batch),
+                Throws.InstanceOf<EventHubsException>().With.Property("Reason").EqualTo(EventHubsException.FailureReason.InvalidClientState),
+                "The client should not allow an uninitialized partition state.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentHonorsCancellationIfSetWhenCalledWithABatch()
+        {
+            var expectedPartition = "5";
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Assert.That(async () => await producer.SendAsync(batch, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentHonorsCancellationIfSetWhenInitializingPartitionStateWithABatch()
+        {
+            var expectedPartition = "5";
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .Callback(() => cancellationSource.Cancel())
+                .ReturnsAsync(expectedProperties)
+                .Verifiable();
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            Assert.That(async () => await producer.SendAsync(batch, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentAppliesSequenceNumbersWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 6;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable("The events should have been sent using the transport producer.");
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await producer.SendAsync(batch);
+            Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(startingSequence + 1), "The batch did not have the correct starting sequence number.");
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence + batch.Count), "The sequence number for partition state should have been updated.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentRollsBackSequenceNumbersOnFailureWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 6;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new OverflowException()));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            Assert.That(async () => await producer.SendAsync(batch), Throws.Exception, "The send operation should have failed.");
+            Assert.That(batch.StartingPublishedSequenceNumber, Is.Null, "The batch should not have a starting sequence number.");
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence), "The sequence number for partition state should have been rolled back.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentRollsOverSequenceNumbersToZeroWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 6;
+            var startingSequence = int.MaxValue;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Verifiable("The events should have been sent using the transport producer.");
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await producer.SendAsync(batch);
+            Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(0), "The batch did not roll over the starting sequence number to zero.");
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(batch.Count - 1), "The sequence number for partition state should have been updated.");
+
+            mockTransport.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentOrdersConcurrentRequestsWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var batches = new[]
+            {
+                new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition }),
+                new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition }),
+                new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition }),
+            };
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            // Each send operation will wait less time before completing to give later operations an
+            // advantage to complete first if synchronization does not take place properly.
+
+            var sendCountdown = batches.Length;
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await Task.WhenAll(batches.Select(batch => producer.SendAsync(batch)));
+
+            for (var index = 0; index < batches.Length; ++index)
+            {
+                var batch = batches[index];
+                Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(startingSequence + 1 + (index * eventCount)), $"The batch in position `{ index }` did not have the correct starting sequence number.");
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence + (batches.Length * eventCount)), "The sequence number for partition state should have been updated.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendIdempotentAllowsConcurrentRequestsToDifferentPartitionsWithABatch()
+        {
+            var eventCount = 5;
+            var startingSequence = 435;
+            var partition = 0;
+            var expectedProperties = new PartitionPublishingProperties(true, 123, 456, startingSequence);
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var batches = new[]
+            {
+                new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = (++partition).ToString() }),
+                new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = (++partition).ToString() }),
+                new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = (++partition).ToString() }),
+            };
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            // Each send operation will wait less time before completing to give later operations an
+            // advantage to complete first if synchronization does not take place properly.
+
+            var sendCountdown = batches.Length;
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            await Task.WhenAll(batches.Select(batch => producer.SendAsync(batch)));
+
+            for (var index = 0; index < batches.Length; ++index)
+            {
+                var batch = batches[index];
+                Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(startingSequence + 1), $"The batch in position `{ index }` did not have the correct starting sequence number.");
+            }
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+
+            foreach (var stateKey in partitionStateCollection.Keys)
+            {
+                Assert.That(partitionStateCollection.TryGetValue(stateKey, out var partitionState), Is.True, $"The state collection should have an entry for the partition `{ stateKey }`.");
+                Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence + eventCount), $"The sequence number for partition `{ stateKey }` state should have been updated.");
+            }
         }
 
         /// <summary>
@@ -558,6 +1614,10 @@ namespace Azure.Messaging.EventHubs.Tests
             mockTransportBatch
                 .Setup(transport => transport.TryAdd(It.IsAny<EventData>()))
                 .Returns(true);
+
+            mockTransportBatch
+                .Setup(transport => transport.Count)
+                .Returns(1);
 
             mockTransportProducer
                 .Setup(transport => transport.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
@@ -657,8 +1717,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheTransportProducers()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new SendEventOptions { PartitionId = "1" });
-            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new SendEventOptions { PartitionId = "2" });
+            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", new SendEventOptions { PartitionId = "1" });
+            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", new SendEventOptions { PartitionId = "2" });
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.SendAsync(mockFirstBatch).IgnoreExceptions();
@@ -779,10 +1839,10 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </remarks>
         ///
         [Test]
-        public async Task EventHubProducerClientShouldCloseAProducer()
+        public async Task EventHubProducerClientShouldCloseAProducerWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var eventHubConnection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -806,16 +1866,16 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </remarks>
         ///
         [Test]
-        public async Task EventHubProducerClientShouldCloseAProducerWithABatch()
+        public async Task EventHubProducerClientShouldCloseAProducer()
         {
             var options = new SendEventOptions { PartitionId = "0" };
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new ObservableTransportProducerMock();
             var eventHubConnection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
             var mockTransportProducerPool = new MockTransportProducerPool(new ObservableTransportProducerMock(), eventHubConnection, retryPolicy);
             var mockPooledProducer = mockTransportProducerPool.GetPooledProducer(options.PartitionId) as MockPooledProducer;
             var producerClient = new EventHubProducerClient(eventHubConnection, transportProducer, mockTransportProducerPool);
-            var events = new EventData[0];
 
             await producerClient.SendAsync(events, options);
             Assert.That(mockPooledProducer.WasClosed, Is.True, $"A { nameof(TransportProducerPool.PooledProducer) } should be closed when disposed (for a batch).");
@@ -837,7 +1897,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockTransportProducerPool = new MockTransportProducerPool(transportProducer.Object, eventHubConnection, retryPolicy);
             var mockPooledProducer = mockTransportProducerPool.GetPooledProducer(options.PartitionId) as MockPooledProducer;
             var producerClient = new EventHubProducerClient(eventHubConnection, transportProducer.Object, mockTransportProducerPool);
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
 
             transportProducer
                 .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
@@ -868,7 +1928,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void EventHubProducerClientShouldRetrySendingWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -965,7 +2025,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotStartWhenPartitionIdIsNull()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -996,7 +2056,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotStartWhenPartitionIdIsNullWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1025,7 +2085,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task RetryLogicDoesNotWorkForClosedConnections()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1062,7 +2122,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task RetryLogicDoesNotWorkForClosedConnectionsWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1080,7 +2140,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(true);
 
             await eventHubConnection.CloseAsync(CancellationToken.None);
-
             Assert.That(async () => await producerClient.SendAsync(batch), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
 
             transportProducer.Verify(t => t.SendAsync(It.IsAny<EventDataBatch>(),
@@ -1097,7 +2156,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotWorkForClosedEventHubProducerClients()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1134,7 +2193,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotWorkForClosedEventHubProducerClientsWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1152,7 +2211,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(true);
 
             SetIsClosed(producerClient, true);
-
             Assert.That(async () => await producerClient.SendAsync(batch), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
 
             transportProducer.Verify(t => t.SendAsync(It.IsAny<EventDataBatch>(),
@@ -1169,7 +2227,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicShouldNotStartWhenCancellationTriggered()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1196,7 +2254,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicShouldNotStartWhenCancellationTriggeredWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1206,7 +2264,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var cancellationTokenSource = new CancellationTokenSource();
 
             cancellationTokenSource.Cancel();
-
             Assert.That(async () => await producerClient.SendAsync(batch, cancellationTokenSource.Token), Throws.InstanceOf<OperationCanceledException>());
 
             transportProducer.Verify(t => t.SendAsync(It.IsAny<EventDataBatch>(),
@@ -1225,7 +2282,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDetectsAnEmbeddedAmqpErrorForOperationCanceled()
         {
             var options = new SendEventOptions { PartitionId = "0" };
-            var events = new EventData[0];
+            var events = new[] { new EventData(Array.Empty<byte>()) };
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1251,7 +2308,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDetectsAnEmbeddedAmqpErrorForOperationCanceledWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
+            var batch = new EventDataBatch(new MockTransportBatch(1), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1286,6 +2343,16 @@ namespace Azure.Messaging.EventHubs.Tests
             (EventHubsRetryPolicy)
                 typeof(EventHubProducerClient)
                     .GetProperty("RetryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(producer);
+
+        /// <summary>
+        ///   Retrieves the PartitionState for the producer using its private accessor.
+        /// </summary>
+        ///
+        private static ConcurrentDictionary<string, PartitionPublishingState> GetPartitionState(EventHubProducerClient producer) =>
+            (ConcurrentDictionary<string, PartitionPublishingState>)
+                typeof(EventHubProducerClient)
+                    .GetProperty("PartitionState", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(producer);
 
         /// <summary>
@@ -1336,6 +2403,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 return new ValueTask<TransportEventBatch>(Task.FromResult((TransportEventBatch)new MockTransportBatch()));
             }
 
+            public override ValueTask<PartitionPublishingProperties> ReadInitializationPublishingPropertiesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+
             public override Task CloseAsync(CancellationToken cancellationToken)
             {
                 WasCloseCalled = true;
@@ -1353,21 +2422,34 @@ namespace Azure.Messaging.EventHubs.Tests
             public EventHubsRetryPolicy GetPropertiesInvokedWith = null;
             public EventHubsRetryPolicy GetPartitionIdsInvokedWith = null;
             public EventHubsRetryPolicy GetPartitionPropertiesInvokedWith = null;
-            public Func<TransportProducer> TransportProducerFactory = () => Mock.Of<TransportProducer>();
             public Mock<TransportClient> InnerClientMock = null;
-
             public bool WasClosed = false;
+
+            public Func<string, TransportProducerFeatures, PartitionPublishingOptions, EventHubsRetryPolicy, TransportProducer> TransportProducerFactory =
+                (partition, features, options, retry) => Mock.Of<TransportProducer>();
+
 
             public MockConnection(string namespaceName = "fakeNamespace",
                                   string eventHubName = "fakeEventHub") : base(namespaceName, eventHubName, new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net").Object)
             {
             }
 
-            public MockConnection(Func<TransportProducer> transportProducerFactory,
+            public MockConnection(Func<string, TransportProducerFeatures, PartitionPublishingOptions, EventHubsRetryPolicy, TransportProducer> transportProducerFactory,
                                   string namespaceName,
                                   string eventHubName) : this(namespaceName, eventHubName)
             {
                 TransportProducerFactory = transportProducerFactory;
+            }
+
+            public MockConnection(Func<TransportProducer> transportProducerFactory,
+                                  string namespaceName,
+                                  string eventHubName) : this((partition, features, options, retry) => transportProducerFactory(), namespaceName, eventHubName)
+            {
+            }
+
+            public MockConnection(Func<string, TransportProducerFeatures, PartitionPublishingOptions, EventHubsRetryPolicy, TransportProducer> transportProducerFactory)
+                : this(transportProducerFactory, "fakeNamespace", "fakeEventHub")
+            {
             }
 
             public MockConnection(Func<TransportProducer> transportProducerFactory) : this(transportProducerFactory, "fakeNamespace", "fakeEventHub")
@@ -1397,7 +2479,9 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override TransportProducer CreateTransportProducer(string partitionId,
-                                                                        EventHubsRetryPolicy retryPolicy) => TransportProducerFactory();
+                                                                        TransportProducerFeatures requestedFeatures,
+                                                                        PartitionPublishingOptions partitionOptions,
+                                                                        EventHubsRetryPolicy retryPolicy) => TransportProducerFactory(partitionId, requestedFeatures, partitionOptions, retryPolicy);
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace,
                                                                     string eventHubName, EventHubTokenCredential credential,
@@ -1429,14 +2513,29 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class MockTransportBatch : TransportEventBatch
         {
+            private List<EventData> Events { get; } = new List<EventData>();
+
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
             public override int? StartingPublishedSequenceNumber { get; set; }
-            public override int Count { get; }
-            public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
-            public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
-            public override void Clear() => throw new NotImplementedException();
+            public override int Count => Events.Count;
+            public override IEnumerable<T> AsEnumerable<T>() => (IEnumerable<T>)Events;
+            public override void Clear() => Events.Clear();
             public override void Dispose() => throw new NotImplementedException();
+
+            public MockTransportBatch()
+            {
+            }
+            public MockTransportBatch(int generatedEventCount)
+            {
+                Events.AddRange(EventGenerator.CreateEvents(generatedEventCount));
+            }
+
+            public override bool TryAdd(EventData eventData)
+            {
+                Events.Add(eventData);
+                return true;
+            }
         }
 
         /// <summary>
@@ -1454,7 +2553,6 @@ namespace Azure.Messaging.EventHubs.Tests
             public override ValueTask DisposeAsync()
             {
                 WasClosed = true;
-
                 return new ValueTask(Task.CompletedTask);
             }
         }
@@ -1473,7 +2571,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                              EventHubConnection connection,
                                              EventHubsRetryPolicy retryPolicy,
                                              ConcurrentDictionary<string, PoolItem> pool = default,
-                                             TimeSpan? expirationInterval = default): base(connection, retryPolicy, pool, expirationInterval)
+                                             TimeSpan? expirationInterval = default) : base(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), pool, expirationInterval)
             {
                 MockPooledProducer = new MockPooledProducer(transportProducer);
             }
@@ -1482,7 +2580,6 @@ namespace Azure.Messaging.EventHubs.Tests
                                                              TimeSpan? removeAfterDuration = default)
             {
                 GetPooledProducerWasCalled = true;
-
                 return MockPooledProducer;
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ["1"] = new TransportProducerPool.PoolItem("0", transportProducer),
                 ["2"] = new TransportProducerPool.PoolItem("0", transportProducer),
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             GetExpirationCallBack(transportProducerPool).Invoke(null);
 
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 // An expired item in the pool
                 ["0"] = new TransportProducerPool.PoolItem("0", transportProducer, removeAfter: oneMinuteAgo)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             // This call should refresh the timespan associated to the item
             _ = transportProducerPool.GetPooledProducer("0");
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
             var connection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy));
             var expectedTime = DateTimeOffset.UtcNow.AddMinutes(10);
 
             await using var pooledProducer = transportProducerPool.GetPooledProducer("0");
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 // An expired item in the pool
                 ["0"] = new TransportProducerPool.PoolItem("0", transportProducer, removeAfter: oneMinuteAgo)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             var pooledProducer = transportProducerPool.GetPooledProducer("0");
             startingPool.TryGetValue("0", out var poolItem);
@@ -148,7 +148,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", transportProducer)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, startingPool);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), startingPool);
 
             var pooledProducer = transportProducerPool.GetPooledProducer("0", TimeSpan.FromMinutes(-1));
 
@@ -179,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", partitionProducer)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, eventHubProducer: transportProducer);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer);
 
             var returnedProducer = transportProducerPool.GetPooledProducer(partitionId).TransportProducer as ObservableTransportProducerMock;
 
@@ -202,7 +202,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", partitionProducer.Object)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, eventHubProducer: transportProducer.Object);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer.Object);
 
             transportProducer
                 .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
@@ -229,7 +229,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 ["0"] = new TransportProducerPool.PoolItem("0", partitionProducer.Object)
             };
-            TransportProducerPool transportProducerPool = new TransportProducerPool(connection, retryPolicy, eventHubProducer: transportProducer.Object);
+            TransportProducerPool transportProducerPool = new TransportProducerPool(partition => connection.CreateTransportProducer(partition, TransportProducerFeatures.None, null, retryPolicy), eventHubProducer: transportProducer.Object);
 
             partitionProducer
                 .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
@@ -302,6 +302,8 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override TransportProducer CreateTransportProducer(string partitionId,
+                                                                        TransportProducerFeatures requestedFeatures,
+                                                                        PartitionPublishingOptions partitionOptions,
                                                                         EventHubsRetryPolicy retryPolicy) => TransportProducerFactory();
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace,
@@ -358,6 +360,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchCalledWith = options;
                 return new ValueTask<TransportEventBatch>(Task.FromResult((TransportEventBatch)new MockTransportBatch()));
             }
+
+            public override ValueTask<PartitionPublishingProperties> ReadInitializationPublishingPropertiesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
 
             public override Task CloseAsync(CancellationToken cancellationToken)
             {


### PR DESCRIPTION
# Summary

The focus of these changes is implementing the idempotent publishing feature infrastructure into the `EventHubProducerClient` and associated types,
refactoring the current structure to support idempotent and non-idempotent publishing as unique code paths.

Not included in these changes is the addition of the `ReadPartitionPublishingProperties` member and live tests; those will be covered in dedicated work streams.

**Note:**  These API changes are part of a preview feature.  The design and API surface were informally reviewed with the language architect but have not yet undergone formal review with the architecture board.  I expect some changes, particularly around naming.

# Last Upstream Rebase

Wednesday, September 9, 4:33pm (EDT)

# References and Related Issues

- [Idempotent Publishing Design](https://gist.github.com/jsquire/1cc4db6b3ca4ef13d26dc5315483555b)
- [Idempotent Publishing Requirements with Usage](https://gist.github.com/jsquire/0f3bc5701388fe03ccd027e86f1994f1)
- [Idempotent Publishing Support](https://github.com/Azure/azure-sdk-for-net/issues/13941) ([#13941](https://github.com/Azure/azure-sdk-for-net/issues/13941))