### PR TITLE
SDK version 4.2.0 (Hotfix on 4.1.3): Enable a way to Unregister Message Handler and Session Handler (#14021)

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Release History
+## 4.2.0
+### Improvements
+- Enable a way to Unregister Message Handler and Session Handler [PR 14021](https://github.com/Azure/azure-sdk-for-net/pull/14021)
 
 ## 4.1.3 (2020-04-17)
 - Add `GetQueuesRuntimeInfoAsync`, `GetTopicsRuntimeInfoAsync` and `GetSubscriptionsRuntimeInfoAsync` to `ManagementClient` to allow retrieval of batched entity runtime information. [PR 10261](https://github.com/Azure/azure-sdk-for-net/pull/10261)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/IReceiverClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/IReceiverClient.cs
@@ -64,6 +64,14 @@ namespace Microsoft.Azure.ServiceBus.Core
         void RegisterMessageHandler(Func<Message, CancellationToken, Task> handler, MessageHandlerOptions messageHandlerOptions);
 
         /// <summary>
+        /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
+        /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
+        /// registered. 
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
+        /// </summary>
+        Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout);
+
+        /// <summary>
         /// Completes a <see cref="Message"/> using its lock token. This will delete the message from the queue.
         /// </summary>
         /// <param name="lockToken">The lock token of the corresponding message to complete.</param>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -54,7 +54,11 @@ namespace Microsoft.Azure.ServiceBus.Core
         int prefetchCount;
         long lastPeekedSequenceNumber;
         MessageReceivePump receivePump;
+        // Cancellation token to cancel the message pump. Once this is fired, all future message handling operations registered by application will be
+        // cancelled. 
         CancellationTokenSource receivePumpCancellationTokenSource;
+        // Cancellation token to cancel the inflight message handling operations registered by application in the message pump. 
+        CancellationTokenSource runningTaskCancellationTokenSource;
 
         /// <summary>
         /// Creates a new MessageReceiver from a <see cref="ServiceBusConnectionStringBuilder"/>.
@@ -900,6 +904,51 @@ namespace Microsoft.Azure.ServiceBus.Core
         }
 
         /// <summary>
+        /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
+        /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
+        /// registered. 
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
+        /// </summary>
+        public async Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout)
+        {
+            this.ThrowIfClosed();
+
+            if (inflightMessageHandlerTasksWaitTimeout <= TimeSpan.Zero)
+            {
+                throw Fx.Exception.ArgumentOutOfRange(nameof(inflightMessageHandlerTasksWaitTimeout), inflightMessageHandlerTasksWaitTimeout, Resources.TimeoutMustBePositiveNonZero.FormatForUser(nameof(inflightMessageHandlerTasksWaitTimeout), inflightMessageHandlerTasksWaitTimeout));
+            }
+
+            MessagingEventSource.Log.UnregisterMessageHandlerStart(this.ClientId);
+            lock (this.messageReceivePumpSyncLock)
+            {
+                if (this.receivePump == null || this.receivePumpCancellationTokenSource.IsCancellationRequested)
+                {
+                    // Silently return if handler has already been unregistered. 
+                    return;
+                }
+
+                this.receivePumpCancellationTokenSource.Cancel();
+                this.receivePumpCancellationTokenSource.Dispose();
+            }
+
+            Stopwatch stopWatch = Stopwatch.StartNew();
+            while (this.receivePump != null
+                && stopWatch.Elapsed < inflightMessageHandlerTasksWaitTimeout
+                && this.receivePump.maxConcurrentCallsSemaphoreSlim.CurrentCount < this.receivePump.registerHandlerOptions.MaxConcurrentCalls)
+            {
+                await Task.Delay(10).ConfigureAwait(false);
+            }
+
+            lock (this.messageReceivePumpSyncLock)
+            {
+                this.runningTaskCancellationTokenSource.Cancel();
+                this.runningTaskCancellationTokenSource.Dispose();
+                this.receivePump = null;
+            }
+            MessagingEventSource.Log.UnregisterMessageHandlerStop(this.ClientId);
+        }
+
+        /// <summary>
         /// Registers a <see cref="ServiceBusPlugin"/> to be used with this receiver.
         /// </summary>
         public override void RegisterPlugin(ServiceBusPlugin serviceBusPlugin)
