### PR TITLE
SchemaRegistry: Fix broken encoding

### DIFF
--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Generated/SchemaRestClient.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/Generated/SchemaRestClient.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,7 +66,7 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="schemaId"> References specific schema in registry namespace. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="schemaId"/> is null. </exception>
-        public async Task<ResponseWithHeaders<string, SchemaGetByIdHeaders>> GetByIdAsync(string schemaId, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<Stream, SchemaGetByIdHeaders>> GetByIdAsync(string schemaId, CancellationToken cancellationToken = default)
         {
             if (schemaId == null)
             {
@@ -79,9 +80,7 @@ namespace Azure.Data.SchemaRegistry
             {
                 case 200:
                     {
-                        string value = default;
-                        using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        value = document.RootElement.GetString();
+                        var value = message.ExtractResponseContent();
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -93,7 +92,7 @@ namespace Azure.Data.SchemaRegistry
         /// <param name="schemaId"> References specific schema in registry namespace. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="schemaId"/> is null. </exception>
-        public ResponseWithHeaders<string, SchemaGetByIdHeaders> GetById(string schemaId, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<Stream, SchemaGetByIdHeaders> GetById(string schemaId, CancellationToken cancellationToken = default)
         {
             if (schemaId == null)
             {
@@ -107,9 +106,7 @@ namespace Azure.Data.SchemaRegistry
             {
                 case 200:
                     {
-                        string value = default;
-                        using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        value = document.RootElement.GetString();
+                        var value = message.ExtractResponseContent();
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -132,11 +129,9 @@ namespace Azure.Data.SchemaRegistry
             uri.AppendQuery("api-version", apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("X-Schema-Type", xSchemaType.ToString());
-            request.Headers.Add("Content-Type", "application/json");
+            request.Headers.Add("Content-Type", "text/plain");
             request.Headers.Add("Accept", "application/json");
-            var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteStringValue(schemaContent);
-            request.Content = content;
+            request.Content = new StringRequestContent(schemaContent);
             return message;
         }
 
@@ -233,11 +228,9 @@ namespace Azure.Data.SchemaRegistry
             uri.AppendQuery("api-version", apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("X-Schema-Type", xSchemaType.ToString());
-            request.Headers.Add("Content-Type", "application/json");
+            request.Headers.Add("Content-Type", "text/plain");
             request.Headers.Add("Accept", "application/json");
-            var content = new Utf8JsonRequestContent();
-            content.JsonWriter.WriteStringValue(schemaContent);
-            request.Content = content;
+            request.Content = new StringRequestContent(schemaContent);
             return message;
         }
 

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaRegistryClient.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/SchemaRegistryClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -175,7 +176,9 @@ namespace Azure.Data.SchemaRegistry
             try
             {
                 var response = await RestClient.GetByIdAsync(schemaId, cancellationToken).ConfigureAwait(false);
-                var properties = new SchemaProperties(response.Value, response.Headers.Location, response.Headers.XSchemaType, response.Headers.XSchemaId, response.Headers.XSchemaVersion);
+                using var reader = new StreamReader(response.Value);
+                var content = await reader.ReadToEndAsync().ConfigureAwait(false);
+                var properties = new SchemaProperties(content, response.Headers.Location, response.Headers.XSchemaType, response.Headers.XSchemaId, response.Headers.XSchemaVersion);
                 return Response.FromValue(properties, response);
             }
             catch (Exception e)
@@ -198,7 +201,9 @@ namespace Azure.Data.SchemaRegistry
             try
             {
                 var response = RestClient.GetById(schemaId, cancellationToken);
-                var properties = new SchemaProperties(response.Value, response.Headers.Location, response.Headers.XSchemaType, response.Headers.XSchemaId, response.Headers.XSchemaVersion);
+                using var reader = new StreamReader(response.Value);
+                var content = reader.ReadToEnd();
+                var properties = new SchemaProperties(content, response.Headers.Location, response.Headers.XSchemaType, response.Headers.XSchemaId, response.Headers.XSchemaVersion);
                 return Response.FromValue(properties, response);
             }
             catch (Exception e)

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/autorest.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/autorest.md
@@ -3,5 +3,5 @@
 Run `dotnet msbuild /t:GenerateCode` to generate code.
 
 ``` yaml
-require: https://github.com/Azure/azure-rest-api-specs/blob/a90b9146e543d3eec11381bd52d3b6ff271b1b78/specification/schemaregistry/data-plane/readme.md
+input-file: schemaregistry.json
 ```

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/schemaregistry.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/src/schemaregistry.json
@@ -1,0 +1,339 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Azure Schema Registry",
+    "version": "2018-01-01-preview",
+    "description": "Azure Schema Registry is as a central schema repository for enterprise-level data infrastructure, complete with support for versioning and management."
+  },
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}",
+    "useSchemePrefix": true,
+    "parameters": [
+      {
+        "$ref": "#/parameters/Endpoint"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/$schemagroups/getSchemaById/{schema-id}": {
+      "get": {
+        "summary": "Get a registered schema by its unique ID reference.",
+        "description": "Gets a registered schema by its unique ID.  Azure Schema Registry guarantees that ID is unique within a namespace.",
+        "x-ms-examples": {
+          "Get schema by ID": {
+            "$ref": "./examples/OperationSchema_GetById.json"
+          }
+        },
+        "operationId": "Schema_GetById",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "schema-id",
+            "in": "path",
+            "description": "References specific schema in registry namespace.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "URL location of schema, identified by schema group, schema name, and version."
+              },
+              "X-Schema-Type": {
+                "type": "string",
+                "description": "Serialization type for the schema being stored."
+              },
+              "X-Schema-Id": {
+                "type": "string",
+                "description": "References specific schema in registry namespace."
+              },
+              "X-Schema-Id-Location": {
+                "type": "string",
+                "description": "URL location of schema, identified by schema ID."
+              },
+              "X-Schema-Version": {
+                "type": "integer",
+                "description": "Version of the returned schema."
+              }
+            },
+            "schema": {
+              "type": "object",
+              "format": "binary"
+            }
+          },
+          "default": {
+            "description": "An error response received from the Azure Schema Registry service.",
+            "schema": {
+              "$ref": "#/definitions/ServiceErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/$schemagroups/{group-name}/schemas/{schema-name}": {
+      "post": {
+        "summary": "Get ID for existing schema.",
+        "description": "Gets the ID referencing an existing schema within the specified schema group, as matched by schema content comparison.",
+        "x-ms-examples": {
+          "Get schema ID": {
+            "$ref": "./examples/OperationSchema_QueryIdByContent.json"
+          }
+        },
+        "operationId": "Schema_QueryIdByContent",
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "name": "group-name",
+            "in": "path",
+            "description": "Schema group under which schema is registered.  Group's serialization type should match the serialization type specified in the request.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schema-name",
+            "in": "path",
+            "description": "Name of the registered schema.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schema-content",
+            "in": "body",
+            "description": "String representation of the registered schema.",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "format": "binary"
+            }
+          },
+          {
+            "name": "X-Schema-Type",
+            "in": "header",
+            "type": "string",
+            "description": "Serialization type for the schema being registered.",
+            "required": true,
+            "enum": [
+              "avro"
+            ],
+            "x-ms-enum": {
+              "name": "SerializationType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "value": "avro",
+                  "name": "AVRO",
+                  "description": "Avro Serialization schema type"
+                }
+              ]
+            },
+            "x-nullable": false
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "URL location of schema, identified by schema group, schema name, and version."
+              },
+              "X-Schema-Type": {
+                "type": "string",
+                "description": "Serialization type for the schema being stored."
+              },
+              "X-Schema-Id": {
+                "type": "string",
+                "description": "References specific schema in registry namespace."
+              },
+              "X-Schema-Id-Location": {
+                "type": "string",
+                "description": "URL location of schema, identified by schema ID."
+              },
+              "X-Schema-Version": {
+                "type": "integer",
+                "description": "Version of the returned schema."
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/SchemaId"
+            }
+          },
+          "default": {
+            "description": "An error response received from the Azure Schema Registry service.",
+            "schema": {
+              "$ref": "#/definitions/ServiceErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Register new schema",
+        "description": "Register new schema. If schema of specified name does not exist in specified group, schema is created at version 1. If schema of specified name exists already in specified group, schema is created at latest version + 1.\n",
+        "x-ms-examples": {
+          "Register schema": {
+            "$ref": "./examples/OperationSchema_Register.json"
+          }
+        },
+        "operationId": "Schema_Register",
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "text/plain"
+        ],
+        "parameters": [
+          {
+            "name": "group-name",
+            "in": "path",
+            "description": "Schema group under which schema should be registered.  Group's serialization type should match the serialization type specified in the request.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schema-name",
+            "in": "path",
+            "description": "Name of schema being registered.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "X-Schema-Type",
+            "in": "header",
+            "type": "string",
+            "description": "Serialization type for the schema being registered.",
+            "required": true,
+            "enum": [
+              "avro"
+            ],
+            "x-ms-enum": {
+              "name": "SerializationType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "value": "avro",
+                  "name": "AVRO",
+                  "description": "Avro Serialization schema type"
+                }
+              ]
+            },
+            "x-nullable": false
+          },
+          {
+            "name": "schema-content",
+            "in": "body",
+            "description": "String representation of the schema being registered.",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "format": "binary"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "URL location of schema, identified by schema group, schema name, and version."
+              },
+              "X-Schema-Type": {
+                "type": "string",
+                "description": "Serialization type for the schema being registered."
+              },
+              "X-Schema-Id": {
+                "type": "string",
+                "description": "References specific schema in registry namespace."
+              },
+              "X-Schema-Id-Location": {
+                "type": "string",
+                "description": "URL location of schema, identified by schema ID."
+              },
+              "X-Schema-Version": {
+                "type": "integer",
+                "description": "Version of the returned schema."
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/SchemaId"
+            }
+          },
+          "default": {
+            "description": "An error response received from the Azure Schema Registry service.",
+            "schema": {
+              "$ref": "#/definitions/ServiceErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "SchemaId": {
+      "type": "object",
+      "description": "JSON Object received from the registry containing schema identifiers.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Schema ID that uniquely identifies a schema in the registry namespace."
+        }
+      }
+    },
+    "ServiceErrorResponse": {
+      "description": "Error response returned from Azure Schema Registry service.",
+      "type": "string"
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Schema Registry service API version that should be used."
+    },
+    "Endpoint": {
+      "name": "endpoint",
+      "description": "The Schema Registry service endpoint, for example my-namespace.servicebus.windows.net.",
+      "required": true,
+      "type": "string",
+      "in": "path",
+      "x-ms-skip-url-encoding": true,
+      "x-ms-parameter-location": "client"
+    }
+  }
+}

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaRegistryClientLiveTest.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaRegistryClientLiveTest.cs
@@ -71,7 +71,7 @@ namespace Azure.Data.SchemaRegistry.Tests
             Assert.IsNotNull(schemaProperties.Value);
             Assert.IsNotNull(schemaProperties.Value.Id);
             Assert.IsTrue(Guid.TryParse(schemaProperties.Value.Id, out Guid _));
-            Assert.AreEqual(SchemaContent, schemaProperties.Value.Content);
+            Assert.AreEqual(SchemaContent.Replace(" ", ""), schemaProperties.Value.Content);
         }
     }
 }

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchema.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchema.json
@@ -6,43 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a9bb4e4bb92bb7199b81a2fe15c1bf1d",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:43 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:40:00 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "19ce9e525b5b410fa34ee4d0c2977ede"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     },
     {
-      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "789557cb0beea63b2b639b6c79b01992",
@@ -52,18 +52,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:43 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:40:00 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
-      "ResponseBody": "\u0022{\\\u0022type\\\u0022 : \\\u0022record\\\u0022,\\\u0022namespace\\\u0022 : \\\u0022TestSchema\\\u0022,\\\u0022name\\\u0022 : \\\u0022Employee\\\u0022,\\\u0022fields\\\u0022 : [{ \\\u0022name\\\u0022 : \\\u0022Name\\\u0022 , \\\u0022type\\\u0022 : \\\u0022string\\\u0022 },{ \\\u0022name\\\u0022 : \\\u0022Age\\\u0022, \\\u0022type\\\u0022 : \\\u0022int\\\u0022 }]}\u0022"
+      "ResponseBody": {
+        "type": "record",
+        "namespace": "TestSchema",
+        "name": "Employee",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      }
     }
   ],
   "Variables": {

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchemaAsync.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchemaAsync.json
@@ -6,43 +6,43 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "23519c599ecca90a5a65530717191100",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:45 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:40:00 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "19ce9e525b5b410fa34ee4d0c2977ede"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     },
     {
-      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "fa78deb88eafe71485ee6b337d7d6b2d",
@@ -52,18 +52,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:45 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:40:02 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
-      "ResponseBody": "\u0022{\\\u0022type\\\u0022 : \\\u0022record\\\u0022,\\\u0022namespace\\\u0022 : \\\u0022TestSchema\\\u0022,\\\u0022name\\\u0022 : \\\u0022Employee\\\u0022,\\\u0022fields\\\u0022 : [{ \\\u0022name\\\u0022 : \\\u0022Name\\\u0022 , \\\u0022type\\\u0022 : \\\u0022string\\\u0022 },{ \\\u0022name\\\u0022 : \\\u0022Age\\\u0022, \\\u0022type\\\u0022 : \\\u0022int\\\u0022 }]}\u0022"
+      "ResponseBody": {
+        "type": "record",
+        "namespace": "TestSchema",
+        "name": "Employee",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      }
     }
   ],
   "Variables": {

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchemaId.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchemaId.json
@@ -6,33 +6,33 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2c620897d9de14f8847756ca36bfb1dd",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:44 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:36:04 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "19ce9e525b5b410fa34ee4d0c2977ede"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     },
     {
@@ -41,33 +41,33 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f81747feb3bdd74d2da2f268fd8a6e28",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:44 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/11?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:36:04 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "5c48f8ad9d364b579883ffa05ae9f5e4",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/5c48f8ad9d364b579883ffa05ae9f5e4?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "11",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "5c48f8ad9d364b579883ffa05ae9f5e4"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     }
   ],

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchemaIdAsync.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanGetSchemaIdAsync.json
@@ -6,33 +6,33 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5417cde1a45d14a2ae3731d071449823",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:47 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:36:06 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "19ce9e525b5b410fa34ee4d0c2977ede"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     },
     {
@@ -41,33 +41,33 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ebf572ccf2140bd54101f2c44b198261",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:47 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/11?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:36:07 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "5c48f8ad9d364b579883ffa05ae9f5e4",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/5c48f8ad9d364b579883ffa05ae9f5e4?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "11",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "5c48f8ad9d364b579883ffa05ae9f5e4"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     }
   ],

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanRegisterSchema.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanRegisterSchema.json
@@ -6,33 +6,34 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
+        "Request-Id": "|9b3389cc-48a7ffe61eae74f2.",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "06149688c0d107fba9beaa6650213cc6",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:45 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:35:15 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "19ce9e525b5b410fa34ee4d0c2977ede"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     }
   ],

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanRegisterSchemaAsync.json
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SessionRecords/SchemaRegistryClientLiveTest/CanRegisterSchemaAsync.json
@@ -6,33 +6,34 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "306",
-        "Content-Type": "application/json",
+        "Content-Length": "154",
+        "Content-Type": "text/plain",
+        "Request-Id": "|9b3389ce-48a7ffe61eae74f2.",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "10d841304c76af44a9857366d3cdcece",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022 : \\u0022record\\u0022,\\u0022namespace\\u0022 : \\u0022TestSchema\\u0022,\\u0022name\\u0022 : \\u0022Employee\\u0022,\\u0022fields\\u0022 : [{ \\u0022name\\u0022 : \\u0022Name\\u0022 , \\u0022type\\u0022 : \\u0022string\\u0022 },{ \\u0022name\\u0022 : \\u0022Age\\u0022, \\u0022type\\u0022 : \\u0022int\\u0022 }]}\u0022",
+      "RequestBody": "{\u0022type\u0022 : \u0022record\u0022,\u0022namespace\u0022 : \u0022TestSchema\u0022,\u0022name\u0022 : \u0022Employee\u0022,\u0022fields\u0022 : [{ \u0022name\u0022 : \u0022Name\u0022 , \u0022type\u0022 : \u0022string\u0022 },{ \u0022name\u0022 : \u0022Age\u0022, \u0022type\u0022 : \u0022int\u0022 }]}",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:29:48 GMT",
-        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/24?api-version=2017-04",
+        "Date": "Mon, 21 Sep 2020 23:35:23 GMT",
+        "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/test1/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "19ce9e525b5b410fa34ee4d0c2977ede",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/19ce9e525b5b410fa34ee4d0c2977ede?api-version=2017-04",
+        "X-Schema-Id": "10bd9f4c18154bada093e495dda33fee",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/10bd9f4c18154bada093e495dda33fee?api-version=2017-04",
         "X-Schema-Type": "Avro",
