### PR TITLE
[Event Hubs Client] Idempotent Producer Service Integration

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
@@ -48,6 +48,18 @@ namespace Azure.Messaging.EventHubs
         public static AmqpSymbol ArgumentOutOfRangeError { get; } = AmqpConstants.Vendor + ":argument-out-of-range";
 
         /// <summary>
+        ///   Indicates that a sequence number was out of order.
+        /// </summary>
+        ///
+        public static AmqpSymbol SequenceOutOfOrderError { get; } = AmqpConstants.Vendor + ":out-of-order-sequence";
+
+        /// <summary>
+        ///   Indicates that a partition was stolen by another producer with exclusive access.
+        /// </summary>
+        ///
+        public static AmqpSymbol ProducerStolenError { get; } = AmqpConstants.Vendor + ":producer-epoch-stolen";
+
+        /// <summary>
         ///   The expression to test for when the service returns a "Not Found" response to determine the context.
         /// </summary>
         ///
@@ -177,6 +189,20 @@ namespace Azure.Messaging.EventHubs
             if (string.Equals(condition, AmqpErrorCode.Stolen.Value, StringComparison.InvariantCultureIgnoreCase))
             {
                 return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ConsumerDisconnected);
+            }
+
+            // The producer was superseded by one with a higher owner level.
+
+            if (string.Equals(condition, ProducerStolenError.Value, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ProducerDisconnected);
+            }
+
+            // The client-supplied sequence number was not in the expected order.
+
+            if (string.Equals(condition, SequenceOutOfOrderError.Value, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.InvalidClientState);
             }
 
             // Authorization was denied.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -325,6 +325,21 @@ namespace Azure.Messaging.EventHubs.Amqp
                 message.MessageAnnotations.Map[AmqpProperty.PartitionKey] = partitionKey;
             }
 
+            if (source.PendingPublishSequenceNumber.HasValue)
+            {
+                message.MessageAnnotations.Map[AmqpProperty.PublishedSequenceNumber] = source.PendingPublishSequenceNumber;
+            }
+
+            if (source.PendingProducerGroupId.HasValue)
+            {
+                message.MessageAnnotations.Map[AmqpProperty.ProducerGroupId] = source.PendingProducerGroupId;
+            }
+
+            if (source.PendingProducerOwnerLevel.HasValue)
+            {
+                message.MessageAnnotations.Map[AmqpProperty.ProducerOwnerLevel] = source.PendingProducerOwnerLevel;
+            }
+
             return message;
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -66,6 +66,17 @@ namespace Azure.Messaging.EventHubs.Amqp
         private TransportProducerFeatures ActiveFeatures { get; }
 
         /// <summary>
+        ///   The set of options currently active for the partition associated with this producer.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   These options are managed by the producer and will be mutated as part of state
+        ///   updates.
+        /// </remarks>
+        ///
+        private PartitionPublishingOptions ActiveOptions { get; }
+
+        /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
@@ -139,8 +150,6 @@ namespace Azure.Messaging.EventHubs.Amqp
                             TransportProducerFeatures requestedFeatures = TransportProducerFeatures.None,
                             PartitionPublishingOptions partitionOptions = null)
         {
-            partitionOptions ??= new PartitionPublishingOptions();
-
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));
             Argument.AssertNotNull(messageConverter, nameof(messageConverter));
@@ -152,9 +161,10 @@ namespace Azure.Messaging.EventHubs.Amqp
             ConnectionScope = connectionScope;
             MessageConverter = messageConverter;
             ActiveFeatures = requestedFeatures;
+            ActiveOptions = partitionOptions?.Clone() ?? new PartitionPublishingOptions();
 
             SendLink = new FaultTolerantAmqpObject<SendingAmqpLink>(
-                timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, partitionOptions, timeout, CancellationToken.None),
+                timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, ActiveOptions, timeout, CancellationToken.None),
                 link =>
                 {
                     link.Session?.SafeClose();
@@ -280,7 +290,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             options.MaximumSizeInBytes ??= MaximumMessageSize;
             Argument.AssertInRange(options.MaximumSizeInBytes.Value, EventHubProducerClient.MinimumBatchSizeLimit, MaximumMessageSize.Value, nameof(options.MaximumSizeInBytes));
 
-            return new AmqpEventBatch(MessageConverter, options, IsSequenceMeasurementRequired(ActiveFeatures));
+            return new AmqpEventBatch(MessageConverter, options, ActiveFeatures);
         }
 
         /// <summary>