@@ -1003,6 +1052,9 @@ namespace Microsoft.Azure.ServiceBus.Core
                 {
                     this.receivePumpCancellationTokenSource.Cancel();
                     this.receivePumpCancellationTokenSource.Dispose();
+                    // For back-compatibility 
+                    this.runningTaskCancellationTokenSource.Cancel();
+                    this.runningTaskCancellationTokenSource.Dispose();
                     this.receivePump = null;
                 }
             }
@@ -1279,7 +1331,13 @@ namespace Microsoft.Azure.ServiceBus.Core
                 }
 
                 this.receivePumpCancellationTokenSource = new CancellationTokenSource();
-                this.receivePump = new MessageReceivePump(this, registerHandlerOptions, callback, this.ServiceBusConnection.Endpoint, this.receivePumpCancellationTokenSource.Token);
+
+                if (this.runningTaskCancellationTokenSource == null)
+                {
+                    this.runningTaskCancellationTokenSource = new CancellationTokenSource();
+                }
+
+                this.receivePump = new MessageReceivePump(this, registerHandlerOptions, callback, this.ServiceBusConnection.Endpoint, this.receivePumpCancellationTokenSource.Token, this.runningTaskCancellationTokenSource.Token);
             }
 
             try
@@ -1295,6 +1353,8 @@ namespace Microsoft.Azure.ServiceBus.Core
                     {
                         this.receivePumpCancellationTokenSource.Cancel();
                         this.receivePumpCancellationTokenSource.Dispose();
+                        this.runningTaskCancellationTokenSource.Cancel();
+                        this.runningTaskCancellationTokenSource.Dispose();
                         this.receivePump = null;
                     }
                 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/IQueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/IQueueClient.cs
@@ -77,5 +77,13 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="sessionHandlerOptions">Options used to configure the settings of the session pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate. </remarks>
         void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions);
+
+        /// <summary>
+        /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
+        /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
+        /// registered. 
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
+        /// </summary>
+        Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout);
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/ISubscriptionClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/ISubscriptionClient.cs
@@ -114,5 +114,13 @@ namespace Microsoft.Azure.ServiceBus
         /// <param name="sessionHandlerOptions">Options used to configure the settings of the session pump.</param>
         /// <remarks>Enable prefetch to speed up the receive rate. </remarks>
         void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions sessionHandlerOptions);
+
+        /// <summary>
+        /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
+        /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
+        /// registered. 
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
+        /// </summary>
+        Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout);
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessagingEventSource.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessagingEventSource.cs
@@ -1380,6 +1380,42 @@ namespace Microsoft.Azure.ServiceBus
                 this.WriteEvent(117, objectName, details);
             }
         }
+
+        [Event(118, Level = EventLevel.Informational, Message = "{0}: Unregister MessageHandler start.")]
+        public void UnregisterMessageHandlerStart(string clientId)
+        {
+            if (this.IsEnabled())
+            {
+                this.WriteEvent(118, clientId);
+            }
+        }
+
+        [Event(119, Level = EventLevel.Informational, Message = "{0}: Unregister MessageHandler done.")]
+        public void UnregisterMessageHandlerStop(string clientId)
+        {
+            if (this.IsEnabled())
+            {
+                this.WriteEvent(119, clientId);
+            }
+        }
+
+        [Event(120, Level = EventLevel.Informational, Message = "{0}: Unregister SessionHandler start.")]
+        public void UnregisterSessionHandlerStart(string clientId)
+        {
+            if (this.IsEnabled())
+            {
+                this.WriteEvent(120, clientId);
+            }
+        }
+
+        [Event(121, Level = EventLevel.Informational, Message = "{0}: Unregister SessionHandler done.")]
+        public void UnregisterSessionHandlerStop(string clientId)
+        {
+            if (this.IsEnabled())
+            {
+                this.WriteEvent(121, clientId);
+            }
+        }
     }
 
     internal static class TraceHelper

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Azure ServiceBus SDK</AssemblyTitle>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
-    <Version>4.1.3</Version>
+    <Version>4.2.0</Version>
     <PackageTags>Microsoft;Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic</PackageTags>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
