### PR TITLE
Update FromObjectAsync return type

### DIFF
--- a/sdk/core/Azure.Core.Experimental/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Experimental/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 0.1.0-preview.6 (Unreleased)
+
+### Breaking Changes
+- `BinaryData`: Change return type of `FromObjectAsync` from `Task<T>` to `ValueTask<T>`
+
 ## 0.1.0-preview.5 (2020-09-03)
 
 ### Added

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -16,8 +16,8 @@ namespace Azure
         public static Azure.BinaryData FromBytes(byte[] data) { throw null; }
         public static Azure.BinaryData FromBytes(System.ReadOnlyMemory<byte> data) { throw null; }
         public static Azure.BinaryData FromBytes(System.ReadOnlySpan<byte> data) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.BinaryData> FromObjectAsync<T>(T serializable, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.Task<Azure.BinaryData> FromObjectAsync<T>(T jsonSerializable, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.ValueTask<Azure.BinaryData> FromObjectAsync<T>(T serializable, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.ValueTask<Azure.BinaryData> FromObjectAsync<T>(T jsonSerializable, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static Azure.BinaryData FromObject<T>(T serializable, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static Azure.BinaryData FromObject<T>(T jsonSerializable, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static Azure.BinaryData FromStream(System.IO.Stream stream) { throw null; }

--- a/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
+++ b/sdk/core/Azure.Core.Experimental/src/Primitives/BinaryData.cs
@@ -231,7 +231,7 @@ namespace Azure
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during serialization.</param>
         ///
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
-        public static async Task<BinaryData> FromObjectAsync<T>(
+        public static async ValueTask<BinaryData> FromObjectAsync<T>(
             T jsonSerializable,
             CancellationToken cancellationToken = default) =>
             await FromObjectInternalAsync<T>(jsonSerializable, s_jsonSerializer, true, cancellationToken).ConfigureAwait(false);
@@ -266,13 +266,13 @@ namespace Azure
         ///
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use during serialization.</param>
         /// <returns>A <see cref="BinaryData"/> instance.</returns>
-        public static async Task<BinaryData> FromObjectAsync<T>(
+        public static async ValueTask<BinaryData> FromObjectAsync<T>(
             T serializable,
             ObjectSerializer serializer,
             CancellationToken cancellationToken = default) =>
             await FromObjectInternalAsync<T>(serializable, serializer, true, cancellationToken).ConfigureAwait(false);
 
-        private static async Task<BinaryData> FromObjectInternalAsync<T>(
+        private static async ValueTask<BinaryData> FromObjectInternalAsync<T>(
             T data,
             ObjectSerializer serializer,
             bool async,


### PR DESCRIPTION
`ToObjectAsync` already returned `ValueTask<T>` as does `ObjectSerializer.Serialize` (which is what `FromObjectAsync` calls into).