@@ -538,7 +548,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             try
             {
-                link = await ConnectionScope.OpenProducerLinkAsync(partitionId, timeout, cancellationToken).ConfigureAwait(false);
+                link = await ConnectionScope.OpenProducerLinkAsync(partitionId, ActiveFeatures, partitionOptions, timeout, cancellationToken).ConfigureAwait(false);
 
                 if (!MaximumMessageSize.HasValue)
                 {
@@ -556,14 +566,16 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if (InitializedPartitionProperties == null)
                 {
-                    if ((ActiveFeatures & TransportProducerFeatures.IdempotentPublishing) != 0)
-                    {
-                        throw new NotImplementedException(nameof(CreateLinkAndEnsureProducerStateAsync));
-                    }
-                    else
-                    {
-                        InitializedPartitionProperties = new PartitionPublishingProperties(false, null, null, null);
-                    }
+                    var producerGroup = link.ExtractSettingPropertyValueOrDefault(AmqpProperty.ProducerGroupId, default(long?));
+                    var ownerLevel = link.ExtractSettingPropertyValueOrDefault(AmqpProperty.ProducerOwnerLevel, default(short?));
+                    var sequence = link.ExtractSettingPropertyValueOrDefault(AmqpProperty.SequenceNumber, default(int?));
+
+                    // Once the properties are initialized, clear the starting sequence number to ensure that the current
+                    // sequence tracked by the service is used should the link need to be recreated; this avoids the need for
+                    // the transport producer to have awareness of the sequence numbers of events being sent.
+
+                    InitializedPartitionProperties = new PartitionPublishingProperties(false, producerGroup, ownerLevel, sequence);
+                    partitionOptions.StartingSequenceNumber = null;
                 }
 
             }
@@ -574,18 +586,6 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             return link;
         }
-
-        /// <summary>
-        ///   Determines if measuring a sequence number is required to accurately calculate
-        ///   the size of an event.
-        /// </summary>
-        ///
-        /// <param name="activeFeatures">The set of features which are active for the producer.</param>
-        ///
-        /// <returns><c>true</c> if a sequence number should be measured; otherwise, <c>false</c>.</returns>
-        ///
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsSequenceMeasurementRequired(TransportProducerFeatures activeFeatures) => ((activeFeatures & TransportProducerFeatures.IdempotentPublishing) != 0);
 
         /// <summary>
         ///   Uses the minimum value of the two specified <see cref="TimeSpan" /> instances.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