@@ -447,6 +447,18 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
+        /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
+        /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
+        /// registered. 
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
+        /// </summary>
+        public async Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout)
+        {
+            this.ThrowIfClosed();
+            await this.InnerReceiver.UnregisterMessageHandlerAsync(inflightMessageHandlerTasksWaitTimeout).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
         /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the queue client.
         /// </summary>
@@ -474,6 +486,18 @@ namespace Microsoft.Azure.ServiceBus
         {
             this.ThrowIfClosed();
             this.SessionPumpHost.OnSessionHandler(handler, sessionHandlerOptions);
+        }
+
+        /// <summary>
+        /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
+        /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
+        /// registered. 
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
+        /// </summary>
+        public async Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout)
+        {
+            this.ThrowIfClosed();
+            await this.SessionPumpHost.UnregisterSessionHandlerAsync(inflightSessionHandlerTasksWaitTimeout).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionPumpHost.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionPumpHost.cs
@@ -3,7 +3,9 @@
 
 namespace Microsoft.Azure.ServiceBus
 {
+    using Microsoft.Azure.ServiceBus.Primitives;
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -12,6 +14,7 @@ namespace Microsoft.Azure.ServiceBus
         readonly object syncLock;
         SessionReceivePump sessionReceivePump;
         CancellationTokenSource sessionPumpCancellationTokenSource;
+        CancellationTokenSource runningTaskCancellationTokenSource;
         readonly Uri endpoint;
 
         public SessionPumpHost(string clientId, ReceiveMode receiveMode, ISessionClient sessionClient, Uri endpoint)
@@ -35,6 +38,9 @@ namespace Microsoft.Azure.ServiceBus
             {
                 this.sessionPumpCancellationTokenSource?.Cancel();
                 this.sessionPumpCancellationTokenSource?.Dispose();
+                // For back-compatibility 
+                this.runningTaskCancellationTokenSource?.Cancel();
+                this.runningTaskCancellationTokenSource?.Dispose();
                 this.sessionReceivePump = null;
             }
         }
@@ -53,6 +59,13 @@ namespace Microsoft.Azure.ServiceBus
                 }
 
                 this.sessionPumpCancellationTokenSource = new CancellationTokenSource();
+
+                // Running task cancellation token source can be reused if previously UnregisterSessionHandlerAsync was called
+                if (this.runningTaskCancellationTokenSource == null)
+                {
+                    this.runningTaskCancellationTokenSource = new CancellationTokenSource();
+                }
+
                 this.sessionReceivePump = new SessionReceivePump(
                     this.ClientId,
                     this.SessionClient,
@@ -60,7 +73,8 @@ namespace Microsoft.Azure.ServiceBus
                     sessionHandlerOptions,
                     callback,
                     this.endpoint,
-                    this.sessionPumpCancellationTokenSource.Token);
+                    this.sessionPumpCancellationTokenSource.Token,
+                    this.runningTaskCancellationTokenSource.Token);
             }
 
             try
@@ -81,6 +95,44 @@ namespace Microsoft.Azure.ServiceBus
             }
 
             MessagingEventSource.Log.RegisterOnSessionHandlerStop(this.ClientId);
