### PR TITLE
Fix dev ops publish bug

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -236,9 +236,10 @@ stages:
           echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
           echo "Using DevopsFeedId = $devopsFeedId"
         displayName: Setup DevOpsFeedId
-      - task: NuGetCommand@2
-        displayName: 'Publish to DevOps Feed'
-        inputs:
-          command: push
-          packagesToPush: '$(Pipeline.Workspace)/packages-signed/**/*.nupkg;!$(Pipeline.Workspace)/packages-signed/**/*.symbols.nupkg'
-          publishVstsFeed: $(DevOpsFeedID)
+      - ${{ each artifact in parameters.Artifacts }}:
+        - task: NuGetCommand@2
+          displayName: 'Publish to DevOps Feed'
+          inputs:
+            command: push
+            packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}/*.symbols.nupkg'
+            publishVstsFeed: $(DevOpsFeedID)

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/CHANGELOG.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Release History
 ## 4.0.0-beta.3 (Unreleased)
 
-
 ## 4.0.0-beta.2 (2020-09-24)
 
 ### Added


### PR DESCRIPTION
Move `Publish to DevOps Feed` step into loop to iteratively publish individual artifacts to fix https://dev.azure.com/azure-sdk/internal/_build/results?buildId=552610&view=logs&j=b1e79959-24d8-5aa9-2799-72d40c3e051b&t=4b34df18-a0a9-5141-3485-374c7e76236f