### PR TITLE
[Event Hubs Client] Processor Release Preparation (v5.3.0-beta.1)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -36,11 +36,12 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Connection strings for each of the clients now supports a `SharedAccessSignature` token, allowing a pre-generated SAS to be used for authorization.
 
-- Load balancing now has better recognition for being in a recovery state and will aggressively reclaim partitions for which it is the recognized owner, regardless of whether the current instance made the ownership claim.  Previously, those partitions were redistributed on a 1-by-1 basis as part of the standard cycle. 
+- Load balancing now has better recognition for being in a recovery state and will aggressively reclaim partitions for which it is the recognized owner, regardless of whether the current instance made the ownership claim.  Previously, those partitions were redistributed on a 1-by-1 basis as part of the standard cycle.
 
 ## 5.2.0-preview.3 (2020-08-18)
 
 ### Fixed
+
 - Bug in TaskExtensions.EnsureCompleted method that causes it to unconditionally throw an exception in the environments with synchronization context
 
 ## 5.2.0-preview.2 (2020-08-10)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -13,9 +13,7 @@
   
   <ItemGroup>
     <!-- Version overrides are specific to the v5.3.0-beta.1 release from the branch; this will be removed and the package properties updated when merged to master -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" /><!-- Needed until core v5.3.0-beta.1 package is published -->
-    <!--PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.2.0" /-->
-
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.3.0-beta.1" />
     <PackageReference Include="Azure.Storage.Blobs" VersionOverride="12.6.0"/>
     <PackageReference Include="Microsoft.Azure.Amqp" VersionOverride="2.4.6"/>
     <!-- END v5.3.0-beta.1 SPECIFIC OVERRIDES -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ﻿# Release History
 
+## 5.3.0-beta.2 (Unreleased)
+
 ## 5.3.0-beta.1 (2020-09-15)
 
 ### Changes

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.3.0-beta.1</Version>
+    <Version>5.3.0-beta.2</Version>
     <ApiCompatVersion>5.2.0</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -60,11 +60,11 @@
   <!-- Import the Azure.Core reference -->
   <!-- Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" /> -->
 
-  <!-- 
+  <!--
     THIS SECTION IS SPECIFIC TO THE v5.3.0-beta.1 RELEASE
 
     These are normally set via the above reference to Azure.Core.props, but have been included here
-    to allow a specific override to the Azure.Core version for Event Hubs only; when merged back to 
+    to allow a specific override to the Azure.Core version for Event Hubs only; when merged back to
     master, this section should be removed and the above import restored.
   -->
   <ItemGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the event processor package for its v5.3.0-beta.1 release.

# Last Upstream Rebase

Tuesday, September 15, 11:57am (EDT)