### PR TITLE
[Identity] Move DeviceCodeCallback to DeviceCodeCredentialOptions

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,7 +3,11 @@
 
 ### New Features
 - Update `DeviceCodeCredential` to output device code information and authentication instructions in the console, in the case no `deviceCodeCallback` is specified.
+  - Added `DeviceCodeCallback` to `DeviceCodeCredentialOptions`
+  - Added default constructor to `DeviceCodeCredential`
 
+### Breaking Changes
+- Replaced `DeviceCodeCredential` constructor overload taking `deviceCodeCallback` and `DeviceCodeCredentialOptions` with constructor taking only `DeviceCodeCredentialOptions`
 
 ## 1.3.0-beta.1 (2020-09-11)
 

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -118,7 +118,6 @@ namespace Azure.Identity
     {
         public DeviceCodeCredential() { }
         public DeviceCodeCredential(Azure.Identity.DeviceCodeCredentialOptions options) { }
-        public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, Azure.Identity.DeviceCodeCredentialOptions options = null) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public DeviceCodeCredential(System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> deviceCodeCallback, string clientId, Azure.Identity.TokenCredentialOptions options = null) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -136,6 +135,7 @@ namespace Azure.Identity
         public bool AllowUnencryptedCache { get { throw null; } set { } }
         public Azure.Identity.AuthenticationRecord AuthenticationRecord { get { throw null; } set { } }
         public string ClientId { get { throw null; } set { } }
+        public System.Func<Azure.Identity.DeviceCodeInfo, System.Threading.CancellationToken, System.Threading.Tasks.Task> DeviceCodeCallback { get { throw null; } set { } }
         public bool DisableAutomaticAuthentication { get { throw null; } set { } }
         public bool EnablePersistentCache { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -17,44 +17,32 @@ namespace Azure.Identity
     /// </summary>
     public class DeviceCodeCredential : TokenCredential
     {
-        private readonly MsalPublicClient _client = null;
-        private readonly CredentialPipeline _pipeline;
-        private AuthenticationRecord _record = null;
-        private readonly string _clientId;
-        private readonly Func<DeviceCodeInfo, CancellationToken, Task> _deviceCodeCallback;
-        private bool _disableAutomaticAuthentication = false;
+        internal MsalPublicClient Client { get; }
+        internal string ClientId { get; }
+        internal bool DisableAutomaticAuthentication { get; }
+        internal AuthenticationRecord Record { get; private set; }
+        internal Func<DeviceCodeInfo, CancellationToken, Task> DeviceCodeCallback { get; }
+        internal CredentialPipeline Pipeline { get; }
+
         private const string AuthenticationRequiredMessage = "Interactive authentication is needed to acquire token. Call Authenticate to initiate the device code authentication.";
         private const string NoDefaultScopeMessage = "Authenticating in this environment requires specifying a TokenRequestContext.";
 
         /// <summary>
-        /// Creates a new <see cref="DeviceCodeCredential"/>, which will authenticate users using the device code flow, printing the device code message to stdout.
+        /// Creates a new <see cref="DeviceCodeCredential"/>, which will authenticate users using the device code flow.
         /// </summary>
         public DeviceCodeCredential() :
-            this(DefaultDeviceCodeHandler, null, null, null, null)
+            this(DefaultDeviceCodeHandler, null, Constants.DeveloperSignOnClientId, null, null)
         {
 
         }
 
         /// <summary>
-        ///  Creates a new <see cref="DeviceCodeCredential"/> with the specified options, which will authenticate users using the device code flow, printing the device code message to stdout.
+        ///  Creates a new <see cref="DeviceCodeCredential"/> with the specified options, which will authenticate users using the device code flow.
         /// </summary>
         /// <param name="options">The client options for the newly created <see cref="DeviceCodeCredential"/>.</param>
         public DeviceCodeCredential(DeviceCodeCredentialOptions options)
-            : this(DefaultDeviceCodeHandler, options?.TenantId, options?.ClientId, options, null)
+            : this(options?.DeviceCodeCallback ?? DefaultDeviceCodeHandler, options?.TenantId, options?.ClientId ?? Constants.DeveloperSignOnClientId, options, null)
         {
-
-        }
-
-        /// <summary>
-        ///  Creates a new DeviceCodeCredential with the specified options, which will authenticate users using the device code flow.
-        /// </summary>
-        /// <param name="deviceCodeCallback">The callback to be executed to display the device code to the user.</param>
-        /// <param name="options">The client options for the newly created <see cref="DeviceCodeCredential"/>.</param>
-        public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, DeviceCodeCredentialOptions options = default)
-            : this(deviceCodeCallback, options?.TenantId, options?.ClientId, options, null)
-        {
-            _disableAutomaticAuthentication = options?.DisableAutomaticAuthentication ?? false;
-            _record = options?.AuthenticationRecord;
         }
 
         /// <summary>
@@ -90,13 +78,17 @@ namespace Azure.Identity
 
         internal DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId, TokenCredentialOptions options, CredentialPipeline pipeline, MsalPublicClient client)
         {
-            _clientId = clientId ?? Constants.DeveloperSignOnClientId;
+            ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
 
-            _deviceCodeCallback = deviceCodeCallback ?? throw new ArgumentNullException(nameof(deviceCodeCallback));
+            DeviceCodeCallback = deviceCodeCallback ?? throw new ArgumentNullException(nameof(deviceCodeCallback));
 
-            _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
+            DisableAutomaticAuthentication = (options as DeviceCodeCredentialOptions)?.DisableAutomaticAuthentication ?? false;
 
-            _client = client ?? new MsalPublicClient(_pipeline, tenantId, clientId, AzureAuthorityHosts.GetDeviceCodeRedirectUri(_pipeline.AuthorityHost).ToString(), options as ITokenCacheOptions);
+            Record = (options as DeviceCodeCredentialOptions)?.AuthenticationRecord;
+
+            Pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
+
+            Client = client ?? new MsalPublicClient(Pipeline, tenantId, ClientId, AzureAuthorityHosts.GetDeviceCodeRedirectUri(Pipeline.AuthorityHost).ToString(), options as ITokenCacheOptions);
         }
 
         /// <summary>