-        "X-Schema-Version": "24",
+        "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/test1/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "19ce9e525b5b410fa34ee4d0c2977ede"
+        "id": "10bd9f4c18154bada093e495dda33fee"
       }
     }
   ],

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserialize.json
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserialize.json
@@ -6,43 +6,57 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "283",
-        "Content-Type": "application/json",
+        "Content-Length": "131",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a4e0342bf488b2dedfa1a44e27c4ff86",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022:\\u0022record\\u0022,\\u0022name\\u0022:\\u0022Employee\\u0022,\\u0022namespace\\u0022:\\u0022TestSchema\\u0022,\\u0022fields\\u0022:[{\\u0022name\\u0022:\\u0022Name\\u0022,\\u0022type\\u0022:\\u0022string\\u0022},{\\u0022name\\u0022:\\u0022Age\\u0022,\\u0022type\\u0022:\\u0022int\\u0022}]}\u0022",
+      "RequestBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:41 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:34 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "34fa96c2ac67489da0df6d4a245265a7"
+        "id": "e0c3a72cc63f4f3aac10bd76feee6479"
       }
     },
     {
-      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "70654df76b9dc735bed0cf1d43e365c1",
@@ -52,18 +66,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:41 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:35 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
-      "ResponseBody": "\u0022{\\\u0022type\\\u0022:\\\u0022record\\\u0022,\\\u0022name\\\u0022:\\\u0022Employee\\\u0022,\\\u0022namespace\\\u0022:\\\u0022TestSchema\\\u0022,\\\u0022fields\\\u0022:[{\\\u0022name\\\u0022:\\\u0022Name\\\u0022,\\\u0022type\\\u0022:\\\u0022string\\\u0022},{\\\u0022name\\\u0022:\\\u0022Age\\\u0022,\\\u0022type\\\u0022:\\\u0022int\\\u0022}]}\u0022"
+      "ResponseBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      }
     }
   ],
   "Variables": {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserializeAsync.json
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserializeAsync.json
@@ -6,43 +6,57 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "283",
-        "Content-Type": "application/json",
+        "Content-Length": "131",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ff66bdce9ae906e73243e5d65e9c3087",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022:\\u0022record\\u0022,\\u0022name\\u0022:\\u0022Employee\\u0022,\\u0022namespace\\u0022:\\u0022TestSchema\\u0022,\\u0022fields\\u0022:[{\\u0022name\\u0022:\\u0022Name\\u0022,\\u0022type\\u0022:\\u0022string\\u0022},{\\u0022name\\u0022:\\u0022Age\\u0022,\\u0022type\\u0022:\\u0022int\\u0022}]}\u0022",
+      "RequestBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:44 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:36 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "34fa96c2ac67489da0df6d4a245265a7"
+        "id": "e0c3a72cc63f4f3aac10bd76feee6479"
       }
     },
     {
-      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "df21687668ce562470a6755bf133f3ce",
@@ -52,18 +66,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:44 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:37 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
-      "ResponseBody": "\u0022{\\\u0022type\\\u0022:\\\u0022record\\\u0022,\\\u0022name\\\u0022:\\\u0022Employee\\\u0022,\\\u0022namespace\\\u0022:\\\u0022TestSchema\\\u0022,\\\u0022fields\\\u0022:[{\\\u0022name\\\u0022:\\\u0022Name\\\u0022,\\\u0022type\\\u0022:\\\u0022string\\\u0022},{\\\u0022name\\\u0022:\\\u0022Age\\\u0022,\\\u0022type\\\u0022:\\\u0022int\\\u0022}]}\u0022"
+      "ResponseBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      }
     }
   ],
   "Variables": {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserializeGenericRecord.json
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserializeGenericRecord.json
@@ -6,43 +6,57 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "283",
-        "Content-Type": "application/json",
+        "Content-Length": "131",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f53af83530d117a50854958c5671a7b8",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022:\\u0022record\\u0022,\\u0022name\\u0022:\\u0022Employee\\u0022,\\u0022namespace\\u0022:\\u0022TestSchema\\u0022,\\u0022fields\\u0022:[{\\u0022name\\u0022:\\u0022Name\\u0022,\\u0022type\\u0022:\\u0022string\\u0022},{\\u0022name\\u0022:\\u0022Age\\u0022,\\u0022type\\u0022:\\u0022int\\u0022}]}\u0022",
+      "RequestBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:43 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:35 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "34fa96c2ac67489da0df6d4a245265a7"
+        "id": "e0c3a72cc63f4f3aac10bd76feee6479"
       }
     },
     {
-      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "02599ce50745d6b4567fb19a450b6571",
@@ -52,18 +66,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:43 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:36 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
-      "ResponseBody": "\u0022{\\\u0022type\\\u0022:\\\u0022record\\\u0022,\\\u0022name\\\u0022:\\\u0022Employee\\\u0022,\\\u0022namespace\\\u0022:\\\u0022TestSchema\\\u0022,\\\u0022fields\\\u0022:[{\\\u0022name\\\u0022:\\\u0022Name\\\u0022,\\\u0022type\\\u0022:\\\u0022string\\\u0022},{\\\u0022name\\\u0022:\\\u0022Age\\\u0022,\\\u0022type\\\u0022:\\\u0022int\\\u0022}]}\u0022"
+      "ResponseBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      }
     }
   ],
   "Variables": {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserializeGenericRecordAsync.json
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTest/CanSerializeAndDeserializeGenericRecordAsync.json
@@ -6,43 +6,57 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "283",
-        "Content-Type": "application/json",
+        "Content-Length": "131",
+        "Content-Type": "text/plain",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9ba13199bb118cee931fd241601cb425",
         "x-ms-return-client-request-id": "true",
         "X-Schema-Type": "avro"
       },
