### PR TITLE
Testing other clouds in the master branch

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -562,7 +562,7 @@ is based on the cloud to which the template is being deployed:
 
 .PARAMETER Environment
 Name of the cloud environment. The default is the Azure Public Cloud
-('PublicCloud')
+('AzureCloud')
 
 .PARAMETER AdditionalParameters
 Optional key-value pairs of parameters to pass to the ARM template(s).

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -187,7 +187,7 @@ Accept wildcard characters: False
 ### -Environment
 Name of the cloud environment.
 The default is the Azure Public Cloud
-('PublicCloud')
+('AzureCloud')
 
 ```yaml
 Type: String

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -23,85 +23,90 @@ parameters:
 - name: Location
   type: string
   default: ''
-- name: SubscriptionConfiguration
-  type: string
-  default: $(sub-config-azure-cloud-test-resources)
 - name: ServiceDirectory
   type: string
   default: not-specified
 - name: TestSetupSteps
   type: stepList
   default: []
+- name: CloudConfigurations
+  type: object
+  default:
+    AzureCloud:
+      SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
 
 jobs:
-  - ${{ each platform in parameters.Platforms }}:
-    - job:
-      condition: and(succeededOrFailed(), eq(eq(variables['Record'], 'true'), eq('${{ platform.TestMode }}', 'Record')))
-      displayName: ${{ platform.DisplayName }}
-      variables:
-        - template: ../variables/globals.yml
-        - name: OSVmImage
-          value: ${{ platform.OSVmImage }}
+  - ${{ each cloudConfig in parameters.CloudConfigurations }}:
+    - ${{ each platform in parameters.Platforms }}:
+      - job:
+        condition: and(succeededOrFailed(), eq(eq(variables['Record'], 'true'), eq('${{ platform.TestMode }}', 'Record')))
+        displayName: ${{ platform.DisplayName }}_${{ cloudConfig.key }}
+        variables:
+          - template: ../variables/globals.yml
+          - name: OSVmImage
+            value: ${{ platform.OSVmImage }}
 
-      timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+        timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
-      pool:
-        vmImage: $(OSVmImage)
-      ${{ if platform.Container }}:
-        container: ${{ platform.Container }}
+        pool:
+          vmImage: $(OSVmImage)
+        ${{ if platform.Container }}:
+          container: ${{ platform.Container }}
 
-      steps:
-        - ${{ if platform.PreSteps }}:
-          - ${{ platform.PreSteps }}
+        steps:
+          - ${{ if platform.PreSteps }}:
+            - ${{ platform.PreSteps }}
 
-        - ${{ parameters.PreSteps }}
+          - ${{ parameters.PreSteps }}
 
-        - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+          - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
-        - ${{ each step in parameters.TestSetupSteps }}:
-          - ${{ each pair in step }}:
-              ${{ pair.key }}: ${{ pair.value }}
+          - ${{ each step in parameters.TestSetupSteps }}:
+            - ${{ each pair in step }}:
+                ${{ pair.key }}: ${{ pair.value }}
 
-        - template: /eng/common/TestResources/deploy-test-resources.yml
-          parameters:
-            Location: ${{ parameters.Location }}
-            ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-            SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
+          - template: /eng/common/TestResources/deploy-test-resources.yml
+            parameters:
+              Location: ${{ cloudConfig.value.Location }}
+              ServiceDirectory: '${{ parameters.ServiceDirectory }}'
+              SubscriptionConfiguration: ${{ cloudConfig.value.SubscriptionConfiguration }}
+              ArmTemplateParameters: ${{ cloudConfig.value.ArmTemplateParameters }}
 
-        - script: >
-            dotnet test eng/service.proj
-            --framework ${{ platform.TestTargetFramework }}
-            --filter "TestCategory!=Manually"
-            --logger "trx"
-            --logger:"console;verbosity=normal"
-            /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
-            /p:IncludeSrc=false /p:IncludeSamples=false
-            /p:BuildInParallel=${{ parameters.BuildInParallel }}
-            ${{ platform.AdditionalTestArguments }}
+          - script: >
+              dotnet test eng/service.proj
+              --framework ${{ platform.TestTargetFramework }}
+              --filter "TestCategory!=Manually"
+              --logger "trx"
+              --logger:"console;verbosity=normal"
+              /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
+              /p:IncludeSrc=false /p:IncludeSamples=false
+              /p:BuildInParallel=${{ parameters.BuildInParallel }}
+              ${{ platform.AdditionalTestArguments }}
 
-          displayName: "Build & Test (all tests for ${{ platform.TestTargetFramework }})"
-          env:
-            DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-            DOTNET_CLI_TELEMETRY_OPTOUT: 1
-            DOTNET_MULTILEVEL_LOOKUP: 0
-            AZURE_TEST_MODE: "${{ coalesce(platform.TestMode, 'None') }}"
-            ${{ insert }}: ${{ parameters.EnvVars }}
+            displayName: "Build & Test (all tests for ${{ platform.TestTargetFramework }})"
+            env:
+              DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+              DOTNET_CLI_TELEMETRY_OPTOUT: 1
+              DOTNET_MULTILEVEL_LOOKUP: 0
+              AZURE_TEST_MODE: "${{ coalesce(platform.TestMode, 'None') }}"
+              ${{ insert }}: ${{ parameters.EnvVars }}
+              ${{ insert }}: ${{ cloudConfig.value.EnvVars }}
 
-        - template: /eng/common/TestResources/remove-test-resources.yml
-          parameters:
-            ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-            SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
+          - template: /eng/common/TestResources/remove-test-resources.yml
+            parameters:
+              ServiceDirectory: '${{ parameters.ServiceDirectory }}'
+              SubscriptionConfiguration: ${{ cloudConfig.value.SubscriptionConfiguration }}
 
-        - task: PublishTestResults@2
-          condition: always()
-          displayName: "Publish Results (${{ platform.TestTargetFramework }})"
-          inputs:
-            testResultsFiles: "**/*.trx"
-            testRunTitle: "$(OSName) ${{ platform.TestTargetFramework }}"
-            testResultsFormat: "VSTest"
-            mergeTestResults: true
+          - task: PublishTestResults@2
+            condition: always()
+            displayName: "Publish Results (${{ platform.TestTargetFramework }})"
+            inputs:
+              testResultsFiles: "**/*.trx"
+              testRunTitle: "$(OSName) ${{ platform.TestTargetFramework }}"
+              testResultsFormat: "VSTest"
+              mergeTestResults: true
 
-        - ${{ parameters.PostSteps }}
+          - ${{ parameters.PostSteps }}
 
-        - ${{ if platform.PostSteps }}:
-          - ${{ platform.PostSteps }}
+          - ${{ if platform.PostSteps }}:
+            - ${{ platform.PostSteps }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -38,6 +38,9 @@ parameters:
 - name: TestSetupSteps
   type: stepList
   default: []
+- name: Clouds
+  type: string
+  default: 'AzureCloud'
 
 jobs:
 - template: archetype-sdk-tests-jobs.yml
@@ -49,9 +52,63 @@ jobs:
     BuildInParallel: ${{ parameters.BuildInParallel }}
     TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
     Location: ${{ parameters.Location }}
-    SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
     ServiceDirectory: ${{ parameters.ServiceDirectory }}
     TestSetupSteps: ${{ parameters.TestSetupSteps }}
+    CloudConfigurations:
+      ${{ if contains(parameters.Clouds, 'AzureCloud') }}:
+        AzureCloud:
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
+          ArmTemplateParameters: >-
+            @{ keyVaultDomainSuffix = '.vault.azure.net';
+            storageEndpointSuffix = 'core.windows.net';
+            endpointSuffix = '.cognitiveservices.azure.com';
+            azureAuthorityHost = 'https://login.microsoftonline.com/';
+            keyVaultEndpointSuffix = '.vault.azure.net'
+            }
+          EnvVars:
+            SERVICE_MANAGEMENT_URL: https://management.core.windows.net/
+            STORAGE_ENDPOINT_SUFFIX: core.windows.net
+            RESOURCE_MANAGER_URL: https://management.azure.com/
+            SEARCH_ENDPOINT_SUFFIX: search.windows.net
+            COSMOS_TABLES_ENDPOINT_SUFFIX: cosmos.azure.com
+      ${{ if contains(parameters.Clouds, 'AzureUsGovCloud') }}:
+        AzureUsGovCloud:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          ArmTemplateParameters: >-
+            @{ keyVaultDomainSuffix = '.vault.usgovcloudapi.net';
+            storageEndpointSuffix = 'core.usgovcloudapi.net';
+            endpointSuffix = '.cognitiveservices.azure.us';
+            azureAuthorityHost = 'https://login.microsoftonline.us/';
+            keyVaultEndpointSuffix = '.vault.usgovcloudapi.net';
+            enableStorageVersioning = $false
+            }
+          EnvVars:
+            AZURE_AUTHORITY_HOST: https://login.microsoftonline.us
+            RESOURCE_MANAGER_URL: https://management.usgovcloudapi.net/
+            STORAGE_ENDPOINT_SUFFIX: core.usgovcloudapi.net
+            SERVICE_MANAGEMENT_URL: https://management.core.usgovcloudapi.net/
+            SEARCH_ENDPOINT_SUFFIX: search.azure.us
+            COSMOS_TABLES_ENDPOINT_SUFFIX: cosmos.azure.us
+      ${{ if contains(parameters.Clouds, 'AzureChinaCloud') }}:
+        AzureChinaCloud:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          ArmTemplateParameters: >-
+            @{ keyVaultDomainSuffix = '.vault.azure.cn';
+            storageEndpointSuffix = 'core.chinacloudapi.cn';
+            azureAuthorityHost = 'https://login.chinacloudapi.cn/';
+            keyVaultEndpointSuffix = '.vault.azure.cn';
+            keyVaultSku = 'standard';
+            enableStorageVersioning = $false;
+            endpointSuffix = '.cognitiveservices.azure.cn';
+            textAnalyticsSku = 'S'
+            }
+          EnvVars:
+            AZURE_AUTHORITY_HOST: https://login.chinacloudapi.cn
+            SERVICE_MANAGEMENT_URL: https://management.core.chinacloudapi.cn/
+            RESOURCE_MANAGER_URL: https://management.chinacloudapi.cn
+            STORAGE_ENDPOINT_SUFFIX: core.chinacloudapi.cn
+            SEARCH_ENDPOINT_SUFFIX: search.azure.cn
+            COSMOS_TABLES_ENDPOINT_SUFFIX: cosmos.azure.cn
     platforms:
       - DisplayName: "Test on Linux"
         OSVmImage: "ubuntu-18.04"

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -48,10 +48,24 @@
             "metadata": {
                 "description": "Whether to enable soft delete for the Key Vault. The default is true."
             }
+        },
+        "keyVaultDomainSuffix": {
+            "type": "string",
+            "defaultValue": ".vault.azure.net",
+            "metadata": {
+                "description": "Domain suffix for sovereign clouds, requies the preceeding '.'. The default uses the public Azure Cloud (.vault.azure.net)"
+            }
+        },
+        "keyVaultSku": {
+            "type": "string",
+            "defaultValue": "premium",
+            "metadata": {
+                "description": "Key Vault SKU to deploy. The default is 'premium'"
+            }
         }
     },
     "variables": {
-        "azureKeyVaultUrl": "[format('https://{0}.vault.azure.net', parameters('baseName'))]",
+        "azureKeyVaultUrl": "[format('https://{0}{1}', parameters('baseName'), parameters('keyVaultDomainSuffix'))]",
         "mgmtApiVersion": "2019-04-01",
         "blobContainerName": "backup",
         "primaryAccountName": "[concat(parameters('baseName'), 'prim')]",
@@ -81,7 +95,7 @@
             "properties": {
                 "sku": {
                     "family": "A",
-                    "name": "premium"
+                    "name": "[parameters('keyVaultSku')]"
                 },
                 "tenantId": "[parameters('tenantId')]",
                 "accessPolicies": [


### PR DESCRIPTION
@weshaggard  -- Here's a proposal for the architecture using cloud configurations to multiply the matrix. 

There are two big problems I'd like to sort out: 

* Setting up environment-specific environment variables (for 2 definitions of "environment") 
* `ArmTemplateParameters` can't be splatted into the top level `@subscriptionConfiguration` so they'll have to go somewhere else 