@@ -14,10 +14,16 @@ namespace Azure.Messaging.EventHubs
     internal static class AmqpProperty
     {
         /// <summary>
-        ///   The owner level (a.k.a. epoch) to associate with a link.
+        ///   The owner level (a.k.a. epoch) to associate with a receiver link.
         /// </summary>
         ///
-        public static AmqpSymbol OwnerLevel { get; } = AmqpConstants.Vendor + ":epoch";
+        public static AmqpSymbol ConsumerOwnerLevel { get; } = AmqpConstants.Vendor + ":epoch";
+
+        /// <summary>
+        ///   The owner level (a.k.a. epoch) to associate with a sending link.
+        /// </summary>
+        ///
+        public static AmqpSymbol ProducerOwnerLevel { get; } = AmqpConstants.Vendor + ":producer-epoch";
 
         /// <summary>
         ///   The type of Event Hubs entity to associate with a link.
@@ -30,6 +36,24 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         public static AmqpSymbol TrackLastEnqueuedEventProperties { get; } = AmqpConstants.Vendor + ":enable-receiver-runtime-metric";
+
+        /// <summary>
+        ///   The capability for opting-into idempotent publishing.
+        /// </summary>
+        ///
+        public static AmqpSymbol EnableIdempotentPublishing { get; } = AmqpConstants.Vendor + ":idempotent-producer";
+
+        /// <summary>
+        ///   The identifier of the producer group to associate with a producer.
+        /// </summary>
+        ///
+        public static AmqpSymbol ProducerGroupId { get; } = AmqpConstants.Vendor + ":producer-sequence-number";
+
+        /// <summary>
+        ///   The sequence number assigned by a producer to an event when it was published.
+        /// </summary>
+        ///
+        public static AmqpSymbol PublishedSequenceNumber { get; } = AmqpConstants.Vendor + ":producer-id";
 
         /// <summary>
         ///   The timeout to associate with a link.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
@@ -31,17 +31,10 @@ namespace Azure.Messaging.EventHubs.Core
         public abstract long SizeInBytes { get; }
 
         /// <summary>
-        ///   A flag that indicates whether space should be reserved for a publishing
-        ///   sequence number when the event size is measured.  If <c>false</c>, a sequence
-        ///   number is not used in size calculations.
+        ///   The flags specifying the set of special transport features that have been opted-into.
         /// </summary>
         ///
-        /// <remarks>
-        ///   The sequence number is only populated and relevant when certain features
-        ///   of the producer are enabled.  For example, it is used by idempotent publishing.
-        /// </remarks>
-        ///
-        public abstract bool ReserveSpaceForSequenceNumber { get; }
+        public abstract TransportProducerFeatures ActiveFeatures { get; }
 
         /// <summary>
         ///   The count of events contained in the batch.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -884,6 +884,8 @@ namespace Azure.Messaging.EventHubs.Producer
                     {
                         lastSequence = NextSequence(lastSequence);
                         eventData.PendingPublishSequenceNumber = lastSequence;
+                        eventData.PendingProducerGroupId = partitionState.ProducerGroupId;
+                        eventData.PendingProducerOwnerLevel = partitionState.OwnerLevel;
                     }
 
                     // Publish the events.
@@ -893,7 +895,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     EventHubsEventSource.Log.IdempotentSequencePublish(EventHubName, options.PartitionId, firstSequence, lastSequence);
                     await SendInternalAsync(eventSet, options, cancellationToken).ConfigureAwait(false);
 
-                    // Update state and commit the sequencing.
+                    // Update state and commit the state.
 
                     EventHubsEventSource.Log.IdempotentSequenceUpdate(EventHubName, options.PartitionId, partitionState.LastPublishedSequenceNumber.Value, lastSequence);
                     partitionState.LastPublishedSequenceNumber = lastSequence;
@@ -905,11 +907,11 @@ namespace Azure.Messaging.EventHubs.Producer
                 }
                 catch
                 {
-                    // Clear the pending sequence numbers in the face of an exception.
+                    // Clear the pending state in the face of an exception.
 
                     foreach (var eventData in eventSet)
                     {
-                        eventData.PendingPublishSequenceNumber = null;
+                        eventData.ClearPublishingState();
                     }
 
                     throw;
@@ -983,6 +985,8 @@ namespace Azure.Messaging.EventHubs.Producer
                     {
                         lastSequence = NextSequence(lastSequence);
                         eventData.PendingPublishSequenceNumber = lastSequence;
+                        eventData.PendingProducerGroupId = partitionState.ProducerGroupId;
+                        eventData.PendingProducerOwnerLevel = partitionState.OwnerLevel;
                     }
 
                     // Publish the events.
@@ -1005,7 +1009,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                     foreach (var eventData in eventSet)
                     {
-                        eventData.PendingPublishSequenceNumber = null;
+                        eventData.ClearPublishingState();
                     }
 
                     throw;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
@@ -31,6 +31,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             yield return new object[] { AmqpError.TimeoutError, typeof(EventHubsException), EventHubsException.FailureReason.ServiceTimeout };
             yield return new object[] { AmqpError.ServerBusyError, typeof(EventHubsException), EventHubsException.FailureReason.ServiceBusy };
+            yield return new object[] { AmqpError.ProducerStolenError, typeof(EventHubsException), EventHubsException.FailureReason.ProducerDisconnected };
+            yield return new object[] { AmqpError.SequenceOutOfOrderError, typeof(EventHubsException), EventHubsException.FailureReason.InvalidClientState };
             yield return new object[] { AmqpError.ArgumentError, typeof(ArgumentException), null };
             yield return new object[] { AmqpError.ArgumentOutOfRangeError, typeof(ArgumentOutOfRangeException), null };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Azure.Messaging.EventHubs.Amqp;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
 using Microsoft.Azure.Amqp;
 using Microsoft.Azure.Amqp.Framing;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -145,13 +147,15 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public void TryAddHonorsTheMeasureSequenceNumber(bool measureSequenceNumber)
+        [TestCase(TransportProducerFeatures.None)]
+        [TestCase(TransportProducerFeatures.IdempotentPublishing)]
+        public void TryAddHonorStatefulFeatures(byte activeFeatures)
         {
             var maximumSize = 50;
             var batchEnvelopeSize = 0;
             var capturedSequence = default(int?);
+            var capturedGroupId = default(long?);
+            var capturedOwnerLevel = default(short?);
             var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockEvent = new Mock<AmqpMessage>();
@@ -163,6 +167,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateMessageFromEventHandler = (_e, _p) =>
                 {
                     capturedSequence = _e.PendingPublishSequenceNumber;
+                    capturedGroupId = _e.PendingProducerGroupId;
+                    capturedOwnerLevel = _e.PendingProducerOwnerLevel;
                     return mockEvent.Object;
                 }
             };
@@ -175,14 +181,17 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(message => message.SerializedMessageSize)
                 .Returns(maximumSize);
 
-            var batch = new AmqpEventBatch(mockConverter, options, measureSequenceNumber);
+            var batch = new AmqpEventBatch(mockConverter, options, (TransportProducerFeatures)activeFeatures);
             batch.TryAdd(EventGenerator.CreateEvents(1).Single());
 
-            var expectationConstraint = (measureSequenceNumber)
-                ? Is.Not.Null
-                : Is.Null;
+            NullConstraint generateConstraint() =>
+                ((TransportProducerFeatures)activeFeatures == TransportProducerFeatures.None)
+                    ? Is.Null
+                    : Is.Not.Null;
 
-            Assert.That(capturedSequence, expectationConstraint);
+            Assert.That(capturedSequence, generateConstraint(), "The sequence was not set as expected.");
+            Assert.That(capturedGroupId, generateConstraint(), "The group identifier was not set as expected.");
+            Assert.That(capturedOwnerLevel, generateConstraint(), "The owner level was not set as expected.");
         }
 
         /// <summary>
