### PR TITLE
[WIP] [Identity] TokenCache persistence redesign

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -66,9 +66,8 @@ namespace Azure.Identity
     public partial class ClientCertificateCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public ClientCertificateCredentialOptions() { }
-        public bool AllowUnencryptedCache { get { throw null; } set { } }
-        public bool EnablePersistentCache { get { throw null; } set { } }
         public bool IncludeX5CCliamHeader { get { throw null; } set { } }
+        public Azure.Identity.TokenCache TokenCache { get { throw null; } set { } }
     }
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
     {
@@ -82,8 +81,7 @@ namespace Azure.Identity
     public partial class ClientSecretCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public ClientSecretCredentialOptions() { }
-        public bool AllowUnencryptedCache { get { throw null; } set { } }
-        public bool EnablePersistentCache { get { throw null; } set { } }
+        public Azure.Identity.TokenCache TokenCache { get { throw null; } set { } }
     }
     public partial class CredentialUnavailableException : Azure.Identity.AuthenticationFailedException
     {
@@ -130,12 +128,11 @@ namespace Azure.Identity
     public partial class DeviceCodeCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public DeviceCodeCredentialOptions() { }
-        public bool AllowUnencryptedCache { get { throw null; } set { } }
         public Azure.Identity.AuthenticationRecord AuthenticationRecord { get { throw null; } set { } }
         public string ClientId { get { throw null; } set { } }
         public bool DisableAutomaticAuthentication { get { throw null; } set { } }
-        public bool EnablePersistentCache { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
+        public Azure.Identity.TokenCache TokenCache { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct DeviceCodeInfo
@@ -182,9 +179,9 @@ namespace Azure.Identity
         public Azure.Identity.AuthenticationRecord AuthenticationRecord { get { throw null; } set { } }
         public string ClientId { get { throw null; } set { } }
         public bool DisableAutomaticAuthentication { get { throw null; } set { } }
-        public bool EnablePersistentCache { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
+        public Azure.Identity.TokenCache TokenCache { get { throw null; } set { } }
     }
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
     {
@@ -204,10 +201,17 @@ namespace Azure.Identity
     public partial class SharedTokenCacheCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public SharedTokenCacheCredentialOptions() { }
-        public bool AllowUnencryptedCache { get { throw null; } set { } }
         public Azure.Identity.AuthenticationRecord AuthenticationRecord { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
+        public Azure.Identity.TokenCache TokenCache { get { throw null; } }
         public string Username { get { throw null; } set { } }
+    }
+    public partial class TokenCache : System.IDisposable
+    {
+        public TokenCache() { }
+        public static Azure.Identity.TokenCache SharedCache { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
     }
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
@@ -230,8 +234,7 @@ namespace Azure.Identity
     public partial class UsernamePasswordCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public UsernamePasswordCredentialOptions() { }
-        public bool AllowUnencryptedCache { get { throw null; } set { } }
-        public bool EnablePersistentCache { get { throw null; } set { } }
+        public Azure.Identity.TokenCache TokenCache { get { throw null; } set { } }
     }
     public partial class VisualStudioCodeCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -175,7 +175,6 @@ namespace Azure.Identity
     public partial class InteractiveBrowserCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public InteractiveBrowserCredentialOptions() { }
-        public bool AllowUnencryptedCache { get { throw null; } set { } }
         public Azure.Identity.AuthenticationRecord AuthenticationRecord { get { throw null; } set { } }
         public string ClientId { get { throw null; } set { } }
         public bool DisableAutomaticAuthentication { get { throw null; } set { } }
@@ -189,6 +188,17 @@ namespace Azure.Identity
         public ManagedIdentityCredential(string clientId = null, Azure.Identity.TokenCredentialOptions options = null) { }
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class PersistentTokenCache : Azure.Identity.TokenCache
+    {
+        public PersistentTokenCache(Azure.Identity.PersistentTokenCacheOptions options) { }
+        public PersistentTokenCache(bool allowUnencryptedStorage = true) { }
+    }
+    public partial class PersistentTokenCacheOptions
+    {
+        public PersistentTokenCacheOptions() { }
+        public bool AllowUnencryptedStorage { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
     }
     public partial class SharedTokenCacheCredential : Azure.Core.TokenCredential
     {
@@ -209,9 +219,18 @@ namespace Azure.Identity
     public partial class TokenCache : System.IDisposable
     {
         public TokenCache() { }
-        public static Azure.Identity.TokenCache SharedCache { get { throw null; } }
+        public event System.Func<Azure.Identity.TokenCacheUpdatedArgs, System.Threading.Tasks.Task> Updated { add { } remove { } }
+        public static Azure.Identity.TokenCache Deserialize(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Identity.TokenCache> DeserializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public void Serialize(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
+        public System.Threading.Tasks.Task SerializeAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class TokenCacheUpdatedArgs
+    {
+        internal TokenCacheUpdatedArgs() { }
+        public Azure.Identity.TokenCache Cache { get { throw null; } }
     }
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {

--- a/sdk/identity/Azure.Identity/samples/ClientSideUserAuthentication.md
+++ b/sdk/identity/Azure.Identity/samples/ClientSideUserAuthentication.md
@@ -1,0 +1,105 @@
+# Client side user authentication
+
+Client side applications often need to authenticate users to interact with resources in Azure. Some examples of this might be a command line tool which fetches secrets a user has access to from a key vault to setup a local test environment, or a GUI based application which allows a user to browse storage blobs they have access to. This sample demonstrates authenticating users with the `Azure.Identity` library.
+
+## Interactive user authentication
+
+Most often authenticating users requires some user interaction. Properly handling this user interaction for OAuth2 authorization code or device code authentication can be challenging. To simplify this for client side applications the `Azure.Identity` library provides the `InteractiveBrowserCredential` and the `DeviceCodeCredential`. These credentials are designed to handle the user interactions needed to authenticate via these two client side authentication flows, so the application developer can simply create the credential and authenticate clients with it.
+
+
+## Authenticating users with the InteractiveBrowserCredential
+
+For clients which have a default browser available, the `InteractiveBrowserCredential` provides the most simple user authentication experience. In the sample below an application authenticates a `SecretClient` using the `InteractiveBrowserCredential`.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_SimpleInteractiveBrowser
+var client = new SecretClient(new Uri("https://myvault.azure.vaults.net/"), new InteractiveBrowserCredential());
+```
+As code uses the `SecretClient` in the above sample, the `InteractiveBrowserCredential` will automatically authenticate the user by launching the default system browser prompting the user to login. In this case the user interaction happens on demand as is necessary to authenticate calls from the client.
+
+
+## Authenticating users with the DeviceCodeCredential
+
+For terminal clients without an available web browser, or clients with limited UI capabilities the `DeviceCodeCredential` provides the ability to authenticate any client using a device code. The next sample shows authenticating a `BlobClient` using the `DeviceCodeCredential`.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_SimpleDeviceCode
+var credential = new DeviceCodeCredential((deviceCodeInfo, _) => { Console.WriteLine(deviceCodeInfo.Message); return Task.CompletedTask; });
+
+var client = new BlobClient(new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"), credential);
+```
+Similiarly to the `InteractiveBrowserCredential` the `DeviceCodeCredential` will also initiate the user interaction automatically as needed. To instantiate the `DeviceCodeCredential` the application must provide a callback which is called to display the device code along with details on how to authenticate to the user. In the above sample a lambda is provided which prints the full device code message to the console.
+
+
+## Controlling user interaction
+
+In many cases applications require tight control over user interaction. In these applications automatically blocking on required user interaction is often undesired or impractical. For this reason, credentials in the `Azure.Identity` library which interact with the user offer mechanisms to fully control user interaction.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_DisableAutomaticAuthentication
+var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { DisableAutomaticAuthentication = true });
+
+await credential.AuthenticateAsync();
+
+var client = new SecretClient(new Uri("https://myvault.azure.vaults.net/"), credential);
+```
+In this sample the application is again using the `InteractiveBrowserCredential` to authenticate a `SecretClient`, but with two major differences from our first example. First, in this example the application is explicitly forcing any user interaction to happen before the credential is given to the client by calling `AuthenticateAsync`. 
+
+The second difference is here the application is preventing the credential from automatically initiating user interaction. Even though the application authenticates the user before the credential is used, further interaction might still be needed, for instance in the case that the user's refresh token expires, or a specific method require additional consent or authentication. 
+
+By setting the option `DisableAutomaticAuthentication` to `true` the credential will fail to automatically authenticate calls where user interaction is necessary. Instead, the credential will throw an `AuthenticationRequiredException`. The following example demonstrates an application handling such an exception to prompt the user to authenticate only after some application logic has completed.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_DisableAutomaticAuthentication_ExHandling
+try
+{
+    client.GetSecret("secret");
+}
+catch (AuthenticationRequiredException e)
+{
+    await EnsureAnimationCompleteAsync();
+
+    await credential.AuthenticateAsync(e.TokenRequestContext);
+
+    client.GetSecret("secret");
+}
+```
+
+## Persisting user authentication data
+
+Quite often applications desire the ability to be run multiple times without having to reauthenticate the user on each execution. This requires that data from the original authentication be persisted outside of the application memory, so that it can authenticate silently on subsequent executions. Specifically two pieces of data need to be persisted, the `TokenCache` and the `AuthenticationRecord`. 
+
+### Persisting the TokenCache
+
+The `TokenCache` contains all the data needed to silently authenticate, one or many accounts. It contains sensitive data such as refresh tokens, and access tokens and must be protected to prevent compromising the accounts it houses tokens for. The `Azure.Identity` library provides the `PersistentTokenCache` class which by default will protect and persist the cache using available platform data protection. 
+
+To use the `PersistentTokenCache` to persist the cache of any credential simply set the `TokenCache` option.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_Persist_TokenCache
+var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
+```
+
+### Persisting the AuthenticationRecord
+
+The `AuthenticationRecord` which is returned from the `Authenticate` and `AuthenticateAsync`, contains data identifying an authenticated account. It is needed to identify the appropriate entry in the `TokenCache` to silently on subsequent executions. There is no sensitive data in the `AuthenticationRecord` so it can be persisted in a non-protected state.
+
+Here is an example of an application storing the `AuthenticationRecord` to the local file system after authenticating the user.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_Persist_AuthRecord
+AuthenticationRecord authRecord = await credential.AuthenticateAsync();
+
+using var authRecordStream = new FileStream(AUTH_RECORD_PATH, FileMode.Create, FileAccess.Write);
+
+await authRecord.SerializeAsync(authRecordStream);
+
+await authRecordStream.FlushAsync();
+```
+### Silent authentication with AuthenticationRecord and PersistentTokenCache
+
+Once an application has persisted both the `TokenCache` and the `AuthenticationRecord` this data can be used to silently authenticate. This example demonstrates an application using the `PersistentTokenCache` and retrieving an `AuthenticationRecord` from the local file system to create an `InteractiveBrowserCredential` capable of silent authentication.
+
+```C# Snippet:Identity_ClientSideUserAuthentication_Persist_SilentAuth
+using var authRecordStream = new FileStream(AUTH_RECORD_PATH, FileMode.Open, FileAccess.Read);
+
+AuthenticationRecord authRecord = await AuthenticationRecord.DeserializeAsync(authRecordStream);
+
+var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache(), AuthenticationRecord = authRecord });
+```
+
+The credential created in this example will silently authenticate given that a valid token for corresponding to the `AuthenticationRecord` still exists in the `TokenCache`. There are some cases where interaction will still be required such as on token expiry, or when additional authentication is required for a particular resource.

--- a/sdk/identity/Azure.Identity/samples/TokenCache.md
+++ b/sdk/identity/Azure.Identity/samples/TokenCache.md
@@ -1,7 +1,7 @@
 # Persisting the credential TokenCache
 Many credential implementations in the Azure.Identity library have an underlying `TokenCache` which caches sensitive authentication data such as account information, access tokens, and refresh tokens. By default this `TokenCache` instance is an in memory cache which is specific to the credential instance. However, there are scenarios where an application needs to share the token cache across credentials, and persist it across executions. To accomplish this the Azure.Identity provides the `TokenCache` and `PeristantTokenCache` classes.
 
->IMPORTANT! The `TokenCache` contains sensitive data and **MUST** be protected to prevent compromising accounts. All application decisions regarding the storage of the token cache must consider that a breach of the `TokenCache` data will fully compromise all the accounts it contains.
+>IMPORTANT! The `TokenCache` contains sensitive data and **MUST** be protected to prevent compromising accounts. All application decisions regarding the storage of the `TokenCache` must consider that a breach of its content will fully compromise all the accounts it contains.
 
 ## Using the default PersistentTokenCache
 

--- a/sdk/identity/Azure.Identity/samples/TokenCache.md
+++ b/sdk/identity/Azure.Identity/samples/TokenCache.md
@@ -1,0 +1,81 @@
+# Persisting the credential token cache
+Many credential implementations in the Azure.Identity library have an underlying `TokenCache` which caches sensitive authentication data such as account information, access tokens, and refresh tokens. By default this `TokenCache` instance is an in memory cache which is specific to the credential instance. However, there are scenarios where an application needs to share the token cache across credentials, and persist it across executions. To accomplish this the Azure.Identity provides the `TokenCache` and `PeristantTokenCache` classes.
+
+>IMPORTANT! The `TokenCache` contains sensitive data and **MUST** be protected to prevent compromising accounts. All application decisions regarding the storage of the token cache must consider that a breach of the `TokenCache` data will fully compromise all the accounts it contains.
+
+## Using the default PersistentTokenCache
+
+The simplest way to persist the `TokenCache` of a credential is to to use the default `PersistentTokenCache`. This will persist and read the `TokenCache` from a shared persisted token cache protected to the current account.
+
+```C# Snippet:Identity_TokenCache_PersistentDefault
+var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
+```
+
+## Using a named PersistentTokenCache
+
+Some applications may prefer to isolate the `PersistentTokenCache` they user rather than using the shared instance. To accomplish this they can specify a `PersistentTokenCacheOptions` when creating the `PersistentTokenCache` and provide a `Name` for the persisted cache instance.
+
+```C# Snippet:Identity_TokenCache_PersistentNamed
+var tokenCache = new PersistentTokenCache(new PersistentTokenCacheOptions { Name = "my_application_name" });
+
+var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = tokenCache });
+```
+
+## Allowing unencrypted storage
+By default the `PersistentTokenCache` will protect any data which is persisted using the user data protection APIs available on the current platform. However, there are cases where no data protection is available, and applications may choose to still persist the token cache in an unencrypted state. This is accomplished with the `AllowUnencryptedStorage` option.
+
+```C# Snippet:Identity_TokenCache_PersistentUnencrypted
+var tokenCache = new PersistentTokenCache(new PersistentTokenCacheOptions { AllowUnencryptedStorage = true });
+
+var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache =  tokenCache});
+```
+By setting `AllowUnencryptedStorage` to `true`, the `PersistentTokenCache` will encrypt the contents of the `TokenCache` before persisting it if data protection is available on the current platform, otherwise it will write and read the `TokenCache` data to an unencrypted local file ACL'd to the current account. If `AllowUnencryptedStorage` is `false` (the default) a `CredentialUnavailableException` will be raised in the case no data protection is available.
+
+## Implementing custom TokenCache persistence 
+Some applications may require complete control of how the `TokenCache` is persisted. To enable this the `TokenCache` provides the methods `Serialize`, `SerializeAsync`, `Deserialize` and `DeserializeAsync` methods so applications can write the `TokenCache` to any stream. The following samples illustrate how to use these serialization methods to write and read the cache from a stream. 
+
+> IMPORTANT! This sample assumes the location of the file it is using for storage is secure. The `Serialize` and `SerializeAsync` methods will write the unencrypted content of the `TokenCache` to the provide stream. It is the responsibility the implementer to properly protect the `TokenCache` data.
+
+The `Serialize` or `SerializeAsync` methods can be used to write out content of a `TokenCache` to any writeable stream.
+
+```C# Snippet:Identity_TokenCache_CustomPersistence_Write
+using var cacheStream = new FileStream(TokenCachePath, FileMode.Create, FileAccess.Write);
+
+await tokenCache.SerializeAsync(cacheStream);
+```
+
+The `Deserialize` or `DeserializeAsync` methods can be used to read the content of a `TokenCache` from any readable stream.
+
+```C# Snippet:Identity_TokenCache_CustomPersistence_Read
+using var cacheStream = new FileStream(TokenCachePath, FileMode.OpenOrCreate, FileAccess.Read);
+
+var tokenCache = await TokenCache.DeserializeAsync(cacheStream);
+```
+
+Applications can combine these methods along with the `Updated` event to automatically persist and read the token from a storage solution of their choice.
+```C# Snippet:Identity_TokenCache_CustomPersistence_Usage
+public static async Task<TokenCache> ReadTokenCacheAsync()
+{
+    using var cacheStream = new FileStream(TokenCachePath, FileMode.OpenOrCreate, FileAccess.Read);
+
+    var tokenCache = await TokenCache.DeserializeAsync(cacheStream);
+
+    tokenCache.Updated += WriteCacheOnUpdateAsync;
+
+    return tokenCache;
+}
+
+public static async Task WriteCacheOnUpdateAsync(TokenCacheUpdatedArgs args)
+{
+    using var cacheStream = new FileStream(TokenCachePath, FileMode.Create, FileAccess.Write);
+
+    await args.Cache.SerializeAsync(cacheStream);
+}
+
+public static async Task Main()
+{
+    var tokenCache = await ReadTokenCacheAsync();
+
+    var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = tokenCache });
+}
+```

--- a/sdk/identity/Azure.Identity/samples/TokenCache.md
+++ b/sdk/identity/Azure.Identity/samples/TokenCache.md
@@ -1,4 +1,4 @@
-# Persisting the credential token cache
+# Persisting the credential TokenCache
 Many credential implementations in the Azure.Identity library have an underlying `TokenCache` which caches sensitive authentication data such as account information, access tokens, and refresh tokens. By default this `TokenCache` instance is an in memory cache which is specific to the credential instance. However, there are scenarios where an application needs to share the token cache across credentials, and persist it across executions. To accomplish this the Azure.Identity provides the `TokenCache` and `PeristantTokenCache` classes.
 
 >IMPORTANT! The `TokenCache` contains sensitive data and **MUST** be protected to prevent compromising accounts. All application decisions regarding the storage of the token cache must consider that a breach of the `TokenCache` data will fully compromise all the accounts it contains.

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
@@ -8,16 +8,10 @@ namespace Azure.Identity
     /// </summary>
     public class ClientCertificateCredentialOptions : TokenCredentialOptions, ITokenCacheOptions
     {
-
         /// <summary>
-        /// If set to true the credential will store tokens in a cache persisted to the machine, protected to the current user, which can be shared by other credentials and processes.
+        /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public bool EnablePersistentCache { get; set; }
-
-        /// <summary>
-        /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.
-        /// </summary>
-        public bool AllowUnencryptedCache { get; set; }
+        public TokenCache TokenCache { get; set; }
 
         /// <summary>
         /// Will include x5c header to enable subject name / issuer based authentication for the <see cref="ClientCertificateCredential"/>.

--- a/sdk/identity/Azure.Identity/src/ClientSecretCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ClientSecretCredentialOptions.cs
@@ -8,15 +8,10 @@ namespace Azure.Identity
     /// </summary>
     public class ClientSecretCredentialOptions : TokenCredentialOptions, ITokenCacheOptions
     {
-
         /// <summary>
-        /// If set to true the credential will store tokens in a persistent cache shared by other credentials.
+        /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public bool EnablePersistentCache { get; set; }
+        public TokenCache TokenCache { get; set; }
 
-        /// <summary>
-        /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.
-        /// </summary>
-        public bool AllowUnencryptedCache { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -34,7 +34,7 @@ namespace Azure.Identity
 
         public virtual TokenCredential CreateInteractiveBrowserCredential(string tenantId)
         {
-            return new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions { EnablePersistentCache = true }, Pipeline);
+            return new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions { TokenCache = TokenCache.SharedCache }, Pipeline);
         }
 
         public virtual TokenCredential CreateAzureCliCredential()

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -34,7 +34,7 @@ namespace Azure.Identity
 
         public virtual TokenCredential CreateInteractiveBrowserCredential(string tenantId)
         {
-            return new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions { TokenCache = TokenCache.SharedCache }, Pipeline);
+            return new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() }, Pipeline);
         }
 
         public virtual TokenCredential CreateAzureCliCredential()

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -102,7 +102,7 @@ namespace Azure.Identity
         /// Interactively authenticates a user via the default browser.
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        /// <returns>The <see cref="AuthenticationRecord"/> which can be used to silently authenticate the account on future execution if persistent caching was enabled via <see cref="DeviceCodeCredentialOptions.EnablePersistentCache"/> when credential was instantiated.</returns>
+        /// <returns>The <see cref="AuthenticationRecord"/> which can be used to silently authenticate the account on future execution of credentials using the same <see cref="DeviceCodeCredentialOptions.TokenCache"/>.</returns>
         public virtual async Task<AuthenticationRecord> AuthenticateAsync(CancellationToken cancellationToken = default)
         {
             // get the default scope for the authority, throw if no default scope exists

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
@@ -27,14 +27,9 @@ namespace Azure.Identity
         public string ClientId { get; set; } = Constants.DeveloperSignOnClientId;
 
         /// <summary>
-        /// If set to true the credential will store tokens in a cache persisted to the machine, protected to the current user, which can be shared by other credentials and processes.
+        /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public bool EnablePersistentCache { get; set; }
-
-        /// <summary>
-        /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.
-        /// </summary>
-        public bool AllowUnencryptedCache { get; set; }
+        public TokenCache TokenCache { get; set; }
 
         /// <summary>
         /// The <see cref="Identity.AuthenticationRecord"/> captured from a previous authentication.

--- a/sdk/identity/Azure.Identity/src/ITokenCacheOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ITokenCacheOptions.cs
@@ -9,8 +9,6 @@ namespace Azure.Identity
 {
     internal interface ITokenCacheOptions
     {
-        bool EnablePersistentCache { get; }
-
-        bool AllowUnencryptedCache { get; }
+        TokenCache TokenCache { get; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
@@ -33,11 +33,6 @@ namespace Azure.Identity
         public TokenCache TokenCache { get; set; }
 
         /// <summary>
-        /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.
-        /// </summary>
-        public bool AllowUnencryptedCache { get; set; }
-
-        /// <summary>
         /// Uri where the STS will call back the application with the security token. This parameter is not required if the caller is not using a custom <see cref="ClientId"/>. In
         /// the case that the caller is using their own <see cref="ClientId"/> the value must match the redirect url specified when creating the application registration.
         /// </summary>

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
@@ -28,9 +28,9 @@ namespace Azure.Identity
         public string ClientId { get; set; } = Constants.DeveloperSignOnClientId;
 
         /// <summary>
-        /// If set to true the credential will store tokens in a cache persisted to the machine, protected to the current user, which can be shared by other credentials and processes.
+        /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public bool EnablePersistentCache { get; set; }
+        public TokenCache TokenCache { get; set; }
 
         /// <summary>
         /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -12,10 +12,6 @@ namespace Azure.Identity
     internal abstract class MsalClientBase<TClient>
         where TClient : IClientApplicationBase
     {
-        // we are creating the MsalCacheHelper with a random guid based clientId to work around issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98
-        // This does not impact the functionality of the cacheHelper as the ClientId is only used to iterate accounts in the cache not for authentication purposes.
-        private static readonly string s_msalCacheClientId = Guid.NewGuid().ToString();
-
         private readonly AsyncLockWithValue<TClient> _clientAsyncLock;
 
         /// <summary>
@@ -33,9 +29,7 @@ namespace Azure.Identity
 
             ClientId = clientId;
 
-            EnablePersistentCache = cacheOptions?.EnablePersistentCache ?? false;
-
-            AllowUnencryptedCache = cacheOptions?.AllowUnencryptedCache ?? false;
+            TokenCache = cacheOptions?.TokenCache;
 
             _clientAsyncLock = new AsyncLockWithValue<TClient>();
         }
@@ -44,9 +38,7 @@ namespace Azure.Identity
 
         internal string ClientId { get; }
 
-        internal bool EnablePersistentCache { get; }
-
-        internal bool AllowUnencryptedCache { get; }
+        internal TokenCache TokenCache { get; }
 
         protected CredentialPipeline Pipeline { get; }
 
@@ -62,54 +54,13 @@ namespace Azure.Identity
 
             var client = await CreateClientAsync(async, cancellationToken).ConfigureAwait(false);
 
-            if (EnablePersistentCache)
+            if (TokenCache != null)
             {
-                MsalCacheHelper cacheHelper;
-
-                StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
-                    .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
-                    .WithLinuxKeyring(Constants.DefaultMsalTokenCacheKeyringSchema, Constants.DefaultMsalTokenCacheKeyringCollection, Constants.DefaultMsalTokenCacheKeyringLabel, Constants.DefaultMsaltokenCacheKeyringAttribute1, Constants.DefaultMsaltokenCacheKeyringAttribute2)
-                    .Build();
-
-                try
-                {
-                    cacheHelper = await CreateCacheHelper(storageProperties, async).ConfigureAwait(false);
-
-                    cacheHelper.VerifyPersistence();
-                }
-                catch (MsalCachePersistenceException)
-                {
-                    if (AllowUnencryptedCache)
-                    {
-                        storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
-                            .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
-                            .WithLinuxUnprotectedFile()
-                            .Build();
-
-                        cacheHelper = await CreateCacheHelper(storageProperties, async).ConfigureAwait(false);
-
-                        cacheHelper.VerifyPersistence();
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-
-                cacheHelper.RegisterCache(client.UserTokenCache);
+                await TokenCache.RegisterCache(async, client.UserTokenCache, cancellationToken).ConfigureAwait(false);
             }
 
             asyncLock.SetValue(client);
             return client;
-        }
-
-        private static async ValueTask<MsalCacheHelper> CreateCacheHelper(StorageCreationProperties storageProperties, bool async)
-        {
-            return async
-                ? await MsalCacheHelper.CreateAsync(storageProperties).ConfigureAwait(false)
-#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
-                : MsalCacheHelper.CreateAsync(storageProperties).GetAwaiter().GetResult();
-#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/PersistentTokenCache.cs
+++ b/sdk/identity/Azure.Identity/src/PersistentTokenCache.cs
@@ -66,7 +66,7 @@ namespace Azure.Identity
 
             try
             {
-                cacheHelper = string.IsNullOrEmpty(_name) ? await GetProtectedCacheHelperAsync(async, cancellationToken).ConfigureAwait(false) : await GetProtectedCacheHelperAsync(async, _name, cancellationToken).ConfigureAwait(false);
+                cacheHelper = string.IsNullOrEmpty(_name) ? await GetProtectedCacheHelperAsync(async, cancellationToken).ConfigureAwait(false) : await GetProtectedCacheHelperAsync(async, _name).ConfigureAwait(false);
 
                 cacheHelper.VerifyPersistence();
             }
@@ -74,7 +74,7 @@ namespace Azure.Identity
             {
                 if (_allowUnencryptedStorage)
                 {
-                    cacheHelper = string.IsNullOrEmpty(_name) ? await GetFallbackCacheHelperAsync(async, cancellationToken).ConfigureAwait(false) : await GetFallbackCacheHelperAsync(async, _name, cancellationToken).ConfigureAwait(false);
+                    cacheHelper = string.IsNullOrEmpty(_name) ? await GetFallbackCacheHelperAsync(async, cancellationToken).ConfigureAwait(false) : await GetFallbackCacheHelperAsync(async, _name).ConfigureAwait(false);
 
                     cacheHelper.VerifyPersistence();
                 }
@@ -98,14 +98,14 @@ namespace Azure.Identity
                 return asyncLock.Value;
             }
 
-            MsalCacheHelper cacheHelper = await GetProtectedCacheHelperAsync(async, Constants.DefaultMsalTokenCacheName, cancellationToken).ConfigureAwait(false);
+            MsalCacheHelper cacheHelper = await GetProtectedCacheHelperAsync(async, Constants.DefaultMsalTokenCacheName).ConfigureAwait(false);
 
             asyncLock.SetValue(cacheHelper);
 
             return cacheHelper;
         }
 
-        private static async Task<MsalCacheHelper> GetProtectedCacheHelperAsync(bool async, string name, CancellationToken cancellationToken)
+        private static async Task<MsalCacheHelper> GetProtectedCacheHelperAsync(bool async, string name)
         {
             StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(name, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
                 .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, name)
@@ -126,17 +126,17 @@ namespace Azure.Identity
                 return asyncLock.Value;
             }
 
-            MsalCacheHelper cacheHelper = await GetFallbackCacheHelperAsync(async, Constants.DefaultMsalTokenCacheName, cancellationToken).ConfigureAwait(false);
+            MsalCacheHelper cacheHelper = await GetFallbackCacheHelperAsync(async, Constants.DefaultMsalTokenCacheName).ConfigureAwait(false);
 
             asyncLock.SetValue(cacheHelper);
 
             return cacheHelper;
         }
 
-        private static async Task<MsalCacheHelper> GetFallbackCacheHelperAsync(bool async, string name, CancellationToken cancellationToken)
+        private static async Task<MsalCacheHelper> GetFallbackCacheHelperAsync(bool async, string name)
         {
-            StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
-                .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
+            StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(name, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
+                .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, name)
                 .WithLinuxUnprotectedFile()
                 .Build();
 

--- a/sdk/identity/Azure.Identity/src/PersistentTokenCache.cs
+++ b/sdk/identity/Azure.Identity/src/PersistentTokenCache.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Persistent token cache.
+    /// </summary>
+    public class PersistentTokenCache : TokenCache
+    {
+        // we are creating the MsalCacheHelper with a random guid based clientId to work around issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98
+        // This does not impact the functionality of the cacheHelper as the ClientId is only used to iterate accounts in the cache not for authentication purposes.
+        private static readonly string s_msalCacheClientId = Guid.NewGuid().ToString();
+
+        private AsyncLockWithValue<MsalCacheHelper> _cacheHelperLock = new AsyncLockWithValue<MsalCacheHelper>();
+        private bool _allowUnencryptedStorage;
+
+        /// <summary>
+        /// Creation.
+        /// </summary>
+        /// <param name="allowUnencryptedStorage"></param>
+        public PersistentTokenCache(bool allowUnencryptedStorage)
+        {
+            _allowUnencryptedStorage = allowUnencryptedStorage;
+        }
+
+        internal override async Task RegisterCache(bool async, ITokenCache tokenCache, CancellationToken cancellationToken)
+        {
+            MsalCacheHelper cacheHelper = await GetCacheHelperAsync(async, cancellationToken).ConfigureAwait(false);
+
+            cacheHelper.RegisterCache(tokenCache);
+
+            await base.RegisterCache(async, tokenCache, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<MsalCacheHelper> GetCacheHelperAsync(bool async, CancellationToken cancellationToken)
+        {
+            using var asyncLock = await _cacheHelperLock.GetLockOrValueAsync(async, cancellationToken).ConfigureAwait(false);
+
+            if (asyncLock.HasValue)
+            {
+                return asyncLock.Value;
+            }
+
+            MsalCacheHelper cacheHelper;
+
+            StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
+                .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
+                .WithLinuxKeyring(Constants.DefaultMsalTokenCacheKeyringSchema, Constants.DefaultMsalTokenCacheKeyringCollection, Constants.DefaultMsalTokenCacheKeyringLabel, Constants.DefaultMsaltokenCacheKeyringAttribute1, Constants.DefaultMsaltokenCacheKeyringAttribute2)
+                .Build();
+
+            try
+            {
+                cacheHelper = await CreateCacheHelper(async, storageProperties).ConfigureAwait(false);
+
+                cacheHelper.VerifyPersistence();
+            }
+            catch (MsalCachePersistenceException)
+            {
+                if (_allowUnencryptedStorage)
+                {
+                    storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
+                        .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
+                        .WithLinuxUnprotectedFile()
+                        .Build();
+
+                    cacheHelper = await CreateCacheHelper(async, storageProperties).ConfigureAwait(false);
+
+                    cacheHelper.VerifyPersistence();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            asyncLock.SetValue(cacheHelper);
+
+            return cacheHelper;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            MsalCacheHelper helper;
+            base.Dispose(disposing);
+        }
+
+        private static async Task<MsalCacheHelper> CreateCacheHelper(bool async, StorageCreationProperties storageProperties)
+        {
+            return async
+                ? await MsalCacheHelper.CreateAsync(storageProperties).ConfigureAwait(false)
+#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
+                : MsalCacheHelper.CreateAsync(storageProperties).GetAwaiter().GetResult();
+#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/PersistentTokenCacheOptions.cs
+++ b/sdk/identity/Azure.Identity/src/PersistentTokenCacheOptions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Options controlling the storage of the <see cref="PersistentTokenCache"/>.
+    /// </summary>
+    public class PersistentTokenCacheOptions
+    {
+        /// <summary>
+        /// Name uniquely identifying the <see cref="PersistentTokenCache"/>.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// If set to true the token cache may be persisted as an unencrypted file if no OS level user encryption is available. When set to false the <see cref="PersistentTokenCache"/>
+        /// will throw a <see cref="CredentialUnavailableException"/> in the event no OS level user encryption is available.
+        /// </summary>
+        public bool AllowUnencryptedStorage { get; set; }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
@@ -28,7 +28,7 @@ namespace Azure.Identity
         /// <summary>
         /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public TokenCache TokenCache => TokenCache.SharedCache;
+        public TokenCache TokenCache => new PersistentTokenCache();
 
     }
 }

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
@@ -26,10 +26,9 @@ namespace Azure.Identity
         public AuthenticationRecord AuthenticationRecord { get; set; }
 
         /// <summary>
-        /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.
+        /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public bool AllowUnencryptedCache { get; set; }
+        public TokenCache TokenCache => TokenCache.SharedCache;
 
-        bool ITokenCacheOptions.EnablePersistentCache => true;
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCache.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCache.cs
@@ -119,7 +119,7 @@ namespace Azure.Identity
         {
             if (async)
             {
-                await stream.WriteAsync(_data, 0, _data.Length).ConfigureAwait(false);
+                await stream.WriteAsync(_data, 0, _data.Length, cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -133,7 +133,7 @@ namespace Azure.Identity
 
             if (async)
             {
-                await stream.ReadAsync(data, 0, data.Length).ConfigureAwait(false);
+                await stream.ReadAsync(data, 0, data.Length, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/sdk/identity/Azure.Identity/src/TokenCache.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCache.cs
@@ -1,0 +1,239 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// A cache for Tokens.
+    /// </summary>
+    public class TokenCache : IDisposable
+    {
+        private SemaphoreSlim _lock = new SemaphoreSlim(1,1);
+        private byte[] _serialized;
+        private DateTimeOffset _lastUpdated;
+        private Dictionary<object, DateTimeOffset> _cacheAccessMap;
+        private bool _disposedValue;
+
+        private static Lazy<TokenCache> s_SharedCache = new Lazy<TokenCache>(() => new SharedTokenCache(true), LazyThreadSafetyMode.ExecutionAndPublication);
+
+        /// <summary>
+        /// Instantiates a new <see cref="TokenCache"/>.
+        /// </summary>
+        public TokenCache()
+        {
+            _serialized = Array.Empty<byte>();
+            _lastUpdated = DateTimeOffset.UtcNow;
+            _cacheAccessMap = new Dictionary<object, DateTimeOffset>();
+        }
+
+        /// <summary>
+        /// The shared token cache.
+        /// </summary>
+        public static TokenCache SharedCache => s_SharedCache.Value;
+
+        internal virtual async Task RegisterCache(bool async, ITokenCache tokenCache, CancellationToken cancellationToken)
+        {
+            if (async)
+            {
+                await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _lock.Wait(cancellationToken);
+            }
+
+            try
+            {
+                if (!_cacheAccessMap.ContainsKey(tokenCache))
+                {
+                    tokenCache.SetBeforeAccessAsync(OnBeforeCacheAccessAsync);
+
+                    tokenCache.SetAfterAccessAsync(OnAfterCacheAccessAsync);
+
+                    _cacheAccessMap.Add(tokenCache, DateTimeOffset.MinValue);
+                }
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        private async Task OnBeforeCacheAccessAsync(TokenCacheNotificationArgs args)
+        {
+            await _lock.WaitAsync().ConfigureAwait(false);
+
+            try
+            {
+                args.TokenCache.DeserializeMsalV3(_serialized, true);
+
+                _cacheAccessMap[args.TokenCache] = DateTimeOffset.UtcNow;
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+
+        private async Task OnAfterCacheAccessAsync(TokenCacheNotificationArgs args)
+        {
+            if (args.HasStateChanged)
+            {
+                await _lock.WaitAsync().ConfigureAwait(false);
+
+                try
+                {
+                    if (!_cacheAccessMap.TryGetValue(args.TokenCache, out DateTimeOffset lastRead) || lastRead < _lastUpdated)
+                    {
+                        _serialized = await MergeCacheData(_serialized, args.TokenCache.SerializeMsalV3()).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _serialized = args.TokenCache.SerializeMsalV3();
+                    }
+                }
+                finally
+                {
+                    _lock.Release();
+                }
+            }
+        }
+
+        private static async Task<byte[]> MergeCacheData(byte[] cacheA, byte[] cacheB)
+        {
+            byte[] merged = null;
+
+            var client = PublicClientApplicationBuilder.Create(Guid.NewGuid().ToString()).Build();
+
+            client.UserTokenCache.SetBeforeAccess(args => args.TokenCache.DeserializeMsalV3(cacheA));
+
+            await client.GetAccountsAsync().ConfigureAwait(false);
+
+            client.UserTokenCache.SetBeforeAccess(args => args.TokenCache.DeserializeMsalV3(cacheB, shouldClearExistingCache: false));
+
+            client.UserTokenCache.SetAfterAccess(args => merged = args.TokenCache.SerializeMsalV3());
+
+            await client.GetAccountsAsync().ConfigureAwait(false);
+
+            return merged;
+        }
+
+        /// <summary>
+        /// Disposes of the <see cref="TokenCache"/>.
+        /// </summary>
+        /// <param name="disposing">Flag to indicate whether managed resources should be disposed of.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _lock.Dispose();
+                }
+
+                _cacheAccessMap = null;
+
+                _serialized = null;
+
+                _disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Disposes of the <see cref="TokenCache"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private class SharedTokenCache : TokenCache
+        {
+            // we are creating the MsalCacheHelper with a random guid based clientId to work around issue https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/issues/98
+            // This does not impact the functionality of the cacheHelper as the ClientId is only used to iterate accounts in the cache not for authentication purposes.
+            private static readonly string s_msalCacheClientId = Guid.NewGuid().ToString();
+
+            private AsyncLockWithValue<MsalCacheHelper> _cacheHelperLock = new AsyncLockWithValue<MsalCacheHelper>();
+            private bool _allowUnencryptedStorage;
+
+            public SharedTokenCache(bool allowUnencryptedStorage)
+            {
+                _allowUnencryptedStorage = allowUnencryptedStorage;
+            }
+
+            internal override async Task RegisterCache(bool async, ITokenCache tokenCache, CancellationToken cancellationToken)
+            {
+                MsalCacheHelper cacheHelper = await GetCacheHelperAsync(async, cancellationToken).ConfigureAwait(false);
+
+                cacheHelper.RegisterCache(tokenCache);
+
+                await base.RegisterCache(async, tokenCache, cancellationToken).ConfigureAwait(false);
+            }
+
+            private async Task<MsalCacheHelper> GetCacheHelperAsync(bool async, CancellationToken cancellationToken)
+            {
+                using var asyncLock = await _cacheHelperLock.GetLockOrValueAsync(async, cancellationToken).ConfigureAwait(false);
+
+                if (asyncLock.HasValue)
+                {
+                    return asyncLock.Value;
+                }
+
+                MsalCacheHelper cacheHelper;
+
+                StorageCreationProperties storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
+                    .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
+                    .WithLinuxKeyring(Constants.DefaultMsalTokenCacheKeyringSchema, Constants.DefaultMsalTokenCacheKeyringCollection, Constants.DefaultMsalTokenCacheKeyringLabel, Constants.DefaultMsaltokenCacheKeyringAttribute1, Constants.DefaultMsaltokenCacheKeyringAttribute2)
+                    .Build();
+
+                try
+                {
+                    cacheHelper = await CreateCacheHelper(async, storageProperties).ConfigureAwait(false);
+
+                    cacheHelper.VerifyPersistence();
+                }
+                catch (MsalCachePersistenceException)
+                {
+                    if (_allowUnencryptedStorage)
+                    {
+                        storageProperties = new StorageCreationPropertiesBuilder(Constants.DefaultMsalTokenCacheName, Constants.DefaultMsalTokenCacheDirectory, s_msalCacheClientId)
+                            .WithMacKeyChain(Constants.DefaultMsalTokenCacheKeychainService, Constants.DefaultMsalTokenCacheKeychainAccount)
+                            .WithLinuxUnprotectedFile()
+                            .Build();
+
+                        cacheHelper = await CreateCacheHelper(async, storageProperties).ConfigureAwait(false);
+
+                        cacheHelper.VerifyPersistence();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+
+                asyncLock.SetValue(cacheHelper);
+
+                return cacheHelper;
+            }
+
+            private static async Task<MsalCacheHelper> CreateCacheHelper(bool async, StorageCreationProperties storageProperties)
+            {
+                return async
+                    ? await MsalCacheHelper.CreateAsync(storageProperties).ConfigureAwait(false)
+#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
+                : MsalCacheHelper.CreateAsync(storageProperties).GetAwaiter().GetResult();
+#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/TokenCacheUpdatedArgs.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCacheUpdatedArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Data regarding an update of a <see cref="TokenCache"/>.
+    /// </summary>
+    public class TokenCacheUpdatedArgs
+    {
+        internal TokenCacheUpdatedArgs(TokenCache cache)
+        {
+            Cache = cache;
+        }
+
+        /// <summary>
+        /// The <see cref="TokenCache"/> instance which was updated.
+        /// </summary>
+        public TokenCache Cache { get; }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/TokenCacheUpdatedArgs.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCacheUpdatedArgs.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace Azure.Identity
 {

--- a/sdk/identity/Azure.Identity/src/UsernamePasswordCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/UsernamePasswordCredentialOptions.cs
@@ -9,13 +9,9 @@ namespace Azure.Identity
     public class UsernamePasswordCredentialOptions : TokenCredentialOptions, ITokenCacheOptions
     {
         /// <summary>
-        /// If set to true the credential will store tokens in a persistent cache shared by other user credentials.
+        /// Specifies the <see cref="TokenCache"/> to be used by the credential.
         /// </summary>
-        public bool EnablePersistentCache { get; set; }
+        public TokenCache TokenCache { get; set; }
 
-        /// <summary>
-        /// If set to true the credential will fall back to storing tokens in an unencrypted file if no OS level user encryption is available.
-        /// </summary>
-        public bool AllowUnencryptedCache { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialCtorTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialCtorTests.cs
@@ -36,8 +36,7 @@ namespace Azure.Identity.Tests
                 TenantId = Guid.NewGuid().ToString(),
                 AuthorityHost = new Uri("https://login.myauthority.com/"),
                 DisableAutomaticAuthentication = true,
-                EnablePersistentCache = true,
-                AllowUnencryptedCache = true,
+                TokenCache = new TokenCache(),
                 AuthenticationRecord = new AuthenticationRecord(),
                 RedirectUri = new Uri("https://localhost:8080"),
             };
@@ -116,8 +115,7 @@ namespace Azure.Identity.Tests
             Assert.AreEqual(options.TenantId, credential.Client.TenantId);
             Assert.AreEqual(options.AuthorityHost, credential.Pipeline.AuthorityHost);
             Assert.AreEqual(options.DisableAutomaticAuthentication, credential.DisableAutomaticAuthentication);
-            Assert.AreEqual(options.EnablePersistentCache, credential.Client.EnablePersistentCache);
-            Assert.AreEqual(options.AllowUnencryptedCache, credential.Client.AllowUnencryptedCache);
+            Assert.AreEqual(options.TokenCache, credential.Client.TokenCache);
             Assert.AreEqual(options.AuthenticationRecord, credential.Record);
 
             if (options.RedirectUri != null)

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -74,12 +74,12 @@ namespace Azure.Identity.Tests
         [Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithSharedTokenCacheAsync()
         {
-            var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = TokenCache.SharedCache });
+            var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
 
             // this should pop browser
             AuthenticationRecord record = await cred.AuthenticateAsync();
 
-            var cred2 = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = TokenCache.SharedCache, AuthenticationRecord = record });
+            var cred2 = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache(), AuthenticationRecord = record });
 
             // this should not pop browser
             AccessToken token = await cred2.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -73,12 +74,32 @@ namespace Azure.Identity.Tests
         [Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithSharedTokenCacheAsync()
         {
-            var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { EnablePersistentCache = true });
+            var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = TokenCache.SharedCache });
 
             // this should pop browser
             AuthenticationRecord record = await cred.AuthenticateAsync();
 
-            var cred2 = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { EnablePersistentCache = true, AuthenticationRecord = record });
+            var cred2 = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = TokenCache.SharedCache, AuthenticationRecord = record });
+
+            // this should not pop browser
+            AccessToken token = await cred2.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);
+
+            Assert.NotNull(token.Token);
+        }
+
+
+        [Test]
+        [Ignore("This test is an integration test which can only be run with user interaction")]
+        public async Task AuthenticateWithCommonTokenCacheAsync()
+        {
+            var tokenCache = new TokenCache();
+
+            var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = tokenCache });
+
+            // this should pop browser
+            AuthenticationRecord record = await cred.AuthenticateAsync();
+
+            var cred2 = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = tokenCache, AuthenticationRecord = record });
 
             // this should not pop browser
             AccessToken token = await cred2.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);

--- a/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests.Mock
             => new SharedTokenCacheCredential(tenantId, username, default, Pipeline);
 
         public override TokenCredential CreateInteractiveBrowserCredential(string tenantId)
-            => new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions { EnablePersistentCache = true }, Pipeline);
+            => new InteractiveBrowserCredential(tenantId, Constants.DeveloperSignOnClientId, new InteractiveBrowserCredentialOptions(), Pipeline);
 
         public override TokenCredential CreateAzureCliCredential()
             => new AzureCliCredential(Pipeline, _processService);

--- a/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
@@ -1,22 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace Azure.Identity.Samples
 {
     public class TokenCacheSnippets
     {
-
-        public void Identity_TokenCache_CustomCachePersistence()
+        public void Identity_TokenCache_PersistentDefault()
         {
-            throw new NotImplementedException();
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
+
+
         }
 
         public void Identity_TokenCache_SharedCacheInstance()
         {
             throw new NotImplementedException();
         }
+
+        public void Identity_TokenCache_CustomCachePersistence()
+        {
+            throw new NotImplementedException();
+        }
+
     }
 }

--- a/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Azure;
 
 namespace Azure.Identity.Samples
 {
@@ -9,20 +12,76 @@ namespace Azure.Identity.Samples
     {
         public void Identity_TokenCache_PersistentDefault()
         {
+            #region Snippet:Identity_TokenCache_PersistentDefault
             var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
-
-
+            #endregion
         }
 
-        public void Identity_TokenCache_SharedCacheInstance()
+        public void Identity_TokenCache_PersistentNamed()
         {
-            throw new NotImplementedException();
+            #region Snippet:Identity_TokenCache_PersistentNamed
+            var tokenCache = new PersistentTokenCache(new PersistentTokenCacheOptions { Name = "my_application_name" });
+
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = tokenCache });
+            #endregion
         }
 
-        public void Identity_TokenCache_CustomCachePersistence()
+        public void Identity_TokenCache_PersistentUnencrypted()
         {
-            throw new NotImplementedException();
+            #region Snippet:Identity_TokenCache_PersistentUnencrypted
+            var tokenCache = new PersistentTokenCache(new PersistentTokenCacheOptions { AllowUnencryptedStorage = true });
+
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache =  tokenCache});
+            #endregion
         }
 
+        public async Task Identity_TokenCache_CustomPersistence_Read()
+        {
+            #region Snippet:Identity_TokenCache_CustomPersistence_Read
+            using var cacheStream = new FileStream(TokenCachePath, FileMode.OpenOrCreate, FileAccess.Read);
+
+            var tokenCache = await TokenCache.DeserializeAsync(cacheStream);
+            #endregion
+        }
+
+        public async Task Identity_TokenCache_CustomPersistence_Write()
+        {
+            var tokenCache = new TokenCache();
+
+            #region Snippet:Identity_TokenCache_CustomPersistence_Write
+            using var cacheStream = new FileStream(TokenCachePath, FileMode.Create, FileAccess.Write);
+
+            await tokenCache.SerializeAsync(cacheStream);
+            #endregion
+        }
+
+        private const string TokenCachePath = "./tokencache.bin";
+
+        #region Snippet:Identity_TokenCache_CustomPersistence_Usage
+        public static async Task<TokenCache> ReadTokenCacheAsync()
+        {
+            using var cacheStream = new FileStream(TokenCachePath, FileMode.OpenOrCreate, FileAccess.Read);
+
+            var tokenCache = await TokenCache.DeserializeAsync(cacheStream);
+
+            tokenCache.Updated += WriteCacheOnUpdateAsync;
+
+            return tokenCache;
+        }
+
+        public static async Task WriteCacheOnUpdateAsync(TokenCacheUpdatedArgs args)
+        {
+            using var cacheStream = new FileStream(TokenCachePath, FileMode.Create, FileAccess.Write);
+
+            await args.Cache.SerializeAsync(cacheStream);
+        }
+
+        public static async Task Main()
+        {
+            var tokenCache = await ReadTokenCacheAsync();
+
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = tokenCache });
+        }
+        #endregion
     }
 }

--- a/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/TokenCacheSnippets.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Identity.Samples
+{
+    public class TokenCacheSnippets
+    {
+
+        public void Identity_TokenCache_CustomCachePersistence()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Identity_TokenCache_SharedCacheInstance()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/samples/UserAuthenticationSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/UserAuthenticationSnippets.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;

--- a/sdk/identity/Azure.Identity/tests/samples/UserAuthenticationSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/UserAuthenticationSnippets.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Security.KeyVault.Secrets;
+using Azure.Storage.Blobs;
+
+namespace Azure.Identity.Samples
+{
+    public class UserAuthenticationSnippets
+    {
+        public void Identity_ClientSideUserAuthentication_SimpleInteractiveBrowser()
+        {
+            #region Snippet:Identity_ClientSideUserAuthentication_SimpleInteractiveBrowser
+            var client = new SecretClient(new Uri("https://myvault.azure.vaults.net/"), new InteractiveBrowserCredential());
+            #endregion
+        }
+
+        public void Identity_ClientSideUserAuthentication_SimpleDeviceCode()
+        {
+            #region Snippet:Identity_ClientSideUserAuthentication_SimpleDeviceCode
+            var credential = new DeviceCodeCredential((deviceCodeInfo, _) => { Console.WriteLine(deviceCodeInfo.Message); return Task.CompletedTask; });
+
+            var client = new BlobClient(new Uri("https://myaccount.blob.core.windows.net/mycontainer/myblob"), credential);
+            #endregion
+        }
+
+        public async Task Identity_ClientSideUserAuthentication_DisableAutomaticAuthentication()
+        {
+            #region Snippet:Identity_ClientSideUserAuthentication_DisableAutomaticAuthentication
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { DisableAutomaticAuthentication = true });
+
+            await credential.AuthenticateAsync();
+
+            var client = new SecretClient(new Uri("https://myvault.azure.vaults.net/"), credential);
+            #endregion
+
+            #region Snippet:Identity_ClientSideUserAuthentication_DisableAutomaticAuthentication_ExHandling
+            try
+            {
+                client.GetSecret("secret");
+            }
+            catch (AuthenticationRequiredException e)
+            {
+                await EnsureAnimationCompleteAsync();
+
+                await credential.AuthenticateAsync(e.TokenRequestContext);
+
+                client.GetSecret("secret");
+            }
+            #endregion
+        }
+
+        private Task EnsureAnimationCompleteAsync() => Task.CompletedTask;
+
+        private const string AUTH_RECORD_PATH = @".\Data\authrecord.bin";
+
+
+        public static async Task<TokenCredential> GetUserCredentialAsync()
+        {
+            if (!File.Exists(AUTH_RECORD_PATH))
+            {
+
+                #region Snippet:Identity_ClientSideUserAuthentication_Persist_TokenCache
+                var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
+                #endregion
+
+                #region Snippet:Identity_ClientSideUserAuthentication_Persist_AuthRecord
+                AuthenticationRecord authRecord = await credential.AuthenticateAsync();
+
+                using var authRecordStream = new FileStream(AUTH_RECORD_PATH, FileMode.Create, FileAccess.Write);
+
+                await authRecord.SerializeAsync(authRecordStream);
+
+                await authRecordStream.FlushAsync();
+                #endregion
+
+                return credential;
+            }
+            else
+            {
+                #region Snippet:Identity_ClientSideUserAuthentication_Persist_SilentAuth
+                using var authRecordStream = new FileStream(AUTH_RECORD_PATH, FileMode.Open, FileAccess.Read);
+
+                AuthenticationRecord authRecord = await AuthenticationRecord.DeserializeAsync(authRecordStream);
+
+                var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache(), AuthenticationRecord = authRecord });
+                #endregion
+
+                return credential;
+            }
+        }
+
+
+        public static async Task Main()
+        {
+            InteractiveBrowserCredential credential;
+
+            if (!File.Exists(AUTH_RECORD_PATH))
+            {
+                credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache() });
+
+                AuthenticationRecord authRecord = await credential.AuthenticateAsync();
+
+                using var authRecordStream = new FileStream(AUTH_RECORD_PATH, FileMode.Create, FileAccess.Write);
+
+                await authRecord.SerializeAsync(authRecordStream);
+
+                await authRecordStream.FlushAsync();
+            }
+            else
+            {
+                using var authRecordStream = new FileStream(AUTH_RECORD_PATH, FileMode.Open, FileAccess.Read);
+
+                AuthenticationRecord authRecord = await AuthenticationRecord.DeserializeAsync(authRecordStream);
+
+                credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TokenCache = new PersistentTokenCache(), AuthenticationRecord = authRecord });
+            }
+
+            var client = new SecretClient(new Uri("https://myvault.azure.vaults.net/"), credential);
+        }
+    }
+}


### PR DESCRIPTION
This PR is a redesign of the mechanisms provided for persisting the token cache. 
- Removes the `EnablePersistentCache` and `AllowUnencryptedCache` options from the various `TokenCredentialOptions` classes providing them and replaces them with the `TokenCache` property.
- Adds the classes `TokenCache` and the derived class `PersistentTokenCache` to enable applications to persist the token cache either via the built in MSAL extensions mechanisms, or in a completely custom way