@@ -107,7 +99,7 @@ namespace Azure.Identity
         public virtual AuthenticationRecord Authenticate(CancellationToken cancellationToken = default)
         {
             // get the default scope for the authority, throw if no default scope exists
-            string defaultScope = AzureAuthorityHosts.GetDefaultScope(_pipeline.AuthorityHost) ?? throw new CredentialUnavailableException(NoDefaultScopeMessage);
+            string defaultScope = AzureAuthorityHosts.GetDefaultScope(Pipeline.AuthorityHost) ?? throw new CredentialUnavailableException(NoDefaultScopeMessage);
 
             return Authenticate(new TokenRequestContext(new string[] { defaultScope }), cancellationToken);
         }
@@ -120,7 +112,7 @@ namespace Azure.Identity
         public virtual async Task<AuthenticationRecord> AuthenticateAsync(CancellationToken cancellationToken = default)
         {
             // get the default scope for the authority, throw if no default scope exists
-            string defaultScope = AzureAuthorityHosts.GetDefaultScope(_pipeline.AuthorityHost) ?? throw new CredentialUnavailableException(NoDefaultScopeMessage);
+            string defaultScope = AzureAuthorityHosts.GetDefaultScope(Pipeline.AuthorityHost) ?? throw new CredentialUnavailableException(NoDefaultScopeMessage);
 
             return await AuthenticateAsync(new TokenRequestContext(new string[] { defaultScope }), cancellationToken).ConfigureAwait(false);
         }
@@ -169,9 +161,16 @@ namespace Azure.Identity
             return await GetTokenImplAsync(true, requestContext, cancellationToken).ConfigureAwait(false);
         }
 