+        }
+
+        public async Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout)
+        {
+            if (inflightSessionHandlerTasksWaitTimeout <= TimeSpan.Zero)
+            {
+                throw Fx.Exception.ArgumentOutOfRange(nameof(inflightSessionHandlerTasksWaitTimeout), inflightSessionHandlerTasksWaitTimeout, Resources.TimeoutMustBePositiveNonZero.FormatForUser(nameof(inflightSessionHandlerTasksWaitTimeout), inflightSessionHandlerTasksWaitTimeout));
+            }
+
+            MessagingEventSource.Log.UnregisterSessionHandlerStart(this.ClientId);
+            lock (this.syncLock)
+            {
+                if (this.sessionReceivePump == null || this.sessionPumpCancellationTokenSource.IsCancellationRequested)
+                {
+                    // Silently return if handler has already been unregistered. 
+                    return;
+                }
+
+                this.sessionPumpCancellationTokenSource.Cancel();
+                this.sessionPumpCancellationTokenSource.Dispose();
+            }
+
+            Stopwatch stopWatch = Stopwatch.StartNew();
+            while (this.sessionReceivePump != null
+                && stopWatch.Elapsed < inflightSessionHandlerTasksWaitTimeout
+                && (this.sessionReceivePump.maxConcurrentSessionsSemaphoreSlim.CurrentCount < 
+                    this.sessionReceivePump.sessionHandlerOptions.MaxConcurrentSessions
+                || this.sessionReceivePump.maxPendingAcceptSessionsSemaphoreSlim.CurrentCount <           
+                this.sessionReceivePump.sessionHandlerOptions.MaxConcurrentAcceptSessionCalls))
+            {
+                await Task.Delay(10).ConfigureAwait(false);
+            }
+
+            lock (this.sessionPumpCancellationTokenSource)
+            {
+                this.sessionReceivePump = null;
+            }
+            MessagingEventSource.Log.UnregisterSessionHandlerStop(this.ClientId);
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionReceivePump.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionReceivePump.cs
@@ -11,15 +11,16 @@ namespace Microsoft.Azure.ServiceBus
 
     sealed class SessionReceivePump
     {
+        public readonly SemaphoreSlim maxConcurrentSessionsSemaphoreSlim;
+        public readonly SemaphoreSlim maxPendingAcceptSessionsSemaphoreSlim;
+        public readonly SessionHandlerOptions sessionHandlerOptions;
         readonly string clientId;
         readonly ISessionClient client;
         readonly Func<IMessageSession, Message, CancellationToken, Task> userOnSessionCallback;
-        readonly SessionHandlerOptions sessionHandlerOptions;
         readonly string endpoint;
         readonly string entityPath;
         readonly CancellationToken pumpCancellationToken;
-        readonly SemaphoreSlim maxConcurrentSessionsSemaphoreSlim;
-        readonly SemaphoreSlim maxPendingAcceptSessionsSemaphoreSlim;
+        readonly CancellationToken runningTaskCancellationToken;
         private readonly ServiceBusDiagnosticSource diagnosticSource;
 
         public SessionReceivePump(string clientId,
@@ -28,7 +29,8 @@ namespace Microsoft.Azure.ServiceBus
             SessionHandlerOptions sessionHandlerOptions,
             Func<IMessageSession, Message, CancellationToken, Task> callback,
             Uri endpoint,
-            CancellationToken token)
+            CancellationToken pumpToken,
+            CancellationToken runningTaskToken)
         {
             this.client = client ?? throw new ArgumentException(nameof(client));
             this.clientId = clientId;
@@ -37,7 +39,8 @@ namespace Microsoft.Azure.ServiceBus
             this.userOnSessionCallback = callback;
             this.endpoint = endpoint.Authority;
             this.entityPath = client.EntityPath;
-            this.pumpCancellationToken = token;
+            this.pumpCancellationToken = pumpToken;
+            this.runningTaskCancellationToken = runningTaskToken;
             this.maxConcurrentSessionsSemaphoreSlim = new SemaphoreSlim(this.sessionHandlerOptions.MaxConcurrentSessions);
             this.maxPendingAcceptSessionsSemaphoreSlim = new SemaphoreSlim(this.sessionHandlerOptions.MaxConcurrentAcceptSessionCalls);
             this.diagnosticSource = new ServiceBusDiagnosticSource(client.EntityPath, endpoint);
@@ -229,7 +232,7 @@ namespace Microsoft.Azure.ServiceBus
                         var callbackExceptionOccurred = false;
                         try
                         {
-                            processTask = this.userOnSessionCallback(session, message, this.pumpCancellationToken);
+                            processTask = this.userOnSessionCallback(session, message, this.runningTaskCancellationToken);
                             await processTask.ConfigureAwait(false);
                         }
                         catch (Exception exception)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SubscriptionClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SubscriptionClient.cs
@@ -420,6 +420,18 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
+        /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
+        /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
+        /// registered. 
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
+        /// </summary>
+        public async Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout)
+        {
+            this.ThrowIfClosed();
+            await this.InnerSubscriptionClient.InnerReceiver.UnregisterMessageHandlerAsync(inflightMessageHandlerTasksWaitTimeout).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Receive session messages continuously from the queue. Registers a message handler and begins a new thread to receive session-messages.
         /// This handler(<see cref="Func{IMessageSession, Message, CancellationToken, Task}"/>) is awaited on every time a new message is received by the subscription client.
         /// </summary>
@@ -447,6 +459,18 @@ namespace Microsoft.Azure.ServiceBus
         {
             this.ThrowIfClosed();
             this.SessionPumpHost.OnSessionHandler(handler, sessionHandlerOptions);
+        }
+
+        /// <summary>
+        /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
+        /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
+        /// registered. 
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
+        /// </summary>
+        public async Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout)
+        {
+            this.ThrowIfClosed();
+            await this.SessionPumpHost.UnregisterSessionHandlerAsync(inflightSessionHandlerTasksWaitTimeout).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -113,6 +113,7 @@ namespace Microsoft.Azure.ServiceBus
         string QueueName { get; }
         void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions);
         void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
+        System.Threading.Tasks.Task UnregisterSessionHandlerAsync(System.TimeSpan inflightSessionHandlerTasksWaitTimeout);
     }
     public interface ISessionClient : Microsoft.Azure.ServiceBus.IClientEntity
     {
@@ -132,6 +133,7 @@ namespace Microsoft.Azure.ServiceBus
         void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions);
         void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
         System.Threading.Tasks.Task RemoveRuleAsync(string ruleName);
