### PR TITLE
[Event Hubs] Canary support for live tests

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -26,6 +26,9 @@ parameters:
 - name: SubscriptionConfiguration
   type: string
   default: $(sub-config-azure-cloud-test-resources)
+- name: TestCanary
+  type: boolean
+  default: false
 - name: ServiceDirectory
   type: string
   default: not-specified
@@ -65,6 +68,12 @@ jobs:
       - DisplayName: "Test on MacOS"
         OSVmImage: "macOS-10.15"
         TestTargetFramework: netcoreapp2.1
+      ${{ if eq(parameters.TestCanary, 'true') }}:          
+        - DisplayName: "Test on Windows for .Net Framework - Canary region"
+          OSVmImage: "windows-2019"
+          TestTargetFramework: net461
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)            
+          Location: centraluseuap
       - DisplayName: "Record on Windows for NetCoreApp"
         OSVmImage: "windows-2019"
         TestMode: Record

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -72,9 +72,9 @@ jobs:
         OSVmImage: "macOS-10.15"
         TestTargetFramework: netcoreapp2.1
       - ${{ if eq(parameters.TestCanary, 'true') }}:          
-        - DisplayName: "Test on Windows for .Net Framework - Canary region"
+        - DisplayName: "Test on Windows for NetCoreApp - Canary region"
           OSVmImage: "windows-2019"
-          TestTargetFramework: net461
+          TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)            
           Location: ${{ parameters.ResourceGroupLocationCanary }}
       - DisplayName: "Record on Windows for NetCoreApp"

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -29,6 +29,9 @@ parameters:
 - name: TestCanary
   type: boolean
   default: false
+- name: ResourceGroupLocationCanary
+  type: string
+  default: "centraluseuap"
 - name: ServiceDirectory
   type: string
   default: not-specified
@@ -73,7 +76,7 @@ jobs:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)            
-          Location: centraluseuap
+          Location: ${{ parameters.ResourceGroupLocationCanary }}
       - DisplayName: "Record on Windows for NetCoreApp"
         OSVmImage: "windows-2019"
         TestMode: Record

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -68,7 +68,7 @@ jobs:
       - DisplayName: "Test on MacOS"
         OSVmImage: "macOS-10.15"
         TestTargetFramework: netcoreapp2.1
-      ${{ if eq(parameters.TestCanary, 'true') }}:          
+      - ${{ if eq(parameters.TestCanary, 'true') }}:          
         - DisplayName: "Test on Windows for .Net Framework - Canary region"
           OSVmImage: "windows-2019"
           TestTargetFramework: net461

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -6,3 +6,4 @@ extends:
     MaxParallel: 6
     ServiceDirectory: eventhub
     TimeoutInMinutes: 120
+    TestCanary: true


### PR DESCRIPTION
Last triggered pipeline - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=553341&view=results

More relevant info - https://github.com/Azure/azure-sdk-for-js/pull/11318