### PR TITLE
[Event Hubs Client] Idempotent Producer Client

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -464,9 +464,10 @@ namespace Azure.Messaging.EventHubs.Producer
         public override int GetHashCode() { throw null; }
         public virtual System.Threading.Tasks.Task<string[]> GetPartitionIdsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.PartitionProperties> GetPartitionPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.Producer.PartitionPublishingProperties> ReadPartitionPublishingPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(Azure.Messaging.EventHubs.Producer.EventDataBatch eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventSet, Azure.Messaging.EventHubs.Producer.SendEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventSet, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
@@ -490,6 +491,12 @@ namespace Azure.Messaging.EventHubs.Producer
         public short? OwnerLevel { get { throw null; } set { } }
         public long? ProducerGroupId { get { throw null; } set { } }
         public int? StartingSequenceNumber { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
     }
     public partial class PartitionPublishingProperties
     {
@@ -498,6 +505,12 @@ namespace Azure.Messaging.EventHubs.Producer
         public int? LastPublishedSequenceNumber { get { throw null; } }
         public short? OwnerLevel { get { throw null; } }
         public long? ProducerGroupId { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
     }
     public partial class SendEventOptions
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -277,9 +278,9 @@ namespace Azure.Messaging.EventHubs.Amqp
             // default to the maximum size allowed by the link.
 
             options.MaximumSizeInBytes ??= MaximumMessageSize;
-
             Argument.AssertInRange(options.MaximumSizeInBytes.Value, EventHubProducerClient.MinimumBatchSizeLimit, MaximumMessageSize.Value, nameof(options.MaximumSizeInBytes));
-            return new AmqpEventBatch(MessageConverter, options);
+
+            return new AmqpEventBatch(MessageConverter, options, IsSequenceMeasurementRequired(ActiveFeatures));
         }
 
         /// <summary>
@@ -573,6 +574,18 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             return link;
         }
+
+        /// <summary>
+        ///   Determines if measuring a sequence number is required to accurately calculate
+        ///   the size of an event.
+        /// </summary>
+        ///
+        /// <param name="activeFeatures">The set of features which are active for the producer.</param>
+        ///
+        /// <returns><c>true</c> if a sequence number should be measured; otherwise, <c>false</c>.</returns>
+        ///
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsSequenceMeasurementRequired(TransportProducerFeatures activeFeatures) => ((activeFeatures & TransportProducerFeatures.IdempotentPublishing) != 0);
 
         /// <summary>
         ///   Uses the minimum value of the two specified <see cref="TimeSpan" /> instances.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
@@ -31,23 +31,17 @@ namespace Azure.Messaging.EventHubs.Core
         public abstract long SizeInBytes { get; }
 
         /// <summary>
-        ///   The publishing sequence number assigned to the first event in the batch at the time
-        ///   the batch was successfully published.
+        ///   A flag that indicates whether space should be reserved for a publishing
+        ///   sequence number when the event size is measured.  If <c>false</c>, a sequence
+        ///   number is not used in size calculations.
         /// </summary>
         ///
-        /// <value>
-        ///   The sequence number of the first event in the batch, if the batch was successfully
-        ///   published by a sequence-aware producer.  If the producer was not configured to apply
-        ///   sequence numbering or if the batch has not yet been successfully published, this member
-        ///   will be <c>null</c>.
-        ///</value>
-        ///
         /// <remarks>
-        ///   The starting published sequence number is only populated and relevant when certain features
+        ///   The sequence number is only populated and relevant when certain features
         ///   of the producer are enabled.  For example, it is used by idempotent publishing.
         /// </remarks>
         ///
-        public abstract int? StartingPublishedSequenceNumber { get; set; }
+        public abstract bool ReserveSpaceForSequenceNumber { get; }
 
         /// <summary>
         ///   The count of events contained in the batch.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -323,7 +323,7 @@ namespace Azure.Messaging.EventHubs
         ///   Transitions the pending publishing sequence number to the published sequence number.
         /// </summary>
         ///