+        System.Threading.Tasks.Task UnregisterSessionHandlerAsync(System.TimeSpan inflightSessionHandlerTasksWaitTimeout);
     }
     public interface ITopicClient : Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity
     {
@@ -241,7 +243,9 @@ namespace Microsoft.Azure.ServiceBus
         public System.Threading.Tasks.Task<long> ScheduleMessageAsync(Microsoft.Azure.ServiceBus.Message message, System.DateTimeOffset scheduleEnqueueTimeUtc) { }
         public System.Threading.Tasks.Task SendAsync(Microsoft.Azure.ServiceBus.Message message) { }
         public System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Message> messageList) { }
+        public System.Threading.Tasks.Task UnregisterMessageHandlerAsync(System.TimeSpan inflightMessageHandlerTasksWaitTimeout) { }
         public override void UnregisterPlugin(string serviceBusPluginName) { }
+        public System.Threading.Tasks.Task UnregisterSessionHandlerAsync(System.TimeSpan inflightSessionHandlerTasksWaitTimeout) { }
     }
     public sealed class QuotaExceededException : Microsoft.Azure.ServiceBus.ServiceBusException
     {
@@ -454,7 +458,9 @@ namespace Microsoft.Azure.ServiceBus
         public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.SessionHandlerOptions sessionHandlerOptions) { }
         public void RegisterSessionHandler(System.Func<Microsoft.Azure.ServiceBus.IMessageSession, Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler) { }
         public System.Threading.Tasks.Task RemoveRuleAsync(string ruleName) { }
+        public System.Threading.Tasks.Task UnregisterMessageHandlerAsync(System.TimeSpan inflightMessageHandlerTasksWaitTimeout) { }
         public override void UnregisterPlugin(string serviceBusPluginName) { }
+        public System.Threading.Tasks.Task UnregisterSessionHandlerAsync(System.TimeSpan inflightSessionHandlerTasksWaitTimeout) { }
     }
     public class TopicClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.ITopicClient
     {
@@ -527,6 +533,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         System.Threading.Tasks.Task DeadLetterAsync(string lockToken, string deadLetterReason, string deadLetterErrorDescription = null);
         void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, Microsoft.Azure.ServiceBus.MessageHandlerOptions messageHandlerOptions);
         void RegisterMessageHandler(System.Func<Microsoft.Azure.ServiceBus.Message, System.Threading.CancellationToken, System.Threading.Tasks.Task> handler, System.Func<Microsoft.Azure.ServiceBus.ExceptionReceivedEventArgs, System.Threading.Tasks.Task> exceptionReceivedHandler);
+        System.Threading.Tasks.Task UnregisterMessageHandlerAsync(System.TimeSpan inflightMessageHandlerTasksWaitTimeout);
     }
     public interface ISenderClient : Microsoft.Azure.ServiceBus.IClientEntity
     {
@@ -579,6 +586,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }
         public System.Threading.Tasks.Task RenewLockAsync(Microsoft.Azure.ServiceBus.Message message) { }
         public System.Threading.Tasks.Task<System.DateTime> RenewLockAsync(string lockToken) { }
+        public System.Threading.Tasks.Task UnregisterMessageHandlerAsync(System.TimeSpan inflightMessageHandlerTasksWaitTimeout) { }
         public override void UnregisterPlugin(string serviceBusPluginName) { }
     }
     public class MessageSender : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.IMessageSender, Microsoft.Azure.ServiceBus.Core.ISenderClient, Microsoft.Azure.ServiceBus.IClientEntity

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/OnMessageQueueTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/OnMessageQueueTests.cs
@@ -132,6 +132,42 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     await queueClient.CloseAsync();
                 }
             });
