### PR TITLE
Treat service directory as single scope

### DIFF
--- a/eng/SnippetGenerator/Program.cs
+++ b/eng/SnippetGenerator/Program.cs
@@ -20,7 +20,7 @@ namespace SnippetGenerator
         {
             var baseDirectory = new DirectoryInfo(BasePath).Name;
             var baseDirParent = Directory.GetParent(BasePath).Name;
-            if (baseDirectory.Equals("sdk") || baseDirParent.Equals("sdk"))
+            if (baseDirectory.Equals("sdk"))
             {
                 Parallel.ForEach(Directory.GetDirectories(BasePath), sdkDir => new DirectoryProcessor(sdkDir).Process());
             }
@@ -32,16 +32,23 @@ namespace SnippetGenerator
 
         public static int Main(string[] args)
         {
+            ConsoleColor foreground = Console.ForegroundColor;
+
             try
             {
                 return CommandLineApplication.Execute<Program>(args);
             }
             catch (Exception e)
             {
+                Console.ForegroundColor = ConsoleColor.Red;
+
                 Console.Error.WriteLine(e.ToString());
                 return 1;
             }
-
+            finally
+            {
+                Console.ForegroundColor = foreground;
+            }
         }
     }
 }

--- a/eng/SnippetGenerator/Program.cs
+++ b/eng/SnippetGenerator/Program.cs
@@ -19,7 +19,6 @@ namespace SnippetGenerator
         public void OnExecuteAsync()
         {
             var baseDirectory = new DirectoryInfo(BasePath).Name;
-            var baseDirParent = Directory.GetParent(BasePath).Name;
             if (baseDirectory.Equals("sdk"))
             {
                 Parallel.ForEach(Directory.GetDirectories(BasePath), sdkDir => new DirectoryProcessor(sdkDir).Process());


### PR DESCRIPTION
Fixes #14969

Also write error output as red for easy identification in development environment.