### PR TITLE
Azure Monitor Exporter - Convert Activity.Events as EventTelemetry

### DIFF
--- a/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/src/TagsExtension.cs
+++ b/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/src/TagsExtension.cs
@@ -95,18 +95,28 @@ namespace OpenTelemetry.Exporter.AzureMonitor
                     StringBuilder sw = new StringBuilder();
                     foreach (var item in array)
                     {
-                        sw.Append(item);
-                        sw.Append(',');
+                        if (item != null)
+                        {
+                            sw.Append(item);
+                            sw.Append(',');
+                        }
                     }
 
-                    sw.Length--;
+                    if (sw.Length > 0)
+                    {
+                        sw.Length--;
+                    }
+
                     partCTags.Add(entry.Key, sw.ToString());
 
                     continue;
                 }
                 else
                 {
-                    partCTags.Add(entry.Key, entry.Value.ToString());
+                    if (entry.Value != null)
+                    {
+                        partCTags.Add(entry.Key, entry.Value.ToString());
+                    }
                 }
             }
 

--- a/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/src/TagsExtension.cs
+++ b/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/src/TagsExtension.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace OpenTelemetry.Exporter.AzureMonitor
 {
@@ -77,5 +79,38 @@ namespace OpenTelemetry.Exporter.AzureMonitor
             return partBTags;
         }
 
+        internal static Dictionary<string, string> ToAzureMonitorTags(this IEnumerable<KeyValuePair<string, object>> tagObjects)
+        {
+            if (tagObjects == null)
+            {
+                return null;
+            }
+
+            Dictionary<string, string> partCTags = new Dictionary<string, string>();
+
+            foreach (var entry in tagObjects)
+            {
+                if (entry.Value is Array array)
+                {
+                    StringBuilder sw = new StringBuilder();
+                    foreach (var item in array)
+                    {
+                        sw.Append(item);
+                        sw.Append(',');
+                    }
+
+                    sw.Length--;
+                    partCTags.Add(entry.Key, sw.ToString());
+
+                    continue;
+                }
+                else
+                {
+                    partCTags.Add(entry.Key, entry.Value.ToString());
+                }
+            }
+
+            return partCTags;
+        }
     }
 }

--- a/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/src/TelemetryItem.cs
+++ b/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/src/TelemetryItem.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace OpenTelemetry.Exporter.AzureMonitor.Models
+{
+    public partial class TelemetryItem
+    {
+        public TelemetryItem Clone(string telemetryName, DateTimeOffset dateTimeOffset)
+        {
+            TelemetryItem telemetryItem = new TelemetryItem(telemetryName, dateTimeOffset)
+            {
+                InstrumentationKey = this.InstrumentationKey
+            };
+
+            foreach (var tag in this.Tags)
+            {
+                telemetryItem.Tags.Add(tag);
+            }
+
+            return telemetryItem;
+        }
+    }
+}

--- a/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/tests/OpenTelemetry.Exporter.AzureMonitor.Demo.Tracing/InstrumentationWithActivitySource.cs
+++ b/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/tests/OpenTelemetry.Exporter.AzureMonitor.Demo.Tracing/InstrumentationWithActivitySource.cs
@@ -63,19 +63,20 @@ namespace OpenTelemetry.Exporter.AzureMonitor.Demo.Tracing
                                 activity?.SetTag($"http.header.{headerKey}", headerValue);
                             }
 
-                            activity?.SetTag("http.url", context.Request.Url.AbsolutePath);
+                            activity?.SetTag("http.url", context.Request.Url.ToString());
                             activity?.SetTag("http.host", context.Request.Url.Host);
 
                             string requestContent;
-                            using (var childSpan = source.StartActivity("ReadStream", ActivityKind.Consumer))
+                            // using (var childSpan = source.StartActivity("ReadStream", ActivityKind.Consumer))
                             using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
                             {
                                 requestContent = reader.ReadToEnd();
-                                childSpan.AddEvent(new ActivityEvent("StreamReader.ReadToEnd"));
+                                activity.AddEvent(new ActivityEvent("StreamReader.ReadToEnd"));
                             }
 
                             activity?.SetTag("request.content", requestContent);
                             activity?.SetTag("request.length", requestContent.Length.ToString(CultureInfo.InvariantCulture));
+                            activity?.SetTag("http.status_code", $"{context.Response.StatusCode:D}");
 
                             var echo = Encoding.UTF8.GetBytes("echo: " + requestContent);
                             context.Response.ContentEncoding = Encoding.UTF8;

--- a/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/tests/OpenTelemetry.Exporter.AzureMonitor.UnitTest/TagsExtensionTest.cs
+++ b/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/tests/OpenTelemetry.Exporter.AzureMonitor.UnitTest/TagsExtensionTest.cs
@@ -30,11 +30,14 @@ namespace OpenTelemetry.Exporter.AzureMonitor
                 ["objectKey"] = new Test(),
                 ["arrayKey"] = new int[] { 1, 2, 3 },
                 ["dateKey"] = dateTime,