+
+            await ServiceBusScope.UsingQueueAsync(partitioned, sessionEnabled, async queueName =>
+            {
+                var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, mode);
+                try
+                {
+                    await this.OnMessageAsyncUnregisterHandlerLongTimeoutTestCase(
+                        queueClient.InnerSender,
+                        queueClient.InnerReceiver,
+                        maxConcurrentCalls,
+                        autoComplete,
+                        messageCount);
+                }
+                finally
+                {
+                    await queueClient.CloseAsync();
+                }
+            });
+
+            await ServiceBusScope.UsingQueueAsync(partitioned, sessionEnabled, async queueName =>
+            {
+                var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, mode);
+                try
+                {
+                    await this.OnMessageAsyncUnregisterHandlerShortTimeoutTestCase(
+                        queueClient.InnerSender,
+                        queueClient.InnerReceiver,
+                        maxConcurrentCalls,
+                        autoComplete,
+                        messageCount);
+                }
+                finally
+                {
+                    await queueClient.CloseAsync();
+                }
+            });
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/OnMessageTopicSubscriptionTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/OnMessageTopicSubscriptionTests.cs
@@ -62,6 +62,56 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                     await topicClient.CloseAsync();
                 }
             });
+
+            await ServiceBusScope.UsingTopicAsync(partitioned, sessionEnabled, async (topicName, subscriptionName) =>
+            {
+                var topicClient = new TopicClient(TestUtility.NamespaceConnectionString, topicName);
+                var subscriptionClient = new SubscriptionClient(
+                    TestUtility.NamespaceConnectionString,
+                    topicName,
+                    subscriptionName,
+                    mode);
+
+                try
+                {
+                    await this.OnMessageAsyncUnregisterHandlerLongTimeoutTestCase(
+                        topicClient.InnerSender,
+                        subscriptionClient.InnerSubscriptionClient.InnerReceiver,
+                        maxConcurrentCalls,
+                        autoComplete,
+                        messageCount);
+                }
+                finally
+                {
+                    await subscriptionClient.CloseAsync();
+                    await topicClient.CloseAsync();
+                }
+            });
+
+            await ServiceBusScope.UsingTopicAsync(partitioned, sessionEnabled, async (topicName, subscriptionName) =>
+            {
+                var topicClient = new TopicClient(TestUtility.NamespaceConnectionString, topicName);
+                var subscriptionClient = new SubscriptionClient(
+                    TestUtility.NamespaceConnectionString,
+                    topicName,
+                    subscriptionName,
+                    mode);
+
+                try
+                {
+                    await this.OnMessageAsyncUnregisterHandlerShortTimeoutTestCase(
+                        topicClient.InnerSender,
+                        subscriptionClient.InnerSubscriptionClient.InnerReceiver,
+                        maxConcurrentCalls,
+                        autoComplete,
+                        messageCount);
+                }
+                finally
+                {
+                    await subscriptionClient.CloseAsync();
+                    await topicClient.CloseAsync();
+                }
+            });
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/OnSessionQueueTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/OnSessionQueueTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -186,6 +187,114 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
                     // Verify messages were received.
                     await testSessionHandler.VerifyRun();
