### PR TITLE
Summary comments were inverted

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -28,7 +28,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         /// <summary>
         /// Checks if <see cref="KeyVaultSecret"/> value should be retrieved.
         /// </summary>
-        /// <param name="secret">The <see cref="KeyVaultSecret"/> instance.</param>
+        /// <param name="secret">The <see cref="SecretProperties"/> instance.</param>
         /// <returns><code>true</code> if secrets value should be loaded, otherwise <code>false</code>.</returns>
         public virtual bool Load(SecretProperties secret)
         {

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -14,21 +14,22 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
     {
         internal static KeyVaultSecretManager Instance { get; } = new KeyVaultSecretManager();
 
-        /// <summary>
-        /// Checks if <see cref="KeyVaultSecret"/> value should be retrieved.
-        /// </summary>
-        /// <param name="secret">The <see cref="KeyVaultSecret"/> instance.</param>
-        /// <returns><code>true</code> if secrets value should be loaded, otherwise <code>false</code>.</returns>
-        public virtual string GetKey(KeyVaultSecret secret)
-        {
-            return secret.Name.Replace("--", ConfigurationPath.KeyDelimiter);
-        }
 
         /// <summary>
         /// Maps secret to a configuration key.
         /// </summary>
         /// <param name="secret">The <see cref="KeyVaultSecret"/> instance.</param>
         /// <returns>Configuration key name to store secret value.</returns>
+        public virtual string GetKey(KeyVaultSecret secret)
+        {
+            return secret.Name.Replace("--", ConfigurationPath.KeyDelimiter);
+        }
+
+        /// <summary>
+        /// Checks if <see cref="KeyVaultSecret"/> value should be retrieved.
+        /// </summary>
+        /// <param name="secret">The <see cref="KeyVaultSecret"/> instance.</param>
+        /// <returns><code>true</code> if secrets value should be loaded, otherwise <code>false</code>.</returns>
         public virtual bool Load(SecretProperties secret)
         {
             return true;


### PR DESCRIPTION
This PR attempts to fix `<summary>` block that seems to be inverted

Side note:
I change this:
`/// <param name="secret">The <see cref="KeyVaultSecret"/> instance.</param>`
that looked wrong for `public virtual bool Load(SecretProperties secret)`

Thought, what about this one:
`/// Checks if <see cref="KeyVaultSecret"/> value should be retrieved.` for `Load`m should it still be `KeyVaultSecret` or `SecretProperties` ?

![image](https://user-images.githubusercontent.com/2266487/94014869-6b065200-fdac-11ea-8a60-3b811ad58c72.png)