-        internal void CommitPublishingSequenceNumber()
+        internal void CommitPublishingState()
         {
             PublishedSequenceNumber = PendingPublishSequenceNumber;
             PendingPublishSequenceNumber = default;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/CreateBatchOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/CreateBatchOptions.cs
@@ -41,20 +41,6 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="CreateBatchOptions" />, cloning its attributes into a new instance.
-        /// </summary>
-        ///
-        /// <returns>A new copy of <see cref="CreateBatchOptions" />.</returns>
-        ///
-        internal CreateBatchOptions Clone() =>
-            new CreateBatchOptions
-            {
-                PartitionId = PartitionId,
-                PartitionKey = PartitionKey,
-                _maximumSizeInBytes = MaximumSizeInBytes
-            };
-
-        /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
         /// </summary>
         ///
@@ -82,5 +68,19 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="CreateBatchOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="CreateBatchOptions" />.</returns>
+        ///
+        internal new CreateBatchOptions Clone() =>
+            new CreateBatchOptions
+            {
+                PartitionId = PartitionId,
+                PartitionKey = PartitionKey,
+                _maximumSizeInBytes = _maximumSizeInBytes
+            };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -58,11 +58,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   of the producer are enabled.  For example, it is used by idempotent publishing.
         /// </remarks>
         ///
-        public int? StartingPublishedSequenceNumber
-        {
-            get => InnerBatch.StartingPublishedSequenceNumber;
-            internal set => InnerBatch.StartingPublishedSequenceNumber = value;
-        }
+        public int? StartingPublishedSequenceNumber { get; internal set; }
 
         /// <summary>
         ///   The count of events contained in the batch.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.EventHubs.Core;
+using System.ComponentModel;
 
 namespace Azure.Messaging.EventHubs.Producer
 {
@@ -78,6 +78,35 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <seealso cref="EventHubProducerClientOptions.EnableIdempotentPartitions" />
         ///
         public int? StartingSequenceNumber { get; set; }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
 
         /// <summary>
         ///   Creates a new copy of the current <see cref="PartitionPublishingOptions" />, cloning its attributes into a new instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ComponentModel;
+
 namespace Azure.Messaging.EventHubs.Producer
 {
     /// <summary>
@@ -35,6 +37,35 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </summary>
         ///
         public int? LastPublishedSequenceNumber { get; }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventOptions.cs
@@ -114,5 +114,18 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="SendEventOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="SendEventOptions" />.</returns>
+        ///
+        internal SendEventOptions Clone() =>
+            new SendEventOptions
+            {
+                PartitionId = PartitionId,
+                PartitionKey = PartitionKey
+            };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventData.CommitPublishingSequenceNumber "/>
+        ///   Verifies functionality of the <see cref="EventData.CommitPublishingState "/>
         ///   property.
         /// </summary>
         ///
@@ -71,7 +71,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(eventData.PendingPublishSequenceNumber, Is.EqualTo(expectedSequence), "The pending sequence number should have been set.");
 
-            eventData.CommitPublishingSequenceNumber();
+            eventData.CommitPublishingState();
 
             Assert.That(eventData.PublishedSequenceNumber, Is.EqualTo(expectedSequence), "The published sequence number should have been set.");
             Assert.That(eventData.PendingPublishSequenceNumber, Is.EqualTo(default(int?)), "The pending sequence number should have been cleared.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -96,7 +96,6 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(batch.MaximumSizeInBytes, Is.EqualTo(mockBatch.MaximumSizeInBytes), "The maximum size should have been delegated.");
             Assert.That(batch.SizeInBytes, Is.EqualTo(mockBatch.SizeInBytes), "The size should have been delegated.");
             Assert.That(batch.Count, Is.EqualTo(mockBatch.Count), "The count should have been delegated.");
-            Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(mockBatch.StartingPublishedSequenceNumber), "The starting published sequence number should have been delegated.");
         }
 
         /// <summary>
@@ -276,7 +275,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public override long SizeInBytes { get; } = 100;
 
-            public override int? StartingPublishedSequenceNumber { get; set; } = 300;
+            public override bool ReserveSpaceForSequenceNumber { get; } = true;
 
             public override int Count { get; } = 400;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/SendEventOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/SendEventOptionsTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Messaging.EventHubs.Producer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="SendEventOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class SendEventOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="SendEventOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new SendEventOptions
+            {
+                PartitionId = "0",
+                PartitionKey = "some_partition_123"
+            };
+
+            var clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+            Assert.That(clone, Is.TypeOf<SendEventOptions>(), "The clone should be a SendEventOptions instance.");
+            Assert.That(clone, Is.Not.SameAs(options), "The clone should not the same reference as the options.");
+            Assert.That(clone.PartitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the clone should match.");
+            Assert.That(clone.PartitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the clone should match.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -382,7 +382,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
             public override int Count { get; }
-            public override int? StartingPublishedSequenceNumber { get; set; }
+            public override bool ReserveSpaceForSequenceNumber { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
             public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();


### PR DESCRIPTION
# Summary

The focus of these changes is to enable the `EventDataBatch` to reserve appropriate space for publishing sequence numbers, when required by the active
producer configuration and to complete the client API surface by implementing the `ReadPartitionPublishingProperties` method.

**Note:**  These API changes are part of a preview feature.  The design and API surface were informally reviewed with the language architect but have not yet undergone formal review with the architecture board.  I expect some changes, particularly around naming.

# Last Upstream Rebase

Saturday, September 12, 12:57pm (EDT)

# References and Related Issues

- [Idempotent Publishing Design](https://gist.github.com/jsquire/1cc4db6b3ca4ef13d26dc5315483555b)
- [Idempotent Publishing Requirements with Usage](https://gist.github.com/jsquire/0f3bc5701388fe03ccd027e86f1994f1)
- [Idempotent Publishing Support](https://github.com/Azure/azure-sdk-for-net/issues/13941) ([#13941](https://github.com/Azure/azure-sdk-for-net/issues/13941))