### PR TITLE
Fixing a regression at processor shutdown.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionPump.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionPump.cs
@@ -95,22 +95,6 @@ namespace Microsoft.Azure.EventHubs.Processor
             ProcessorEventSource.Log.PartitionPumpCloseStart(this.Host.HostName, this.PartitionContext.PartitionId, reason.ToString());
             this.PumpStatus = PartitionPumpStatus.Closing;
 
-            // Release lease as the first thing since closing receiver can take up to operation timeout.
-            // This helps other available hosts discover lease available sooner.
-            if (reason != CloseReason.LeaseLost)
-            {
-                // Since this pump is dead, release the lease.
-                try
-                {
-                    await this.Host.LeaseManager.ReleaseLeaseAsync(this.PartitionContext.Lease).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    // Log and ignore any failure since expired lease will be picked by another host.
-                    this.Host.EventProcessorOptions.NotifyOfException(this.Host.HostName, this.PartitionContext.PartitionId, e, EventProcessorHostActionStrings.ReleasingLease);
-                }
-            }
-
             try
             {
                 this.cancellationTokenSource.Cancel();
@@ -136,6 +120,24 @@ namespace Microsoft.Azure.EventHubs.Processor
                 // If closing the processor has failed, the state of the processor is suspect.
                 // Report the failure to the general error handler instead.
                 this.Host.EventProcessorOptions.NotifyOfException(this.Host.HostName, this.PartitionContext.PartitionId, e, "Closing Event Processor");
+            }
+            finally
+            {
+                // Release the lease regardless of result from pump's close call above.
+                // Increase the chance of a healthy host grabbing the lease here.
+                if (reason != CloseReason.LeaseLost)
+                {
+                    // Since this pump is dead, release the lease.
+                    try
+                    {
+                        await this.Host.LeaseManager.ReleaseLeaseAsync(this.PartitionContext.Lease).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        // Log and ignore any failure since expired lease will be picked by another host.
+                        this.Host.EventProcessorOptions.NotifyOfException(this.Host.HostName, this.PartitionContext.PartitionId, e, EventProcessorHostActionStrings.ReleasingLease);
+                    }
+                }
             }
 
             this.PumpStatus = PartitionPumpStatus.Closed;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -79,6 +79,18 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal static string GetEntityConnectionString(string entityName) =>
             new EventHubsConnectionStringBuilder(EventHubsConnectionString) { EntityPath = entityName }.ToString();
 
+        internal static async Task SendToEventhubAsync(EventHubClient ehClient, int numberOfMessages = 1)
+        {
+            TestUtility.Log($"Starting to send {numberOfMessages} messages.");
+
+            for (int i = 0; i < numberOfMessages; i++)
+            {
+                await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello Event Hubs!")));
+            }
+
+            TestUtility.Log("Sends done.");
+        }
+
         internal static Task SendToPartitionAsync(EventHubClient ehClient, string partitionId, string messageBody, int numberOfMessages = 1)
         {
             return SendToPartitionAsync(ehClient, partitionId, new EventData(Encoding.UTF8.GetBytes(messageBody)), numberOfMessages);


### PR DESCRIPTION
This is a fix addressing a regression in the 4.3.0 release. PartitionPump should release 'lease' after CloseAsync call on the IEventProcessor instance. This enables checkpointing at shutdown scenarios.

Fixing issue reported at https://github.com/Azure/azure-sdk-for-net/issues/14732

And also adding a test to catch similar regressions.