### PR TITLE
Prototype of Search with a TokenCredential

### DIFF
--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -27,6 +27,8 @@ namespace Azure.Search.Documents
         protected SearchClient() { }
         public SearchClient(System.Uri endpoint, string indexName, Azure.AzureKeyCredential credential) { }
         public SearchClient(System.Uri endpoint, string indexName, Azure.AzureKeyCredential credential, Azure.Search.Documents.SearchClientOptions options) { }
+        public SearchClient(System.Uri endpoint, string indexName, Azure.Core.TokenCredential credential) { }
+        public SearchClient(System.Uri endpoint, string indexName, Azure.Core.TokenCredential credential, Azure.Search.Documents.SearchClientOptions options) { }
         public virtual System.Uri Endpoint { get { throw null; } }
         public virtual string IndexName { get { throw null; } }
         public virtual string ServiceName { get { throw null; } }
@@ -56,6 +58,7 @@ namespace Azure.Search.Documents
     public partial class SearchClientOptions : Azure.Core.ClientOptions
     {
         public SearchClientOptions(Azure.Search.Documents.SearchClientOptions.ServiceVersion version = Azure.Search.Documents.SearchClientOptions.ServiceVersion.V2020_06_30) { }
+        public string AuthenticationScope { get { throw null; } set { } }
         public Azure.Core.Serialization.ObjectSerializer Serializer { get { throw null; } set { } }
         public Azure.Search.Documents.SearchClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
@@ -129,6 +132,8 @@ namespace Azure.Search.Documents.Indexes
         protected SearchIndexClient() { }
         public SearchIndexClient(System.Uri endpoint, Azure.AzureKeyCredential credential) { }
         public SearchIndexClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.Search.Documents.SearchClientOptions options) { }
+        public SearchIndexClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
+        public SearchIndexClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.Search.Documents.SearchClientOptions options) { }
         public virtual System.Uri Endpoint { get { throw null; } }
         public virtual string ServiceName { get { throw null; } }
         public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<Azure.Search.Documents.Indexes.Models.AnalyzedTokenInfo>> AnalyzeText(string indexName, Azure.Search.Documents.Indexes.Models.AnalyzeTextOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -172,6 +177,8 @@ namespace Azure.Search.Documents.Indexes
         protected SearchIndexerClient() { }
         public SearchIndexerClient(System.Uri endpoint, Azure.AzureKeyCredential credential) { }
         public SearchIndexerClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.Search.Documents.SearchClientOptions options) { }
+        public SearchIndexerClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
+        public SearchIndexerClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.Search.Documents.SearchClientOptions options) { }
         public virtual System.Uri Endpoint { get { throw null; } }
         public virtual string ServiceName { get { throw null; } }
         public virtual Azure.Response<Azure.Search.Documents.Indexes.Models.SearchIndexerDataSourceConnection> CreateDataSourceConnection(Azure.Search.Documents.Indexes.Models.SearchIndexerDataSourceConnection dataSourceConnection, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs
@@ -69,6 +69,59 @@ namespace Azure.Search.Documents.Indexes
             Uri endpoint,
             AzureKeyCredential credential,
             SearchClientOptions options)