-                ["dictKey"] = new Dictionary<string, object> { ["key"] = true}
+                ["nullKey"] = null,
+                ["nullArrKey"] = new string[] {"test", null},
+                ["allNullKey"] = new object[] {null, null},
+                ["dictKey"] = new Dictionary<string, object> { ["key"] = true }
             };
 
             var PartCTags = tagObjects.ToAzureMonitorTags();
-            Assert.Equal(16, PartCTags.Count);
+            Assert.Equal(18, PartCTags.Count);
 
             Assert.Equal("True", PartCTags["boolKey"]);
             Assert.Equal("27", PartCTags["byteKey"]);
@@ -51,6 +54,9 @@ namespace OpenTelemetry.Exporter.AzureMonitor
             Assert.Equal("OpenTelemetry.Exporter.AzureMonitor.TagsExtensionTest+Test", PartCTags["objectKey"]);
             Assert.Equal("1,2,3", PartCTags["arrayKey"]);
             Assert.Equal(dateTime.ToString(), PartCTags["dateKey"]);
+            Assert.Throws<KeyNotFoundException>(() => PartCTags["nullKey"]);
+            Assert.Equal("test", PartCTags["nullArrKey"]);
+            Assert.Empty(PartCTags["allNullKey"]);
             Assert.Equal("System.Collections.Generic.Dictionary`2[System.String,System.Object]", PartCTags["dictKey"]);
         }
 

--- a/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/tests/OpenTelemetry.Exporter.AzureMonitor.UnitTest/TagsExtensionTest.cs
+++ b/sdk/monitor/OpenTelemetry.Exporter.AzureMonitor/tests/OpenTelemetry.Exporter.AzureMonitor.UnitTest/TagsExtensionTest.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.AzureMonitor
+{
+    public class TagsExtensionTest
+    {
+        [Fact]
+        public void TagObjects_OnlyPartC()
+        {
+            DateTime dateTime = DateTime.Now;
+            IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object>
+            {
+                ["boolKey"] = true,
+                ["byteKey"] = (byte)27,
+                ["sbyteKey"] = (sbyte)27,
+                ["shortKey"] = (short) 1000,
+                ["ushortKey"] = (ushort)63000,
+                ["intKey"] = 1,
+                ["uintKey"] = (uint)1,
+                ["longKey"] = (long) 100000000000,
+                ["ulongKey"] = (ulong)100000000001,
+                ["floatKey"] = (float)3.5F,
+                ["doubleKey"] = 3.1D,
+                ["stringKey"] = "test",
+                ["objectKey"] = new Test(),
+                ["arrayKey"] = new int[] { 1, 2, 3 },
+                ["dateKey"] = dateTime,
+                ["dictKey"] = new Dictionary<string, object> { ["key"] = true}
+            };
+
+            var PartCTags = tagObjects.ToAzureMonitorTags();
+            Assert.Equal(16, PartCTags.Count);
+
+            Assert.Equal("True", PartCTags["boolKey"]);
+            Assert.Equal("27", PartCTags["byteKey"]);
+            Assert.Equal("27", PartCTags["sbyteKey"]);
+            Assert.Equal("1000", PartCTags["shortKey"]);
+            Assert.Equal("63000", PartCTags["ushortKey"]);
+            Assert.Equal("1", PartCTags["intKey"]);
+            Assert.Equal("1", PartCTags["uintKey"]);
+            Assert.Equal("100000000000", PartCTags["longKey"]);
+            Assert.Equal("100000000001", PartCTags["ulongKey"]);
+            Assert.Equal("3.5", PartCTags["floatKey"]);
+            Assert.Equal("3.1", PartCTags["doubleKey"]);
+            Assert.Equal("test", PartCTags["stringKey"]);
+            Assert.Equal("OpenTelemetry.Exporter.AzureMonitor.TagsExtensionTest+Test", PartCTags["objectKey"]);
+            Assert.Equal("1,2,3", PartCTags["arrayKey"]);
+            Assert.Equal(dateTime.ToString(), PartCTags["dateKey"]);
+            Assert.Equal("System.Collections.Generic.Dictionary`2[System.String,System.Object]", PartCTags["dictKey"]);
+        }
+
+        [Fact]
+        public void TagObjects_OnlyPartC_NullOrEmpty()
+        {
+            DateTime dateTime = DateTime.Now;
+            IEnumerable<KeyValuePair<string, object>> tagObjects = null;
+
+            var PartCTags = tagObjects.ToAzureMonitorTags();
+            Assert.Null(PartCTags);
+
+            tagObjects = new Dictionary<string, object>();
+            PartCTags = tagObjects.ToAzureMonitorTags();
+            Assert.Empty(PartCTags);
+        }
+
+        private class Test
+        {
+            public int TestProperty { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Application Insights correlates both request and event telemetry.
 
![image](https://user-images.githubusercontent.com/9479006/93527119-3fd3bc80-f8ed-11ea-81f3-985e6d40954c.png)
