### PR TITLE
Addressed Error for Events Missing Required Fields  

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
@@ -29,11 +29,9 @@ namespace Azure.Messaging.EventGrid
                     egEventInternal.Data,
                     egEventInternal.Subject,
                     egEventInternal.EventType,
-                    egEventInternal.DataVersion)
-            {
-                Id = egEventInternal.Id,
-                EventTime = egEventInternal.EventTime
-            };
+                    egEventInternal.DataVersion,
+                    egEventInternal.EventTime,
+                    egEventInternal.Id);
 
             return egEvent;
         }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
@@ -25,14 +25,14 @@ namespace Azure.Messaging.EventGrid
             JsonDocument requestDocument = JsonDocument.Parse(binaryData.ToBytes());
             EventGridEventInternal egEventInternal = EventGridEventInternal.DeserializeEventGridEventInternal(requestDocument.RootElement);
 
-            EventGridEvent egEvent = new EventGridEvent()
+            EventGridEvent egEvent = new EventGridEvent(
+                    egEventInternal.Data,
+                    egEventInternal.Subject,
+                    egEventInternal.EventType,
+                    egEventInternal.DataVersion)
             {
-                Subject = egEventInternal.Subject,
-                EventType = egEventInternal.EventType,
-                DataVersion = egEventInternal.DataVersion,
                 Id = egEventInternal.Id,
-                EventTime = egEventInternal.EventTime,
-                SerializedData = egEventInternal.Data
+                EventTime = egEventInternal.EventTime
             };
 
             return egEvent;

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
@@ -54,17 +54,15 @@ namespace Azure.Messaging.EventGrid
             }
 
             CloudEvent cloudEvent = new CloudEvent(
-                cloudEventInternal.Source,
-                cloudEventInternal.Type)
-            {
-                Id = cloudEventInternal.Id,
-                Time = cloudEventInternal.Time,
-                DataBase64 = cloudEventInternal.DataBase64,
-                DataSchema = cloudEventInternal.Dataschema,
-                DataContentType = cloudEventInternal.Datacontenttype,
-                Subject = cloudEventInternal.Subject,
-                SerializedData = cloudEventInternal.Data
-            };
+                    cloudEventInternal.Id,
+                    cloudEventInternal.Source,
+                    cloudEventInternal.Type,
+                    cloudEventInternal.Time,
+                    cloudEventInternal.Dataschema,
+                    cloudEventInternal.Datacontenttype,
+                    cloudEventInternal.Subject,
+                    cloudEventInternal.Data,
+                    cloudEventInternal.DataBase64);
 
             if (cloudEventInternal.AdditionalProperties != null)
             {

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEvent.cs
@@ -85,7 +85,7 @@ namespace Azure.Messaging.EventGrid
             ExtensionAttributes = new Dictionary<string, object>();
         }
 
-        private CloudEvent(string id, string source, string type)
+        internal CloudEvent(string id, string source, string type, DateTimeOffset? time, string dataSchema, string dataContentType, string subject, JsonElement? serializedData, byte[] dataBase64)
         {
             Argument.AssertNotNull(id, nameof(id));
             Argument.AssertNotNull(source, nameof(source));
@@ -94,6 +94,12 @@ namespace Azure.Messaging.EventGrid
             Id = id;
             Source = source;
             Type = type;
+            Time = time;
+            DataSchema = dataSchema;
+            DataContentType = dataContentType;
+            Subject = subject;
+            SerializedData = serializedData;
+            DataBase64 = dataBase64;
             ExtensionAttributes = new Dictionary<string, object>();
         }
 