+        internal static Task DefaultDeviceCodeHandler(DeviceCodeInfo deviceCodeInfo, CancellationToken cancellationToken)
+        {
+            Console.WriteLine(deviceCodeInfo.Message);
+
+            return Task.CompletedTask;
+        }
+
         private async Task<AuthenticationRecord> AuthenticateImplAsync(bool async, TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            using CredentialDiagnosticScope scope = _pipeline.StartGetTokenScope($"{nameof(DeviceCodeCredential)}.{nameof(Authenticate)}", requestContext);
+            using CredentialDiagnosticScope scope = Pipeline.StartGetTokenScope($"{nameof(DeviceCodeCredential)}.{nameof(Authenticate)}", requestContext);
 
             try
             {
@@ -179,7 +178,7 @@ namespace Azure.Identity
 
                 scope.Succeeded(token);
 
-                return _record;
+                return Record;
             }
             catch (Exception e)
             {
@@ -189,17 +188,17 @@ namespace Azure.Identity
 
         private async ValueTask<AccessToken> GetTokenImplAsync(bool async, TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            using CredentialDiagnosticScope scope = _pipeline.StartGetTokenScope($"{nameof(DeviceCodeCredential)}.{nameof(GetToken)}", requestContext);
+            using CredentialDiagnosticScope scope = Pipeline.StartGetTokenScope($"{nameof(DeviceCodeCredential)}.{nameof(GetToken)}", requestContext);
 
             try
             {
                 Exception inner = null;
 
-                if (_record != null)
+                if (Record != null)
                 {
                     try
                     {
-                        AuthenticationResult result = await _client.AcquireTokenSilentAsync(requestContext.Scopes, (AuthenticationAccount)_record, async, cancellationToken).ConfigureAwait(false);
+                        AuthenticationResult result = await Client.AcquireTokenSilentAsync(requestContext.Scopes, (AuthenticationAccount)Record, async, cancellationToken).ConfigureAwait(false);
 
                         return scope.Succeeded(new AccessToken(result.AccessToken, result.ExpiresOn));
                     }
@@ -209,7 +208,7 @@ namespace Azure.Identity
                     }
                 }
 
-                if (_disableAutomaticAuthentication)
+                if (DisableAutomaticAuthentication)
                 {
                     throw new AuthenticationRequiredException(AuthenticationRequiredMessage, requestContext, inner);
                 }
@@ -224,23 +223,17 @@ namespace Azure.Identity
 
         private async Task<AccessToken> GetTokenViaDeviceCodeAsync(string[] scopes, bool async, CancellationToken cancellationToken)
         {
-            AuthenticationResult result = await _client.AcquireTokenWithDeviceCodeAsync(scopes, code => DeviceCodeCallback(code, cancellationToken), async, cancellationToken).ConfigureAwait(false);
+            AuthenticationResult result = await Client.AcquireTokenWithDeviceCodeAsync(scopes, code => DeviceCodeCallbackImpl(code, cancellationToken), async, cancellationToken).ConfigureAwait(false);
 
-            _record = new AuthenticationRecord(result, _clientId);
+            Record = new AuthenticationRecord(result, ClientId);
 
             return new AccessToken(result.AccessToken, result.ExpiresOn);
         }
 
-        private Task DeviceCodeCallback(DeviceCodeResult deviceCode, CancellationToken cancellationToken)
+        private Task DeviceCodeCallbackImpl(DeviceCodeResult deviceCode, CancellationToken cancellationToken)
         {
-            return _deviceCodeCallback(new DeviceCodeInfo(deviceCode), cancellationToken);
+            return DeviceCodeCallback(new DeviceCodeInfo(deviceCode), cancellationToken);
         }
 
-        private static Task DefaultDeviceCodeHandler(DeviceCodeInfo deviceCodeInfo, CancellationToken cancellationToken)
-        {
-            Console.WriteLine(deviceCodeInfo.Message);
-
-            return Task.CompletedTask;
-        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
@@ -40,5 +42,10 @@ namespace Azure.Identity
         /// The <see cref="Identity.AuthenticationRecord"/> captured from a previous authentication.
         /// </summary>
         public AuthenticationRecord AuthenticationRecord { get; set; }
+
+        /// <summary>
+        /// The callback which will be executed to display the device code login details to the user. In not specified the device code and login instructions will be printed to the console.
+        /// </summary>
+        public Func<DeviceCodeInfo, CancellationToken, Task> DeviceCodeCallback { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialCtorTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialCtorTests.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class DeviceCodeCredentialCtorTests
+    {
+        private Task DummyCallback(DeviceCodeInfo _info, CancellationToken _cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        [Test]
+        public void ValidateDefaultConstructor()
+        {
+            var credential = new DeviceCodeCredential();
+
+            AssertOptionsHonored(new DeviceCodeCredentialOptions(), credential);
+        }
+
+        [Test]
+        public void ValidateConstructorOverload1()
+        {
+            // tests the DeviceCodeCredential constructor overload
+            // public DeviceCodeCredential(DeviceCodeCredentialOptions options)
+
+            // null
+            var credential = new DeviceCodeCredential(null);
+
+            AssertOptionsHonored(new DeviceCodeCredentialOptions(), credential);
+
+            // with options
+
+            // with options
+            var options = new DeviceCodeCredentialOptions
+            {
+                ClientId = Guid.NewGuid().ToString(),
+                TenantId = Guid.NewGuid().ToString(),
+                AuthorityHost = new Uri("https://login.myauthority.com/"),
+                DisableAutomaticAuthentication = true,
+                EnablePersistentCache = true,
+                AllowUnencryptedCache = true,
+                AuthenticationRecord = new AuthenticationRecord(),
+                DeviceCodeCallback = DummyCallback,
+            };
+
+            credential = new DeviceCodeCredential(options);
+
+            AssertOptionsHonored(options, credential);
+        }
+
+        [Test]
+        public void ValidateConstructorOverload2()
+        {
+            // tests the DeviceCodeCredential constructor overload
+            // public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string clientId, TokenCredentialOptions options = default)
+
+            var options = new DeviceCodeCredentialOptions
+            {
+                ClientId = Guid.NewGuid().ToString(),
+                DeviceCodeCallback = DummyCallback,
+            };
+
+            // deviceCodeCallback null
+            Assert.Throws<ArgumentNullException>(() => new DeviceCodeCredential(null, options.ClientId));
+
+            // clientId null
+            Assert.Throws<ArgumentNullException>(() => new DeviceCodeCredential(options.DeviceCodeCallback, null));
+
+            // without options
+            var credential = new DeviceCodeCredential(options.DeviceCodeCallback, options.ClientId);
+
+            AssertOptionsHonored(options, credential);
+
+            // with options
+            options.AuthorityHost = new Uri("https://login.myauthority.com/");
+
+            credential = new DeviceCodeCredential(options.DeviceCodeCallback, options.ClientId, new TokenCredentialOptions { AuthorityHost = options.AuthorityHost });
+
+            AssertOptionsHonored(options, credential);
+        }
+
+        [Test]
+        public void ValidateConstructorOverload3()
+        {
+            // tests the DeviceCodeCredential constructor overload
+            // public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId, TokenCredentialOptions options = default)
+
+            var options = new DeviceCodeCredentialOptions
+            {
+                ClientId = Guid.NewGuid().ToString(),
+                TenantId = Guid.NewGuid().ToString(),
+                DeviceCodeCallback = DummyCallback,
+            };
+
+            // deviceCodeCallback null
+            Assert.Throws<ArgumentNullException>(() => new DeviceCodeCredential(null, options.TenantId, options.ClientId));
+
+            // clientId null
+            Assert.Throws<ArgumentNullException>(() => new DeviceCodeCredential(options.DeviceCodeCallback, options.TenantId, (string)null));
+
+            // without options
+            var credential = new DeviceCodeCredential(options.DeviceCodeCallback, options.TenantId, options.ClientId);
+
+            AssertOptionsHonored(options, credential);
+
+            // with options
+            options.AuthorityHost = new Uri("https://login.myauthority.com/");
+
+            credential = new DeviceCodeCredential(options.DeviceCodeCallback, options.TenantId, options.ClientId, new TokenCredentialOptions { AuthorityHost = options.AuthorityHost });
+
+            AssertOptionsHonored(options, credential);
+        }
+
+        public void AssertOptionsHonored(DeviceCodeCredentialOptions options, DeviceCodeCredential credential)
+        {
+            Assert.AreEqual(options.ClientId, credential.ClientId);
+            Assert.AreEqual(options.TenantId, credential.Client.TenantId);
+            Assert.AreEqual(options.AuthorityHost, credential.Pipeline.AuthorityHost);
+            Assert.AreEqual(options.DisableAutomaticAuthentication, credential.DisableAutomaticAuthentication);
+            Assert.AreEqual(options.EnablePersistentCache, credential.Client.EnablePersistentCache);
+            Assert.AreEqual(options.AllowUnencryptedCache, credential.Client.AllowUnencryptedCache);
+            Assert.AreEqual(options.AuthenticationRecord, credential.Record);
+
+            AssertCallbacksEqual(options.DeviceCodeCallback ?? DeviceCodeCredential.DefaultDeviceCodeHandler, credential.DeviceCodeCallback);
+        }
+
+        public void AssertCallbacksEqual(Func<DeviceCodeInfo, CancellationToken, Task> expected, Func<DeviceCodeInfo, CancellationToken, Task> actual)
+        {
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -199,7 +199,7 @@ namespace Azure.Identity.Tests
         {
             var expectedCode = Guid.NewGuid().ToString();
 
-            var cred = InstrumentClient(new DeviceCodeCredential((code, cancelToken) => VerifyDeviceCode(code, expectedCode), new DeviceCodeCredentialOptions { DisableAutomaticAuthentication = true }));
+            var cred = InstrumentClient(new DeviceCodeCredential(new DeviceCodeCredentialOptions { DisableAutomaticAuthentication = true, DeviceCodeCallback = (code, cancelToken) => VerifyDeviceCode(code, expectedCode) }));
 
             var expTokenRequestContext = new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }, Guid.NewGuid().ToString());
 


### PR DESCRIPTION

- Added `DeviceCodeCallback` to `DeviceCodeCredentialOptions`
- Replaced `DeviceCodeCredential` constructor overload taking `deviceCodeCallback` and `DeviceCodeCredentialOptions` with constructor taking only `DeviceCodeCredentialOptions`
- Added tests for constructor overload argument handling