+
+                    testSessionHandler.ClearData();
+                }
+                finally
+                {
+                    await queueClient.CloseAsync();
+                }
+            });
+
+            // test UnregisterSessionHandler can wait for message handling upto the timeout user defined. 
+            await ServiceBusScope.UsingQueueAsync(partitioned, sessionEnabled, async queueName =>
+            {
+                TestUtility.Log($"Queue: {queueName}, MaxConcurrentCalls: {maxConcurrentCalls}, Receive Mode: {mode.ToString()}, AutoComplete: {autoComplete}");
+                var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, mode);
+                try
+                {
+                    var sessionHandlerOptions =
+                        new SessionHandlerOptions(ExceptionReceivedHandler)
+                        {
+                            MaxConcurrentSessions = maxConcurrentCalls,
+                            MessageWaitTimeout = TimeSpan.FromSeconds(5),
+                            AutoComplete = autoComplete
+                        };
+
+                    var testSessionHandler = new TestSessionHandler(
+                        queueClient.ReceiveMode,
+                        sessionHandlerOptions,
+                        queueClient.InnerSender,
+                        queueClient.SessionPumpHost);
+
+                    // Send messages to Session first
+                    await testSessionHandler.SendSessionMessages();
+
+                    // Register handler
+                    var count = 0;
+                    testSessionHandler.RegisterSessionHandler(
+                       async (session, message, token) =>
+                       {
+                           await Task.Delay(TimeSpan.FromSeconds(8));
+                           TestUtility.Log($"Received Session: {session.SessionId} message: SequenceNumber: {message.SystemProperties.SequenceNumber}");
+
+                           if (queueClient.ReceiveMode == ReceiveMode.PeekLock && !sessionHandlerOptions.AutoComplete)
+                           {
+                               await session.CompleteAsync(message.SystemProperties.LockToken);
+                           }
+                           Interlocked.Increment(ref count);
+                       },
+                       sessionHandlerOptions);
+
+                    await Task.Delay(TimeSpan.FromSeconds(2));
+                    // UnregisterSessionHandler should wait up to the provided timeout to finish the message handling tasks
+                    await testSessionHandler.UnregisterSessionHandler(TimeSpan.FromSeconds(10));
+                    Assert.True(count == maxConcurrentCalls);
+
+                    testSessionHandler.ClearData();
+                }
+                finally
+                {
+                    await queueClient.CloseAsync();
+                }
+            });
+
+            // test UnregisterSessionHandler can close down in time when message handling takes longer than wait timeout user defined. 
+            await ServiceBusScope.UsingQueueAsync(partitioned, sessionEnabled, async queueName =>
+            {
+                TestUtility.Log($"Queue: {queueName}, MaxConcurrentCalls: {maxConcurrentCalls}, Receive Mode: {mode.ToString()}, AutoComplete: {autoComplete}");
+                var queueClient = new QueueClient(TestUtility.NamespaceConnectionString, queueName, mode);
+                try
+                {
+                    var sessionHandlerOptions =
+                        new SessionHandlerOptions(ExceptionReceivedHandler)
+                        {
+                            MaxConcurrentSessions = maxConcurrentCalls,
+                            MessageWaitTimeout = TimeSpan.FromSeconds(5),
+                            AutoComplete = autoComplete
+                        };
+
+                    var testSessionHandler = new TestSessionHandler(
+                        queueClient.ReceiveMode,
+                        sessionHandlerOptions,
+                        queueClient.InnerSender,
+                        queueClient.SessionPumpHost);
+
+                    // Send messages to Session first
+                    await testSessionHandler.SendSessionMessages();
+
+                    // Register handler
+                    var count = 0;
+                    testSessionHandler.RegisterSessionHandler(
+                       async (session, message, token) =>
+                       {
+                           await Task.Delay(TimeSpan.FromSeconds(8));
+                           TestUtility.Log($"Received Session: {session.SessionId} message: SequenceNumber: {message.SystemProperties.SequenceNumber}");
+
+                           if (queueClient.ReceiveMode == ReceiveMode.PeekLock && !sessionHandlerOptions.AutoComplete)
+                           {
+                               await session.CompleteAsync(message.SystemProperties.LockToken);
+                           }
+                           Interlocked.Increment(ref count);
+                       },
+                       sessionHandlerOptions);
+
+                    await Task.Delay(TimeSpan.FromSeconds(2));
+                    // UnregisterSessionHandler should wait up to the provided timeout to finish the message handling tasks
+                    await testSessionHandler.UnregisterSessionHandler(TimeSpan.FromSeconds(2));
+                    Assert.True(count == 0);
+
+                    testSessionHandler.ClearData();
                 }
                 finally
                 {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/TestSessionHandler.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/TestSessionHandler.cs
@@ -37,9 +37,19 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             this.sessionMessageMap = new ConcurrentDictionary<string, int>();
         }
 
+        public void RegisterSessionHandler(Func<IMessageSession, Message, CancellationToken, Task> handler, SessionHandlerOptions handlerOptions)
+        {
+            this.sessionPumpHost.OnSessionHandler(handler, handlerOptions);
+        }
+
         public void RegisterSessionHandler(SessionHandlerOptions handlerOptions)
         {
             this.sessionPumpHost.OnSessionHandler(this.OnSessionHandler, this.sessionHandlerOptions);
+        }
+
+        public async Task UnregisterSessionHandler(TimeSpan inflightSessionHandlerTasksWaitTimeout)
+        {
+            await this.sessionPumpHost.UnregisterSessionHandlerAsync(inflightSessionHandlerTasksWaitTimeout).ConfigureAwait(false);
         }
 
         public async Task SendSessionMessages()


### PR DESCRIPTION
Publish a minor Nuget version to address customer needs for Unregister Message Handler and Session Handler functionality. 