@@ -177,15 +183,13 @@ namespace Azure.Messaging.EventGrid
                 CloudEvent cloudEvent = new CloudEvent(
                     cloudEventInternal.Id,
                     cloudEventInternal.Source,
-                    cloudEventInternal.Type)
-                {
-                    Time = cloudEventInternal.Time,
-                    DataBase64 = cloudEventInternal.DataBase64,
-                    DataSchema = cloudEventInternal.Dataschema,
-                    DataContentType = cloudEventInternal.Datacontenttype,
-                    Subject = cloudEventInternal.Subject,
-                    SerializedData = cloudEventInternal.Data
-                };
+                    cloudEventInternal.Type,
+                    cloudEventInternal.Time,
+                    cloudEventInternal.Dataschema,
+                    cloudEventInternal.Datacontenttype,
+                    cloudEventInternal.Subject,
+                    cloudEventInternal.Data,
+                    cloudEventInternal.DataBase64);
 
                 if (cloudEventInternal.AdditionalProperties != null)
                 {

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEvent.cs
@@ -85,6 +85,18 @@ namespace Azure.Messaging.EventGrid
             ExtensionAttributes = new Dictionary<string, object>();
         }
 
+        private CloudEvent(string id, string source, string type)
+        {
+            Argument.AssertNotNull(id, nameof(id));
+            Argument.AssertNotNull(source, nameof(source));
+            Argument.AssertNotNull(type, nameof(type));
+
+            Id = id;
+            Source = source;
+            Type = type;
+            ExtensionAttributes = new Dictionary<string, object>();
+        }
+
         /// <summary> An identifier for the event. The combination of id and source must be unique for each distinct event. </summary>
         public string Id { get; set; } = Guid.NewGuid().ToString();
 
@@ -163,10 +175,10 @@ namespace Azure.Messaging.EventGrid
                 }
 
                 CloudEvent cloudEvent = new CloudEvent(
+                    cloudEventInternal.Id,
                     cloudEventInternal.Source,
                     cloudEventInternal.Type)
                 {
-                    Id = cloudEventInternal.Id,
                     Time = cloudEventInternal.Time,
                     DataBase64 = cloudEventInternal.DataBase64,
                     DataSchema = cloudEventInternal.Dataschema,

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridEvent.cs
@@ -26,7 +26,6 @@ namespace Azure.Messaging.EventGrid
         public EventGridEvent(object data, string subject, string eventType, string dataVersion)
         {
             Argument.AssertNotNull(subject, nameof(subject));
-            Argument.AssertNotNull(data, nameof(data));
             Argument.AssertNotNull(eventType, nameof(eventType));
             Argument.AssertNotNull(dataVersion, nameof(dataVersion));
 
@@ -36,20 +35,19 @@ namespace Azure.Messaging.EventGrid
             DataVersion = dataVersion;
         }
 
-        internal EventGridEvent(JsonElement serializedData, string subject, string eventType, string dataVersion)
+        internal EventGridEvent(JsonElement serializedData, string subject, string eventType, string dataVersion, DateTimeOffset eventTime, string id)
         {
             Argument.AssertNotNull(subject, nameof(subject));
             Argument.AssertNotNull(eventType, nameof(eventType));
             Argument.AssertNotNull(dataVersion, nameof(dataVersion));
-            if (serializedData.ValueKind == JsonValueKind.Null)
-            {
-                throw new ArgumentNullException(nameof(serializedData));
-            }
+            Argument.AssertNotNull(id, nameof(id));
 
             Subject = subject;
             SerializedData = serializedData;
             EventType = eventType;
             DataVersion = dataVersion;
+            EventTime = eventTime;
+            Id = id;
         }
 
         /// <summary> An unique identifier for the event. </summary>
@@ -116,11 +114,9 @@ namespace Azure.Messaging.EventGrid
                     egEventInternal.Data,
                     egEventInternal.Subject,
                     egEventInternal.EventType,
-                    egEventInternal.DataVersion)
-                {
-                    Id = egEventInternal.Id,
-                    EventTime = egEventInternal.EventTime
-                };
+                    egEventInternal.DataVersion,
+                    egEventInternal.EventTime,
+                    egEventInternal.Id);
 
                 egEvents.Add(egEvent);
             }

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridEvent.cs
@@ -26,6 +26,7 @@ namespace Azure.Messaging.EventGrid
         public EventGridEvent(object data, string subject, string eventType, string dataVersion)
         {
             Argument.AssertNotNull(subject, nameof(subject));
+            Argument.AssertNotNull(data, nameof(data));
             Argument.AssertNotNull(eventType, nameof(eventType));
             Argument.AssertNotNull(dataVersion, nameof(dataVersion));
 

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridEvent.cs
@@ -36,8 +36,20 @@ namespace Azure.Messaging.EventGrid
             DataVersion = dataVersion;
         }
 