@@ -191,7 +200,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void TryAddRemovesTheMeasureSequenceNumber()
+        public void TryAddResetsPublishingState()
         {
             var maximumSize = 50;
             var batchEnvelopeSize = 0;
@@ -219,10 +228,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(message => message.SerializedMessageSize)
                 .Returns(maximumSize);
 
-            var batch = new AmqpEventBatch(mockConverter, options, true);
+            var batch = new AmqpEventBatch(mockConverter, options, TransportProducerFeatures.IdempotentPublishing);
             batch.TryAdd(EventGenerator.CreateEvents(1).Single());
 
-            Assert.That(capturedEvent.PublishedSequenceNumber, Is.Null);
+            Assert.That(capturedEvent.PublishedSequenceNumber, Is.Null, "The final sequence should not have been set.");
+            Assert.That(capturedEvent.PendingPublishSequenceNumber, Is.Null, "The pending sequence was not cleared.");
+            Assert.That(capturedEvent.PendingProducerGroupId, Is.Null, "The group identifier was not cleared.");
+            Assert.That(capturedEvent.PendingProducerOwnerLevel, Is.Null, "The owner level was not cleared.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -60,6 +60,27 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///  The set of test cases for optional idempotent publishing properties.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> IdempotentPropertyTestCases()
+        {
+            // The values represent the test arguments:
+            //   - Pending Sequence Number (int?)
+            //   - Pending Producer Group Id (long?)
+            //   - Pending Owner Level (short?)
+
+            yield return new object[] { (int?)123, (long?)456, (short?)789 };
+            yield return new object[] { null, (long?)456, (short?)789 };
+            yield return new object[] { (int?)123, null, (short?)789 };
+            yield return new object[] { (int?)123, (long?)456, null };
+            yield return new object[] { (int?)123, null, null };
+            yield return new object[] { null, (long?)456, null };
+            yield return new object[] { null, null, (short?)789 };
+            yield return new object[] { null, null, null };
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="AmqpMessageConverter.CreateMessageFromEvent" />
         ///   method.
         /// </summary>
@@ -179,6 +200,58 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 Assert.That(containsValue, Is.True, $"The message properties did not contain: [{ property }]");
                 Assert.That(value, Is.EqualTo(eventData.Properties[property]), $"The property value did not match for: [{ property }]");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpMessageConverter.CreateMessageFromEvent" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(IdempotentPropertyTestCases))]
+        public void CreateMessageFromEventPopulatesIdempotentAnnotations(int? pendingSequenceNumber,
+                                                                         long? pendingGroupId,
+                                                                         short? pendingOwnerLevel)
+        {
+            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x33 });
+            eventData.PendingPublishSequenceNumber = pendingSequenceNumber;
+            eventData.PendingProducerGroupId = pendingGroupId;
+            eventData.PendingProducerOwnerLevel = pendingOwnerLevel;
+
+            using AmqpMessage message = new AmqpMessageConverter().CreateMessageFromEvent(eventData);
+
+            Assert.That(message, Is.Not.Null, "The AMQP message should have been created.");
+            Assert.That(message.DataBody, Is.Not.Null, "The AMQP message should a body.");
+            Assert.That(message.MessageAnnotations, Is.Not.Null, "The AMQP message annotations should be present.");
+
+            // Each annotation should only be present if a value was assigned.
+
+            if (pendingSequenceNumber.HasValue)
+            {
+                Assert.That(message.MessageAnnotations.Map[AmqpProperty.PublishedSequenceNumber], Is.EqualTo(eventData.PendingPublishSequenceNumber.Value), "The publishing sequence number should have been set.");
+            }
+            else
+            {
+                Assert.That(message.MessageAnnotations.Map.Any(item => item.Key.ToString() == AmqpProperty.PublishedSequenceNumber.Value), Is.False, "The publishing sequence number should not have been set.");
+            }
+
+            if (pendingGroupId.HasValue)
+            {
+                Assert.That(message.MessageAnnotations.Map[AmqpProperty.ProducerGroupId], Is.EqualTo(eventData.PendingProducerGroupId.Value), "The producer group should have been set.");
+            }
+            else
+            {
+                Assert.That(message.MessageAnnotations.Map.Any(item => item.Key.ToString() == AmqpProperty.ProducerGroupId.Value), Is.False, "The producer group should not have been set.");
+            }
+
+            if (pendingOwnerLevel.HasValue)
+            {
+                Assert.That(message.MessageAnnotations.Map[AmqpProperty.ProducerOwnerLevel], Is.EqualTo(eventData.PendingProducerOwnerLevel.Value), "The producer owner level should have been set.");
+            }
+            else
+            {
+                Assert.That(message.MessageAnnotations.Map.Any(item => item.Key.ToString() == AmqpProperty.ProducerOwnerLevel.Value), Is.False, "The producer owner level should not have been set.");
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -275,7 +275,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public override long SizeInBytes { get; } = 100;
 
-            public override bool ReserveSpaceForSequenceNumber { get; } = true;
+            public override TransportProducerFeatures ActiveFeatures { get; } = TransportProducerFeatures.None;
 
             public override int Count { get; } = 400;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -13,7 +12,6 @@ using Azure.Core;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
-using Microsoft.Azure.Amqp;
 using Moq;
 using NUnit.Framework;
 
@@ -2651,7 +2649,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
-            public override bool ReserveSpaceForSequenceNumber { get; }
+            public override TransportProducerFeatures ActiveFeatures { get; }
             public override int Count => Events.Count;
             public override IEnumerable<T> AsEnumerable<T>() => (IEnumerable<T>)Events;
             public override void Clear() => Events.Clear();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -382,7 +382,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
             public override int Count { get; }
-            public override bool ReserveSpaceForSequenceNumber { get; }
+            public override TransportProducerFeatures ActiveFeatures { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
             public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();


### PR DESCRIPTION
# Summary

The focus of these changes is to complete the initial round of end-to-end integration with the Event Hubs service.  Functionality has been unit tested
and confirmed to not cause regressions in the non-idempotent Live tests.

Live tests for the idempotent feature are not included; they will follow as a dedicated unit of work pending local tests.  Until service-support for the
feature is rolled out to the public cloud, Live testing as part of nightly runs will not be possible.

# Last Upstream Rebase

Tuesday, September 22, 3:02pm (EDT)

# References and Related Issues

- [Idempotent Publishing Design](https://gist.github.com/jsquire/1cc4db6b3ca4ef13d26dc5315483555b)
- [Idempotent Publishing Requirements with Usage](https://gist.github.com/jsquire/0f3bc5701388fe03ccd027e86f1994f1)
- [Idempotent Publishing Support](https://github.com/Azure/azure-sdk-for-net/issues/13941) ([#13941](https://github.com/Azure/azure-sdk-for-net/issues/13941))