### PR TITLE
SchemaRegistry - Mark tests as playback only

### DIFF
--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Samples/Sample01_ReadmeSnippets.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/Samples/Sample01_ReadmeSnippets.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 
 namespace Azure.Data.SchemaRegistry.Tests.Samples
 {
+    [Ignore("Only verifying that the sample builds")]
     public class Sample01_ReadmeSnippets : SamplesBase<SchemaRegistryClientTestEnvironment>
     {
         [Ignore("Only verifying that the sample builds")]

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaRegistryClientLiveTest.cs
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/tests/SchemaRegistryClientLiveTest.cs
@@ -25,6 +25,7 @@ namespace Azure.Data.SchemaRegistry.Tests
         private const string SchemaContent = "{\"type\" : \"record\",\"namespace\" : \"TestSchema\",\"name\" : \"Employee\",\"fields\" : [{ \"name\" : \"Name\" , \"type\" : \"string\" },{ \"name\" : \"Age\", \"type\" : \"int\" }]}";
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CanRegisterSchema()
         {
             var client = CreateClient();
@@ -40,6 +41,7 @@ namespace Azure.Data.SchemaRegistry.Tests
         }
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CanGetSchemaId()
         {
             var client = CreateClient();
@@ -56,6 +58,7 @@ namespace Azure.Data.SchemaRegistry.Tests
         }
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CanGetSchema()
         {
             var client = CreateClient();

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/Samples/Sample01_ReadmeSnippets.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/Samples/Sample01_ReadmeSnippets.cs
@@ -11,6 +11,7 @@ using TestSchema;
 
 namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests.Samples
 {
+    [Ignore("Only verifying that the sample builds")]
     public class Sample01_ReadmeSnippets : SamplesBase<SchemaRegistryClientTestEnvironment>
     {
         [Ignore("Only verifying that the sample builds")]

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTest.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTest.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             ));
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CanSerializeAndDeserialize()
         {
             var client = CreateClient();
@@ -48,6 +49,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
         }
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CanSerializeAndDeserializeGenericRecord()
         {
             var client = CreateClient();
@@ -69,6 +71,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
         }
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CannotSerializeUnsupportedType()
         {
             var client = CreateClient();
@@ -82,6 +85,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
         }
 
         [Test]
+        [PlaybackOnly("Service not provisioned to all regions yet.")]
         public async Task CannotDeserializeUnsupportedType()
         {
             var client = CreateClient();


### PR DESCRIPTION
See: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=553556&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=bf6cf4cf-6432-59cf-d384-6b3bcf32ede2

The weekly pipeline failed because you cannot run any of the SR tests as live yet. I wasn't aware of this pipeline's existence so I didn't mark them as playback only originally. By bad, dawg.