-      "RequestBody": "\u0022{\\u0022type\\u0022:\\u0022record\\u0022,\\u0022name\\u0022:\\u0022Employee\\u0022,\\u0022namespace\\u0022:\\u0022TestSchema\\u0022,\\u0022fields\\u0022:[{\\u0022name\\u0022:\\u0022Name\\u0022,\\u0022type\\u0022:\\u0022string\\u0022},{\\u0022name\\u0022:\\u0022Age\\u0022,\\u0022type\\u0022:\\u0022int\\u0022}]}\u0022",
+      "RequestBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:45 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:37 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
       "ResponseBody": {
-        "id": "34fa96c2ac67489da0df6d4a245265a7"
+        "id": "e0c3a72cc63f4f3aac10bd76feee6479"
       }
     },
     {
-      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+      "RequestUri": "https://sr-playground.servicebus.windows.net/$schemagroups/getSchemaById/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200910.1",
+          "azsdk-net-Data.SchemaRegistry/1.0.0-alpha.20200921.1",
           "(.NET Core 4.6.28801.04; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "fa6e728278df4a3f9923106cdf43fd7f",
@@ -52,18 +66,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json",
-        "Date": "Thu, 10 Sep 2020 22:34:45 GMT",
+        "Date": "Tue, 22 Sep 2020 00:32:38 GMT",
         "Location": "https://sr-playground.servicebus.windows.net/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions/1?api-version=2017-04",
         "Server": "Microsoft-HTTPAPI/2.0",
         "Strict-Transport-Security": "max-age=31536000",
         "Transfer-Encoding": "chunked",
-        "X-Schema-Id": "34fa96c2ac67489da0df6d4a245265a7",
-        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/34fa96c2ac67489da0df6d4a245265a7?api-version=2017-04",
+        "X-Schema-Id": "e0c3a72cc63f4f3aac10bd76feee6479",
+        "X-Schema-Id-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/getschemabyid/e0c3a72cc63f4f3aac10bd76feee6479?api-version=2017-04",
         "X-Schema-Type": "Avro",
         "X-Schema-Version": "1",
         "X-Schema-Versions-Location": "https://sr-playground.servicebus.windows.net:443/$schemagroups/miyanni_srgroup/schemas/TestSchema.Employee/versions?api-version=2017-04"
       },
-      "ResponseBody": "\u0022{\\\u0022type\\\u0022:\\\u0022record\\\u0022,\\\u0022name\\\u0022:\\\u0022Employee\\\u0022,\\\u0022namespace\\\u0022:\\\u0022TestSchema\\\u0022,\\\u0022fields\\\u0022:[{\\\u0022name\\\u0022:\\\u0022Name\\\u0022,\\\u0022type\\\u0022:\\\u0022string\\\u0022},{\\\u0022name\\\u0022:\\\u0022Age\\\u0022,\\\u0022type\\\u0022:\\\u0022int\\\u0022}]}\u0022"
+      "ResponseBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      }
     }
   ],
   "Variables": {


### PR DESCRIPTION
This replaces the use of the swagger from a branch to instead use one with its own changes. This is a workaround for now. The schema is now treated as raw bytes instead of a Json string.

Diff for swagger: https://www.diffchecker.com/7e2C2qpm