### PR TITLE
Enable the link check on aggregate-report

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -34,7 +34,8 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/verify-links.yml
         parameters:
           Directory: ""
-
+          CheckLinkGuidance: $true
+          
       - pwsh: |
           mkdir "$(System.ArtifactsDirectory)/BuildArtifacts"
           ls "$(PIPELINE.WORKSPACE)/net-core/packages"


### PR DESCRIPTION
Follow up PR for https://github.com/Azure/azure-sdk-for-net/pull/15223

Manually triggered one pipeline as the one associate does not work
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=543134&view=logs&j=10327055-d4d6-50a6-a312-3d2cd4bd9cb9&t=94e5e63e-8835-580a-ce90-55871b77badb