+            : this(endpoint, (object)credential, options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchIndexClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">Required. The URI endpoint of the Search service. This is likely to be similar to "https://{search_service}.search.windows.net". The URI must use HTTPS.</param>
+        /// <param name="credential">
+        /// Required.  The token credential used to authenticate requests
+        /// against the search service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
+        public SearchIndexClient(Uri endpoint, TokenCredential credential) :
+            this(endpoint, credential, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchIndexClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">Required. The URI endpoint of the Search service. This is likely to be similar to "https://{search_service}.search.windows.net". The URI must use HTTPS.</param>
+        /// <param name="credential">
+        /// Required.  The token credential used to authenticate requests
+        /// against the search service.
+        /// </param>
+        /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
+        public SearchIndexClient(
+            Uri endpoint,
+            TokenCredential credential,
+            SearchClientOptions options)
+            : this(endpoint, (object)credential, options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchIndexClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">Required. The URI endpoint of the Search service. This is likely to be similar to "https://{search_service}.search.windows.net". The URI must use HTTPS.</param>
+        /// <param name="credential">
+        /// Required.  A credential used to authenticate requests against the
+        /// search service.
+        /// </param>
+        /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
+        private SearchIndexClient(
+            Uri endpoint,
+            object credential,
+            SearchClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             endpoint.AssertHttpsScheme(nameof(endpoint));

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
@@ -79,6 +79,67 @@ namespace Azure.Search.Documents.Indexes
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="SearchIndexerClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">Required. The URI endpoint of the Search service. This is likely to be similar to "https://{search_service}.search.windows.net". The URI must use HTTPS.</param>
+        /// <param name="credential">
+        /// Required.  The token credential used to authenticate requests
+        /// against the search service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
+        public SearchIndexerClient(Uri endpoint, TokenCredential credential) :
+            this(endpoint, credential, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchIndexerClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">Required. The URI endpoint of the Search service. This is likely to be similar to "https://{search_service}.search.windows.net". The URI must use HTTPS.</param>
+        /// <param name="credential">
+        /// Required.  The token credential used to authenticate requests
+        /// against the search service.
+        /// </param>
+        /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
+        public SearchIndexerClient(
+            Uri endpoint,
+            TokenCredential credential,
+            SearchClientOptions options)
+            : this(endpoint, (object)credential, options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchIndexerClient"/> class.
+        /// </summary>
+        /// <param name="endpoint">Required. The URI endpoint of the Search service. This is likely to be similar to "https://{search_service}.search.windows.net". The URI must use HTTPS.</param>
+        /// <param name="credential">
+        /// Required.  A credential used to authenticate requests against the
+        /// search service.
+        /// </param>
+        /// <param name="options">Client configuration options for connecting to Azure Cognitive Search.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="endpoint"/> or <paramref name="credential"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="endpoint"/> is not using HTTPS.</exception>
+        private SearchIndexerClient(
+            Uri endpoint,
+            object credential,
+            SearchClientOptions options)
+        {
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
+            endpoint.AssertHttpsScheme(nameof(endpoint));
+            Argument.AssertNotNull(credential, nameof(credential));
+
+            options ??= new SearchClientOptions();
+            Endpoint = endpoint;
+            _clientDiagnostics = new ClientDiagnostics(options);
+            _pipeline = options.Build(credential);
+            _version = options.Version;
+        }
+
+        /// <summary>
         /// Gets the URI endpoint of the Search service.  This is likely
         /// to be similar to "https://{search_service}.search.windows.net".
         /// </summary>

--- a/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexerClient.cs
@@ -66,16 +66,8 @@ namespace Azure.Search.Documents.Indexes
             Uri endpoint,
             AzureKeyCredential credential,
             SearchClientOptions options)
+            : this(endpoint, (object)credential, options)
         {
-            Argument.AssertNotNull(endpoint, nameof(endpoint));
-            endpoint.AssertHttpsScheme(nameof(endpoint));
-            Argument.AssertNotNull(credential, nameof(credential));
-
-            options ??= new SearchClientOptions();
-            Endpoint = endpoint;
-            _clientDiagnostics = new ClientDiagnostics(options);
-            _pipeline = options.Build(credential);
-            _version = options.Version;
         }
 
         /// <summary>

--- a/sdk/search/Azure.Search.Documents/src/SearchClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/SearchClient.cs
@@ -161,6 +161,115 @@ namespace Azure.Search.Documents
             string indexName,
             AzureKeyCredential credential,
             SearchClientOptions options)
+            : this(endpoint, indexName, (object)credential, options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SearchClient class for
+        /// querying an index and uploading, merging, or deleting documents.
+        /// </summary>
+        /// <param name="endpoint">
+        /// Required.  The URI endpoint of the Search Service.  This is likely
+        /// to be similar to "https://{search_service}.search.windows.net".
+        /// The URI must use HTTPS.
+        /// </param>
+        /// <param name="indexName">
+        /// Required.  The name of the Search Index.
+        /// </param>
+        /// <param name="credential">
+        /// Required.  The token credential used to authenticate requests
+        /// against the search service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the <paramref name="endpoint"/>,
+        /// <paramref name="indexName"/>, or <paramref name="credential"/> is
+        /// null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the <paramref name="endpoint"/> is not using HTTPS or
+        /// the <paramref name="indexName"/> is empty.
+        /// </exception>
+        public SearchClient(
+            Uri endpoint,
+            string indexName,
+            TokenCredential credential) :
+            this(endpoint, indexName, credential, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SearchClient class for
+        /// querying an index and uploading, merging, or deleting documents.
+        /// </summary>
+        /// <param name="endpoint">
+        /// Required.  The URI endpoint of the Search Service.  This is likely
+        /// to be similar to "https://{search_service}.search.windows.net".
+        /// The URI must use HTTPS.
+        /// </param>
+        /// <param name="indexName">
+        /// Required.  The name of the Search Index.
+        /// </param>
+        /// <param name="credential">
+        /// Required.  The token credential used to authenticate requests
+        /// against the search service.
+        /// </param>
+        /// <param name="options">
+        /// Client configuration options for connecting to Azure Cognitive
+        /// Search.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the <paramref name="endpoint"/>,
+        /// <paramref name="indexName"/>, or <paramref name="credential"/> is
+        /// null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the <paramref name="endpoint"/> is not using HTTPS or
+        /// the <paramref name="indexName"/> is empty.
+        /// </exception>
+        public SearchClient(
+            Uri endpoint,
+            string indexName,
+            TokenCredential credential,
+            SearchClientOptions options)
+            : this(endpoint, indexName, (object)credential, options)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SearchClient class for
+        /// querying an index and uploading, merging, or deleting documents.
+        /// </summary>
+        /// <param name="endpoint">
+        /// Required.  The URI endpoint of the Search Service.  This is likely
+        /// to be similar to "https://{search_service}.search.windows.net".
+        /// The URI must use HTTPS.
+        /// </param>
+        /// <param name="indexName">
+        /// Required.  The name of the Search Index.
+        /// </param>
+        /// <param name="credential">
+        /// Required.  A credential used to authenticate requests against the
+        /// search service.
+        /// </param>
+        /// <param name="options">
+        /// Client configuration options for connecting to Azure Cognitive
+        /// Search.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the <paramref name="endpoint"/>,
+        /// <paramref name="indexName"/>, or <paramref name="credential"/> is
+        /// null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the <paramref name="endpoint"/> is not using HTTPS or
+        /// the <paramref name="indexName"/> is empty.
+        /// </exception>
+        private SearchClient(
+            Uri endpoint,
+            string indexName,
+            object credential,
+            SearchClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             endpoint.AssertHttpsScheme(nameof(endpoint));

--- a/sdk/search/Azure.Search.Documents/tests/SearchClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchClientTests.cs
@@ -29,8 +29,8 @@ namespace Azure.Search.Documents.Tests
             Assert.Throws<ArgumentNullException>(() => new SearchClient(null, indexName, new AzureKeyCredential("fake")));
             Assert.Throws<ArgumentNullException>(() => new SearchClient(endpoint, null, new AzureKeyCredential("fake")));
             Assert.Throws<ArgumentException>(() => new SearchClient(endpoint, string.Empty, new AzureKeyCredential("fake")));
-            Assert.Throws<ArgumentNullException>(() => new SearchClient(endpoint, indexName, null));
-            Assert.Throws<ArgumentException>(() => new SearchClient(new Uri("http://bing.com"), indexName, null));
+            Assert.Throws<ArgumentNullException>(() => new SearchClient(endpoint, indexName, (AzureKeyCredential)null));
+            Assert.Throws<ArgumentException>(() => new SearchClient(new Uri("http://bing.com"), indexName, (AzureKeyCredential)null));
         }
 
         [Test]

--- a/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchIndexerClientTests.cs
@@ -32,8 +32,8 @@ namespace Azure.Search.Documents.Tests
             Assert.AreEqual(serviceName, service.ServiceName);
 
             Assert.Throws<ArgumentNullException>(() => new SearchIndexerClient(null, new AzureKeyCredential("fake")));
-            Assert.Throws<ArgumentNullException>(() => new SearchIndexerClient(endpoint, null));
-            Assert.Throws<ArgumentException>(() => new SearchIndexerClient(new Uri("http://bing.com"), null));
+            Assert.Throws<ArgumentNullException>(() => new SearchIndexerClient(endpoint, (AzureKeyCredential)null));
+            Assert.Throws<ArgumentException>(() => new SearchIndexerClient(new Uri("http://bing.com"), (AzureKeyCredential)null));
         }
 
         [Test]


### PR DESCRIPTION
You should now be able to create clients passing in `TokenCredential`s.

```C#
SearchClient client = new SearchClient(new Uri("..."), new DefaultAzureCredential());
```

You can also (temporarily) set the scope name if it's not `https://search.azure.com/.default`:

```C#
SearchClient client = new SearchClient(
    new Uri("..."),
    new DefaultAzureCredential(),
    new SearchClientOptions { AuthenticationScope = "https://search.azure.com/.default" });
```

[Read more about Azure.Identity](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity) or [watch our intro video.](https://www.youtube.com/watch?v=1VRx_Xpvlro) to dig in deeper.