### PR TITLE
[Identity] Added default console output for DeviceCodeCredential

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 ## 1.3.0-beta.2 (Unreleased)
 
+### New Features
+- Update `DeviceCodeCredential` to output device code information and authentication instructions in the console, in the case no `deviceCodeCallback` is specified.
+
 
 ## 1.3.0-beta.1 (2020-09-11)
 

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -119,7 +119,9 @@ namespace Azure.Identity
         public DeviceCodeCredential() { }
         public DeviceCodeCredential(Azure.Identity.DeviceCodeCredentialOptions options) { }
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, Azure.Identity.DeviceCodeCredentialOptions options = null) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string clientId, Azure.Identity.TokenCredentialOptions options = null) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options = null) { }
         public virtual Azure.Identity.AuthenticationRecord Authenticate(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Identity.AuthenticationRecord Authenticate(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -116,7 +116,8 @@ namespace Azure.Identity
     }
     public partial class DeviceCodeCredential : Azure.Core.TokenCredential
     {
-        protected DeviceCodeCredential() { }
+        public DeviceCodeCredential() { }
+        public DeviceCodeCredential(Azure.Identity.DeviceCodeCredentialOptions options) { }
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, Azure.Identity.DeviceCodeCredentialOptions options = null) { }
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string clientId, Azure.Identity.TokenCredentialOptions options = null) { }
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options = null) { }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -26,9 +26,10 @@ namespace Azure.Identity
         private const string NoDefaultScopeMessage = "Authenticating in this environment requires specifying a TokenRequestContext.";
 
         /// <summary>
-        /// Protected constructor for mocking
+        /// Creates a new <see cref="DeviceCodeCredential"/>, which will authenticate users using the device code flow, printing the device code message to stdout.
         /// </summary>
-        protected DeviceCodeCredential()
+        public DeviceCodeCredential() :
+            this(DefaultDeviceCodeHandler, null, null, null, null)
         {
 
         }
@@ -58,6 +59,16 @@ namespace Azure.Identity
         }
 
         /// <summary>
+        ///  Creates a new <see cref="DeviceCodeCredential"/> with the specified options, which will authenticate users using the device code flow, printing the device code message to stdout.
+        /// </summary>
+        /// <param name="options">The client options for the newly created <see cref="DeviceCodeCredential"/>.</param>
+        public DeviceCodeCredential(DeviceCodeCredentialOptions options)
+            : this(DefaultDeviceCodeHandler, options?.TenantId, options?.ClientId, options, null)
+        {
+
+        }
+
+        /// <summary>
         ///  Creates a new DeviceCodeCredential with the specified options, which will authenticate users using the device code flow.
         /// </summary>
         /// <param name="deviceCodeCallback">The callback to be executed to display the device code to the user.</param>
@@ -76,7 +87,7 @@ namespace Azure.Identity
 
         internal DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId, TokenCredentialOptions options, CredentialPipeline pipeline, MsalPublicClient client)
         {
-            _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            _clientId = clientId ?? Constants.DeveloperSignOnClientId;
 
             _deviceCodeCallback = deviceCodeCallback ?? throw new ArgumentNullException(nameof(deviceCodeCallback));
 
@@ -222,6 +233,11 @@ namespace Azure.Identity
             return _deviceCodeCallback(new DeviceCodeInfo(deviceCode), cancellationToken);
         }
 
+        private static Task DefaultDeviceCodeHandler(DeviceCodeInfo deviceCodeInfo, CancellationToken cancellationToken)
+        {
+            Console.WriteLine(deviceCodeInfo.Message);
 
+            return Task.CompletedTask;
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -5,6 +5,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Identity.Client;
 using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,30 +36,6 @@ namespace Azure.Identity
         }
 
         /// <summary>