-        internal EventGridEvent()
+        internal EventGridEvent(JsonElement serializedData, string subject, string eventType, string dataVersion)
         {
+            Argument.AssertNotNull(subject, nameof(subject));
+            Argument.AssertNotNull(eventType, nameof(eventType));
+            Argument.AssertNotNull(dataVersion, nameof(dataVersion));
+            if (serializedData.ValueKind == JsonValueKind.Null)
+            {
+                throw new ArgumentNullException(nameof(serializedData));
+            }
+
+            Subject = subject;
+            SerializedData = serializedData;
+            EventType = eventType;
+            DataVersion = dataVersion;
         }
 
         /// <summary> An unique identifier for the event. </summary>
@@ -100,14 +112,14 @@ namespace Azure.Messaging.EventGrid
 
             foreach (EventGridEventInternal egEventInternal in egEventsInternal)
             {
-                EventGridEvent egEvent = new EventGridEvent()
+                EventGridEvent egEvent = new EventGridEvent(
+                    egEventInternal.Data,
+                    egEventInternal.Subject,
+                    egEventInternal.EventType,
+                    egEventInternal.DataVersion)
                 {
-                    Subject = egEventInternal.Subject,
-                    EventType = egEventInternal.EventType,
-                    DataVersion = egEventInternal.DataVersion,
                     Id = egEventInternal.Id,
-                    EventTime = egEventInternal.EventTime,
-                    SerializedData = egEventInternal.Data
+                    EventTime = egEventInternal.EventTime
                 };
 
                 egEvents.Add(egEvent);

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/ConsumeEventTests.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/ConsumeEventTests.cs
@@ -129,6 +129,16 @@ namespace Azure.Messaging.EventGrid.Tests
                 Assert.AreEqual("512d38b6-c7b8-40c8-89fe-f46f9e9622b6", eventData1.ItemSku);
             }
         }
+
+        [Test]
+        public void EGEventParseThrowsIfMissingRequiredProperties()
+        {
+            // missing Id and DataVersion
+            string requestContent = "[{  \"subject\": \"\",  \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  },  \"eventType\": \"Contoso.Items.ItemReceived\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\"}]";
+
+            Assert.That(() => EventGridEvent.Parse(requestContent),
+                Throws.InstanceOf<ArgumentNullException>());
+        }
         #endregion
 
         #region Custom event tests
@@ -1478,6 +1488,16 @@ namespace Azure.Messaging.EventGrid.Tests
                 ContosoItemReceivedEventData eventData2 = binaryEventData.ToObject<ContosoItemReceivedEventData>();
                 Assert.AreEqual("512d38b6-c7b8-40c8-89fe-f46f9e9622b6", eventData1.ItemSku);
             }
+        }
+
+        [Test]
+        public void CloudEventParseThrowsIfMissingRequiredProperties()
+        {
+            // missing Id and Source
+            string requestContent = "[{ \"subject\": \"\",  \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  },  \"type\": \"Contoso.Items.ItemReceived\"}]";
+
+            Assert.That(() => CloudEvent.Parse(requestContent),
+                Throws.InstanceOf<ArgumentNullException>());
         }
         #endregion
 


### PR DESCRIPTION
Should throw an `ArgumentNullException` if required fields for `EventGridEvent` are missing when `EventGridEvent.Parse` is called (matches the behavior for CloudEvents). Before, no error would be thrown (and would throw an error when trying to access event data).