### PR TITLE
Enable master link replacement feature in .NET

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -214,7 +214,8 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.ArtifactName}}-signed
                           TargetFolder: ${{artifact.safeName}}/packages
-                          FileFilter: ${{artifact.name}}.[0-9]*.[0-9]*.[0-9]*
+                          FileFilter: "${{artifact.name}}.[0-9]*.[0-9]*.[0-9]*"
+                          Exclude: "*.symbols.nupkg"
                       - template: /eng/pipelines/templates/steps/stage-artifacts.yml
                         parameters:
                           SourceFolder: Docs.${{artifact.name}}
@@ -230,6 +231,7 @@ stages:
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'dotnet'
+                          ArtifactLocation: '$(Pipeline.Workspace)/${{artifact.safeName}}/packages'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
                           ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
 

--- a/eng/pipelines/templates/steps/stage-artifacts.yml
+++ b/eng/pipelines/templates/steps/stage-artifacts.yml
@@ -2,10 +2,10 @@ parameters:
   SourceFolder: '' # ArtifactName (aka "packages")
   TargetFolder: '' # artifact.safename (azuretemplate)
   FileFilter: '' #${{artifact.name}}.[0-9]*.[0-9]*.[0-9]*
-  
+  Exclude: '' # Regex of the exlude packges (aka "*.symbols.nupkg")
 steps:
   - pwsh: |
       New-Item -Force -Type Directory -Name ${{parameters.TargetFolder}} -Path $(Pipeline.Workspace)
       Write-Host "Copy-Item -Force -Recurse $(Pipeline.Workspace)/${{parameters.SourceFolder}}/${{parameters.FileFilter}} $(Pipeline.Workspace)/${{parameters.TargetFolder}}"
-      Copy-Item -Force -Recurse $(Pipeline.Workspace)/${{parameters.SourceFolder}}/${{parameters.FileFilter}} $(Pipeline.Workspace)/${{parameters.TargetFolder}}
+      Copy-Item -Force -Recurse $(Pipeline.Workspace)/${{parameters.SourceFolder}}/${{parameters.FileFilter}} $(Pipeline.Workspace)/${{parameters.TargetFolder}} -Exclude "${{parameters.Exclude}}"
     displayName: Stage artifacts

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Release History
+# 1.0.3-beta.11 (Unreleased)
 
-## 1.0.3-beta.8 (Unreleased)
 
+## 1.0.3-beta.10 (2020-09-09)
+- Enable the master link replacement feature, attempt 3
+
+## 1.0.3-beta.9 (2020-09-09)
+- Enable the master link replacement feature, attempt 2
+
+## 1.0.3-beta.8 (2020-09-09)
+- Enable the master link replacement feature, attempt 1
 
 ## 1.0.3-beta.7 (2020-09-04)
 - Test release tag replacement

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.3-beta.8</Version>
+    <Version>1.0.3-beta.11</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
This is a follow up step of master link replacement work.

Tested in template:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=531026&view=logs&j=ceb84d66-6af3-5d95-9875-cd812f26b59e&t=bb6510a9-1dd3-5240-6b4b-d1bd7663119b

Retrieved release tag successfully:
![image](https://user-images.githubusercontent.com/48036328/92670441-e0f8bc80-f2c8-11ea-9ac5-29b6b3d2a6b1.png)

Doc.Ms:
![image](https://user-images.githubusercontent.com/48036328/92670594-33d27400-f2c9-11ea-9dd5-ebd1ee4b5fde.png)

Github IO:
https://azuresdkdocs.blob.core.windows.net/$web/dotnet/Azure.Template/1.0.3-beta.10/index.html