-        /// Creates a new DeviceCodeCredential with the specified options, which will authenticate users with the specified application.
-        /// </summary>
-        /// <param name="deviceCodeCallback">The callback to be executed to display the device code to the user</param>
-        /// <param name="clientId">The client id of the application to which the users will authenticate</param>
-        /// <param name="options">The client options for the newly created DeviceCodeCredential</param>
-        public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string clientId, TokenCredentialOptions options = default)
-            : this(deviceCodeCallback, null, clientId, options, null)
-        {
-
-        }
-
-        /// <summary>
-        /// Creates a new DeviceCodeCredential with the specified options, which will authenticate users with the specified application.
-        /// </summary>
-        /// <param name="deviceCodeCallback">The callback to be executed to display the device code to the user</param>
-        /// <param name="tenantId">The tenant id of the application to which users will authenticate.  This can be null for multi-tenanted applications.</param>
-        /// <param name="clientId">The client id of the application to which the users will authenticate</param>
-        /// <param name="options">The client options for the newly created DeviceCodeCredential</param>
-        public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId,  TokenCredentialOptions options = default)
-            : this(deviceCodeCallback, tenantId, clientId, options, null)
-        {
-        }
-
-        /// <summary>
         ///  Creates a new <see cref="DeviceCodeCredential"/> with the specified options, which will authenticate users using the device code flow, printing the device code message to stdout.
         /// </summary>
         /// <param name="options">The client options for the newly created <see cref="DeviceCodeCredential"/>.</param>
@@ -78,6 +55,32 @@ namespace Azure.Identity
         {
             _disableAutomaticAuthentication = options?.DisableAutomaticAuthentication ?? false;
             _record = options?.AuthenticationRecord;
+        }
+
+        /// <summary>
+        /// Creates a new DeviceCodeCredential with the specified options, which will authenticate users with the specified application.
+        /// </summary>
+        /// <param name="deviceCodeCallback">The callback to be executed to display the device code to the user</param>
+        /// <param name="clientId">The client id of the application to which the users will authenticate</param>
+        /// <param name="options">The client options for the newly created DeviceCodeCredential</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string clientId, TokenCredentialOptions options = default)
+            : this(deviceCodeCallback, null, clientId, options, null)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates a new DeviceCodeCredential with the specified options, which will authenticate users with the specified application.
+        /// </summary>
+        /// <param name="deviceCodeCallback">The callback to be executed to display the device code to the user</param>
+        /// <param name="tenantId">The tenant id of the application to which users will authenticate.  This can be null for multi-tenanted applications.</param>
+        /// <param name="clientId">The client id of the application to which the users will authenticate</param>
+        /// <param name="options">The client options for the newly created DeviceCodeCredential</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId,  TokenCredentialOptions options = default)
+            : this(deviceCodeCallback, tenantId, clientId, options, null)
+        {
         }
 
         internal DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId, TokenCredentialOptions options, CredentialPipeline pipeline)

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -97,6 +97,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
+        [NonParallelizable]
         public async Task AuthenticateWithDeviceCodeNoCallback()
         {
             var capturedOut = new StringBuilder();

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -6,6 +6,7 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,6 +94,41 @@ namespace Azure.Identity.Tests
             AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }));
 
             Assert.AreEqual(token.Token, expectedToken);
+        }
+
+        [Test]
+        public async Task AuthenticateWithDeviceCodeNoCallback()
+        {
+            var capturedOut = new StringBuilder();
+
+            var capturedOutWriter = new StringWriter(capturedOut);
+
+            var stdOut = Console.Out;
+
+            Console.SetOut(capturedOutWriter);
+
+            try
+            {
+                var expectedCode = Guid.NewGuid().ToString();
+
+                var expectedToken = Guid.NewGuid().ToString();
+
+                var mockTransport = new MockTransport(request => ProcessMockRequest(request, expectedCode, expectedToken));
+
+                var options = new DeviceCodeCredentialOptions() { Transport = mockTransport };
+
+                var cred = InstrumentClient(new DeviceCodeCredential(options));
+
+                AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }));
+
+                Assert.AreEqual(token.Token, expectedToken);
+
+                Assert.AreEqual(expectedCode + Environment.NewLine, capturedOut.ToString());
+            }
+            finally
+            {
+                Console.SetOut(stdOut);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Adding support for printing device code message to console when no `deviceCodeCallback` is specified.

Fixes #13689 