### PR TITLE
Removing need for blob contributor role for recursive acl tests

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -332,6 +332,19 @@ namespace Azure.Storage.Files.DataLake.Tests
             return builder.ToSasQueryParameters(userDelegationKey, accountName);
         }
 
+        public DataLakeSasQueryParameters GetNewDataLakeSasCredentialsOwner(string fileSystemName, string ownerName, UserDelegationKey userDelegationKey, string accountName)
+        {
+            DataLakeSasBuilder dataLakeSasBuilder = new DataLakeSasBuilder
+            {
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(1),
+                FileSystemName = fileSystemName,
+                AgentObjectId = ownerName
+            };
+            dataLakeSasBuilder.SetPermissions(DataLakeSasPermissions.All);
+            return dataLakeSasBuilder.ToSasQueryParameters(userDelegationKey, accountName);
+        }
+
         //TODO consider removing this.
         public async Task<string> SetupPathMatchCondition(DataLakePathClient path, string match)
         {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_ContinueOnFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_ContinueOnFailure.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-95c4ad3bb82f784dadb4fc24a464160d-db458e6983d9864f-00",
+        "traceparent": "00-f6a8bb9aec82af47ab2ea96739cf886c-f26e535a4195cd4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "19a3a890-a793-bd79-aad7-eeaad7d074b9",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:13 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:14 GMT",
-        "ETag": "\u00220x8D83D85C0732922\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:14 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D829C751AF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:53 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "19a3a890-a793-bd79-aad7-eeaad7d074b9",
-        "x-ms-request-id": "4e200ace-501e-0046-6f6e-6fc2a6000000",
+        "x-ms-request-id": "49b8c492-601e-0072-20c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7b6b86c99bbeec4da1a869d2f93d3595-9b5e1394ce296749-00",
+        "traceparent": "00-2d6901d9b0d2314dbbb1d9798f7a53ad-22cbf3342b442b4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "9c697432-8381-eb23-d265-4cc28dba463e",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:15 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:15 GMT",
-        "ETag": "\u00220x8D83D85C10BA3C7\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:15 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D829C91225\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:53 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9c697432-8381-eb23-d265-4cc28dba463e",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864b3-801f-0008-046e-6fec2e000000",
+        "x-ms-request-id": "49ae99de-d01f-0077-1dc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-265ba7be25778246a5fbc92384c8e608-735ef53c38d9cd46-00",
+        "traceparent": "00-02cc0a10c3ea814fa6af14f75ba84c77-b4ee00ca94e4b047-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "62773f26-d767-af37-3b81-576033f1f5a0",
+        "x-ms-client-request-id": "88c58a1e-9f12-8d2d-cc58-a760c5f40dbe",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C1B4C4F9\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D829EF3A28\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "62773f26-d767-af37-3b81-576033f1f5a0",
-        "x-ms-request-id": "84ba891d-d01f-0015-4e6e-6fe192000000",
+        "x-ms-client-request-id": "88c58a1e-9f12-8d2d-cc58-a760c5f40dbe",
+        "x-ms-request-id": "49ae99df-d01f-0077-1ec1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-88c58a1e-9f12-8d2d-cc58-a760c5f40dbe?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-4d9bf8a9-e342-c9d7-4194-d5004d47dd03?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3f2c449905e8ec458dd7fdde128e0248-a6ccbed4ff092946-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "53101d2c-334e-8741-12e9-960f2fd7ea46",
+        "x-ms-client-request-id": "3bb79974-a755-3a5d-b3fc-477ec92c3f85",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C1C2EDB4\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D829FDE13F\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "53101d2c-334e-8741-12e9-960f2fd7ea46",
-        "x-ms-request-id": "84ba891e-d01f-0015-4f6e-6fe192000000",
+        "x-ms-client-request-id": "3bb79974-a755-3a5d-b3fc-477ec92c3f85",
+        "x-ms-request-id": "49ae99e0-d01f-0077-1fc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-88c58a1e-9f12-8d2d-cc58-a760c5f40dbe/test-file-3bb79974-a755-3a5d-b3fc-477ec92c3f85?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-4d9bf8a9-e342-c9d7-4194-d5004d47dd03/test-file-a734a47a-b9e4-756f-b614-3a594dc7996a?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "b48c8faa-a28f-84ad-c0d6-a052ecc3bde5",
+        "x-ms-client-request-id": "8b9510aa-42a2-ba61-2942-84416d04eceb",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C1D9DB97\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D82A0C41C3\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b48c8faa-a28f-84ad-c0d6-a052ecc3bde5",
-        "x-ms-request-id": "84ba891f-d01f-0015-506e-6fe192000000",
+        "x-ms-client-request-id": "8b9510aa-42a2-ba61-2942-84416d04eceb",
+        "x-ms-request-id": "49ae99e1-d01f-0077-20c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-88c58a1e-9f12-8d2d-cc58-a760c5f40dbe/test-file-8b9510aa-42a2-ba61-2942-84416d04eceb?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-4d9bf8a9-e342-c9d7-4194-d5004d47dd03/test-file-3ad4dc62-8aa0-d7f6-f6af-e70e191d88f3?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "3cae5457-0e32-67c7-2dd2-8b4d1e6c17bb",
+        "x-ms-client-request-id": "10f0b5e9-82ef-1f45-1abd-94f35a53a10c",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C1E958BA\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D82A190597\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "3cae5457-0e32-67c7-2dd2-8b4d1e6c17bb",
-        "x-ms-request-id": "84ba8920-d01f-0015-516e-6fe192000000",
+        "x-ms-client-request-id": "10f0b5e9-82ef-1f45-1abd-94f35a53a10c",
+        "x-ms-request-id": "49ae99e2-d01f-0077-21c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-10f0b5e9-82ef-1f45-1abd-94f35a53a10c?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cdcdb0066f45e749b3c9ca0c48540845-45ec195974354744-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "64252c98-782c-d404-0f8f-227579d40cda",
+        "x-ms-client-request-id": "8d937f31-fe81-3865-fc9b-fb8375772071",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C1F6851D\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D82A25509A\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "64252c98-782c-d404-0f8f-227579d40cda",
-        "x-ms-request-id": "84ba8921-d01f-0015-526e-6fe192000000",
+        "x-ms-client-request-id": "8d937f31-fe81-3865-fc9b-fb8375772071",
+        "x-ms-request-id": "49ae99e3-d01f-0077-22c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-10f0b5e9-82ef-1f45-1abd-94f35a53a10c/test-file-8d937f31-fe81-3865-fc9b-fb8375772071?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a/test-file-2e5a0903-3c2e-41df-8c15-09c68e43da40?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "809d325f-2b15-9908-c6ec-68917c815e98",
+        "x-ms-client-request-id": "6f71b06e-de79-f4ac-9f51-016cf59eaab8",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,190 +241,420 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C2044118\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:53 GMT",
+        "ETag": "\u00220x8D863D82A322483\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "809d325f-2b15-9908-c6ec-68917c815e98",
-        "x-ms-request-id": "84ba8922-d01f-0015-536e-6fe192000000",
+        "x-ms-client-request-id": "6f71b06e-de79-f4ac-9f51-016cf59eaab8",
+        "x-ms-request-id": "49ae99e4-d01f-0077-23c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-10f0b5e9-82ef-1f45-1abd-94f35a53a10c/test-file-6f71b06e-de79-f4ac-9f51-016cf59eaab8?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-a84c39f9c7dcac49837a333f9695c7a7-675f7180e3c04943-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "dd5871b6-6bd1-81c7-86a8-e0c42a9ca428",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C211F1B5\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "dd5871b6-6bd1-81c7-86a8-e0c42a9ca428",
-        "x-ms-request-id": "0ee864b5-801f-0008-056e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-10f0b5e9-82ef-1f45-1abd-94f35a53a10c/test-file-c1d0af41-1b5d-cebe-5599-6eb8766a1f51?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-260efe0fc8a30d45bd0a594d3832b83d-9e71767d46eae549-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "25003f1c-037d-9bad-b28a-8837fc0e0a1b",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C2239CEB\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "25003f1c-037d-9bad-b28a-8837fc0e0a1b",
-        "x-ms-request-id": "0ee864b6-801f-0008-066e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-10f0b5e9-82ef-1f45-1abd-94f35a53a10c/test-file-34388e89-20e6-74e2-c77a-cebb5d8d0dbd?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-24b8400bc5191e438a9fe61a9fca40f2-79a52eebe61c0647-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "31a7a197-785f-fb7e-5d8b-5d0235f23d25",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:17 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C22F9C29\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:17 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "31a7a197-785f-fb7e-5d8b-5d0235f23d25",
-        "x-ms-request-id": "0ee864b7-801f-0008-076e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6/test-directory-10f0b5e9-82ef-1f45-1abd-94f35a53a10c/test-directory-f34bca7c-d371-8fb1-baaf-eccc4e262f18?resource=directory",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-30caf7ee36b7b4498100bab4059c1591-97e81e96e4cf7d47-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "7a3fabdb-6564-c374-f018-77b08bb1ad36",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:17 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
-        "ETag": "\u00220x8D83D85C23B193C\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:17 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "7a3fabdb-6564-c374-f018-77b08bb1ad36",
-        "x-ms-request-id": "0ee864b8-801f-0008-086e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-d882bffe-337a-1fcd-9d01-e2f945259db6?action=setAccessControlRecursive\u0026mode=remove\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e7580ded4039ca4392041c7f939b6592-63b824e552be8845-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
-        "x-ms-client-request-id": "a3f0975b-b4e6-bcb3-745f-cacd65aee8d8",
+        "x-ms-client-request-id": "c1d0af41-1b5d-cebe-5599-6eb8766a1f51",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "x-ms-owner": "4323bac0-a0d9-d75b-01c0-6741d44dc50b",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:17 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D829EF3A28\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1d0af41-1b5d-cebe-5599-6eb8766a1f51",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99e5-d01f-0077-24c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-4d9bf8a9-e342-c9d7-4194-d5004d47dd03?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "25003f1c-037d-9bad-b28a-8837fc0e0a1b",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "x-ms-owner": "4323bac0-a0d9-d75b-01c0-6741d44dc50b",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D829FDE13F\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "25003f1c-037d-9bad-b28a-8837fc0e0a1b",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99e7-d01f-0077-25c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-4d9bf8a9-e342-c9d7-4194-d5004d47dd03/test-file-a734a47a-b9e4-756f-b614-3a594dc7996a?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "369c08ec-f96a-88d4-4819-d1bb44af58e5",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "x-ms-owner": "4323bac0-a0d9-d75b-01c0-6741d44dc50b",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82A0C41C3\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "369c08ec-f96a-88d4-4819-d1bb44af58e5",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99e8-d01f-0077-26c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-4d9bf8a9-e342-c9d7-4194-d5004d47dd03/test-file-3ad4dc62-8aa0-d7f6-f6af-e70e191d88f3?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f34bca7c-d371-8fb1-baaf-eccc4e262f18",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "x-ms-owner": "4323bac0-a0d9-d75b-01c0-6741d44dc50b",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82A190597\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f34bca7c-d371-8fb1-baaf-eccc4e262f18",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99e9-d01f-0077-27c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "7a3fabdb-6564-c374-f018-77b08bb1ad36",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "x-ms-owner": "4323bac0-a0d9-d75b-01c0-6741d44dc50b",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82A25509A\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a3fabdb-6564-c374-f018-77b08bb1ad36",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99ea-d01f-0077-28c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a/test-file-2e5a0903-3c2e-41df-8c15-09c68e43da40?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a3f0975b-b4e6-bcb3-745f-cacd65aee8d8",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "x-ms-owner": "4323bac0-a0d9-d75b-01c0-6741d44dc50b",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82A322483\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a3f0975b-b4e6-bcb3-745f-cacd65aee8d8",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99eb-d01f-0077-29c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a/test-file-5682a2f3-07f0-5985-6b9f-0e8dfba3c91e?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "57dc91ef-9d4f-53f7-1197-3746a626c1d0",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82A8CEC07\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "57dc91ef-9d4f-53f7-1197-3746a626c1d0",
+        "x-ms-request-id": "49ae99ec-d01f-0077-2ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a/test-file-d6a8ac96-f359-e917-52db-c3cc2e16a2f8?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0ad90863-63ca-fb64-79f3-0474d92b25fb",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82A99ACCD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0ad90863-63ca-fb64-79f3-0474d92b25fb",
+        "x-ms-request-id": "49ae99ed-d01f-0077-2bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a/test-file-55e13ff4-5688-2409-dd21-405810ed1649?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9334e7db-ab27-0ce3-feb4-2da9230bea8b",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82AA684E0\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9334e7db-ab27-0ce3-feb4-2da9230bea8b",
+        "x-ms-request-id": "49ae99ee-d01f-0077-2cc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54/test-directory-18ea90b9-b055-54b8-146c-0cceffa9b98a/test-directory-8199badc-fec1-5dbd-11df-69e56535b781?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b2f665b7-2cc1-ddaa-29d7-814741fea6c8",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:54 GMT",
+        "ETag": "\u00220x8D863D82AB2ED05\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:55 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b2f665b7-2cc1-ddaa-29d7-814741fea6c8",
+        "x-ms-request-id": "49ae99ef-d01f-0077-2dc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-c9b08c22d2289448a710e3388b514cfd-93112a52cf93fc41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "002d8801-043e-47c0-2a9f-ffe002daed75",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:58:55Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "002d8801-043e-47c0-2a9f-ffe002daed75",
+        "x-ms-request-id": "72c5c6db-201e-004c-6dc1-956611000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:58:56Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:58:55Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EX0HGoyObtyObI9xW2\u002B87w00hHIaUiMydeCZKs8YRLx4=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d/test-directory-104378a0-a581-10a7-f421-be2edd13bc54?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A58%3A56Z\u0026ske=2020-09-28T18%3A58%3A55Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A58%3A55Z\u0026se=2020-09-28T18%3A58%3A55Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=4323bac0-a0d9-d75b-01c0-6741d44dc50b\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=remove\u0026forceFlag=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
+        "x-ms-client-request-id": "b945f5e4-a6d0-f88a-ebee-24f0c2f156bd",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "a3f0975b-b4e6-bcb3-745f-cacd65aee8d8",
+        "x-ms-client-request-id": "b945f5e4-a6d0-f88a-ebee-24f0c2f156bd",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "84ba8924-d01f-0015-556e-6fe192000000",
+        "x-ms-request-id": "49ae99f0-d01f-0077-2ec1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktZDg4MmJmZmUtMzM3YS0xZmNkLTlkMDEtZTJmOTQ1MjU5ZGI2L3Rlc3QtZGlyZWN0b3J5LTEwZjBiNWU5LTgyZWYtMWY0NS0xYWJkLTk0ZjM1YTUzYTEwYy90ZXN0LWRpcmVjdG9yeS1mMzRiY2E3Yy1kMzcxLThmYjEtYmFhZi1lY2NjNGUyNjJmMTgiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LWQ4ODJiZmZlLTMzN2EtMWZjZC05ZDAxLWUyZjk0NTI1OWRiNi90ZXN0LWRpcmVjdG9yeS0xMGYwYjVlOS04MmVmLTFmNDUtMWFiZC05NGYzNWE1M2ExMGMvdGVzdC1maWxlLTZmNzFiMDZlLWRlNzktZjRhYy05ZjUxLTAxNmNmNTllYWFiOCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LWQ4ODJiZmZlLTMzN2EtMWZjZC05ZDAxLWUyZjk0NTI1OWRiNi90ZXN0LWRpcmVjdG9yeS0xMGYwYjVlOS04MmVmLTFmNDUtMWFiZC05NGYzNWE1M2ExMGMvdGVzdC1maWxlLTM0Mzg4ZTg5LTIwZTYtNzRlMi1jNzdhLWNlYmI1ZDhkMGRiZCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LWQ4ODJiZmZlLTMzN2EtMWZjZC05ZDAxLWUyZjk0NTI1OWRiNi90ZXN0LWRpcmVjdG9yeS0xMGYwYjVlOS04MmVmLTFmNDUtMWFiZC05NGYzNWE1M2ExMGMvdGVzdC1maWxlLWMxZDBhZjQxLTFiNWQtY2ViZS01NTk5LTZlYjg3NjZhMWY1MSIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMTA0Mzc4YTAtYTU4MS0xMGE3LWY0MjEtYmUyZWRkMTNiYzU0L3Rlc3QtZGlyZWN0b3J5LTE4ZWE5MGI5LWIwNTUtNTRiOC0xNDZjLTBjY2VmZmE5Yjk4YS90ZXN0LWZpbGUtZDZhOGFjOTYtZjM1OS1lOTE3LTUyZGItYzNjYzJlMTZhMmY4IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMTA0Mzc4YTAtYTU4MS0xMGE3LWY0MjEtYmUyZWRkMTNiYzU0L3Rlc3QtZGlyZWN0b3J5LTE4ZWE5MGI5LWIwNTUtNTRiOC0xNDZjLTBjY2VmZmE5Yjk4YS90ZXN0LWZpbGUtNTVlMTNmZjQtNTY4OC0yNDA5LWRkMjEtNDA1ODEwZWQxNjQ5IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMTA0Mzc4YTAtYTU4MS0xMGE3LWY0MjEtYmUyZWRkMTNiYzU0L3Rlc3QtZGlyZWN0b3J5LTE4ZWE5MGI5LWIwNTUtNTRiOC0xNDZjLTBjY2VmZmE5Yjk4YS90ZXN0LWRpcmVjdG9yeS04MTk5YmFkYy1mZWMxLTVkYmQtMTFkZi02OWU1NjUzNWI3ODEiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTEwNDM3OGEwLWE1ODEtMTBhNy1mNDIxLWJlMmVkZDEzYmM1NC90ZXN0LWRpcmVjdG9yeS0xOGVhOTBiOS1iMDU1LTU0YjgtMTQ2Yy0wY2NlZmZhOWI5OGEvdGVzdC1maWxlLTU2ODJhMmYzLTA3ZjAtNTk4NS02YjlmLTBlOGRmYmEzYzkxZSIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-8cf677f1-b9ac-baca-ded0-15ff75e9764d?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4b9bb7cd550b114bacdd971d68668c8d-77254e82e7643d4a-00",
+        "traceparent": "00-7635b9343c53804e8999debeb6a01659-ae754a01d4967246-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f4548e24-0ac0-a750-9224-d86fb7723abd",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:17 GMT",
+        "x-ms-client-request-id": "0cfc0a97-3495-0fa5-d592-d1606a6133a1",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -428,20 +662,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:16 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f4548e24-0ac0-a750-9224-d86fb7723abd",
-        "x-ms-request-id": "4e200dc6-501e-0046-1c6e-6fc2a6000000",
+        "x-ms-client-request-id": "0cfc0a97-3495-0fa5-d592-d1606a6133a1",
+        "x-ms-request-id": "49b8c5bb-601e-0072-33c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:58:55.3919471-07:00",
     "RandomSeed": "232219146",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_ContinueOnFailureAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_ContinueOnFailureAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-bce056b0f3ac5b48b5563b0d2e1f7385-db2553beb4de0b42-00",
+        "traceparent": "00-b7ec5f0337c1b14c948fc7b8de979195-ca1cdf805767944f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "89724313-0803-bfe7-3c8f-e08a604ea309",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:24 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C68510A4\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:24 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:37 GMT",
+        "ETag": "\u00220x8D863D84474E996\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:38 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "89724313-0803-bfe7-3c8f-e08a604ea309",
-        "x-ms-request-id": "4e2013a2-501e-0046-6d6e-6fc2a6000000",
+        "x-ms-request-id": "49b8d23c-601e-0072-2fc1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a8d8452d893e414f819316ccd2515e23-f2cc049497477f4e-00",
+        "traceparent": "00-5657ec24da4c9248aaae61bc786ad6d5-ad10a533131b0b44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "177aba00-cdc8-c5c1-b217-ee76804c5e87",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:24 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:24 GMT",
-        "ETag": "\u00220x8D83D85C6865892\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:24 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "ETag": "\u00220x8D863D844761F9D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:38 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "177aba00-cdc8-c5c1-b217-ee76804c5e87",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864d5-801f-0008-246e-6fec2e000000",
+        "x-ms-request-id": "49ae9a6a-d01f-0077-1cc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0968c013d1dcb643b181e4b728d65f4c-89cdd7bc6e86d445-00",
+        "traceparent": "00-f9941c6328169d41aaaeafd2ebcca9b8-b770f7e771c39643-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "a68906c9-8bd3-0c40-a05f-0cb9609ea69d",
+        "x-ms-client-request-id": "c559897e-8c52-ea36-ceb6-e77d2e9acea0",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:24 GMT",
-        "ETag": "\u00220x8D83D85C6F66DFA\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "ETag": "\u00220x8D863D8449FA9EF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:38 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a68906c9-8bd3-0c40-a05f-0cb9609ea69d",
-        "x-ms-request-id": "3601b41b-801f-007a-246e-6feb61000000",
+        "x-ms-client-request-id": "c559897e-8c52-ea36-ceb6-e77d2e9acea0",
+        "x-ms-request-id": "49ae9a6b-d01f-0077-1dc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-c559897e-8c52-ea36-ceb6-e77d2e9acea0?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-7aacde7a-b8c2-efb4-1cce-984409336490?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6baadd710723e1429cae790cced72ef3-37f03bb94c7d5a42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "6da801a4-d7b8-3cbd-cf9e-d71da4c3dd06",
+        "x-ms-client-request-id": "813e6b90-2bf1-c6da-d56a-a884f4f2e09b",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:24 GMT",
-        "ETag": "\u00220x8D83D85C703B527\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "ETag": "\u00220x8D863D844AC6EA9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:38 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6da801a4-d7b8-3cbd-cf9e-d71da4c3dd06",
-        "x-ms-request-id": "3601b41e-801f-007a-276e-6feb61000000",
+        "x-ms-client-request-id": "813e6b90-2bf1-c6da-d56a-a884f4f2e09b",
+        "x-ms-request-id": "49ae9a6c-d01f-0077-1ec1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-c559897e-8c52-ea36-ceb6-e77d2e9acea0/test-file-813e6b90-2bf1-c6da-d56a-a884f4f2e09b?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-7aacde7a-b8c2-efb4-1cce-984409336490/test-file-2dd85751-61f2-a2e7-2170-aa24e0964b58?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "9eb392f0-e2f4-789e-26e2-984e2e3947dc",
+        "x-ms-client-request-id": "4dcb3cbe-b0eb-2f14-849c-5f8181b6e53f",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:24 GMT",
-        "ETag": "\u00220x8D83D85C7161056\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "ETag": "\u00220x8D863D844B98FEF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9eb392f0-e2f4-789e-26e2-984e2e3947dc",
-        "x-ms-request-id": "3601b41f-801f-007a-286e-6feb61000000",
+        "x-ms-client-request-id": "4dcb3cbe-b0eb-2f14-849c-5f8181b6e53f",
+        "x-ms-request-id": "49ae9a6d-d01f-0077-1fc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-c559897e-8c52-ea36-ceb6-e77d2e9acea0/test-file-4dcb3cbe-b0eb-2f14-849c-5f8181b6e53f?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-7aacde7a-b8c2-efb4-1cce-984409336490/test-file-6293501f-423f-6fa6-b860-060fc89873e8?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "a465cd28-fdca-406d-7d84-1958821df76f",
+        "x-ms-client-request-id": "de2f59fc-e5a6-7b9d-955c-958ba90466eb",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "ETag": "\u00220x8D83D85C734B4E2\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "ETag": "\u00220x8D863D844C6696D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a465cd28-fdca-406d-7d84-1958821df76f",
-        "x-ms-request-id": "3601b421-801f-007a-2a6e-6feb61000000",
+        "x-ms-client-request-id": "de2f59fc-e5a6-7b9d-955c-958ba90466eb",
+        "x-ms-request-id": "49ae9a6e-d01f-0077-20c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-de2f59fc-e5a6-7b9d-955c-958ba90466eb?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cb4fb6ee17a4384985375229545752d8-0e82303ee44ace40-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "6f139668-9569-4342-2fea-0e6d68e29679",
+        "x-ms-client-request-id": "0b2f2d1d-44c5-bb1e-e40d-fb5300e35246",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "ETag": "\u00220x8D83D85C74562AD\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844D2BB8E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6f139668-9569-4342-2fea-0e6d68e29679",
-        "x-ms-request-id": "3601b424-801f-007a-2c6e-6feb61000000",
+        "x-ms-client-request-id": "0b2f2d1d-44c5-bb1e-e40d-fb5300e35246",
+        "x-ms-request-id": "49ae9a6f-d01f-0077-21c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-de2f59fc-e5a6-7b9d-955c-958ba90466eb/test-file-0b2f2d1d-44c5-bb1e-e40d-fb5300e35246?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a/test-file-1322fa70-f7f1-9281-3414-83663206b800?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "fb9c6bbc-e01f-24d4-7757-8a5c9aef424c",
+        "x-ms-client-request-id": "6dfdc797-83bf-2688-ab9c-d6b0c1b789dd",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,190 +241,420 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "ETag": "\u00220x8D83D85C756BDC0\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844DF7FEE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "fb9c6bbc-e01f-24d4-7757-8a5c9aef424c",
-        "x-ms-request-id": "3601b426-801f-007a-2e6e-6feb61000000",
+        "x-ms-client-request-id": "6dfdc797-83bf-2688-ab9c-d6b0c1b789dd",
+        "x-ms-request-id": "49ae9a70-d01f-0077-22c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-de2f59fc-e5a6-7b9d-955c-958ba90466eb/test-file-6dfdc797-83bf-2688-ab9c-d6b0c1b789dd?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-829b60289766db46b501a72f0820c751-26589cdd96c95243-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "6ace36d2-4b09-3841-e276-4f820a2463bf",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "ETag": "\u00220x8D83D85C76FB426\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "6ace36d2-4b09-3841-e276-4f820a2463bf",
-        "x-ms-request-id": "0ee864d9-801f-0008-276e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-de2f59fc-e5a6-7b9d-955c-958ba90466eb/test-file-a007acce-ad57-4006-a06d-47c1e8eeb886?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-cb07bb25b9da6b47982c9f0407fa3503-5662b1ae9cceb34f-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c1cbdb9b-581e-24ed-308e-ca9b037f50f3",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:25 GMT",
-        "ETag": "\u00220x8D83D85C782C5E6\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "c1cbdb9b-581e-24ed-308e-ca9b037f50f3",
-        "x-ms-request-id": "0ee864db-801f-0008-296e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-de2f59fc-e5a6-7b9d-955c-958ba90466eb/test-file-79ddc9bd-d846-b0d6-d7fe-e7f9fa3538fb?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f514c682c369574e8ceca9898a405f71-15a2f00894f4084d-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "3e12bf0d-0cc7-c2ba-041b-e91f71f42afa",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "ETag": "\u00220x8D83D85C7A489FC\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "3e12bf0d-0cc7-c2ba-041b-e91f71f42afa",
-        "x-ms-request-id": "0ee864dc-801f-0008-2a6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5/test-directory-de2f59fc-e5a6-7b9d-955c-958ba90466eb/test-directory-bdb3cf55-4359-c6cf-6091-d68c7e7c5b9e?resource=directory",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f6e0d5450f501d448a668f2a5270da6a-fa7173f1f0d45046-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "85055f8f-4885-cae0-ef4b-de35352e4388",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "ETag": "\u00220x8D83D85C7C338F2\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "85055f8f-4885-cae0-ef4b-de35352e4388",
-        "x-ms-request-id": "0ee864dd-801f-0008-2b6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-e79dc088-88f3-61e0-a2d5-778e5a3a57c5?action=setAccessControlRecursive\u0026mode=remove\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b7fe3f943f50784a93a17dadd90b350f-62f2754c6cf5634e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
-        "x-ms-client-request-id": "1ffd28b6-d676-b018-cd20-4bd71cfda65d",
+        "x-ms-client-request-id": "a007acce-ad57-4006-a06d-47c1e8eeb886",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-owner": "9597fa54-5746-8f27-25fe-9b996d25f845",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D8449FA9EF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a007acce-ad57-4006-a06d-47c1e8eeb886",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a71-d01f-0077-23c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-7aacde7a-b8c2-efb4-1cce-984409336490?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "c1cbdb9b-581e-24ed-308e-ca9b037f50f3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-owner": "9597fa54-5746-8f27-25fe-9b996d25f845",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844AC6EA9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:38 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1cbdb9b-581e-24ed-308e-ca9b037f50f3",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a72-d01f-0077-24c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-7aacde7a-b8c2-efb4-1cce-984409336490/test-file-2dd85751-61f2-a2e7-2170-aa24e0964b58?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0d2646e8-f723-4c68-a2b9-595a54380539",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-owner": "9597fa54-5746-8f27-25fe-9b996d25f845",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844B98FEF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0d2646e8-f723-4c68-a2b9-595a54380539",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a73-d01f-0077-25c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-7aacde7a-b8c2-efb4-1cce-984409336490/test-file-6293501f-423f-6fa6-b860-060fc89873e8?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bdb3cf55-4359-c6cf-6091-d68c7e7c5b9e",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-owner": "9597fa54-5746-8f27-25fe-9b996d25f845",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844C6696D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bdb3cf55-4359-c6cf-6091-d68c7e7c5b9e",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a74-d01f-0077-26c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "85055f8f-4885-cae0-ef4b-de35352e4388",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-owner": "9597fa54-5746-8f27-25fe-9b996d25f845",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844D2BB8E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "85055f8f-4885-cae0-ef4b-de35352e4388",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a75-d01f-0077-27c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a/test-file-1322fa70-f7f1-9281-3414-83663206b800?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1ffd28b6-d676-b018-cd20-4bd71cfda65d",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-owner": "9597fa54-5746-8f27-25fe-9b996d25f845",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D844DF7FEE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ffd28b6-d676-b018-cd20-4bd71cfda65d",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a76-d01f-0077-28c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a/test-file-c3498020-1722-a0a5-88aa-e9af16eb8f28?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bad5d52f-f47d-9ef5-825c-96cbed699ae2",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D84538D977\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bad5d52f-f47d-9ef5-825c-96cbed699ae2",
+        "x-ms-request-id": "49ae9a77-d01f-0077-29c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a/test-file-56442291-997e-fb2b-6e61-91ac21bdfc89?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "815613db-e8ba-961e-a9d9-4c1b62497dc4",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D845459613\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "815613db-e8ba-961e-a9d9-4c1b62497dc4",
+        "x-ms-request-id": "49ae9a78-d01f-0077-2ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a/test-file-a15f0d60-59ea-bbcc-76a5-869e0e576d27?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8073c662-59e6-81dd-479a-0a1562808851",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D845526A62\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:40 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8073c662-59e6-81dd-479a-0a1562808851",
+        "x-ms-request-id": "49ae9a79-d01f-0077-2bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f/test-directory-b3587728-4151-2174-e352-e4ba294eec9a/test-directory-99b5246c-6f78-e55d-3edb-7301c18f32e7?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "64d04660-a3d9-f30d-688d-420be6dcbfb7",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:39 GMT",
+        "ETag": "\u00220x8D863D8455ED232\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:40 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "64d04660-a3d9-f30d-688d-420be6dcbfb7",
+        "x-ms-request-id": "49ae9a7a-d01f-0077-2cc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-81cf2307136c704bbdedca2b9d8a037b-0f67812a5c4bf84b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "7ba0c6ba-cdbf-c60d-f148-df56aa35260f",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:40Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "7ba0c6ba-cdbf-c60d-f148-df56aa35260f",
+        "x-ms-request-id": "21f05ae8-d01e-0058-78c1-952e7e000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:41Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:40Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EHdE9tC14IDnQ/9IlmX6kuiBPBUD1hfrok7UWIg3qt8w=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919/test-directory-39da5d7b-16a3-c4ec-2f4b-9f26f6129c0f?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A41Z\u0026ske=2020-09-28T18%3A59%3A40Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A40Z\u0026se=2020-09-28T18%3A59%3A40Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=9597fa54-5746-8f27-25fe-9b996d25f845\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=remove\u0026forceFlag=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
+        "x-ms-client-request-id": "1f50bc17-443c-9af8-15e6-70fc6116d4ad",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "1ffd28b6-d676-b018-cd20-4bd71cfda65d",
+        "x-ms-client-request-id": "1f50bc17-443c-9af8-15e6-70fc6116d4ad",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "3601b42b-801f-007a-336e-6feb61000000",
+        "x-ms-request-id": "49ae9a7b-d01f-0077-2dc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktZTc5ZGMwODgtODhmMy02MWUwLWEyZDUtNzc4ZTVhM2E1N2M1L3Rlc3QtZGlyZWN0b3J5LWRlMmY1OWZjLWU1YTYtN2I5ZC05NTVjLTk1OGJhOTA0NjZlYi90ZXN0LWZpbGUtYTAwN2FjY2UtYWQ1Ny00MDA2LWEwNmQtNDdjMWU4ZWViODg2IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktZTc5ZGMwODgtODhmMy02MWUwLWEyZDUtNzc4ZTVhM2E1N2M1L3Rlc3QtZGlyZWN0b3J5LWRlMmY1OWZjLWU1YTYtN2I5ZC05NTVjLTk1OGJhOTA0NjZlYi90ZXN0LWZpbGUtNzlkZGM5YmQtZDg0Ni1iMGQ2LWQ3ZmUtZTdmOWZhMzUzOGZiIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktZTc5ZGMwODgtODhmMy02MWUwLWEyZDUtNzc4ZTVhM2E1N2M1L3Rlc3QtZGlyZWN0b3J5LWRlMmY1OWZjLWU1YTYtN2I5ZC05NTVjLTk1OGJhOTA0NjZlYi90ZXN0LWRpcmVjdG9yeS1iZGIzY2Y1NS00MzU5LWM2Y2YtNjA5MS1kNjhjN2U3YzViOWUiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LWU3OWRjMDg4LTg4ZjMtNjFlMC1hMmQ1LTc3OGU1YTNhNTdjNS90ZXN0LWRpcmVjdG9yeS1kZTJmNTlmYy1lNWE2LTdiOWQtOTU1Yy05NThiYTkwNDY2ZWIvdGVzdC1maWxlLTZkZmRjNzk3LTgzYmYtMjY4OC1hYjljLWQ2YjBjMWI3ODlkZCIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMzlkYTVkN2ItMTZhMy1jNGVjLTJmNGItOWYyNmY2MTI5YzBmL3Rlc3QtZGlyZWN0b3J5LWIzNTg3NzI4LTQxNTEtMjE3NC1lMzUyLWU0YmEyOTRlZWM5YS90ZXN0LWZpbGUtYTE1ZjBkNjAtNTllYS1iYmNjLTc2YTUtODY5ZTBlNTc2ZDI3IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMzlkYTVkN2ItMTZhMy1jNGVjLTJmNGItOWYyNmY2MTI5YzBmL3Rlc3QtZGlyZWN0b3J5LWIzNTg3NzI4LTQxNTEtMjE3NC1lMzUyLWU0YmEyOTRlZWM5YS90ZXN0LWZpbGUtNTY0NDIyOTEtOTk3ZS1mYjJiLTZlNjEtOTFhYzIxYmRmYzg5IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMzlkYTVkN2ItMTZhMy1jNGVjLTJmNGItOWYyNmY2MTI5YzBmL3Rlc3QtZGlyZWN0b3J5LWIzNTg3NzI4LTQxNTEtMjE3NC1lMzUyLWU0YmEyOTRlZWM5YS90ZXN0LWRpcmVjdG9yeS05OWI1MjQ2Yy02Zjc4LWU1NWQtM2VkYi03MzAxYzE4ZjMyZTciLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTM5ZGE1ZDdiLTE2YTMtYzRlYy0yZjRiLTlmMjZmNjEyOWMwZi90ZXN0LWRpcmVjdG9yeS1iMzU4NzcyOC00MTUxLTIxNzQtZTM1Mi1lNGJhMjk0ZWVjOWEvdGVzdC1maWxlLWMzNDk4MDIwLTE3MjItYTBhNS04OGFhLWU5YWYxNmViOGYyOCIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-82f01d47-d85f-fedc-4331-27f259a67919?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b9bc0aecb53b2845b73c8ceb24068879-23957929f9e53441-00",
+        "traceparent": "00-78f23f16864c3d40adc2909b43993445-f3be9c06deba284e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "0d7fc693-2431-e812-3175-f6e7a4fe3e9d",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "x-ms-client-request-id": "ed3e07ff-07e4-4cd2-15c9-37264e6cbfc2",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -428,20 +662,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:40 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "0d7fc693-2431-e812-3175-f6e7a4fe3e9d",
-        "x-ms-request-id": "4e20157e-501e-0046-216e-6fc2a6000000",
+        "x-ms-client-request-id": "ed3e07ff-07e4-4cd2-15c9-37264e6cbfc2",
+        "x-ms-request-id": "49b8d350-601e-0072-38c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:40.1390765-07:00",
     "RandomSeed": "256377884",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-eaaa3e9fc09267429eee9a8c222b0df5-ae011f0141422d4c-00",
+        "traceparent": "00-ec0669ec1dc91c40a0e45fb92867a812-1e75030c13f8d847-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "4bac3a6e-3715-992c-55b5-7d25e6d2a4b8",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:17 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:56 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:17 GMT",
-        "ETag": "\u00220x8D83D85C29618EE\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:17 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82BB2D027\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4bac3a6e-3715-992c-55b5-7d25e6d2a4b8",
-        "x-ms-request-id": "4e200dea-501e-0046-3d6e-6fc2a6000000",
+        "x-ms-request-id": "49b8c5c7-601e-0072-3fc1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d0085a494ab862478d2ecaa13a6dda9b-ee9444d1c0b9774c-00",
+        "traceparent": "00-5323768d8e61aa42be1a636f72a02258-d8afcf07372d4c4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "f7bf0386-55e1-1409-5a51-1d14048fb529",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:18 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:18 GMT",
-        "ETag": "\u00220x8D83D85C2B7B0C9\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:17 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82BB63104\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f7bf0386-55e1-1409-5a51-1d14048fb529",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864b9-801f-0008-096e-6fec2e000000",
+        "x-ms-request-id": "49ae99f1-d01f-0077-2fc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1b2df9406c84754495b4bc89f87ca830-d668044ad8b97e4a-00",
+        "traceparent": "00-80a0e5836a036944967f5971e2f8b55f-d94748c0446b2f44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "e29fa58b-ac12-3cd6-5e50-d42daaa31319",
+        "x-ms-client-request-id": "5b2c075b-29d5-27e7-a318-754db3050dd7",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:18 GMT",
-        "ETag": "\u00220x8D83D85C388E9D0\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:19 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82BCF6ED7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e29fa58b-ac12-3cd6-5e50-d42daaa31319",
-        "x-ms-request-id": "aa73a81a-501f-00b2-0a6e-6f0950000000",
+        "x-ms-client-request-id": "5b2c075b-29d5-27e7-a318-754db3050dd7",
+        "x-ms-request-id": "49ae99f2-d01f-0077-30c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f/test-directory-5b2c075b-29d5-27e7-a318-754db3050dd7?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-5e8940bf-d2f0-d116-d466-a19e8a32fcdf?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c4b40291023e50449295634623b29294-b8af13efd4e8fc4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "ffa8887f-3656-6106-be78-3ffa37898858",
+        "x-ms-client-request-id": "6a6dfd43-b519-8929-f15a-876f88499d71",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:18 GMT",
-        "ETag": "\u00220x8D83D85C3AB7525\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:19 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82BDBBF3D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ffa8887f-3656-6106-be78-3ffa37898858",
-        "x-ms-request-id": "aa73a81c-501f-00b2-0c6e-6f0950000000",
+        "x-ms-client-request-id": "6a6dfd43-b519-8929-f15a-876f88499d71",
+        "x-ms-request-id": "49ae99f3-d01f-0077-31c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f/test-directory-5b2c075b-29d5-27e7-a318-754db3050dd7/test-file-6a6dfd43-b519-8929-f15a-876f88499d71?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-5e8940bf-d2f0-d116-d466-a19e8a32fcdf/test-file-2bcd961c-0e5d-8981-3927-a078931c9a4b?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "8d5b49de-92c4-cac5-5f1f-0dfbae97d974",
+        "x-ms-client-request-id": "a0ddceda-5dbb-35fb-7be4-30f215b0f5d5",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
-        "ETag": "\u00220x8D83D85C3C2FE88\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:19 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82BE89816\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "8d5b49de-92c4-cac5-5f1f-0dfbae97d974",
-        "x-ms-request-id": "aa73a81e-501f-00b2-0e6e-6f0950000000",
+        "x-ms-client-request-id": "a0ddceda-5dbb-35fb-7be4-30f215b0f5d5",
+        "x-ms-request-id": "49ae99f4-d01f-0077-32c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f/test-directory-5b2c075b-29d5-27e7-a318-754db3050dd7/test-file-a0ddceda-5dbb-35fb-7be4-30f215b0f5d5?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-5e8940bf-d2f0-d116-d466-a19e8a32fcdf/test-file-3e913cc0-10ed-8aac-d103-cb3d0086daa1?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "c59d2b4d-f93e-808f-4e26-11e061d2b5ae",
+        "x-ms-client-request-id": "723a3829-9b06-ca86-2153-cfb791bd34f5",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
-        "ETag": "\u00220x8D83D85C3ED8027\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:19 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82BF56DF8\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c59d2b4d-f93e-808f-4e26-11e061d2b5ae",
-        "x-ms-request-id": "aa73a821-501f-00b2-116e-6f0950000000",
+        "x-ms-client-request-id": "723a3829-9b06-ca86-2153-cfb791bd34f5",
+        "x-ms-request-id": "49ae99f5-d01f-0077-33c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f/test-directory-723a3829-9b06-ca86-2153-cfb791bd34f5?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-e9a48e0a-3013-c796-ac10-f0c7fecb29fe?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e4016161f9105240ac3f9c697fcce493-57c3bb06f14d124a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "c8141c4e-674b-b29b-a4d2-a3eb2ad8ef90",
+        "x-ms-client-request-id": "d2d61cf1-cb2e-f99a-a173-c6f5aabfcb55",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
-        "ETag": "\u00220x8D83D85C3FA2FAA\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:56 GMT",
+        "ETag": "\u00220x8D863D82C01BD8B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c8141c4e-674b-b29b-a4d2-a3eb2ad8ef90",
-        "x-ms-request-id": "aa73a824-501f-00b2-146e-6f0950000000",
+        "x-ms-client-request-id": "d2d61cf1-cb2e-f99a-a173-c6f5aabfcb55",
+        "x-ms-request-id": "49ae99f6-d01f-0077-34c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f/test-directory-723a3829-9b06-ca86-2153-cfb791bd34f5/test-file-d2d61cf1-cb2e-f99a-a173-c6f5aabfcb55?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-e9a48e0a-3013-c796-ac10-f0c7fecb29fe/test-file-7469d029-6ca9-a2a9-f3f1-44408cab9cd3?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "e2d55f21-56f5-82d0-811a-26d8a1a608e5",
+        "x-ms-client-request-id": "5ac14d07-7a6f-85e7-7333-df3c87596cf6",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,94 +241,328 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
-        "ETag": "\u00220x8D83D85C4079BC0\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82C0E8205\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e2d55f21-56f5-82d0-811a-26d8a1a608e5",
-        "x-ms-request-id": "aa73a825-501f-00b2-156e-6f0950000000",
+        "x-ms-client-request-id": "5ac14d07-7a6f-85e7-7333-df3c87596cf6",
+        "x-ms-request-id": "49ae99f7-d01f-0077-35c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f/test-directory-723a3829-9b06-ca86-2153-cfb791bd34f5/test-file-5ac14d07-7a6f-85e7-7333-df3c87596cf6?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-96cc852c5bc1fa47990657bd42d48b00-081b0c6689b5984b-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "3f395ee9-42e9-a764-7850-6fc17793fb27",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:20 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:20 GMT",
-        "ETag": "\u00220x8D83D85C4148D28\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:20 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "3f395ee9-42e9-a764-7850-6fc17793fb27",
-        "x-ms-request-id": "0ee864c0-801f-0008-106e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-2cad5e99-6acc-92ad-2c13-e22e328da01f?action=setAccessControlRecursive\u0026mode=remove",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d4f0aa4f90626345946287f9fabf37e5-528da6d54cd22a42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
-        "x-ms-client-request-id": "28539233-2d20-940c-8d2c-d298799e5b6c",
+        "x-ms-client-request-id": "af0130ae-bdd2-1dfc-edee-5a8987583fa2",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "x-ms-owner": "4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82BCF6ED7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af0130ae-bdd2-1dfc-edee-5a8987583fa2",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99f8-d01f-0077-36c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-5e8940bf-d2f0-d116-d466-a19e8a32fcdf?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "14dfcaeb-51ce-2b7a-611b-51fae7db201f",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "x-ms-owner": "4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82BDBBF3D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "14dfcaeb-51ce-2b7a-611b-51fae7db201f",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99f9-d01f-0077-37c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-5e8940bf-d2f0-d116-d466-a19e8a32fcdf/test-file-2bcd961c-0e5d-8981-3927-a078931c9a4b?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bc9dee93-2a79-e2d3-1728-c704db11acb2",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "x-ms-owner": "4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82BE89816\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bc9dee93-2a79-e2d3-1728-c704db11acb2",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99fa-d01f-0077-38c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-5e8940bf-d2f0-d116-d466-a19e8a32fcdf/test-file-3e913cc0-10ed-8aac-d103-cb3d0086daa1?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f9670277-633d-e6a6-f9ac-cd170a03a612",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "x-ms-owner": "4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82BF56DF8\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f9670277-633d-e6a6-f9ac-cd170a03a612",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99fb-d01f-0077-39c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-e9a48e0a-3013-c796-ac10-f0c7fecb29fe?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d88ccae7-b2aa-a874-0ca0-b363a8140dbf",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "x-ms-owner": "4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82C01BD8B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d88ccae7-b2aa-a874-0ca0-b363a8140dbf",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99fc-d01f-0077-3ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-e9a48e0a-3013-c796-ac10-f0c7fecb29fe/test-file-7469d029-6ca9-a2a9-f3f1-44408cab9cd3?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "40308bf9-ce77-0e67-faf0-2b3c44dc73ad",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "x-ms-owner": "4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82C0E8205\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "40308bf9-ce77-0e67-faf0-2b3c44dc73ad",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae99fd-d01f-0077-3bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc/test-directory-e9a48e0a-3013-c796-ac10-f0c7fecb29fe/test-file-5a633a77-f2d2-df05-aa0c-145e7abc3e81?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d20d828e0b82f843b42a725e93d51ea3-84da3a931cd67247-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "30418bd7-5126-07b4-8550-956bba08933e",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:57 GMT",
+        "ETag": "\u00220x8D863D82C67506C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "30418bd7-5126-07b4-8550-956bba08933e",
+        "x-ms-request-id": "49ae9a00-d01f-0077-3ec1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-2a1ac194961f7a44857d523f687be351-199eb8836b6c914d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "ef872ccf-0e7b-a25a-7862-979337dc2e6e",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:58:58Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "ef872ccf-0e7b-a25a-7862-979337dc2e6e",
+        "x-ms-request-id": "e83be2bd-901e-0076-77c1-957c69000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:58:58Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:58:58Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EuHjYHXf0eH\u002BUU9C5/9qoUkxtuTZmtkp5VolGBq84Xs0=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82/test-directory-00a2ab7d-5eef-a65f-8293-a104078292dc?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A58%3A58Z\u0026ske=2020-09-28T18%3A58%3A58Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A58%3A58Z\u0026se=2020-09-28T18%3A58%3A58Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=4ad4f2d6-e9e9-d360-ffe6-f28e45d0004c\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=remove",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
+        "x-ms-client-request-id": "8d9bcd4d-a481-a3c2-4ea6-9f10bf357216",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "28539233-2d20-940c-8d2c-d298799e5b6c",
+        "x-ms-client-request-id": "8d9bcd4d-a481-a3c2-4ea6-9f10bf357216",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "aa73a826-501f-00b2-166e-6f0950000000",
+        "x-ms-request-id": "49ae9a01-d01f-0077-3fc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMmNhZDVlOTktNmFjYy05MmFkLTJjMTMtZTIyZTMyOGRhMDFmL3Rlc3QtZGlyZWN0b3J5LTcyM2EzODI5LTliMDYtY2E4Ni0yMTUzLWNmYjc5MWJkMzRmNS90ZXN0LWZpbGUtNWFjMTRkMDctN2E2Zi04NWU3LTczMzMtZGYzYzg3NTk2Y2Y2IiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMDBhMmFiN2QtNWVlZi1hNjVmLTgyOTMtYTEwNDA3ODI5MmRjL3Rlc3QtZGlyZWN0b3J5LWU5YTQ4ZTBhLTMwMTMtYzc5Ni1hYzEwLWYwYzdmZWNiMjlmZS90ZXN0LWZpbGUtNWE2MzNhNzctZjJkMi1kZjA1LWFhMGMtMTQ1ZTdhYmMzZTgxIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-a9470303-c939-d701-4632-87b2b5693b82?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-adddf28d0998d848999483b8aefa0724-f7bfe9e404890b4b-00",
+        "traceparent": "00-88fe9250faa0a04dafe87a7f2b0601cf-3d0c59c3bd876049-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "e58ecc11-d23f-8107-236d-21a5eb64a44e",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "x-ms-client-request-id": "6a45ca88-a140-5aec-c4f7-e3f48563c18c",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -332,20 +570,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e58ecc11-d23f-8107-236d-21a5eb64a44e",
-        "x-ms-request-id": "4e20105f-501e-0046-686e-6fc2a6000000",
+        "x-ms-client-request-id": "6a45ca88-a140-5aec-c4f7-e3f48563c18c",
+        "x-ms-request-id": "49b8c66f-601e-0072-58c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:58:58.2456145-07:00",
     "RandomSeed": "1694560552",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_WithProgressMonitoring_WithFailureAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/RemoveAccessControlRecursiveAsync_WithProgressMonitoring_WithFailureAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cd3829e4935128439ace054205b01563-4a67cf67a4523045-00",
+        "traceparent": "00-04d3cd76201bff479b416e78b7fc84fa-7dcda6a48ebb194d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "8014cf4c-45c8-7483-f996-8743f4fbcf42",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "ETag": "\u00220x8D83D85C80ECF4E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:40 GMT",
+        "ETag": "\u00220x8D863D846418DC2\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8014cf4c-45c8-7483-f996-8743f4fbcf42",
-        "x-ms-request-id": "4e20159d-501e-0046-3d6e-6fc2a6000000",
+        "x-ms-request-id": "49b8d35e-601e-0072-46c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-57febfdca3e2644ea2c5d57573821e2a-8d1f860d1fc35d4b-00",
+        "traceparent": "00-a991ef3adf436a47bc9cd7e2dcde12c7-45c882308b4a7d42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "e1b191e7-03ae-1ebc-1869-df57c498755c",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:26 GMT",
-        "ETag": "\u00220x8D83D85C810308E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:26 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "ETag": "\u00220x8D863D84643BBE7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e1b191e7-03ae-1ebc-1869-df57c498755c",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864e0-801f-0008-2e6e-6fec2e000000",
+        "x-ms-request-id": "49ae9a7c-d01f-0077-2ec1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-06f617d24a2d6f44a619b230f53b2529-2f33979ac1605c41-00",
+        "traceparent": "00-5bf4623ab8b9b045a6bedc56a8dd668f-940768cbf805704f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "625cdb5e-ed4a-1694-20bf-649bd0fb16cb",
+        "x-ms-client-request-id": "b075ad34-ca24-e21c-8515-6475e69de281",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C86D8117\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "ETag": "\u00220x8D863D8465CF439\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "625cdb5e-ed4a-1694-20bf-649bd0fb16cb",
-        "x-ms-request-id": "0a061a35-601f-00e4-0b6e-6ff8bf000000",
+        "x-ms-client-request-id": "b075ad34-ca24-e21c-8515-6475e69de281",
+        "x-ms-request-id": "49ae9a7d-d01f-0077-2fc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384/test-directory-b075ad34-ca24-e21c-8515-6475e69de281?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-e9f97175-123b-8a11-3a4f-4dd0a070cb81?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fa2737c8f234894d9659949a50a8e0e0-bf321eba42adde44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "8eea5022-4320-9349-be7a-dc35891f2f83",
+        "x-ms-client-request-id": "5f26e2dd-2c02-2190-9beb-76d57d4c4215",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C879938D\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "ETag": "\u00220x8D863D846693D44\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "8eea5022-4320-9349-be7a-dc35891f2f83",
-        "x-ms-request-id": "0a061a36-601f-00e4-0c6e-6ff8bf000000",
+        "x-ms-client-request-id": "5f26e2dd-2c02-2190-9beb-76d57d4c4215",
+        "x-ms-request-id": "49ae9a7e-d01f-0077-30c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384/test-directory-b075ad34-ca24-e21c-8515-6475e69de281/test-file-5f26e2dd-2c02-2190-9beb-76d57d4c4215?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-e9f97175-123b-8a11-3a4f-4dd0a070cb81/test-file-9652e24a-53b2-3161-2765-2ac135dc001b?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "bdf3ca20-6c49-f57f-bfc8-f335cd741671",
+        "x-ms-client-request-id": "a6ebc637-98cd-89d0-81f4-379c02cfecbe",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C889BF1C\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "ETag": "\u00220x8D863D84678CB56\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "bdf3ca20-6c49-f57f-bfc8-f335cd741671",
-        "x-ms-request-id": "0a061a37-601f-00e4-0d6e-6ff8bf000000",
+        "x-ms-client-request-id": "a6ebc637-98cd-89d0-81f4-379c02cfecbe",
+        "x-ms-request-id": "49ae9a7f-d01f-0077-31c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384/test-directory-b075ad34-ca24-e21c-8515-6475e69de281/test-file-a6ebc637-98cd-89d0-81f4-379c02cfecbe?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-e9f97175-123b-8a11-3a4f-4dd0a070cb81/test-file-b3b55aea-8459-ddcb-625c-d6e9602b64b3?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "6e89b94e-5af1-874e-f969-3c5534e3f3f0",
+        "x-ms-client-request-id": "724b34dc-63bf-b218-fb0d-4371c1e62855",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C8962CF8\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "ETag": "\u00220x8D863D84685BA07\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "6e89b94e-5af1-874e-f969-3c5534e3f3f0",
-        "x-ms-request-id": "0a061a38-601f-00e4-0e6e-6ff8bf000000",
+        "x-ms-client-request-id": "724b34dc-63bf-b218-fb0d-4371c1e62855",
+        "x-ms-request-id": "49ae9a80-d01f-0077-32c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384/test-directory-724b34dc-63bf-b218-fb0d-4371c1e62855?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-484d848f-7d45-90cd-0c2d-b9ef4776a97f?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-63985f7b62175b47ac3a34b62c5496dd-7c7fba424855364f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "2b0ce668-f2e0-ebf4-a0d6-73e416ddc512",
+        "x-ms-client-request-id": "b0c6e740-ab95-5faa-67bb-6591a9286b84",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C8A221E9\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "ETag": "\u00220x8D863D84691FD01\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "2b0ce668-f2e0-ebf4-a0d6-73e416ddc512",
-        "x-ms-request-id": "0a061a39-601f-00e4-0f6e-6ff8bf000000",
+        "x-ms-client-request-id": "b0c6e740-ab95-5faa-67bb-6591a9286b84",
+        "x-ms-request-id": "49ae9a81-d01f-0077-33c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384/test-directory-724b34dc-63bf-b218-fb0d-4371c1e62855/test-file-b0c6e740-ab95-5faa-67bb-6591a9286b84?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-484d848f-7d45-90cd-0c2d-b9ef4776a97f/test-file-db08c364-fdd9-9c75-8f61-a76f09e9792f?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "60afa667-f8b0-bdea-3cad-c4248d624278",
+        "x-ms-client-request-id": "527fef6b-ead4-4338-7129-2033033b567e",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,94 +241,328 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C8AEB92F\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D8469EC672\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "60afa667-f8b0-bdea-3cad-c4248d624278",
-        "x-ms-request-id": "0a061a3a-601f-00e4-106e-6ff8bf000000",
+        "x-ms-client-request-id": "527fef6b-ead4-4338-7129-2033033b567e",
+        "x-ms-request-id": "49ae9a82-d01f-0077-34c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384/test-directory-724b34dc-63bf-b218-fb0d-4371c1e62855/test-file-527fef6b-ead4-4338-7129-2033033b567e?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-c00d704bee5e6e4c8bd5338429e05e9c-0ba2f107fdb24341-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1a032f1f-2669-7d5b-6d6b-ee87d7b6b900",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:28 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C8BAF303\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:28 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "1a032f1f-2669-7d5b-6d6b-ee87d7b6b900",
-        "x-ms-request-id": "0ee864e2-801f-0008-306e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-62133f27-9134-8109-1a67-a3fdb1c28384?action=setAccessControlRecursive\u0026mode=remove",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6e7555bf1c2417478d95c562d1572485-4a901ad0188efa4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
-        "x-ms-client-request-id": "d314f319-3b37-1a14-daac-940d1b4d9422",
+        "x-ms-client-request-id": "57e34656-3f39-60ff-1a13-79884a0c0a21",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-owner": "02293541-0a79-6bd4-d94b-9f2c39500f2c",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:28 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D8465CF439\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "57e34656-3f39-60ff-1a13-79884a0c0a21",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a83-d01f-0077-35c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-e9f97175-123b-8a11-3a4f-4dd0a070cb81?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f3d59e91-b86d-dff3-2fa2-ff55add23261",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-owner": "02293541-0a79-6bd4-d94b-9f2c39500f2c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D846693D44\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f3d59e91-b86d-dff3-2fa2-ff55add23261",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a84-d01f-0077-36c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-e9f97175-123b-8a11-3a4f-4dd0a070cb81/test-file-9652e24a-53b2-3161-2765-2ac135dc001b?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "acf6567f-1736-61b4-0034-a4943cbe6d07",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-owner": "02293541-0a79-6bd4-d94b-9f2c39500f2c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D84678CB56\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:41 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "acf6567f-1736-61b4-0034-a4943cbe6d07",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a85-d01f-0077-37c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-e9f97175-123b-8a11-3a4f-4dd0a070cb81/test-file-b3b55aea-8459-ddcb-625c-d6e9602b64b3?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "57d5315d-86dc-4a2b-190c-e36d4235de72",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-owner": "02293541-0a79-6bd4-d94b-9f2c39500f2c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D84685BA07\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "57d5315d-86dc-4a2b-190c-e36d4235de72",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a86-d01f-0077-38c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-484d848f-7d45-90cd-0c2d-b9ef4776a97f?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0a366600-15e8-f22b-0762-34d3cc13699f",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-owner": "02293541-0a79-6bd4-d94b-9f2c39500f2c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D84691FD01\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a366600-15e8-f22b-0762-34d3cc13699f",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a87-d01f-0077-39c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-484d848f-7d45-90cd-0c2d-b9ef4776a97f/test-file-db08c364-fdd9-9c75-8f61-a76f09e9792f?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "dc6c4ae5-d3fe-4689-4a21-70e3c21a02c2",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-owner": "02293541-0a79-6bd4-d94b-9f2c39500f2c",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D8469EC672\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dc6c4ae5-d3fe-4689-4a21-70e3c21a02c2",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a88-d01f-0077-3ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e/test-directory-484d848f-7d45-90cd-0c2d-b9ef4776a97f/test-file-079e37e1-61c6-4445-6dd0-c6e2939a4257?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e332abc3e9029d468c6e9b83a780cc19-f147c9c8532f0b47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "77afbf03-ed11-8343-0428-6e2e0da7b2b0",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D846F7DF5A\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "77afbf03-ed11-8343-0428-6e2e0da7b2b0",
+        "x-ms-request-id": "49ae9a89-d01f-0077-3bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-35c294c8428bac4885195703334cd814-f8ef785c95f86b4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d3de9d2c-cbeb-8046-e76b-7d7d1f72fb1d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:42Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "d3de9d2c-cbeb-8046-e76b-7d7d1f72fb1d",
+        "x-ms-request-id": "fa8ab4d3-901e-00ad-7dc1-95ba54000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:43Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:42Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003E7wS4obuff54A3G5MNgl6ZZPcb2dk7cd0cDmBnVCtLbk=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940/test-directory-6d65cf77-048f-9b0b-7d39-1c1f3b96f46e?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A43Z\u0026ske=2020-09-28T18%3A59%3A42Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A42Z\u0026se=2020-09-28T18%3A59%3A42Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=02293541-0a79-6bd4-d94b-9f2c39500f2c\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=remove",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "mask,default:user,default:group,user:ec3595d6-2c17-4696-8caa-7e139758d24a,group:ec3595d6-2c17-4696-8caa-7e139758d24a,default:user:ec3595d6-2c17-4696-8caa-7e139758d24a,default:group:ec3595d6-2c17-4696-8caa-7e139758d24a",
+        "x-ms-client-request-id": "6f011431-dfc8-13c4-d1f4-afc1029e3424",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "d314f319-3b37-1a14-daac-940d1b4d9422",
+        "x-ms-client-request-id": "6f011431-dfc8-13c4-d1f4-afc1029e3424",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0a061a3b-601f-00e4-116e-6ff8bf000000",
+        "x-ms-request-id": "49ae9a8c-d01f-0077-3ec1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNjIxMzNmMjctOTEzNC04MTA5LTFhNjctYTNmZGIxYzI4Mzg0L3Rlc3QtZGlyZWN0b3J5LTcyNGIzNGRjLTYzYmYtYjIxOC1mYjBkLTQzNzFjMWU2Mjg1NS90ZXN0LWZpbGUtNTI3ZmVmNmItZWFkNC00MzM4LTcxMjktMjAzMzAzM2I1NjdlIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNmQ2NWNmNzctMDQ4Zi05YjBiLTdkMzktMWMxZjNiOTZmNDZlL3Rlc3QtZGlyZWN0b3J5LTQ4NGQ4NDhmLTdkNDUtOTBjZC0wYzJkLWI5ZWY0Nzc2YTk3Zi90ZXN0LWZpbGUtMDc5ZTM3ZTEtNjFjNi00NDQ1LTZkZDAtYzZlMjkzOWE0MjU3IiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-a1180206-98ab-80f9-059c-614217e48940?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3ae76cac6b36b34ea43b56041b7bf017-1a80c4df60bf644e-00",
+        "traceparent": "00-83336546ba543246bad3deb1c541d0d7-148b36d5afdcfb42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "e36dcd61-e6a2-1ac9-31c8-7d8cabf145cd",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:28 GMT",
+        "x-ms-client-request-id": "0a4c8ccf-8b70-7054-0541-61aa5d3c8004",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -332,20 +570,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e36dcd61-e6a2-1ac9-31c8-7d8cabf145cd",
-        "x-ms-request-id": "4e2016c5-501e-0046-4c6e-6fc2a6000000",
+        "x-ms-client-request-id": "0a4c8ccf-8b70-7054-0541-61aa5d3c8004",
+        "x-ms-request-id": "49b8d3f8-601e-0072-54c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:42.8140321-07:00",
     "RandomSeed": "2086607792",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_ContinueOnFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_ContinueOnFailure.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-af73717fa903c348be3cd8e689950922-92289cd15b76aa4d-00",
+        "traceparent": "00-1b70de83d9d02a4f97b4ea01fe5fb138-542936f3f1489c45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "7331eac1-a94a-4f90-8fc2-4735290bd227",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:19 GMT",
-        "ETag": "\u00220x8D83D85C45721BE\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "ETag": "\u00220x8D863D82CF7107A\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7331eac1-a94a-4f90-8fc2-4735290bd227",
-        "x-ms-request-id": "4e201072-501e-0046-7b6e-6fc2a6000000",
+        "x-ms-request-id": "49b8c679-601e-0072-61c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6bf0b54d176d07438b5068e31950350d-781f6684fce3ff43-00",
+        "traceparent": "00-e6597b9882023e40af411af46e012d7a-7af7fe7b595c8a47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "4835c276-c567-1eeb-d92e-3b10d1439fbb",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:20 GMT",
-        "ETag": "\u00220x8D83D85C4586303\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:20 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "ETag": "\u00220x8D863D82CF852FB\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4835c276-c567-1eeb-d92e-3b10d1439fbb",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864c4-801f-0008-136e-6fec2e000000",
+        "x-ms-request-id": "49ae9a02-d01f-0077-40c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-be8f9dab7c84924082d0ef86334d1b17-652f15696fea534b-00",
+        "traceparent": "00-73be2730df079241a436e42cd49b3951-e5c5fd30e0bad048-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "67bf9fc1-89d5-0cc0-1835-1c766bb206ca",
+        "x-ms-client-request-id": "dd990369-f385-ab96-dc1a-210d5fab3441",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:20 GMT",
-        "ETag": "\u00220x8D83D85C4BE7244\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "ETag": "\u00220x8D863D82D1237AE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "67bf9fc1-89d5-0cc0-1835-1c766bb206ca",
-        "x-ms-request-id": "5c27f0d0-301f-001d-656e-6ffb9d000000",
+        "x-ms-client-request-id": "dd990369-f385-ab96-dc1a-210d5fab3441",
+        "x-ms-request-id": "49ae9a03-d01f-0077-41c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-dd990369-f385-ab96-dc1a-210d5fab3441?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-324f591c-3783-d5e5-a01b-f5dcae6faf74?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-48bbdc7960eee24f97e4d32551c02e5b-838e620223298e49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "e6d69c53-33fe-cd5c-0813-8bba68b2ad6d",
+        "x-ms-client-request-id": "1159da00-d363-3146-1dc3-3d69febafd6c",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:20 GMT",
-        "ETag": "\u00220x8D83D85C4CF33B5\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "ETag": "\u00220x8D863D82D1E8936\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e6d69c53-33fe-cd5c-0813-8bba68b2ad6d",
-        "x-ms-request-id": "5c27f0d1-301f-001d-666e-6ffb9d000000",
+        "x-ms-client-request-id": "1159da00-d363-3146-1dc3-3d69febafd6c",
+        "x-ms-request-id": "49ae9a04-d01f-0077-42c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-dd990369-f385-ab96-dc1a-210d5fab3441/test-file-1159da00-d363-3146-1dc3-3d69febafd6c?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-324f591c-3783-d5e5-a01b-f5dcae6faf74/test-file-c2b9ac6b-4ed4-e842-fd81-296fac2b6ced?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "d3db876e-9e15-8011-55a4-c83bf6f3cf4e",
+        "x-ms-client-request-id": "bc4f1e16-eaf9-b298-9871-14e1aad685f2",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C4DCAE14\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "ETag": "\u00220x8D863D82D2B5596\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "d3db876e-9e15-8011-55a4-c83bf6f3cf4e",
-        "x-ms-request-id": "5c27f0d4-301f-001d-686e-6ffb9d000000",
+        "x-ms-client-request-id": "bc4f1e16-eaf9-b298-9871-14e1aad685f2",
+        "x-ms-request-id": "49ae9a05-d01f-0077-43c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-dd990369-f385-ab96-dc1a-210d5fab3441/test-file-bc4f1e16-eaf9-b298-9871-14e1aad685f2?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-324f591c-3783-d5e5-a01b-f5dcae6faf74/test-file-76fa5056-29de-cc57-9a39-6c2f8506f209?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "8d58dbb1-b0db-83f3-ef28-3aa48a2fd57e",
+        "x-ms-client-request-id": "a6e5d61f-59f8-ed6f-c682-21c07d682c92",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C4E9EDA2\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:58 GMT",
+        "ETag": "\u00220x8D863D82D3809A0\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "8d58dbb1-b0db-83f3-ef28-3aa48a2fd57e",
-        "x-ms-request-id": "5c27f0d5-301f-001d-696e-6ffb9d000000",
+        "x-ms-client-request-id": "a6e5d61f-59f8-ed6f-c682-21c07d682c92",
+        "x-ms-request-id": "49ae9a06-d01f-0077-44c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-a6e5d61f-59f8-ed6f-c682-21c07d682c92?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-99ba6528a0f1194eace79d79dcd613c5-0328004fbb9bc248-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "af10ee63-4b21-5811-6c6b-c6588e330586",
+        "x-ms-client-request-id": "7f25a8fc-07ff-2700-bf3f-4980d2b9fe13",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C4F6CD29\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D444DEC\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "af10ee63-4b21-5811-6c6b-c6588e330586",
-        "x-ms-request-id": "5c27f0d6-301f-001d-6a6e-6ffb9d000000",
+        "x-ms-client-request-id": "7f25a8fc-07ff-2700-bf3f-4980d2b9fe13",
+        "x-ms-request-id": "49ae9a07-d01f-0077-45c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-a6e5d61f-59f8-ed6f-c682-21c07d682c92/test-file-7f25a8fc-07ff-2700-bf3f-4980d2b9fe13?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b/test-file-8f5cb640-7c58-3271-f9d7-621231bd1628?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "46b90071-c38e-5b6b-ede9-f0e1029086b3",
+        "x-ms-client-request-id": "d818b36d-75d7-7f2d-37f2-8628a5eef601",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,190 +241,420 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C5043B7A\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D510D88\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "46b90071-c38e-5b6b-ede9-f0e1029086b3",
-        "x-ms-request-id": "5c27f0d7-301f-001d-6b6e-6ffb9d000000",
+        "x-ms-client-request-id": "d818b36d-75d7-7f2d-37f2-8628a5eef601",
+        "x-ms-request-id": "49ae9a08-d01f-0077-46c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-a6e5d61f-59f8-ed6f-c682-21c07d682c92/test-file-d818b36d-75d7-7f2d-37f2-8628a5eef601?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-333f4b8267f11349bff345827b42daa1-c16bd6a17830d94c-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "7ea4af51-3ea5-fc51-d23a-0f9b3c43b6fe",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C5132CC3\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "7ea4af51-3ea5-fc51-d23a-0f9b3c43b6fe",
-        "x-ms-request-id": "0ee864c7-801f-0008-166e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-a6e5d61f-59f8-ed6f-c682-21c07d682c92/test-file-e0b9eff3-b481-b5b3-2d9b-8dd6d2bef3a7?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-45aedccab0f1c24786aa0bc1681f8408-0aa286c7c460bc4d-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "9c7ca44a-50d6-9ce7-fbee-5009b07b2913",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C51F43F0\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:22 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "9c7ca44a-50d6-9ce7-fbee-5009b07b2913",
-        "x-ms-request-id": "0ee864c8-801f-0008-176e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-a6e5d61f-59f8-ed6f-c682-21c07d682c92/test-file-1fda6746-c06c-7bb3-92ce-116eb5ee0d44?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-682dba13818aef46b4f18c01d3c1ba98-dd12dab18e46864a-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "407eebe9-200e-899b-f000-0a073e79e70d",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:22 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C52B956A\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:22 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "407eebe9-200e-899b-f000-0a073e79e70d",
-        "x-ms-request-id": "0ee864ca-801f-0008-196e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936/test-directory-a6e5d61f-59f8-ed6f-c682-21c07d682c92/test-directory-2aae0be0-faee-f0d1-9569-e931c5575340?resource=directory",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-2ef9db737642524196d54e8e94a1bea0-fbd75cc449430340-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1c7bec52-0fa3-ee65-1a8e-aba53769c398",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:22 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C5372357\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:22 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "1c7bec52-0fa3-ee65-1a8e-aba53769c398",
-        "x-ms-request-id": "0ee864cb-801f-0008-1a6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-85d385f0-c62b-13a8-0f35-4cf733993936?action=setAccessControlRecursive\u0026mode=set\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b260e961d3aaea43a8459d1bcf2871e7-e8753ecd1f6e7d48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "d9de2d36-37dc-869c-5796-afe121900281",
+        "x-ms-client-request-id": "e0b9eff3-b481-b5b3-2d9b-8dd6d2bef3a7",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "x-ms-owner": "d10e2128-b7ff-7d85-4a00-a26f8c8f3068",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D1237AE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e0b9eff3-b481-b5b3-2d9b-8dd6d2bef3a7",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a09-d01f-0077-47c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-324f591c-3783-d5e5-a01b-f5dcae6faf74?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9c7ca44a-50d6-9ce7-fbee-5009b07b2913",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "x-ms-owner": "d10e2128-b7ff-7d85-4a00-a26f8c8f3068",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D1E8936\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9c7ca44a-50d6-9ce7-fbee-5009b07b2913",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a0a-d01f-0077-48c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-324f591c-3783-d5e5-a01b-f5dcae6faf74/test-file-c2b9ac6b-4ed4-e842-fd81-296fac2b6ced?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "2e8c865a-5642-71d1-353a-fa5b27523954",
+        "x-ms-date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "x-ms-owner": "d10e2128-b7ff-7d85-4a00-a26f8c8f3068",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D2B5596\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2e8c865a-5642-71d1-353a-fa5b27523954",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a0b-d01f-0077-49c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-324f591c-3783-d5e5-a01b-f5dcae6faf74/test-file-76fa5056-29de-cc57-9a39-6c2f8506f209?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "2aae0be0-faee-f0d1-9569-e931c5575340",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-owner": "d10e2128-b7ff-7d85-4a00-a26f8c8f3068",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D3809A0\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2aae0be0-faee-f0d1-9569-e931c5575340",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a0c-d01f-0077-4ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1c7bec52-0fa3-ee65-1a8e-aba53769c398",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-owner": "d10e2128-b7ff-7d85-4a00-a26f8c8f3068",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D444DEC\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1c7bec52-0fa3-ee65-1a8e-aba53769c398",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a0d-d01f-0077-4bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b/test-file-8f5cb640-7c58-3271-f9d7-621231bd1628?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d9de2d36-37dc-869c-5796-afe121900281",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-owner": "d10e2128-b7ff-7d85-4a00-a26f8c8f3068",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82D510D88\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d9de2d36-37dc-869c-5796-afe121900281",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a0e-d01f-0077-4cc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b/test-file-8294a53f-b058-35c8-4e67-462ecf7a318a?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "17acbe72-21fa-8573-64a9-8a75f06eb6dd",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82DAC1DF6\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "17acbe72-21fa-8573-64a9-8a75f06eb6dd",
+        "x-ms-request-id": "49ae9a0f-d01f-0077-4dc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b/test-file-42f72564-f822-54f6-e81e-566b866bc792?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "48f84d35-b0c5-7922-c858-2edcca07fff8",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82DB8F1C0\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "48f84d35-b0c5-7922-c858-2edcca07fff8",
+        "x-ms-request-id": "49ae9a10-d01f-0077-4ec1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b/test-file-ed01f7e1-a5b1-4b0f-942d-d6395314f3a2?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "68fface9-9845-900c-3ead-b397dae926b3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82DC5B432\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "68fface9-9845-900c-3ead-b397dae926b3",
+        "x-ms-request-id": "49ae9a11-d01f-0077-4fc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1/test-directory-ce2f0a7e-f77d-a516-5c77-86b6eeb3426b/test-directory-32448c64-c7d1-6385-2b3d-0e6e5b9a60e1?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "5e10961c-cc6f-2193-269c-3d088a9d34a3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:58:59 GMT",
+        "ETag": "\u00220x8D863D82DD202A4\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5e10961c-cc6f-2193-269c-3d088a9d34a3",
+        "x-ms-request-id": "49ae9a12-d01f-0077-50c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-f052c381d1f5e74598ee0f4ce39a5c95-bea04785e5e6e443-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "c5511753-028a-6372-de2e-7f794d5575ee",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:00Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "c5511753-028a-6372-de2e-7f794d5575ee",
+        "x-ms-request-id": "3f6cf076-801e-00d3-33c1-952a13000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:01Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:00Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003ENjs160A4dR/zkOyDIf8cFV/18SIw5Ec3S0iZ389RC5c=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196/test-directory-0d28605f-ca11-1be5-275a-6640ea9811e1?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A01Z\u0026ske=2020-09-28T18%3A59%3A00Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A00Z\u0026se=2020-09-28T18%3A59%3A00Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=d10e2128-b7ff-7d85-4a00-a26f8c8f3068\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=set\u0026forceFlag=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "72b44704-6f4b-4a19-6005-8a6bff248bd9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:00 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "d9de2d36-37dc-869c-5796-afe121900281",
+        "x-ms-client-request-id": "72b44704-6f4b-4a19-6005-8a6bff248bd9",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "5c27f0d9-301f-001d-6d6e-6ffb9d000000",
+        "x-ms-request-id": "49ae9a13-d01f-0077-51c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODVkMzg1ZjAtYzYyYi0xM2E4LTBmMzUtNGNmNzMzOTkzOTM2L3Rlc3QtZGlyZWN0b3J5LWE2ZTVkNjFmLTU5ZjgtZWQ2Zi1jNjgyLTIxYzA3ZDY4MmM5Mi90ZXN0LWZpbGUtZTBiOWVmZjMtYjQ4MS1iNWIzLTJkOWItOGRkNmQyYmVmM2E3IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODVkMzg1ZjAtYzYyYi0xM2E4LTBmMzUtNGNmNzMzOTkzOTM2L3Rlc3QtZGlyZWN0b3J5LWE2ZTVkNjFmLTU5ZjgtZWQ2Zi1jNjgyLTIxYzA3ZDY4MmM5Mi90ZXN0LWZpbGUtZDgxOGIzNmQtNzVkNy03ZjJkLTM3ZjItODYyOGE1ZWVmNjAxIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODVkMzg1ZjAtYzYyYi0xM2E4LTBmMzUtNGNmNzMzOTkzOTM2L3Rlc3QtZGlyZWN0b3J5LWE2ZTVkNjFmLTU5ZjgtZWQ2Zi1jNjgyLTIxYzA3ZDY4MmM5Mi90ZXN0LWZpbGUtMWZkYTY3NDYtYzA2Yy03YmIzLTkyY2UtMTE2ZWI1ZWUwZDQ0IiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODVkMzg1ZjAtYzYyYi0xM2E4LTBmMzUtNGNmNzMzOTkzOTM2L3Rlc3QtZGlyZWN0b3J5LWE2ZTVkNjFmLTU5ZjgtZWQ2Zi1jNjgyLTIxYzA3ZDY4MmM5Mi90ZXN0LWRpcmVjdG9yeS0yYWFlMGJlMC1mYWVlLWYwZDEtOTU2OS1lOTMxYzU1NzUzNDAiLCJ0eXBlIjoiRElSRUNUT1JZIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMGQyODYwNWYtY2ExMS0xYmU1LTI3NWEtNjY0MGVhOTgxMWUxL3Rlc3QtZGlyZWN0b3J5LWNlMmYwYTdlLWY3N2QtYTUxNi01Yzc3LTg2YjZlZWIzNDI2Yi90ZXN0LWRpcmVjdG9yeS0zMjQ0OGM2NC1jN2QxLTYzODUtMmIzZC0wZTZlNWI5YTYwZTEiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTBkMjg2MDVmLWNhMTEtMWJlNS0yNzVhLTY2NDBlYTk4MTFlMS90ZXN0LWRpcmVjdG9yeS1jZTJmMGE3ZS1mNzdkLWE1MTYtNWM3Ny04NmI2ZWViMzQyNmIvdGVzdC1maWxlLTgyOTRhNTNmLWIwNTgtMzVjOC00ZTY3LTQ2MmVjZjdhMzE4YSIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTBkMjg2MDVmLWNhMTEtMWJlNS0yNzVhLTY2NDBlYTk4MTFlMS90ZXN0LWRpcmVjdG9yeS1jZTJmMGE3ZS1mNzdkLWE1MTYtNWM3Ny04NmI2ZWViMzQyNmIvdGVzdC1maWxlLWVkMDFmN2UxLWE1YjEtNGIwZi05NDJkLWQ2Mzk1MzE0ZjNhMiIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTBkMjg2MDVmLWNhMTEtMWJlNS0yNzVhLTY2NDBlYTk4MTFlMS90ZXN0LWRpcmVjdG9yeS1jZTJmMGE3ZS1mNzdkLWE1MTYtNWM3Ny04NmI2ZWViMzQyNmIvdGVzdC1maWxlLTQyZjcyNTY0LWY4MjItNTRmNi1lODFlLTU2NmI4NjZiYzc5MiIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-56d53716-766b-0603-c10b-3a1c5f237196?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-292fe7cb4ce76c4585532dace8e05b76-afca079dbd2a4549-00",
+        "traceparent": "00-766ab1977e888f449c69808dd8cc0c92-11627d2eb5f52b43-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "096edfea-ea8a-76bc-2cec-2a5d6dbcf244",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:22 GMT",
+        "x-ms-client-request-id": "067418d9-02a1-01a3-3d2f-98c7f5f19dd3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:01 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -428,20 +662,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "096edfea-ea8a-76bc-2cec-2a5d6dbcf244",
-        "x-ms-request-id": "4e20121b-501e-0046-076e-6fc2a6000000",
+        "x-ms-client-request-id": "067418d9-02a1-01a3-3d2f-98c7f5f19dd3",
+        "x-ms-request-id": "49b8c745-601e-0072-18c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:00.6218540-07:00",
     "RandomSeed": "1713148893",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_ContinueOnFailureAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_ContinueOnFailureAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7851d144de658e44bdcbe95f3d5a4a54-e8cb0b3dbc007a40-00",
+        "traceparent": "00-edd697511e12034f8d60b13c23965dcc-b673f2a687fd8840-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "9b7dd6d7-e704-ce1a-4b14-53ccc433f582",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:28 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:27 GMT",
-        "ETag": "\u00220x8D83D85C900962F\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:28 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:42 GMT",
+        "ETag": "\u00220x8D863D8478E348B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:43 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9b7dd6d7-e704-ce1a-4b14-53ccc433f582",
-        "x-ms-request-id": "4e2016dc-501e-0046-606e-6fc2a6000000",
+        "x-ms-request-id": "49b8d3ff-601e-0072-5bc1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-03c18b621facca43acb48826c3009609-60ecac1548adf843-00",
+        "traceparent": "00-b03aaab18ab4644fa9340c919f00fe6f-5c8e58618b96f747-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "cd620413-6fcd-8bc1-8658-3d2274b5c45d",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:28 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:28 GMT",
-        "ETag": "\u00220x8D83D85C901E512\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:28 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:43 GMT",
+        "ETag": "\u00220x8D863D8478F5C12\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "cd620413-6fcd-8bc1-8658-3d2274b5c45d",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864e6-801f-0008-346e-6fec2e000000",
+        "x-ms-request-id": "49ae9a8d-d01f-0077-3fc1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7318976270c85c42bb333bf708c2499e-a605a98b6c3c954e-00",
+        "traceparent": "00-d9c1169aa83e4948b766ea1bfed13e9a-e61d2cbe0eef2b44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "c0b965f8-28d1-a3b5-79c3-f6e1de6ddbe1",
+        "x-ms-client-request-id": "faa0a9fd-9b69-6c5d-25a7-869f6b7eab8e",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:28 GMT",
-        "ETag": "\u00220x8D83D85C9593064\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:43 GMT",
+        "ETag": "\u00220x8D863D847A85172\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "c0b965f8-28d1-a3b5-79c3-f6e1de6ddbe1",
-        "x-ms-request-id": "ab3366f1-c01f-0036-086e-6f7b51000000",
+        "x-ms-client-request-id": "faa0a9fd-9b69-6c5d-25a7-869f6b7eab8e",
+        "x-ms-request-id": "49ae9a8e-d01f-0077-40c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-faa0a9fd-9b69-6c5d-25a7-869f6b7eab8e?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-0e2a6c8c-04fc-5a8c-536e-07ccb0fddcd9?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8cc1cc163e45b646a1b6fdbaaa66c1ca-dbc16b3d550c6942-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "37452352-d158-5d67-074d-9b29a11537fa",
+        "x-ms-client-request-id": "72546717-cc43-f8e4-1c46-a6fa9490bc27",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:28 GMT",
-        "ETag": "\u00220x8D83D85C9659B80\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:43 GMT",
+        "ETag": "\u00220x8D863D847B49FDD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "37452352-d158-5d67-074d-9b29a11537fa",
-        "x-ms-request-id": "ab3366f4-c01f-0036-0a6e-6f7b51000000",
+        "x-ms-client-request-id": "72546717-cc43-f8e4-1c46-a6fa9490bc27",
+        "x-ms-request-id": "49ae9a8f-d01f-0077-41c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-faa0a9fd-9b69-6c5d-25a7-869f6b7eab8e/test-file-72546717-cc43-f8e4-1c46-a6fa9490bc27?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-0e2a6c8c-04fc-5a8c-536e-07ccb0fddcd9/test-file-484cadcb-7439-ba36-04cc-07af6863b83d?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "48b40c36-6aa9-8696-3e4c-1a112b6cc976",
+        "x-ms-client-request-id": "f35e7491-efc8-a3c1-3199-6d76c43590b8",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C974FEA9\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:43 GMT",
+        "ETag": "\u00220x8D863D847C15F68\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "48b40c36-6aa9-8696-3e4c-1a112b6cc976",
-        "x-ms-request-id": "ab3366f6-c01f-0036-0c6e-6f7b51000000",
+        "x-ms-client-request-id": "f35e7491-efc8-a3c1-3199-6d76c43590b8",
+        "x-ms-request-id": "49ae9a90-d01f-0077-42c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-faa0a9fd-9b69-6c5d-25a7-869f6b7eab8e/test-file-f35e7491-efc8-a3c1-3199-6d76c43590b8?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-0e2a6c8c-04fc-5a8c-536e-07ccb0fddcd9/test-file-87c4698d-73dc-607d-17c5-09ec59248f97?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f41e9003-c504-4774-4b11-160ffc1fc209",
+        "x-ms-client-request-id": "c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C981E1F8\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847D0A36C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f41e9003-c504-4774-4b11-160ffc1fc209",
-        "x-ms-request-id": "ab3366f7-c01f-0036-0d6e-6f7b51000000",
+        "x-ms-client-request-id": "c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c",
+        "x-ms-request-id": "49ae9a91-d01f-0077-43c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a10fdc5f99f28e40abf67f3618448519-968c2a1ff5439c41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f6300003-cd9f-c1ef-f600-fe07e8716176",
+        "x-ms-client-request-id": "260609c6-8eac-20f1-aebc-cd2b05cfc088",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C98E7A10\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847DCF3EF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f6300003-cd9f-c1ef-f600-fe07e8716176",
-        "x-ms-request-id": "ab3366f8-c01f-0036-0e6e-6f7b51000000",
+        "x-ms-client-request-id": "260609c6-8eac-20f1-aebc-cd2b05cfc088",
+        "x-ms-request-id": "49ae9a92-d01f-0077-44c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c/test-file-260609c6-8eac-20f1-aebc-cd2b05cfc088?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7/test-file-e4ffe599-53a4-3b6d-e6b1-3d169dace082?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "5304c61b-3d67-754a-0e0f-48e300c4bb26",
+        "x-ms-client-request-id": "026d7640-7c72-73d1-9cca-3ffa50db8301",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,190 +241,420 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C99B3382\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847E9BD91\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "5304c61b-3d67-754a-0e0f-48e300c4bb26",
-        "x-ms-request-id": "ab3366fa-c01f-0036-106e-6f7b51000000",
+        "x-ms-client-request-id": "026d7640-7c72-73d1-9cca-3ffa50db8301",
+        "x-ms-request-id": "49ae9a93-d01f-0077-45c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c/test-file-026d7640-7c72-73d1-9cca-3ffa50db8301?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-53abb3c4a07cd94a9663f03cc9d52b52-9bb784600aaca641-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "26d616f6-dd3e-9e10-f591-b69dfd502533",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C9A7B88A\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "26d616f6-dd3e-9e10-f591-b69dfd502533",
-        "x-ms-request-id": "0ee864ea-801f-0008-386e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c/test-file-b506468b-7cb4-d35b-5612-67e8a63b6812?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f892157fa7cc6241863e4da2d938be78-a8b498aa569e7f47-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c30aa264-8683-796e-bb03-d02c7527f8b9",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C9B3D45E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "c30aa264-8683-796e-bb03-d02c7527f8b9",
-        "x-ms-request-id": "0ee864eb-801f-0008-396e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c/test-file-e00ea329-eb4b-2d2e-8407-7a4432211cd3?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-e4bdf622dfec944e9deca43a20ff96d4-f5a14a7f3bcc6643-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "13119078-7d73-79ff-73dc-3f7b0c2a469a",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C9BFE576\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "13119078-7d73-79ff-73dc-3f7b0c2a469a",
-        "x-ms-request-id": "0ee864ed-801f-0008-3b6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5/test-directory-c28462bc-41a8-1d9a-f6fd-dc03e5d44a0c/test-directory-5978fde7-f3a3-8488-1306-31c06d2ca1ed?resource=directory",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-8ec944d9e6c3f44c9f9f14622434c541-e3b6e53b831a8247-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "8f1ae344-2f1d-846e-088c-ff6c4b3f0b47",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85C9CB710E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "8f1ae344-2f1d-846e-088c-ff6c4b3f0b47",
-        "x-ms-request-id": "0ee864ee-801f-0008-3c6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-984a1817-8e9a-d79e-cd37-1d3aa44b0ac5?action=setAccessControlRecursive\u0026mode=set\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e7d8b35171060b468eee0346162a231b-d608148ded3e9a4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "8a7bad0b-1111-4ecf-f946-998308f2ecde",
+        "x-ms-client-request-id": "b506468b-7cb4-d35b-5612-67e8a63b6812",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-owner": "3f0f4adc-6dcb-5b20-9a89-d5950a893b22",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847A85172\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b506468b-7cb4-d35b-5612-67e8a63b6812",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a94-d01f-0077-46c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-0e2a6c8c-04fc-5a8c-536e-07ccb0fddcd9?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "c30aa264-8683-796e-bb03-d02c7527f8b9",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-owner": "3f0f4adc-6dcb-5b20-9a89-d5950a893b22",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847B49FDD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c30aa264-8683-796e-bb03-d02c7527f8b9",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a95-d01f-0077-47c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-0e2a6c8c-04fc-5a8c-536e-07ccb0fddcd9/test-file-484cadcb-7439-ba36-04cc-07af6863b83d?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "04831cb4-a431-078f-ae8b-7d028c968912",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-owner": "3f0f4adc-6dcb-5b20-9a89-d5950a893b22",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847C15F68\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "04831cb4-a431-078f-ae8b-7d028c968912",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a96-d01f-0077-48c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-0e2a6c8c-04fc-5a8c-536e-07ccb0fddcd9/test-file-87c4698d-73dc-607d-17c5-09ec59248f97?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "5978fde7-f3a3-8488-1306-31c06d2ca1ed",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-owner": "3f0f4adc-6dcb-5b20-9a89-d5950a893b22",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847D0A36C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5978fde7-f3a3-8488-1306-31c06d2ca1ed",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a97-d01f-0077-49c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8f1ae344-2f1d-846e-088c-ff6c4b3f0b47",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-owner": "3f0f4adc-6dcb-5b20-9a89-d5950a893b22",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847DCF3EF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8f1ae344-2f1d-846e-088c-ff6c4b3f0b47",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a98-d01f-0077-4ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7/test-file-e4ffe599-53a4-3b6d-e6b1-3d169dace082?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8a7bad0b-1111-4ecf-f946-998308f2ecde",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-owner": "3f0f4adc-6dcb-5b20-9a89-d5950a893b22",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D847E9BD91\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8a7bad0b-1111-4ecf-f946-998308f2ecde",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a99-d01f-0077-4bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7/test-file-121849fe-5717-a026-583c-f1dcf3d521d4?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "199a5d55-0d1b-b3e7-86db-32d51ff35a23",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D848432FB8\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "199a5d55-0d1b-b3e7-86db-32d51ff35a23",
+        "x-ms-request-id": "49ae9a9a-d01f-0077-4cc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7/test-file-0717c524-4d91-7d1a-13ee-9069ac0e9551?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "45f28752-ceef-0719-431c-052c7d7d0777",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D8484FF953\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "45f28752-ceef-0719-431c-052c7d7d0777",
+        "x-ms-request-id": "49ae9a9b-d01f-0077-4dc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7/test-file-d86fe046-c46b-1ce8-0cb9-eee236322eb2?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "6ea29fa7-31f1-8e23-9ed6-3835e036d011",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "ETag": "\u00220x8D863D8485CC7FD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6ea29fa7-31f1-8e23-9ed6-3835e036d011",
+        "x-ms-request-id": "49ae9a9c-d01f-0077-4ec1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0/test-directory-3373d509-9b17-c8b3-f47d-3cca5c6e64f7/test-directory-7b4853ee-e266-f65b-7ed8-aaea71ca1980?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "af2f41af-6444-c434-44ab-ef1987381cd3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:45 GMT",
+        "ETag": "\u00220x8D863D848691BFA\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:45 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "af2f41af-6444-c434-44ab-ef1987381cd3",
+        "x-ms-request-id": "49ae9a9d-d01f-0077-4fc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-546624944df3e6428f7b6acdef638a81-75f735d7d1b11143-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "303bb420-6a9b-753c-1e76-51e4cfa82ba6",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:45Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "303bb420-6a9b-753c-1e76-51e4cfa82ba6",
+        "x-ms-request-id": "0e8f2c14-d01e-0005-20c1-9524fa000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:45Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:45Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003E\u002BIJdwVeobBLJhok4sDS59DGrb/KP1bPgkqkyxxUK0pU=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7/test-directory-80110882-a690-bbdf-462e-0442e0f8cbd0?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A45Z\u0026ske=2020-09-28T18%3A59%3A45Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A45Z\u0026se=2020-09-28T18%3A59%3A45Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=3f0f4adc-6dcb-5b20-9a89-d5950a893b22\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=set\u0026forceFlag=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "d2f89dcc-ebfc-5138-7be6-6e84e89c5fe8",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:45 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "8a7bad0b-1111-4ecf-f946-998308f2ecde",
+        "x-ms-client-request-id": "d2f89dcc-ebfc-5138-7be6-6e84e89c5fe8",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "ab3366fc-c01f-0036-126e-6f7b51000000",
+        "x-ms-request-id": "49ae9a9e-d01f-0077-50c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTg0YTE4MTctOGU5YS1kNzllLWNkMzctMWQzYWE0NGIwYWM1L3Rlc3QtZGlyZWN0b3J5LWMyODQ2MmJjLTQxYTgtMWQ5YS1mNmZkLWRjMDNlNWQ0NGEwYy90ZXN0LWZpbGUtYjUwNjQ2OGItN2NiNC1kMzViLTU2MTItNjdlOGE2M2I2ODEyIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTg0YTE4MTctOGU5YS1kNzllLWNkMzctMWQzYWE0NGIwYWM1L3Rlc3QtZGlyZWN0b3J5LWMyODQ2MmJjLTQxYTgtMWQ5YS1mNmZkLWRjMDNlNWQ0NGEwYy90ZXN0LWZpbGUtMDI2ZDc2NDAtN2M3Mi03M2QxLTljY2EtM2ZmYTUwZGI4MzAxIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTg0YTE4MTctOGU5YS1kNzllLWNkMzctMWQzYWE0NGIwYWM1L3Rlc3QtZGlyZWN0b3J5LWMyODQ2MmJjLTQxYTgtMWQ5YS1mNmZkLWRjMDNlNWQ0NGEwYy90ZXN0LWZpbGUtZTAwZWEzMjktZWI0Yi0yZDJlLTg0MDctN2E0NDMyMjExY2QzIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTg0YTE4MTctOGU5YS1kNzllLWNkMzctMWQzYWE0NGIwYWM1L3Rlc3QtZGlyZWN0b3J5LWMyODQ2MmJjLTQxYTgtMWQ5YS1mNmZkLWRjMDNlNWQ0NGEwYy90ZXN0LWRpcmVjdG9yeS01OTc4ZmRlNy1mM2EzLTg0ODgtMTMwNi0zMWMwNmQyY2ExZWQiLCJ0eXBlIjoiRElSRUNUT1JZIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODAxMTA4ODItYTY5MC1iYmRmLTQ2MmUtMDQ0MmUwZjhjYmQwL3Rlc3QtZGlyZWN0b3J5LTMzNzNkNTA5LTliMTctYzhiMy1mNDdkLTNjY2E1YzZlNjRmNy90ZXN0LWZpbGUtZDg2ZmUwNDYtYzQ2Yi0xY2U4LTBjYjktZWVlMjM2MzIyZWIyIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODAxMTA4ODItYTY5MC1iYmRmLTQ2MmUtMDQ0MmUwZjhjYmQwL3Rlc3QtZGlyZWN0b3J5LTMzNzNkNTA5LTliMTctYzhiMy1mNDdkLTNjY2E1YzZlNjRmNy90ZXN0LWZpbGUtMDcxN2M1MjQtNGQ5MS03ZDFhLTEzZWUtOTA2OWFjMGU5NTUxIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktODAxMTA4ODItYTY5MC1iYmRmLTQ2MmUtMDQ0MmUwZjhjYmQwL3Rlc3QtZGlyZWN0b3J5LTMzNzNkNTA5LTliMTctYzhiMy1mNDdkLTNjY2E1YzZlNjRmNy90ZXN0LWRpcmVjdG9yeS03YjQ4NTNlZS1lMjY2LWY2NWItN2VkOC1hYWVhNzFjYTE5ODAiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTgwMTEwODgyLWE2OTAtYmJkZi00NjJlLTA0NDJlMGY4Y2JkMC90ZXN0LWRpcmVjdG9yeS0zMzczZDUwOS05YjE3LWM4YjMtZjQ3ZC0zY2NhNWM2ZTY0ZjcvdGVzdC1maWxlLTEyMTg0OWZlLTU3MTctYTAyNi01ODNjLWYxZGNmM2Q1MjFkNCIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-20ece95c-e203-996e-ce1d-00c21f61a5c7?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-57982fca3f451945bfe46d1a431e5b18-95a256a9e18d2f47-00",
+        "traceparent": "00-901fc1f6f54a9a44a1d375b8027ae78a-b53c899aa6876f4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "9e61006b-81c3-2935-81ad-ab170a07d6aa",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "x-ms-client-request-id": "3117220d-58b0-80a9-7938-e3e9bc778c23",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -428,20 +662,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "9e61006b-81c3-2935-81ad-ab170a07d6aa",
-        "x-ms-request-id": "4e2017f1-501e-0046-5e6e-6fc2a6000000",
+        "x-ms-client-request-id": "3117220d-58b0-80a9-7938-e3e9bc778c23",
+        "x-ms-request-id": "49b8d4a9-601e-0072-6fc1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:45.2332011-07:00",
     "RandomSeed": "2018761075",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-96af17a8f38e894eacdad27228d70773-f60b04f775b0e047-00",
+        "traceparent": "00-9bc50ff0a2755d439c9462aa1773eca9-063a464c10c72a41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "0c2228ea-080d-f9a0-c2e8-7c2ae73977ab",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:01 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:01 GMT",
-        "ETag": "\u00220x8D83D4F6118BA7D\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:01 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D83068F145\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:04 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0c2228ea-080d-f9a0-c2e8-7c2ae73977ab",
-        "x-ms-request-id": "58dac907-601e-00b9-6d38-6ff23b000000",
+        "x-ms-request-id": "49b8c842-601e-0072-7ec1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4b699cac27f219459f26cbb057e6912b-6b017cc73a18ba4f-00",
+        "traceparent": "00-cefea1c64fadec41898f275f07095afc-3bc1a52a3301e949-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "d56cf027-1e0b-3c51-6495-b1fa6ae85e01",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:01 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:04 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:01 GMT",
-        "ETag": "\u00220x8D83D4F611D923A\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:01 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D8306A3600\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:04 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d56cf027-1e0b-3c51-6495-b1fa6ae85e01",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "e0acbfa7-401f-0038-6638-6f52e1000000",
+        "x-ms-request-id": "49ae9a34-d01f-0077-72c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cc90cec4e293744a894809cd23dd864b-8d6e1edd1a5aca4e-00",
+        "traceparent": "00-007677962b4e8e49b1be2b4b107f6e20-e522bba501f88744-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f703e5ed-a2cc-219f-c46f-d03138dcc0f1",
+        "x-ms-client-request-id": "ba284eab-a1e5-71ef-d76c-8313ec4e84c8",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:01 GMT",
-        "ETag": "\u00220x8D83D4F6185885C\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D830849696\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f703e5ed-a2cc-219f-c46f-d03138dcc0f1",
-        "x-ms-request-id": "dc5ed8c0-801f-006a-1038-6f2e09000000",
+        "x-ms-client-request-id": "ba284eab-a1e5-71ef-d76c-8313ec4e84c8",
+        "x-ms-request-id": "49ae9a35-d01f-0077-73c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f/test-directory-ba284eab-a1e5-71ef-d76c-8313ec4e84c8?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-840c10a1-67e5-3934-ab1a-9538e5e7c775?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4a4102748b5d644ea2286de96c59a08d-4a66e6831fbbee45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "69584037-3973-4cbc-f691-1f5f1f8c3475",
+        "x-ms-client-request-id": "289007eb-3cd0-430b-19ef-0eca0cb68cf0",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:01 GMT",
-        "ETag": "\u00220x8D83D4F6191FDBC\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D83090F3EE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "69584037-3973-4cbc-f691-1f5f1f8c3475",
-        "x-ms-request-id": "dc5ed8c8-801f-006a-1138-6f2e09000000",
+        "x-ms-client-request-id": "289007eb-3cd0-430b-19ef-0eca0cb68cf0",
+        "x-ms-request-id": "49ae9a36-d01f-0077-74c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f/test-directory-ba284eab-a1e5-71ef-d76c-8313ec4e84c8/test-file-289007eb-3cd0-430b-19ef-0eca0cb68cf0?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-840c10a1-67e5-3934-ab1a-9538e5e7c775/test-file-abdb0da5-1af5-6755-54bf-8e5448d4191e?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "dd4d1fe5-9f57-fba5-3415-50842bf13f40",
+        "x-ms-client-request-id": "11ba2e04-89b0-d17f-b228-d310aeb7fa44",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "ETag": "\u00220x8D83D4F61A41DFD\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D8309DBB9B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "dd4d1fe5-9f57-fba5-3415-50842bf13f40",
-        "x-ms-request-id": "dc5ed8c9-801f-006a-1238-6f2e09000000",
+        "x-ms-client-request-id": "11ba2e04-89b0-d17f-b228-d310aeb7fa44",
+        "x-ms-request-id": "49ae9a37-d01f-0077-75c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f/test-directory-ba284eab-a1e5-71ef-d76c-8313ec4e84c8/test-file-11ba2e04-89b0-d17f-b228-d310aeb7fa44?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-840c10a1-67e5-3934-ab1a-9538e5e7c775/test-file-ede4efd5-af68-0699-68e0-76e0cad13b62?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "1a504d80-071a-5c6e-9f7c-2a2ecb954d7d",
+        "x-ms-client-request-id": "3bae0b1a-510c-54d7-95b4-a9d0129f06e1",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "ETag": "\u00220x8D83D4F61B0CD7B\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D830AA88D9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "1a504d80-071a-5c6e-9f7c-2a2ecb954d7d",
-        "x-ms-request-id": "dc5ed8ca-801f-006a-1338-6f2e09000000",
+        "x-ms-client-request-id": "3bae0b1a-510c-54d7-95b4-a9d0129f06e1",
+        "x-ms-request-id": "49ae9a38-d01f-0077-76c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f/test-directory-3bae0b1a-510c-54d7-95b4-a9d0129f06e1?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-608f70ec-e066-ce2a-8187-4eec846a3ad3?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7ddb451f43b8ee44a564ddb4db542c1c-8eb64aeaa9e18c45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "bec5f993-0022-2f55-76fb-84655d9e4a00",
+        "x-ms-client-request-id": "5a414975-ed05-3a16-e0df-b98503eacf2a",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "ETag": "\u00220x8D83D4F61BD50CE\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D830B6D11D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "bec5f993-0022-2f55-76fb-84655d9e4a00",
-        "x-ms-request-id": "dc5ed8cb-801f-006a-1438-6f2e09000000",
+        "x-ms-client-request-id": "5a414975-ed05-3a16-e0df-b98503eacf2a",
+        "x-ms-request-id": "49ae9a39-d01f-0077-77c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f/test-directory-3bae0b1a-510c-54d7-95b4-a9d0129f06e1/test-file-5a414975-ed05-3a16-e0df-b98503eacf2a?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-608f70ec-e066-ce2a-8187-4eec846a3ad3/test-file-183cd67a-47d9-ecbe-1a60-e96b5bc570e3?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "3b774d3d-df29-a6cd-e28a-de4346d02b8c",
+        "x-ms-client-request-id": "87eb5a2b-3161-2d26-8a55-3fa403abdf1b",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,94 +241,327 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "ETag": "\u00220x8D83D4F61CA1B72\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D830C48AAA\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "3b774d3d-df29-a6cd-e28a-de4346d02b8c",
-        "x-ms-request-id": "dc5ed8cd-801f-006a-1638-6f2e09000000",
+        "x-ms-client-request-id": "87eb5a2b-3161-2d26-8a55-3fa403abdf1b",
+        "x-ms-request-id": "49ae9a3a-d01f-0077-78c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f/test-directory-3bae0b1a-510c-54d7-95b4-a9d0129f06e1/test-file-87eb5a2b-3161-2d26-8a55-3fa403abdf1b?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-4d9631e1a2b80842b7ddbc4ff36f0e32-543797ef3563624f-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "003f5d35-e9d9-0b82-274a-b0d4a029a237",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "ETag": "\u00220x8D83D4F61D74459\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "003f5d35-e9d9-0b82-274a-b0d4a029a237",
-        "x-ms-request-id": "e0acbfa8-401f-0038-6738-6f52e1000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-8a50ee11-fc57-6a9b-eb12-cf56fd2e2b5f?action=setAccessControlRecursive\u0026mode=set",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e265e443d66006488e8394b0abae099d-ecb449b7936a9e4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "a66ff5af-de6b-8641-543c-8e28e32cfadf",
+        "x-ms-client-request-id": "70d3c2ab-7588-9719-5951-7ecbfbd7c30f",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "x-ms-owner": "b547d66f-9472-9a00-0896-364e697ba549",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D830849696\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "70d3c2ab-7588-9719-5951-7ecbfbd7c30f",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a3b-d01f-0077-79c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-840c10a1-67e5-3934-ab1a-9538e5e7c775?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a6a3fef3-35a7-bfc0-43a8-a6886ab60f4f",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "x-ms-owner": "b547d66f-9472-9a00-0896-364e697ba549",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:04 GMT",
+        "ETag": "\u00220x8D863D83090F3EE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6a3fef3-35a7-bfc0-43a8-a6886ab60f4f",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a3c-d01f-0077-7ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-840c10a1-67e5-3934-ab1a-9538e5e7c775/test-file-abdb0da5-1af5-6755-54bf-8e5448d4191e?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "fdd89e56-1c34-7a68-34b0-62c238b91b9d",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "x-ms-owner": "b547d66f-9472-9a00-0896-364e697ba549",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "ETag": "\u00220x8D863D8309DBB9B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fdd89e56-1c34-7a68-34b0-62c238b91b9d",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a3d-d01f-0077-7bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-840c10a1-67e5-3934-ab1a-9538e5e7c775/test-file-ede4efd5-af68-0699-68e0-76e0cad13b62?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "cb3279f4-12de-691b-38aa-7508990994c7",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "x-ms-owner": "b547d66f-9472-9a00-0896-364e697ba549",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "ETag": "\u00220x8D863D830AA88D9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb3279f4-12de-691b-38aa-7508990994c7",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a3e-d01f-0077-7cc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-608f70ec-e066-ce2a-8187-4eec846a3ad3?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "becd0fd8-4f87-1bbe-2237-0a5dda1d5d28",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "x-ms-owner": "b547d66f-9472-9a00-0896-364e697ba549",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "ETag": "\u00220x8D863D830B6D11D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "becd0fd8-4f87-1bbe-2237-0a5dda1d5d28",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a3f-d01f-0077-7dc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-608f70ec-e066-ce2a-8187-4eec846a3ad3/test-file-183cd67a-47d9-ecbe-1a60-e96b5bc570e3?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8a30b549-d63b-e240-c003-861766c62b5b",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "x-ms-owner": "b547d66f-9472-9a00-0896-364e697ba549",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "ETag": "\u00220x8D863D830C48AAA\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8a30b549-d63b-e240-c003-861766c62b5b",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a40-d01f-0077-7ec1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1/test-directory-608f70ec-e066-ce2a-8187-4eec846a3ad3/test-file-991aa283-c6e7-aa69-0b49-685bfcc1d463?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a479f700-d9a4-8242-4b85-7ef26de5e6ff",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "ETag": "\u00220x8D863D8311E2B40\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a479f700-d9a4-8242-4b85-7ef26de5e6ff",
+        "x-ms-request-id": "49ae9a41-d01f-0077-7fc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-7b90ea5c48727640aa24203e90c0dab7-ae466833557b3945-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "045bda2b-2f47-ebbf-9d91-da6754faff37",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:06Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "045bda2b-2f47-ebbf-9d91-da6754faff37",
+        "x-ms-request-id": "8301ee8d-001e-0090-2cc1-95cc4f000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:06Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:06Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EE\u002BGGyJ3wtDNohrRlOFjmRueiZJ1G38ZMzVQuXQAPBaw=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9/test-directory-593b4bdb-b5a8-ff18-51f8-3203b89cf4a1?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A06Z\u0026ske=2020-09-28T18%3A59%3A06Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A06Z\u0026se=2020-09-28T18%3A59%3A06Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=b547d66f-9472-9a00-0896-364e697ba549\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=set",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "92c65e82-e28a-ffb7-6467-e8212b065cba",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "a66ff5af-de6b-8641-543c-8e28e32cfadf",
+        "x-ms-client-request-id": "92c65e82-e28a-ffb7-6467-e8212b065cba",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "dc5ed8ce-801f-006a-1738-6f2e09000000",
+        "x-ms-request-id": "49ae9a42-d01f-0077-80c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOGE1MGVlMTEtZmM1Ny02YTliLWViMTItY2Y1NmZkMmUyYjVmL3Rlc3QtZGlyZWN0b3J5LTNiYWUwYjFhLTUxMGMtNTRkNy05NWI0LWE5ZDAxMjlmMDZlMS90ZXN0LWZpbGUtODdlYjVhMmItMzE2MS0yZDI2LThhNTUtM2ZhNDAzYWJkZjFiIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNTkzYjRiZGItYjVhOC1mZjE4LTUxZjgtMzIwM2I4OWNmNGExL3Rlc3QtZGlyZWN0b3J5LTYwOGY3MGVjLWUwNjYtY2UyYS04MTg3LTRlZWM4NDZhM2FkMy90ZXN0LWZpbGUtOTkxYWEyODMtYzZlNy1hYTY5LTBiNDktNjg1YmZjYzFkNDYzIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-68525ef6-b63c-748f-d96a-75f03a555db9?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6d4165fe6ad34249a3a16896305eac4e-5dadd8254546d94b-00",
+        "traceparent": "00-33919fc5bf316f479ae96cef34c531ee-22ff8a84ed71c340-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "aa24a086-fcb9-cccc-814d-1c4ce7f0b32c",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "x-ms-client-request-id": "f5e5a5fc-6c34-7bad-2225-1f32aebace83",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:06 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -332,20 +569,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "aa24a086-fcb9-cccc-814d-1c4ce7f0b32c",
-        "x-ms-request-id": "58daca87-601e-00b9-4d38-6ff23b000000",
+        "x-ms-client-request-id": "f5e5a5fc-6c34-7bad-2225-1f32aebace83",
+        "x-ms-request-id": "49b8c8d0-601e-0072-02c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:06.1540568-07:00",
     "RandomSeed": "493654",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_WithProgressMonitoring_WithFailureAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/SetAccessControlRecursiveAsync_WithProgressMonitoring_WithFailureAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ea323da2a6dc954caaa9e63c13755bf3-8bd7c6a886c1f444-00",
+        "traceparent": "00-d783d78662b8ba4ab70bdcf333442242-23fe9a878cd44942-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "9f600ea9-bc2b-ad2b-3879-0ace6ba07e70",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:06 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:06 GMT",
-        "ETag": "\u00220x8D83D4F6431DF65\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:06 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9B71A999\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:42 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9f600ea9-bc2b-ad2b-3879-0ace6ba07e70",
-        "x-ms-request-id": "58dace8e-601e-00b9-7e38-6ff23b000000",
+        "x-ms-request-id": "ea8b8489-c01e-006b-4bc5-9571d5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-48728ec2a8f2974e88fec7a3c1d991e8-216f5eefd98d464a-00",
+        "traceparent": "00-88425e9916e25042ab393d3af78adc59-b7a96c3186421e44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "a08aef54-3e40-1e66-7762-12d2bce909f1",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:06 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:06 GMT",
-        "ETag": "\u00220x8D83D4F6436DD93\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:06 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9B8F11B5\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:42 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a08aef54-3e40-1e66-7762-12d2bce909f1",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "e0acbfb2-401f-0038-6e38-6f52e1000000",
+        "x-ms-request-id": "06bf65af-a01f-0042-44c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-844295209c16bc4e93bb4d83cb5f4939-d4d0193143afc14f-00",
+        "traceparent": "00-9945052c75a64449bf4a9b17b82b90f9-848a39e76cc4e248-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "7c7a73ab-de15-6f2f-ebf9-b6f4baeeb0d2",
+        "x-ms-client-request-id": "6e789b00-7b8c-1c7d-43ae-524d5a45ef2b",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:06 GMT",
-        "ETag": "\u00220x8D83D4F649BAF7B\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9BD7F876\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "7c7a73ab-de15-6f2f-ebf9-b6f4baeeb0d2",
-        "x-ms-request-id": "dbe1b2f0-901f-0059-5738-6f71a2000000",
+        "x-ms-client-request-id": "6e789b00-7b8c-1c7d-43ae-524d5a45ef2b",
+        "x-ms-request-id": "06bf65b0-a01f-0042-45c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92/test-directory-6e789b00-7b8c-1c7d-43ae-524d5a45ef2b?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-4926343f-8d6e-89dc-ec5f-671f82b7215f?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-86b0cd8a02ade64f8172500b994c8868-6ea3771f3452724b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "941f1243-b3d4-3051-f65e-38678be215a5",
+        "x-ms-client-request-id": "86b48a0a-67c8-7363-bfee-812c135d998b",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:06 GMT",
-        "ETag": "\u00220x8D83D4F64AA454F\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9BE47A28\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "941f1243-b3d4-3051-f65e-38678be215a5",
-        "x-ms-request-id": "dbe1b2f1-901f-0059-5838-6f71a2000000",
+        "x-ms-client-request-id": "86b48a0a-67c8-7363-bfee-812c135d998b",
+        "x-ms-request-id": "06bf65b1-a01f-0042-46c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92/test-directory-6e789b00-7b8c-1c7d-43ae-524d5a45ef2b/test-file-86b48a0a-67c8-7363-bfee-812c135d998b?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-4926343f-8d6e-89dc-ec5f-671f82b7215f/test-file-480af28c-5a26-8c57-e3f5-52105475fd0a?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f715c249-9b03-dc97-afac-d5e532241d99",
+        "x-ms-client-request-id": "99daadc4-cdd8-b07f-3328-a2d214521f49",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:06 GMT",
-        "ETag": "\u00220x8D83D4F64BE9023\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9BF1BA99\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f715c249-9b03-dc97-afac-d5e532241d99",
-        "x-ms-request-id": "dbe1b2f2-901f-0059-5938-6f71a2000000",
+        "x-ms-client-request-id": "99daadc4-cdd8-b07f-3328-a2d214521f49",
+        "x-ms-request-id": "06bf65b2-a01f-0042-47c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92/test-directory-6e789b00-7b8c-1c7d-43ae-524d5a45ef2b/test-file-99daadc4-cdd8-b07f-3328-a2d214521f49?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-4926343f-8d6e-89dc-ec5f-671f82b7215f/test-file-51e376f0-a248-f188-5b2e-9879847159be?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "a74cb9d8-649a-7c32-4364-c4dbf8c5c75d",
+        "x-ms-client-request-id": "bbf48b8d-cc41-2251-25e8-3ea934052bc1",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:07 GMT",
-        "ETag": "\u00220x8D83D4F64E665BB\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9BFE3B24\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a74cb9d8-649a-7c32-4364-c4dbf8c5c75d",
-        "x-ms-request-id": "dbe1b2f4-901f-0059-5b38-6f71a2000000",
+        "x-ms-client-request-id": "bbf48b8d-cc41-2251-25e8-3ea934052bc1",
+        "x-ms-request-id": "06bf65b3-a01f-0042-48c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92/test-directory-bbf48b8d-cc41-2251-25e8-3ea934052bc1?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-5bfae4ce-7705-8cae-4466-0de3ddacf996?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d8bc07310e05f247ba392082e3899316-da525ce48f66cc4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f9ec3b66-9e7d-0c7d-682a-81b22688483e",
+        "x-ms-client-request-id": "140c0339-6bca-1557-dc68-76dbbe6d4478",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:07 GMT",
-        "ETag": "\u00220x8D83D4F650BF567\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:42 GMT",
+        "ETag": "\u00220x8D863DC9C0A437E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f9ec3b66-9e7d-0c7d-682a-81b22688483e",
-        "x-ms-request-id": "dbe1b2f5-901f-0059-5c38-6f71a2000000",
+        "x-ms-client-request-id": "140c0339-6bca-1557-dc68-76dbbe6d4478",
+        "x-ms-request-id": "06bf65b4-a01f-0042-49c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92/test-directory-bbf48b8d-cc41-2251-25e8-3ea934052bc1/test-file-140c0339-6bca-1557-dc68-76dbbe6d4478?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-5bfae4ce-7705-8cae-4466-0de3ddacf996/test-file-f843a7ef-3218-3044-66ee-f3daf6fc65bb?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "daaacf1d-e4a0-facb-e4d7-1c1427a24dfa",
+        "x-ms-client-request-id": "7ec209e6-5045-0625-bfdc-addc787c1fe0",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,94 +241,327 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:07 GMT",
-        "ETag": "\u00220x8D83D4F655B7F5A\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9C16D8DF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "daaacf1d-e4a0-facb-e4d7-1c1427a24dfa",
-        "x-ms-request-id": "dbe1b2f7-901f-0059-5e38-6f71a2000000",
+        "x-ms-client-request-id": "7ec209e6-5045-0625-bfdc-addc787c1fe0",
+        "x-ms-request-id": "06bf65b5-a01f-0042-4ac5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92/test-directory-bbf48b8d-cc41-2251-25e8-3ea934052bc1/test-file-7ec209e6-5045-0625-bfdc-addc787c1fe0?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-998f7b9314ddad45aae42ef0da72076b-f5dc90ddd8ce534b-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "ecf4f9a0-e739-cd76-a9a3-1bc337ee8267",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:08 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:08 GMT",
-        "ETag": "\u00220x8D83D4F65704804\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:08 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "ecf4f9a0-e739-cd76-a9a3-1bc337ee8267",
-        "x-ms-request-id": "e0acbfbb-401f-0038-7038-6f52e1000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-1f807234-17c5-72d8-c8ba-f234afa0de92?action=setAccessControlRecursive\u0026mode=set",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8f0d9961d0d1b54d95d9b28b38221738-d2358be3f43a6240-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "7f3be9d3-3288-1aa6-44ef-451f4e14d3ed",
+        "x-ms-client-request-id": "6c123cb8-5ee5-7b37-31b8-a2fd3ce5f18f",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "x-ms-owner": "efbdbb02-6ac3-0ad8-dc48-1440152f08c4",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 17:04:08 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9BD7F876\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6c123cb8-5ee5-7b37-31b8-a2fd3ce5f18f",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "06bf65b6-a01f-0042-4bc5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-4926343f-8d6e-89dc-ec5f-671f82b7215f?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d987acc6-9c1c-42df-c178-bb81457991c4",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "x-ms-owner": "efbdbb02-6ac3-0ad8-dc48-1440152f08c4",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9BE47A28\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d987acc6-9c1c-42df-c178-bb81457991c4",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "06bf65b7-a01f-0042-4cc5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-4926343f-8d6e-89dc-ec5f-671f82b7215f/test-file-480af28c-5a26-8c57-e3f5-52105475fd0a?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8f36b4e4-175d-3772-09f9-bd0f7724d5cb",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "x-ms-owner": "efbdbb02-6ac3-0ad8-dc48-1440152f08c4",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9BF1BA99\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8f36b4e4-175d-3772-09f9-bd0f7724d5cb",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "06bf65b8-a01f-0042-4dc5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-4926343f-8d6e-89dc-ec5f-671f82b7215f/test-file-51e376f0-a248-f188-5b2e-9879847159be?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "909d9e4b-0142-9a66-18b8-44b945cf0e71",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "x-ms-owner": "efbdbb02-6ac3-0ad8-dc48-1440152f08c4",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9BFE3B24\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "909d9e4b-0142-9a66-18b8-44b945cf0e71",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "06bf65b9-a01f-0042-4ec5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-5bfae4ce-7705-8cae-4466-0de3ddacf996?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d8c313d0-4487-5d88-1ad2-aa6b40817efe",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "x-ms-owner": "efbdbb02-6ac3-0ad8-dc48-1440152f08c4",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9C0A437E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d8c313d0-4487-5d88-1ad2-aa6b40817efe",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "06bf65ba-a01f-0042-4fc5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-5bfae4ce-7705-8cae-4466-0de3ddacf996/test-file-f843a7ef-3218-3044-66ee-f3daf6fc65bb?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "31e824f6-360b-ddea-d339-7dd6be8c1ef8",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:44 GMT",
+        "x-ms-owner": "efbdbb02-6ac3-0ad8-dc48-1440152f08c4",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9C16D8DF\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "31e824f6-360b-ddea-d339-7dd6be8c1ef8",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "06bf65bb-a01f-0042-50c5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd/test-directory-5bfae4ce-7705-8cae-4466-0de3ddacf996/test-file-0268c2f5-aa4a-3fcb-12e1-32492db91c0f?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "7dd91f1f-c4a2-4b80-59a9-1f2a04a1b019",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:30:43 GMT",
+        "ETag": "\u00220x8D863DC9C71C2F7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:30:44 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7dd91f1f-c4a2-4b80-59a9-1f2a04a1b019",
+        "x-ms-request-id": "06bf65bc-a01f-0042-51c5-954fa1000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-9bea7e1dbf01624aafaffa5d890c3ac8-f389a708adf15e40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0e2918be-9fe0-476c-5f29-c2ef2dc8b845",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T19:30:44Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 18:30:44 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0e2918be-9fe0-476c-5f29-c2ef2dc8b845",
+        "x-ms-request-id": "7302c023-901e-0082-7ac5-95b79f000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T18:30:45Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T19:30:44Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003E\u002BK8k/W2diGyd\u002BcHxExtAYyYZh5f38TKJ1NKkkOctYRU=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c/test-directory-52ce1c67-3819-dcac-4ef3-e4202f4c22dd?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T18%3A30%3A45Z\u0026ske=2020-09-28T19%3A30%3A44Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T17%3A30%3A44Z\u0026se=2020-09-28T19%3A30%3A44Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=efbdbb02-6ac3-0ad8-dc48-1440152f08c4\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=set",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "ec6c367d-a177-7d39-0183-7fec3f707b06",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 18:30:45 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "7f3be9d3-3288-1aa6-44ef-451f4e14d3ed",
+        "x-ms-client-request-id": "ec6c367d-a177-7d39-0183-7fec3f707b06",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "dbe1b2f9-901f-0059-6038-6f71a2000000",
+        "x-ms-request-id": "06bf65bd-a01f-0042-52c5-954fa1000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMWY4MDcyMzQtMTdjNS03MmQ4LWM4YmEtZjIzNGFmYTBkZTkyL3Rlc3QtZGlyZWN0b3J5LWJiZjQ4YjhkLWNjNDEtMjI1MS0yNWU4LTNlYTkzNDA1MmJjMS90ZXN0LWZpbGUtN2VjMjA5ZTYtNTA0NS0wNjI1LWJmZGMtYWRkYzc4N2MxZmUwIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNTJjZTFjNjctMzgxOS1kY2FjLTRlZjMtZTQyMDJmNGMyMmRkL3Rlc3QtZGlyZWN0b3J5LTViZmFlNGNlLTc3MDUtOGNhZS00NDY2LTBkZTNkZGFjZjk5Ni90ZXN0LWZpbGUtMDI2OGMyZjUtYWE0YS0zZmNiLTEyZTEtMzI0OTJkYjkxYzBmIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-d3eb10c4-5e89-2ed4-118d-e3f4d165170c?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8ac7b40cb8ebf1499daa1a67e57a126e-dca174692ee31642-00",
+        "traceparent": "00-6411b105dcf268429eed305fcd50585a-dd3a66b768ffa54c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "4eef8bb2-02b2-86de-96f7-27f519172c1c",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "x-ms-client-request-id": "f6711a42-cc5c-d4ce-f280-a4dbc516dd4f",
+        "x-ms-date": "Mon, 28 Sep 2020 18:30:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -332,20 +569,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:30:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "4eef8bb2-02b2-86de-96f7-27f519172c1c",
-        "x-ms-request-id": "58dad0b8-601e-00b9-0238-6ff23b000000",
+        "x-ms-client-request-id": "f6711a42-cc5c-d4ce-f280-a4dbc516dd4f",
+        "x-ms-request-id": "ea8b8520-c01e-006b-41c5-9571d5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T11:30:44.2122170-07:00",
     "RandomSeed": "919397420",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_ContinueOnFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_ContinueOnFailure.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-219a11fb02aed1429face193c0e14bce-34c090132f460e4b-00",
+        "traceparent": "00-80514736818c3847b5aab51e0097b50c-0c65f203dc17a44d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "92fbe274-2e73-0292-299f-a92789d549ef",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:22 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:06 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:21 GMT",
-        "ETag": "\u00220x8D83D85C5724C81\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:22 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831A567A9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:06 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "92fbe274-2e73-0292-299f-a92789d549ef",
-        "x-ms-request-id": "4e201231-501e-0046-1c6e-6fc2a6000000",
+        "x-ms-request-id": "49b8c8d6-601e-0072-08c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-26e2c4e1e2b99549b7ff21b006f2cf18-f7a69be7e8f74445-00",
+        "traceparent": "00-01886ee20aa49d48873b09ba7f16cbf0-f6d039f7c1559b4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "d59b5ae0-f84b-44fc-efb9-c63fd1787bf6",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:22 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:22 GMT",
-        "ETag": "\u00220x8D83D85C5739267\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:22 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831A6AB12\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d59b5ae0-f84b-44fc-efb9-c63fd1787bf6",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864cc-801f-0008-1b6e-6fec2e000000",
+        "x-ms-request-id": "49ae9a43-d01f-0077-01c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a7f6826f82a3f94cb5a2c84eba208e9c-53fa37c5c7dd1f4c-00",
+        "traceparent": "00-b7b16fc3efa4164482dbf9e18d45c5b6-b4b087be7b7def46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "2f46a910-743a-9da3-7ca7-1742df13e4e6",
+        "x-ms-client-request-id": "8c789722-f8c3-b863-b6cc-4406c527a389",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C5CA9E53\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831BFF3D2\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "2f46a910-743a-9da3-7ca7-1742df13e4e6",
-        "x-ms-request-id": "f793a23b-201f-0087-636e-6f6544000000",
+        "x-ms-client-request-id": "8c789722-f8c3-b863-b6cc-4406c527a389",
+        "x-ms-request-id": "49ae9a44-d01f-0077-02c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-8c789722-f8c3-b863-b6cc-4406c527a389?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-282e1750-4c31-3fbb-6919-1af41061ef7d?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fcf9353abe060c469769d11ab1d71659-a307d23dd6031240-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "09b24c60-dced-17eb-458d-786e2f9dd754",
+        "x-ms-client-request-id": "c7f18d03-bce4-d5b4-db38-23aadd6ea854",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C5D7D8FF\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831CC5537\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "09b24c60-dced-17eb-458d-786e2f9dd754",
-        "x-ms-request-id": "f793a23c-201f-0087-646e-6f6544000000",
+        "x-ms-client-request-id": "c7f18d03-bce4-d5b4-db38-23aadd6ea854",
+        "x-ms-request-id": "49ae9a47-d01f-0077-05c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-8c789722-f8c3-b863-b6cc-4406c527a389/test-file-c7f18d03-bce4-d5b4-db38-23aadd6ea854?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-282e1750-4c31-3fbb-6919-1af41061ef7d/test-file-79a6c7dd-9975-749c-2c16-e2a4d34d10cb?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "82f0c642-2770-a399-97dc-2eb4b8403ad6",
+        "x-ms-client-request-id": "689024e4-5df7-6adf-f17d-9acdda10028e",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C5E587C4\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831D92768\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "82f0c642-2770-a399-97dc-2eb4b8403ad6",
-        "x-ms-request-id": "f793a23d-201f-0087-656e-6f6544000000",
+        "x-ms-client-request-id": "689024e4-5df7-6adf-f17d-9acdda10028e",
+        "x-ms-request-id": "49ae9a48-d01f-0077-06c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-8c789722-f8c3-b863-b6cc-4406c527a389/test-file-689024e4-5df7-6adf-f17d-9acdda10028e?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-282e1750-4c31-3fbb-6919-1af41061ef7d/test-file-17685728-267e-b5e4-2d02-e1986be8bbec?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "afbf0bdc-a7bc-e4d4-e686-90f28ccbc986",
+        "x-ms-client-request-id": "608c9fda-22d7-be58-3fdb-3af47b46fe09",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C5F3194D\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831E608D1\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "afbf0bdc-a7bc-e4d4-e686-90f28ccbc986",
-        "x-ms-request-id": "f793a23e-201f-0087-666e-6f6544000000",
+        "x-ms-client-request-id": "608c9fda-22d7-be58-3fdb-3af47b46fe09",
+        "x-ms-request-id": "49ae9a49-d01f-0077-07c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-608c9fda-22d7-be58-3fdb-3af47b46fe09?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-37ff09d881af28499b7cf08eba6876ae-1c5990b33d92fa47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "ccbe5a39-5a5b-b914-b200-6fe16de0689f",
+        "x-ms-client-request-id": "de308787-fbdb-8735-cc0b-dd53f261284e",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C6054493\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831F2488F\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "ccbe5a39-5a5b-b914-b200-6fe16de0689f",
-        "x-ms-request-id": "f793a23f-201f-0087-676e-6f6544000000",
+        "x-ms-client-request-id": "de308787-fbdb-8735-cc0b-dd53f261284e",
+        "x-ms-request-id": "49ae9a4a-d01f-0077-08c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-608c9fda-22d7-be58-3fdb-3af47b46fe09/test-file-de308787-fbdb-8735-cc0b-dd53f261284e?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862/test-file-20bbd8b2-3288-67ad-9a36-1b50e3f113a3?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "0d6f901b-4ac0-3d86-2536-ff4f7dc0c751",
+        "x-ms-client-request-id": "942e21d8-4724-5517-dac9-43a4dfe4a3db",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,190 +241,420 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C61301F6\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831FF2934\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "0d6f901b-4ac0-3d86-2536-ff4f7dc0c751",
-        "x-ms-request-id": "f793a240-201f-0087-686e-6f6544000000",
+        "x-ms-client-request-id": "942e21d8-4724-5517-dac9-43a4dfe4a3db",
+        "x-ms-request-id": "49ae9a4b-d01f-0077-09c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-608c9fda-22d7-be58-3fdb-3af47b46fe09/test-file-942e21d8-4724-5517-dac9-43a4dfe4a3db?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-389c622b9ab85d40b0879b0020ae2224-fe2ba79b16604b47-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c278c96f-7ec2-d47e-791a-33f707e25d41",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C62366B9\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "c278c96f-7ec2-d47e-791a-33f707e25d41",
-        "x-ms-request-id": "0ee864cf-801f-0008-1e6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-608c9fda-22d7-be58-3fdb-3af47b46fe09/test-file-43572493-6588-bd5f-93c7-43a74cc5227d?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-54f049f74350814c99f1426cb48a7632-1829005f0ce0434f-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "0ebeb91f-a606-0951-69bb-2efa3ad787b3",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C6306661\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "0ebeb91f-a606-0951-69bb-2efa3ad787b3",
-        "x-ms-request-id": "0ee864d0-801f-0008-1f6e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-608c9fda-22d7-be58-3fdb-3af47b46fe09/test-file-9d17b5f7-47ae-b1d6-0bdc-88247d88d5fd?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-62e67e0869971f469c261dc2902d1ae1-7a96ea623aed1144-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "31e034dc-c27e-d8c0-e30d-03291e2d8ce1",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C63CA01F\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "31e034dc-c27e-d8c0-e30d-03291e2d8ce1",
-        "x-ms-request-id": "0ee864d1-801f-0008-206e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f/test-directory-608c9fda-22d7-be58-3fdb-3af47b46fe09/test-directory-659330e5-f44f-e4ad-3edd-84839b25feed?resource=directory",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-184cd0a245a0004a90d862493251af8c-3128b5d3b4439e45-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "82caca9e-da8a-e894-87fc-f2a13e3d3cbd",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "ETag": "\u00220x8D83D85C648623F\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:23 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "82caca9e-da8a-e894-87fc-f2a13e3d3cbd",
-        "x-ms-request-id": "0ee864d3-801f-0008-226e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-59a3fe32-9629-9fc6-8910-f90fb7478b6f?action=setAccessControlRecursive\u0026mode=modify\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-86dc4479f9de604a826e9c8ac52f4a85-7f9612f63b3ff748-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "d0e499c2-7c5b-c263-105f-c1abb1dd66d7",
+        "x-ms-client-request-id": "43572493-6588-bd5f-93c7-43a74cc5227d",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831BFF3D2\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43572493-6588-bd5f-93c7-43a74cc5227d",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a4c-d01f-0077-0ac1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-282e1750-4c31-3fbb-6919-1af41061ef7d?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0ebeb91f-a606-0951-69bb-2efa3ad787b3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "ETag": "\u00220x8D863D831CC5537\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0ebeb91f-a606-0951-69bb-2efa3ad787b3",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a4d-d01f-0077-0bc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-282e1750-4c31-3fbb-6919-1af41061ef7d/test-file-79a6c7dd-9975-749c-2c16-e2a4d34d10cb?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9387d467-1306-3977-182a-acb0b31d40e3",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D831D92768\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9387d467-1306-3977-182a-acb0b31d40e3",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a4e-d01f-0077-0cc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-282e1750-4c31-3fbb-6919-1af41061ef7d/test-file-17685728-267e-b5e4-2d02-e1986be8bbec?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "659330e5-f44f-e4ad-3edd-84839b25feed",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D831E608D1\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "659330e5-f44f-e4ad-3edd-84839b25feed",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a4f-d01f-0077-0dc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "82caca9e-da8a-e894-87fc-f2a13e3d3cbd",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D831F2488F\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "82caca9e-da8a-e894-87fc-f2a13e3d3cbd",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a50-d01f-0077-0ec1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862/test-file-20bbd8b2-3288-67ad-9a36-1b50e3f113a3?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d0e499c2-7c5b-c263-105f-c1abb1dd66d7",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D831FF2934\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d0e499c2-7c5b-c263-105f-c1abb1dd66d7",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "49ae9a51-d01f-0077-0fc1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862/test-file-f9ebf272-a0c0-5a05-9089-d09b88f3a3d3?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "522d7a88-dac8-2230-9389-3fd2abc7391c",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D8325817AC\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "522d7a88-dac8-2230-9389-3fd2abc7391c",
+        "x-ms-request-id": "49ae9a52-d01f-0077-10c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862/test-file-af83edbc-c1ff-057e-9058-46f5367fd802?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "94c94e92-e00a-c6d4-fb28-c26f943beb14",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D832652D8C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "94c94e92-e00a-c6d4-fb28-c26f943beb14",
+        "x-ms-request-id": "49ae9a53-d01f-0077-11c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862/test-file-afd93cb1-2ab5-6b56-e236-de43b1b0d800?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f11dfcd0-37b6-6735-f75d-b2d30290154a",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D83272AA7D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f11dfcd0-37b6-6735-f75d-b2d30290154a",
+        "x-ms-request-id": "49ae9a54-d01f-0077-12c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af/test-directory-cef0aec1-5351-80d2-8384-30f795f12862/test-directory-38fdc14f-03d8-6c5d-43c1-876916b8dd47?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "cc4ec836-809d-ccbc-9eb0-adf5afcb513f",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "ETag": "\u00220x8D863D8327EE851\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc4ec836-809d-ccbc-9eb0-adf5afcb513f",
+        "x-ms-request-id": "49ae9a55-d01f-0077-13c1-9523b5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-6c7b6aaf563658458054441503be4013-2903f927c1e31543-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4e33f0ab-106a-fca9-8ca7-16e239548b59",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:08Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "4e33f0ab-106a-fca9-8ca7-16e239548b59",
+        "x-ms-request-id": "aea47b17-d01e-0048-01c1-95eb16000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:08Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:08Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EU7jzMrmcFaoFkiluoorV3sRTxfVha3V9TVCI4y1AO8g=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A08Z\u0026ske=2020-09-28T18%3A59%3A08Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A08Z\u0026se=2020-09-28T18%3A59%3A08Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=61383af8-1af1-678d-517d-fb51335de9d9\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify\u0026forceFlag=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "bf4a8ed5-0398-6fd4-c159-2d7549d52e23",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "d0e499c2-7c5b-c263-105f-c1abb1dd66d7",
+        "x-ms-client-request-id": "bf4a8ed5-0398-6fd4-c159-2d7549d52e23",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "f793a241-201f-0087-696e-6f6544000000",
+        "x-ms-request-id": "49ae9a56-d01f-0077-14c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNTlhM2ZlMzItOTYyOS05ZmM2LTg5MTAtZjkwZmI3NDc4YjZmL3Rlc3QtZGlyZWN0b3J5LTYwOGM5ZmRhLTIyZDctYmU1OC0zZmRiLTNhZjQ3YjQ2ZmUwOS90ZXN0LWRpcmVjdG9yeS02NTkzMzBlNS1mNDRmLWU0YWQtM2VkZC04NDgzOWIyNWZlZWQiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTU5YTNmZTMyLTk2MjktOWZjNi04OTEwLWY5MGZiNzQ3OGI2Zi90ZXN0LWRpcmVjdG9yeS02MDhjOWZkYS0yMmQ3LWJlNTgtM2ZkYi0zYWY0N2I0NmZlMDkvdGVzdC1maWxlLTlkMTdiNWY3LTQ3YWUtYjFkNi0wYmRjLTg4MjQ3ZDg4ZDVmZCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTU5YTNmZTMyLTk2MjktOWZjNi04OTEwLWY5MGZiNzQ3OGI2Zi90ZXN0LWRpcmVjdG9yeS02MDhjOWZkYS0yMmQ3LWJlNTgtM2ZkYi0zYWY0N2I0NmZlMDkvdGVzdC1maWxlLTQzNTcyNDkzLTY1ODgtYmQ1Zi05M2M3LTQzYTc0Y2M1MjI3ZCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTU5YTNmZTMyLTk2MjktOWZjNi04OTEwLWY5MGZiNzQ3OGI2Zi90ZXN0LWRpcmVjdG9yeS02MDhjOWZkYS0yMmQ3LWJlNTgtM2ZkYi0zYWY0N2I0NmZlMDkvdGVzdC1maWxlLTk0MmUyMWQ4LTQ3MjQtNTUxNy1kYWM5LTQzYTRkZmU0YTNkYiIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTdiNjBjYjMtMjc5Yy1jZWEzLTkwNDUtMzNkNGExNjU2OWFmL3Rlc3QtZGlyZWN0b3J5LWNlZjBhZWMxLTUzNTEtODBkMi04Mzg0LTMwZjc5NWYxMjg2Mi90ZXN0LWRpcmVjdG9yeS0zOGZkYzE0Zi0wM2Q4LTZjNWQtNDNjMS04NzY5MTZiOGRkNDciLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWFmODNlZGJjLWMxZmYtMDU3ZS05MDU4LTQ2ZjUzNjdmZDgwMiIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWFmZDkzY2IxLTJhYjUtNmI1Ni1lMjM2LWRlNDNiMWIwZDgwMCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWY5ZWJmMjcyLWEwYzAtNWEwNS05MDg5LWQwOWI4OGYzYTNkMyIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c3993bba4ae0454682225329d5e54603-8b80473bfa7dc047-00",
+        "traceparent": "00-6e53bff9b1e46e41b975674d4a03e4ab-07980ac5beb5404e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "a4de0127-6c58-9262-b3cb-6a85828e90d4",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:24 GMT",
+        "x-ms-client-request-id": "ab0c7ded-cb09-a7c1-dc68-65742f048c3b",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -428,20 +662,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:23 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "a4de0127-6c58-9262-b3cb-6a85828e90d4",
-        "x-ms-request-id": "4e20137d-501e-0046-4b6e-6fc2a6000000",
+        "x-ms-client-request-id": "ab0c7ded-cb09-a7c1-dc68-65742f048c3b",
+        "x-ms-request-id": "49b8c973-601e-0072-10c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:08.4662065-07:00",
     "RandomSeed": "1760685888",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_ContinueOnFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_ContinueOnFailure.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-80514736818c3847b5aab51e0097b50c-0c65f203dc17a44d-00",
+        "traceparent": "00-cb48e968f146564b8f6937563fbf9fe7-34bc556cac82404b-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "92fbe274-2e73-0292-299f-a92789d549ef",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,15 +20,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831A567A9\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:06 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC29079E22\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:30 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "92fbe274-2e73-0292-299f-a92789d549ef",
-        "x-ms-request-id": "49b8c8d6-601e-0072-08c1-95f16e000000",
+        "x-ms-request-id": "ca917eaa-701e-00d7-23c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -38,14 +38,14 @@
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-01886ee20aa49d48873b09ba7f16cbf0-f6d039f7c1559b4c-00",
+        "traceparent": "00-f7dc43bf9fbd3943b503e6c324129948-96fb3e33ce2ecd4d-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "d59b5ae0-f84b-44fc-efb9-c63fd1787bf6",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,16 +53,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831A6AB12\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC2916609C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:30 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d59b5ae0-f84b-44fc-efb9-c63fd1787bf6",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a43-d01f-0077-01c1-9523b5000000",
+        "x-ms-request-id": "54c950a8-f01f-003d-5bc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -72,13 +72,13 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b7b16fc3efa4164482dbf9e18d45c5b6-b4b087be7b7def46-00",
+        "traceparent": "00-daa30e7db89bdf4aa2e7ba9e295002e5-c928eb5652872c4d-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8c789722-f8c3-b863-b6cc-4406c527a389",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -86,15 +86,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831BFF3D2\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC29699F2E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8c789722-f8c3-b863-b6cc-4406c527a389",
-        "x-ms-request-id": "49ae9a44-d01f-0077-02c1-9523b5000000",
+        "x-ms-request-id": "54c950a9-f01f-003d-5cc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -109,7 +109,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c7f18d03-bce4-d5b4-db38-23aadd6ea854",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -117,15 +117,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831CC5537\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC2978E376\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c7f18d03-bce4-d5b4-db38-23aadd6ea854",
-        "x-ms-request-id": "49ae9a47-d01f-0077-05c1-9523b5000000",
+        "x-ms-request-id": "54c950aa-f01f-003d-5dc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -140,7 +140,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "689024e4-5df7-6adf-f17d-9acdda10028e",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -148,15 +148,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831D92768\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC298A58B5\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "689024e4-5df7-6adf-f17d-9acdda10028e",
-        "x-ms-request-id": "49ae9a48-d01f-0077-06c1-9523b5000000",
+        "x-ms-request-id": "54c950ab-f01f-003d-5ec5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -171,7 +171,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "608c9fda-22d7-be58-3fdb-3af47b46fe09",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -179,15 +179,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831E608D1\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC2997E2C4\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "608c9fda-22d7-be58-3fdb-3af47b46fe09",
-        "x-ms-request-id": "49ae9a49-d01f-0077-07c1-9523b5000000",
+        "x-ms-request-id": "54c950ac-f01f-003d-5fc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -202,7 +202,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "de308787-fbdb-8735-cc0b-dd53f261284e",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -210,15 +210,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831F2488F\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC29A6B1CD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "de308787-fbdb-8735-cc0b-dd53f261284e",
-        "x-ms-request-id": "49ae9a4a-d01f-0077-08c1-9523b5000000",
+        "x-ms-request-id": "54c950ad-f01f-003d-60c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -233,7 +233,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "942e21d8-4724-5517-dac9-43a4dfe4a3db",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -241,15 +241,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831FF2934\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC29B4724B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "942e21d8-4724-5517-dac9-43a4dfe4a3db",
-        "x-ms-request-id": "49ae9a4b-d01f-0077-09c1-9523b5000000",
+        "x-ms-request-id": "54c950ae-f01f-003d-61c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -264,7 +264,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "43572493-6588-bd5f-93c7-43a74cc5227d",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
         "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
@@ -274,16 +274,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831BFF3D2\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC29699F2E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "43572493-6588-bd5f-93c7-43a74cc5227d",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a4c-d01f-0077-0ac1-9523b5000000",
+        "x-ms-request-id": "54c950af-f01f-003d-62c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -298,7 +298,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0ebeb91f-a606-0951-69bb-2efa3ad787b3",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
         "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
@@ -308,16 +308,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:06 GMT",
-        "ETag": "\u00220x8D863D831CC5537\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:30 GMT",
+        "ETag": "\u00220x8D863DC2978E376\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0ebeb91f-a606-0951-69bb-2efa3ad787b3",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a4d-d01f-0077-0bc1-9523b5000000",
+        "x-ms-request-id": "54c950b0-f01f-003d-63c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -332,7 +332,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9387d467-1306-3977-182a-acb0b31d40e3",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
         "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
@@ -342,16 +342,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D831D92768\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC298A58B5\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9387d467-1306-3977-182a-acb0b31d40e3",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a4e-d01f-0077-0cc1-9523b5000000",
+        "x-ms-request-id": "54c950b1-f01f-003d-64c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -366,7 +366,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "659330e5-f44f-e4ad-3edd-84839b25feed",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:31 GMT",
         "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
         "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
@@ -376,16 +376,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D831E608D1\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC2997E2C4\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "659330e5-f44f-e4ad-3edd-84839b25feed",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a4f-d01f-0077-0dc1-9523b5000000",
+        "x-ms-request-id": "54c950b2-f01f-003d-65c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -400,7 +400,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "82caca9e-da8a-e894-87fc-f2a13e3d3cbd",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:32 GMT",
         "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
         "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
@@ -410,16 +410,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D831F2488F\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC29A6B1CD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "82caca9e-da8a-e894-87fc-f2a13e3d3cbd",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a50-d01f-0077-0ec1-9523b5000000",
+        "x-ms-request-id": "54c950b3-f01f-003d-66c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -434,7 +434,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d0e499c2-7c5b-c263-105f-c1abb1dd66d7",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:32 GMT",
         "x-ms-owner": "61383af8-1af1-678d-517d-fb51335de9d9",
         "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
@@ -444,16 +444,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D831FF2934\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC29B4724B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:31 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d0e499c2-7c5b-c263-105f-c1abb1dd66d7",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a51-d01f-0077-0fc1-9523b5000000",
+        "x-ms-request-id": "54c950b4-f01f-003d-67c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -468,7 +468,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "522d7a88-dac8-2230-9389-3fd2abc7391c",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:32 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -476,15 +476,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D8325817AC\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC2A14DD0D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:32 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "522d7a88-dac8-2230-9389-3fd2abc7391c",
-        "x-ms-request-id": "49ae9a52-d01f-0077-10c1-9523b5000000",
+        "x-ms-request-id": "54c950b5-f01f-003d-68c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -499,7 +499,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "94c94e92-e00a-c6d4-fb28-c26f943beb14",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:32 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -507,15 +507,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D832652D8C\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC2A224D98\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:32 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "94c94e92-e00a-c6d4-fb28-c26f943beb14",
-        "x-ms-request-id": "49ae9a53-d01f-0077-11c1-9523b5000000",
+        "x-ms-request-id": "54c950b6-f01f-003d-69c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -530,7 +530,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f11dfcd0-37b6-6735-f75d-b2d30290154a",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:32 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -538,15 +538,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D83272AA7D\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC2A2FC82B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:32 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f11dfcd0-37b6-6735-f75d-b2d30290154a",
-        "x-ms-request-id": "49ae9a54-d01f-0077-12c1-9523b5000000",
+        "x-ms-request-id": "54c950b7-f01f-003d-6ac5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -561,7 +561,7 @@
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "cc4ec836-809d-ccbc-9eb0-adf5afcb513f",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:32 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -569,15 +569,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
-        "ETag": "\u00220x8D863D8327EE851\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:31 GMT",
+        "ETag": "\u00220x8D863DC2A3CC9DD\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:32 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "cc4ec836-809d-ccbc-9eb0-adf5afcb513f",
-        "x-ms-request-id": "49ae9a55-d01f-0077-13c1-9523b5000000",
+        "x-ms-request-id": "54c950b8-f01f-003d-6bc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -589,7 +589,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "56",
         "Content-Type": "application/xml",
-        "traceparent": "00-6c7b6aaf563658458054441503be4013-2903f927c1e31543-00",
+        "traceparent": "00-f0a6ab6ee75e69429dfc1112a5cb47df-3fcec7daafeb0047-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
@@ -598,24 +598,24 @@
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
-      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:08Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T19:27:32Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Mon, 28 Sep 2020 17:59:07 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "4e33f0ab-106a-fca9-8ca7-16e239548b59",
-        "x-ms-request-id": "aea47b17-d01e-0048-01c1-95eb16000000",
+        "x-ms-request-id": "9dc90841-b01e-0095-4ac5-951e94000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:08Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:08Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EU7jzMrmcFaoFkiluoorV3sRTxfVha3V9TVCI4y1AO8g=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T18:27:34Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T19:27:32Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EbtVEFFOT48yqtRyAaat3yASuw4rtDpb3q\u002B4zaNknAhc=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
     },
     {
-      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A08Z\u0026ske=2020-09-28T18%3A59%3A08Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A08Z\u0026se=2020-09-28T18%3A59%3A08Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=61383af8-1af1-678d-517d-fb51335de9d9\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530/test-directory-97b60cb3-279c-cea3-9045-33d4a16569af?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T18%3A27%3A34Z\u0026ske=2020-09-28T19%3A27%3A32Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T17%3A27%3A32Z\u0026se=2020-09-28T19%3A27%3A32Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=61383af8-1af1-678d-517d-fb51335de9d9\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify\u0026forceFlag=true",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "User-Agent": [
@@ -630,7 +630,7 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -638,23 +638,23 @@
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "bf4a8ed5-0398-6fd4-c159-2d7549d52e23",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a56-d01f-0077-14c1-9523b5000000",
+        "x-ms-request-id": "54c950b9-f01f-003d-6cc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTdiNjBjYjMtMjc5Yy1jZWEzLTkwNDUtMzNkNGExNjU2OWFmL3Rlc3QtZGlyZWN0b3J5LWNlZjBhZWMxLTUzNTEtODBkMi04Mzg0LTMwZjc5NWYxMjg2Mi90ZXN0LWRpcmVjdG9yeS0zOGZkYzE0Zi0wM2Q4LTZjNWQtNDNjMS04NzY5MTZiOGRkNDciLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWFmODNlZGJjLWMxZmYtMDU3ZS05MDU4LTQ2ZjUzNjdmZDgwMiIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWFmZDkzY2IxLTJhYjUtNmI1Ni1lMjM2LWRlNDNiMWIwZDgwMCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWY5ZWJmMjcyLWEwYzAtNWEwNS05MDg5LWQwOWI4OGYzYTNkMyIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTdiNjBjYjMtMjc5Yy1jZWEzLTkwNDUtMzNkNGExNjU2OWFmL3Rlc3QtZGlyZWN0b3J5LWNlZjBhZWMxLTUzNTEtODBkMi04Mzg0LTMwZjc5NWYxMjg2Mi90ZXN0LWZpbGUtZjllYmYyNzItYTBjMC01YTA1LTkwODktZDA5Yjg4ZjNhM2QzIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTdiNjBjYjMtMjc5Yy1jZWEzLTkwNDUtMzNkNGExNjU2OWFmL3Rlc3QtZGlyZWN0b3J5LWNlZjBhZWMxLTUzNTEtODBkMi04Mzg0LTMwZjc5NWYxMjg2Mi90ZXN0LWZpbGUtYWY4M2VkYmMtYzFmZi0wNTdlLTkwNTgtNDZmNTM2N2ZkODAyIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOTdiNjBjYjMtMjc5Yy1jZWEzLTkwNDUtMzNkNGExNjU2OWFmL3Rlc3QtZGlyZWN0b3J5LWNlZjBhZWMxLTUzNTEtODBkMi04Mzg0LTMwZjc5NWYxMjg2Mi90ZXN0LWRpcmVjdG9yeS0zOGZkYzE0Zi0wM2Q4LTZjNWQtNDNjMS04NzY5MTZiOGRkNDciLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTk3YjYwY2IzLTI3OWMtY2VhMy05MDQ1LTMzZDRhMTY1NjlhZi90ZXN0LWRpcmVjdG9yeS1jZWYwYWVjMS01MzUxLTgwZDItODM4NC0zMGY3OTVmMTI4NjIvdGVzdC1maWxlLWFmZDkzY2IxLTJhYjUtNmI1Ni1lMjM2LWRlNDNiMWIwZDgwMCIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
       "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-333ff098-8337-00e5-3621-e95f89b89530?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6e53bff9b1e46e41b975674d4a03e4ab-07980ac5beb5404e-00",
+        "traceparent": "00-2fb483062d1de94d9f3324e45700fff9-7a9a9dfd144edb40-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ab0c7ded-cb09-a7c1-dc68-65742f048c3b",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -662,20 +662,20 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ab0c7ded-cb09-a7c1-dc68-65742f048c3b",
-        "x-ms-request-id": "49b8c973-601e-0072-10c1-95f16e000000",
+        "x-ms-request-id": "ca917f82-701e-00d7-51c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-09-28T10:59:08.4662065-07:00",
+    "DateTimeOffsetNow": "2020-09-28T11:27:32.6095630-07:00",
     "RandomSeed": "1760685888",
     "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_ContinueOnFailureAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_ContinueOnFailureAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-45eb3adda29d5845bcb762ed6ecf082e-d3b435fce9a8e041-00",
+        "traceparent": "00-636b1703e2fa6640a47aca0297b1acaf-6f5f47413e40074b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "9c2a3478-93f7-39a2-69ae-3d39cd3678e6",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:29 GMT",
-        "ETag": "\u00220x8D83D85CA059B54\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2BDACE1B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9c2a3478-93f7-39a2-69ae-3d39cd3678e6",
-        "x-ms-request-id": "4e201804-501e-0046-706e-6fc2a6000000",
+        "x-ms-request-id": "ca917f88-701e-00d7-56c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-58c434e0bd761e48a5234be8937c195a-f995d32b3808d84a-00",
+        "traceparent": "00-132ffebed5348f49bd704446909ea571-2a78483530b6fb4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "ddea985d-559b-9dc4-70c0-f980fb54f4c1",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,31 +53,32 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:30 GMT",
-        "ETag": "\u00220x8D83D85CA06F880\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2BDC4787\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ddea985d-559b-9dc4-70c0-f980fb54f4c1",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "0ee864ef-801f-0008-3d6e-6fec2e000000",
+        "x-ms-request-id": "54c950bb-f01f-003d-6dc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-60156fc0963d244cb228e929dfe481be-bb81e1a8e7932740-00",
+        "traceparent": "00-80ea2c6659f10c418cf84203d0a3b3ee-51f3a9b02244ad49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "35dc075f-9a4b-634a-5d8d-de0947525faf",
+        "x-ms-client-request-id": "ff09d6e3-295c-55d0-0bb3-7cccbca5a2b6",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -85,30 +86,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:30 GMT",
-        "ETag": "\u00220x8D83D85CA6BD3CB\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2BF764E9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "35dc075f-9a4b-634a-5d8d-de0947525faf",
-        "x-ms-request-id": "1557067d-c01f-0026-696e-6fbe39000000",
+        "x-ms-client-request-id": "ff09d6e3-295c-55d0-0bb3-7cccbca5a2b6",
+        "x-ms-request-id": "54c950bc-f01f-003d-6ec5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-ff09d6e3-295c-55d0-0bb3-7cccbca5a2b6?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-f321bb90-bf77-4575-c06a-c9d82884ef0e?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3fde562a3984064e9b03b404a7d78610-7d7ebe6a4cc4ed4d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "243be86f-30b0-35e2-3786-29971d7da6b7",
+        "x-ms-client-request-id": "8c7828eb-6b31-2337-60c4-3ff15ff72c86",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -116,29 +117,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:30 GMT",
-        "ETag": "\u00220x8D83D85CA784FE2\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:30 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2C0463F4\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "243be86f-30b0-35e2-3786-29971d7da6b7",
-        "x-ms-request-id": "1557067e-c01f-0026-6a6e-6fbe39000000",
+        "x-ms-client-request-id": "8c7828eb-6b31-2337-60c4-3ff15ff72c86",
+        "x-ms-request-id": "54c950bd-f01f-003d-6fc5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-ff09d6e3-295c-55d0-0bb3-7cccbca5a2b6/test-file-8c7828eb-6b31-2337-60c4-3ff15ff72c86?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-f321bb90-bf77-4575-c06a-c9d82884ef0e/test-file-d35d6ec4-7d6a-6006-d8eb-bcf095de2742?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "00ed11c4-620b-03dd-b117-c3ecf1f1d53f",
+        "x-ms-client-request-id": "afd3a259-d220-6d4d-2117-b345af468d82",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -146,29 +148,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:30 GMT",
-        "ETag": "\u00220x8D83D85CA8568A4\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2C11DBF1\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "00ed11c4-620b-03dd-b117-c3ecf1f1d53f",
-        "x-ms-request-id": "15570680-c01f-0026-6b6e-6fbe39000000",
+        "x-ms-client-request-id": "afd3a259-d220-6d4d-2117-b345af468d82",
+        "x-ms-request-id": "54c950be-f01f-003d-70c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-ff09d6e3-295c-55d0-0bb3-7cccbca5a2b6/test-file-afd3a259-d220-6d4d-2117-b345af468d82?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-f321bb90-bf77-4575-c06a-c9d82884ef0e/test-file-4e2cfc9c-2c0a-617b-9059-2252b91a6fe7?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "f2977d15-770a-f122-c47f-dff3ae97546a",
+        "x-ms-client-request-id": "f54f4189-87c4-2d35-2771-1fc6affbb407",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -176,30 +179,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:30 GMT",
-        "ETag": "\u00220x8D83D85CA92EF6E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2C1F4948\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "f2977d15-770a-f122-c47f-dff3ae97546a",
-        "x-ms-request-id": "15570681-c01f-0026-6c6e-6fbe39000000",
+        "x-ms-client-request-id": "f54f4189-87c4-2d35-2771-1fc6affbb407",
+        "x-ms-request-id": "54c950bf-f01f-003d-71c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-f54f4189-87c4-2d35-2771-1fc6affbb407?resource=directory",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-03be1be423b380408e9ae29f731d6e6b-100794a4cb7abf45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "78c8b805-7aca-8d22-4869-cb98585c41c9",
+        "x-ms-client-request-id": "e14bd8ca-2267-eeba-c82a-1b8afdaae0a0",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -207,29 +210,30 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:30 GMT",
-        "ETag": "\u00220x8D83D85CAA151D5\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2C2C3D9B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "78c8b805-7aca-8d22-4869-cb98585c41c9",
-        "x-ms-request-id": "15570682-c01f-0026-6d6e-6fbe39000000",
+        "x-ms-client-request-id": "e14bd8ca-2267-eeba-c82a-1b8afdaae0a0",
+        "x-ms-request-id": "54c950c0-f01f-003d-72c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-f54f4189-87c4-2d35-2771-1fc6affbb407/test-file-e14bd8ca-2267-eeba-c82a-1b8afdaae0a0?resource=file",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8/test-file-f7c026bf-3c32-2d3c-aaa2-e946cfdfcc7c?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "74bfc0f8-d03b-e391-fed9-afa05e98909d",
+        "x-ms-client-request-id": "31d92a88-4a9c-8e96-9b1e-37c538731fe9",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -237,190 +241,420 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "ETag": "\u00220x8D83D85CAAED6EA\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:34 GMT",
+        "ETag": "\u00220x8D863DC2C39AF61\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "74bfc0f8-d03b-e391-fed9-afa05e98909d",
-        "x-ms-request-id": "15570683-c01f-0026-6e6e-6fbe39000000",
+        "x-ms-client-request-id": "31d92a88-4a9c-8e96-9b1e-37c538731fe9",
+        "x-ms-request-id": "54c950c1-f01f-003d-73c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-f54f4189-87c4-2d35-2771-1fc6affbb407/test-file-31d92a88-4a9c-8e96-9b1e-37c538731fe9?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-1fcc6433fa845a48a411b5b28267b9af-cfc6d3adb8f2634e-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "a4be4c12-9a05-aee0-2a31-d91d99ccaa8a",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "ETag": "\u00220x8D83D85CABB2EF5\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "a4be4c12-9a05-aee0-2a31-d91d99ccaa8a",
-        "x-ms-request-id": "0ee864f4-801f-0008-406e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-f54f4189-87c4-2d35-2771-1fc6affbb407/test-file-bf42c5ba-5306-1cb2-c5eb-9cbe513d01ff?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-f321adebfa18b04b95bd087f4ebf97cf-6e5cbfa847fca248-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c79e6e32-0f59-be0b-99a2-df1afe215dec",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "ETag": "\u00220x8D83D85CAC78FBC\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "c79e6e32-0f59-be0b-99a2-df1afe215dec",
-        "x-ms-request-id": "0ee864f6-801f-0008-426e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-f54f4189-87c4-2d35-2771-1fc6affbb407/test-file-74ced930-be18-3fd5-e17f-012340f9897e?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-a64d93248fa191478a0d780b76ba9df1-b426c5337d34c442-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "b9892585-e079-74b0-995e-e5da0ee77da0",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "ETag": "\u00220x8D83D85CAD4AAD6\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "b9892585-e079-74b0-995e-e5da0ee77da0",
-        "x-ms-request-id": "0ee864f7-801f-0008-436e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb/test-directory-f54f4189-87c4-2d35-2771-1fc6affbb407/test-directory-2a836019-7b95-f64e-338e-5a246bc2a417?resource=directory",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-470e7f9c203a684383ad9cc45e69eb56-ef0cad1bb8de6441-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "3af9b276-9a46-0a07-d792-85ea858c09d6",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "ETag": "\u00220x8D83D85CAE03CC4\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 23:33:31 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "3af9b276-9a46-0a07-d792-85ea858c09d6",
-        "x-ms-request-id": "0ee864f8-801f-0008-446e-6fec2e000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-8f9a9194-fa41-98b0-c7b4-ef6312c6f1bb?action=setAccessControlRecursive\u0026mode=modify\u0026forceFlag=true",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-451115c85cb39642b88f22c4d8cc19ce-aa1f43b47a69c342-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "b9ad285c-69c9-1fd1-5c93-43dd491a3097",
+        "x-ms-client-request-id": "bf42c5ba-5306-1cb2-c5eb-9cbe513d01ff",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "x-ms-owner": "3c919f5d-6cea-ee64-95dd-f9598d9cce12",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2BF764E9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bf42c5ba-5306-1cb2-c5eb-9cbe513d01ff",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "54c950c2-f01f-003d-74c5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-f321bb90-bf77-4575-c06a-c9d82884ef0e?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "c79e6e32-0f59-be0b-99a2-df1afe215dec",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-owner": "3c919f5d-6cea-ee64-95dd-f9598d9cce12",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2C0463F4\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c79e6e32-0f59-be0b-99a2-df1afe215dec",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "54c950c3-f01f-003d-75c5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-f321bb90-bf77-4575-c06a-c9d82884ef0e/test-file-d35d6ec4-7d6a-6006-d8eb-bcf095de2742?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "e28cd396-399e-40a5-19f4-52129bc9c49d",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-owner": "3c919f5d-6cea-ee64-95dd-f9598d9cce12",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2C11DBF1\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e28cd396-399e-40a5-19f4-52129bc9c49d",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "54c950c4-f01f-003d-76c5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-f321bb90-bf77-4575-c06a-c9d82884ef0e/test-file-4e2cfc9c-2c0a-617b-9059-2252b91a6fe7?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "2a836019-7b95-f64e-338e-5a246bc2a417",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-owner": "3c919f5d-6cea-ee64-95dd-f9598d9cce12",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2C1F4948\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2a836019-7b95-f64e-338e-5a246bc2a417",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "54c950c7-f01f-003d-79c5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "3af9b276-9a46-0a07-d792-85ea858c09d6",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-owner": "3c919f5d-6cea-ee64-95dd-f9598d9cce12",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2C2C3D9B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3af9b276-9a46-0a07-d792-85ea858c09d6",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "54c950c8-f01f-003d-7ac5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8/test-file-f7c026bf-3c32-2d3c-aaa2-e946cfdfcc7c?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b9ad285c-69c9-1fd1-5c93-43dd491a3097",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-owner": "3c919f5d-6cea-ee64-95dd-f9598d9cce12",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2C39AF61\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9ad285c-69c9-1fd1-5c93-43dd491a3097",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "54c950c9-f01f-003d-7bc5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8/test-file-8585710e-87ab-14e8-81af-df799489d7c8?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "c16f6f9b-1d89-d4bc-3f99-37198a578bd2",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2C97C192\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c16f6f9b-1d89-d4bc-3f99-37198a578bd2",
+        "x-ms-request-id": "54c950ca-f01f-003d-7cc5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8/test-file-2cee7bbc-d38b-beb8-6435-88ab3933f52e?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a3f87b74-d363-c7b5-b7b1-5d5395119b0c",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2CA53286\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a3f87b74-d363-c7b5-b7b1-5d5395119b0c",
+        "x-ms-request-id": "54c950cb-f01f-003d-7dc5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8/test-file-eb6908a3-6679-a5b8-3b1d-cbd1b672a56f?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0fa1111e-da8b-0e2c-c253-674608e31144",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2CB2A291\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0fa1111e-da8b-0e2c-c253-674608e31144",
+        "x-ms-request-id": "54c950cc-f01f-003d-7ec5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e/test-directory-3130cca8-9aaf-2578-d93a-898a4c87b2f8/test-directory-b3e4ed0b-ddda-51d1-3d8c-0263f850ec50?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "cc5b2905-8706-4175-3f4f-d1fed7c91571",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:35 GMT",
+        "ETag": "\u00220x8D863DC2CBFD4A9\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cc5b2905-8706-4175-3f4f-d1fed7c91571",
+        "x-ms-request-id": "54c950cd-f01f-003d-7fc5-95803a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-24a1637c4b2ba844b582add155bff13b-1aaa941f97377543-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "cf5efcb7-20f5-5a49-0571-6680c5e5bdeb",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T19:27:36Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 18:27:37 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "cf5efcb7-20f5-5a49-0571-6680c5e5bdeb",
+        "x-ms-request-id": "f892acdf-b01e-00aa-2bc5-95d637000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T18:27:37Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T19:27:36Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EKgJFAwtPegQk9K26YnyzfttVKc\u002BtzznBXFQkmiFLPY0=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402/test-directory-26ce0adf-0765-378d-61cf-981efbb92f3e?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T18%3A27%3A37Z\u0026ske=2020-09-28T19%3A27%3A36Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T17%3A27%3A36Z\u0026se=2020-09-28T19%3A27%3A36Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=3c919f5d-6cea-ee64-95dd-f9598d9cce12\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify\u0026forceFlag=true",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "da4718e8-466b-467c-ce08-87be04f3af22",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 18:27:36 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "b9ad285c-69c9-1fd1-5c93-43dd491a3097",
+        "x-ms-client-request-id": "da4718e8-466b-467c-ce08-87be04f3af22",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "15570684-c01f-0026-6f6e-6fbe39000000",
+        "x-ms-request-id": "54c950ce-f01f-003d-80c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOGY5YTkxOTQtZmE0MS05OGIwLWM3YjQtZWY2MzEyYzZmMWJiL3Rlc3QtZGlyZWN0b3J5LWY1NGY0MTg5LTg3YzQtMmQzNS0yNzcxLTFmYzZhZmZiYjQwNy90ZXN0LWZpbGUtYmY0MmM1YmEtNTMwNi0xY2IyLWM1ZWItOWNiZTUxM2QwMWZmIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOGY5YTkxOTQtZmE0MS05OGIwLWM3YjQtZWY2MzEyYzZmMWJiL3Rlc3QtZGlyZWN0b3J5LWY1NGY0MTg5LTg3YzQtMmQzNS0yNzcxLTFmYzZhZmZiYjQwNy90ZXN0LWZpbGUtNzRjZWQ5MzAtYmUxOC0zZmQ1LWUxN2YtMDEyMzQwZjk4OTdlIiwidHlwZSI6IkZJTEUifSx7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktOGY5YTkxOTQtZmE0MS05OGIwLWM3YjQtZWY2MzEyYzZmMWJiL3Rlc3QtZGlyZWN0b3J5LWY1NGY0MTg5LTg3YzQtMmQzNS0yNzcxLTFmYzZhZmZiYjQwNy90ZXN0LWRpcmVjdG9yeS0yYTgzNjAxOS03Yjk1LWY2NGUtMzM4ZS01YTI0NmJjMmE0MTciLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LThmOWE5MTk0LWZhNDEtOThiMC1jN2I0LWVmNjMxMmM2ZjFiYi90ZXN0LWRpcmVjdG9yeS1mNTRmNDE4OS04N2M0LTJkMzUtMjc3MS0xZmM2YWZmYmI0MDcvdGVzdC1maWxlLTMxZDkyYTg4LTRhOWMtOGU5Ni05YjFlLTM3YzUzODczMWZlOSIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktMjZjZTBhZGYtMDc2NS0zNzhkLTYxY2YtOTgxZWZiYjkyZjNlL3Rlc3QtZGlyZWN0b3J5LTMxMzBjY2E4LTlhYWYtMjU3OC1kOTNhLTg5OGE0Yzg3YjJmOC90ZXN0LWRpcmVjdG9yeS1iM2U0ZWQwYi1kZGRhLTUxZDEtM2Q4Yy0wMjYzZjg1MGVjNTAiLCJ0eXBlIjoiRElSRUNUT1JZIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTI2Y2UwYWRmLTA3NjUtMzc4ZC02MWNmLTk4MWVmYmI5MmYzZS90ZXN0LWRpcmVjdG9yeS0zMTMwY2NhOC05YWFmLTI1NzgtZDkzYS04OThhNGM4N2IyZjgvdGVzdC1maWxlLTJjZWU3YmJjLWQzOGItYmViOC02NDM1LTg4YWIzOTMzZjUyZSIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTI2Y2UwYWRmLTA3NjUtMzc4ZC02MWNmLTk4MWVmYmI5MmYzZS90ZXN0LWRpcmVjdG9yeS0zMTMwY2NhOC05YWFmLTI1NzgtZDkzYS04OThhNGM4N2IyZjgvdGVzdC1maWxlLTg1ODU3MTBlLTg3YWItMTRlOC04MWFmLWRmNzk5NDg5ZDdjOCIsInR5cGUiOiJGSUxFIn0seyJlcnJvck1lc3NhZ2UiOiJUaGlzIHJlcXVlc3QgaXMgbm90IGF1dGhvcml6ZWQgdG8gcGVyZm9ybSB0aGlzIG9wZXJhdGlvbiB1c2luZyB0aGlzIHBlcm1pc3Npb24uIiwibmFtZSI6InRlc3QtZGlyZWN0b3J5LTI2Y2UwYWRmLTA3NjUtMzc4ZC02MWNmLTk4MWVmYmI5MmYzZS90ZXN0LWRpcmVjdG9yeS0zMTMwY2NhOC05YWFmLTI1NzgtZDkzYS04OThhNGM4N2IyZjgvdGVzdC1maWxlLWViNjkwOGEzLTY2NzktYTViOC0zYjFkLWNiZDFiNjcyYTU2ZiIsInR5cGUiOiJGSUxFIn1dLCJmYWlsdXJlQ291bnQiOjQsImZpbGVzU3VjY2Vzc2Z1bCI6M30K"
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-04471a33-bcee-8a9a-aca9-dd5c62c2a402?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-36295b2ccc7b064199e3af087992870e-6897849ce4c1424e-00",
+        "traceparent": "00-987a9915faf9424e8c0d38c4f30a588e-72c22c26aa3fcb4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "5c8e1def-4fdf-500d-fd00-4eb51e52ff40",
-        "x-ms-date": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "x-ms-client-request-id": "ad981012-e29e-cc80-0c3a-0418bf1694c1",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -428,20 +662,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 23:33:31 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "5c8e1def-4fdf-500d-fd00-4eb51e52ff40",
-        "x-ms-request-id": "4e201951-501e-0046-2a6e-6fc2a6000000",
+        "x-ms-client-request-id": "ad981012-e29e-cc80-0c3a-0418bf1694c1",
+        "x-ms-request-id": "ca917fe2-701e-00d7-26c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T11:27:36.8132348-07:00",
     "RandomSeed": "807728781",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
@@ -5,14 +5,14 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0362b04440c8704abb1e181c379f0599-9180cd0cee96794a-00",
+        "traceparent": "00-ef7326a820494d42a43429b752bfc52f-057cc7ada71af742-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "94940364-f523-c040-f1a6-51c89b268dff",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,15 +20,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
-        "ETag": "\u00220x8D863D833015461\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:55 GMT",
+        "ETag": "\u00220x8D863DC37F08D25\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:55 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "94940364-f523-c040-f1a6-51c89b268dff",
-        "x-ms-request-id": "49b8c97e-601e-0072-17c1-95f16e000000",
+        "x-ms-request-id": "ca9182f2-701e-00d7-4fc5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -38,14 +38,14 @@
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e1d071cced3c88499a74fd21606f4cfa-64358977f2e86947-00",
+        "traceparent": "00-81f81eeeabf60f4fbb859f13d48ba164-a50fe7d63c191e44-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "aec54db5-42e5-40d5-f580-c19594b81104",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:55 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,16 +53,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
-        "ETag": "\u00220x8D863D83302AA6E\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:55 GMT",
+        "ETag": "\u00220x8D863DC37F24683\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:55 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "aec54db5-42e5-40d5-f580-c19594b81104",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "49ae9a57-d01f-0077-15c1-9523b5000000",
+        "x-ms-request-id": "54c950dc-f01f-003d-06c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -72,7 +72,7 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-512478429d8b954693c8079fc28e6145-bfc965f62dea424e-00",
+        "traceparent": "00-4a6998f07eac4441bdcdb6b862559004-3205ee55832bf94a-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
@@ -85,15 +85,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
-        "ETag": "\u00220x8D863D8335E754C\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38A7058A\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4d12b505-de61-281a-c8ae-ea0693ecfda5",
-        "x-ms-request-id": "acae8c1f-a01f-0099-13c1-95899c000000",
+        "x-ms-request-id": "8a2bb112-601f-002f-52c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -103,7 +103,7 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-dd2731b86f5b184786afaaed23a0bd1d-b54148d9959d8f47-00",
+        "traceparent": "00-387689b0c2a5054ead365a52187df072-0de04d30321e7b46-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
@@ -116,15 +116,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
-        "ETag": "\u00220x8D863D8336BEEFE\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38B63FE0\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b6119204-15ad-c601-c5c5-4dacb2371d85",
-        "x-ms-request-id": "acae8c20-a01f-0099-14c1-95899c000000",
+        "x-ms-request-id": "8a2bb113-601f-002f-53c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -146,15 +146,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
-        "ETag": "\u00220x8D863D8338533DE\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38C59107\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "04bc1361-84b1-e538-9254-3cdab45a1fd3",
-        "x-ms-request-id": "acae8c21-a01f-0099-15c1-95899c000000",
+        "x-ms-request-id": "8a2bb114-601f-002f-54c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -176,15 +176,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
-        "ETag": "\u00220x8D863D83392F344\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38D3863B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "dfea45aa-3884-bd0b-c030-4d7725a5df72",
-        "x-ms-request-id": "acae8c22-a01f-0099-16c1-95899c000000",
+        "x-ms-request-id": "8a2bb115-601f-002f-55c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -194,7 +194,7 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-660adbde3570ac4cbc9f6160e817a0bb-d892fbde836ed143-00",
+        "traceparent": "00-e0c2d3239f20414cbdb32f1043e6ba1d-10014845f9730c4a-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
@@ -207,15 +207,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
-        "ETag": "\u00220x8D863D833A010B7\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38E0CF28\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c1d1741a-ef8d-1e2b-a7c0-50c67cac014a",
-        "x-ms-request-id": "acae8c23-a01f-0099-17c1-95899c000000",
+        "x-ms-request-id": "8a2bb116-601f-002f-56c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -237,15 +237,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
-        "ETag": "\u00220x8D863D833ADC025\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38EEB419\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ffe58887-88ab-fcfc-362d-087a2aa0650f",
-        "x-ms-request-id": "acae8c24-a01f-0099-18c1-95899c000000",
+        "x-ms-request-id": "8a2bb117-601f-002f-57c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -255,7 +255,7 @@
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f725c2a44bbb7e4cb511f31993560f2e-db9b59f003684e43-00",
+        "traceparent": "00-a89cdf9823be13478d8bb6e9383c0f57-067f2f4ee8a99f42-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
@@ -270,16 +270,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:10 GMT",
-        "ETag": "\u00220x8D863D8335E754C\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:56 GMT",
+        "ETag": "\u00220x8D863DC38A7058A\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c7610964-4fa1-cedd-e115-c16c750af86d",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "acae8c25-a01f-0099-19c1-95899c000000",
+        "x-ms-request-id": "8a2bb118-601f-002f-58c5-95fbea000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -303,16 +303,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:10 GMT",
-        "ETag": "\u00220x8D863D8336BEEFE\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:57 GMT",
+        "ETag": "\u00220x8D863DC38B63FE0\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fa8ec0c4-c467-f7de-a235-4d9cebe730fa",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "b202cefa-101f-0025-6bc1-955f5d000000",
+        "x-ms-request-id": "8500cb96-c01f-0026-55c5-95be39000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -336,16 +336,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:10 GMT",
-        "ETag": "\u00220x8D863D8338533DE\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:57 GMT",
+        "ETag": "\u00220x8D863DC38C59107\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:56 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b4a84b8c-fd7c-dc05-a93b-0866e8c07913",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "d239370f-201f-00ca-4dc1-95aaa8000000",
+        "x-ms-request-id": "498bc8c3-301f-00c6-69c5-953da0000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -369,16 +369,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:11 GMT",
-        "ETag": "\u00220x8D863D83392F344\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:57 GMT",
+        "ETag": "\u00220x8D863DC38D3863B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a0109c0f-7b3f-527d-9df8-1458c75045ec",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "685c58af-401f-0017-53c1-955f2a000000",
+        "x-ms-request-id": "685c5d13-401f-0017-0dc5-955f2a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -402,16 +402,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:12 GMT",
-        "ETag": "\u00220x8D863D833A010B7\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:58 GMT",
+        "ETag": "\u00220x8D863DC38E0CF28\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4b57221c-d8af-47d4-fd7e-6662b78a2cb9",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "9c8edb9c-a01f-001f-0cc1-954525000000",
+        "x-ms-request-id": "1b5dd349-701f-0051-51c5-956bad000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -435,16 +435,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:11 GMT",
-        "ETag": "\u00220x8D863D833ADC025\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:58 GMT",
+        "ETag": "\u00220x8D863DC38EEB419\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:57 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "a53b9a15-faf8-a93d-e4a4-5f6cbbf309de",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "9d86f2af-801f-0008-62c1-95ec2e000000",
+        "x-ms-request-id": "7c0a33cc-501f-0034-24c5-95c5e9000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -466,15 +466,15 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:12 GMT",
-        "ETag": "\u00220x8D863D83524B649\u0022",
-        "Last-Modified": "Mon, 28 Sep 2020 17:59:12 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:58 GMT",
+        "ETag": "\u00220x8D863DC3A6F2FBA\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e0055a47-535f-7153-65df-7c8ff5de089c",
-        "x-ms-request-id": "edab73b3-401f-00dc-15c1-955c7f000000",
+        "x-ms-request-id": "d49c20df-f01f-0002-7ec5-954899000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
@@ -486,7 +486,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "56",
         "Content-Type": "application/xml",
-        "traceparent": "00-c042c6f603183c46b856188f6bf6aa25-b6377af199302a47-00",
+        "traceparent": "00-fcb3ce7b4ba93c408761bf9bd5596792-47ffcbf7ac0f734d-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
@@ -495,24 +495,24 @@
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
-      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:12Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T19:27:59Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Mon, 28 Sep 2020 17:59:13 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "4618b237-9542-893d-0edb-b76e0a312a45",
-        "x-ms-request-id": "91e213b1-201e-00e5-2fc1-95a763000000",
+        "x-ms-request-id": "f6736759-901e-0004-20c5-957b26000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:13Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:12Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EU7Ax07GyBOwX\u002BLuf7WW8DeO8/7dQn434JI8XjSeyEuY=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T18:28:00Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T19:27:59Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003E1nuUyB8JKeuP1IeFm/j4ZSgFBK8S8W03CB5VIfzH5Zo=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
     },
     {
-      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A13Z\u0026ske=2020-09-28T18%3A59%3A12Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A12Z\u0026se=2020-09-28T18%3A59%3A12Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=7b985013-b968-d0a6-3d3e-13f204c98c7f\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T18%3A28%3A00Z\u0026ske=2020-09-28T19%3A27%3A59Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T17%3A27%3A59Z\u0026se=2020-09-28T19%3A27%3A59Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=7b985013-b968-d0a6-3d3e-13f204c98c7f\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "User-Agent": [
@@ -527,7 +527,7 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 28 Sep 2020 17:59:13 GMT",
+        "Date": "Mon, 28 Sep 2020 18:28:00 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -535,7 +535,7 @@
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "4258e1e4-c2c6-9959-8607-4acb3520f4fd",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "edab73b4-401f-00dc-16c1-955c7f000000",
+        "x-ms-request-id": "ca17af1a-f01f-00e6-11c5-954607000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNGQzZWRkNzgtNjUyYi1hMGRkLTM2ZmQtMjIyOWIyNzlkN2Y5L3Rlc3QtZGlyZWN0b3J5LWI3NWFiODBjLThiMTQtMmE5ZC04ZmJkLWJiNWViYzc1MTFjZS90ZXN0LWZpbGUtNGUwMmYwODYtYTNiMC01YzM0LTI4NjktMDU1ZmEwNDg3NjljIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
@@ -545,13 +545,13 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8abe4cb4dfd1354f82deb1f5d2257a72-d6a2d48c516c5a45-00",
+        "traceparent": "00-619606c54a55f74c93e6ecba24e054aa-e3bb02bc4630044d-00",
         "User-Agent": [
           "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "298ae6b1-e7d9-757f-66d8-17f58fe025a9",
-        "x-ms-date": "Mon, 28 Sep 2020 17:59:14 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:28:01 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -559,20 +559,20 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 28 Sep 2020 17:59:13 GMT",
+        "Date": "Mon, 28 Sep 2020 18:28:00 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "298ae6b1-e7d9-757f-66d8-17f58fe025a9",
-        "x-ms-request-id": "49b8cb13-601e-0072-10c1-95f16e000000",
+        "x-ms-request-id": "ca918406-701e-00d7-42c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-09-28T10:59:12.9085011-07:00",
+    "DateTimeOffsetNow": "2020-09-28T11:27:59.7754054-07:00",
     "RandomSeed": "1066276978",
     "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_WithProgressMonitoring_WithFailure.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c5b7054526a00d4c9e735c0d6e628dc5-7b37c480b018c948-00",
+        "traceparent": "00-0362b04440c8704abb1e181c379f0599-9180cd0cee96794a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "94940364-f523-c040-f1a6-51c89b268dff",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:03 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:03 GMT",
-        "ETag": "\u00220x8D83D4F621D4AB8\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:03 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "ETag": "\u00220x8D863D833015461\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "94940364-f523-c040-f1a6-51c89b268dff",
-        "x-ms-request-id": "58dacaad-601e-00b9-6c38-6ff23b000000",
+        "x-ms-request-id": "49b8c97e-601e-0072-17c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4a07ffbeb812824ba901e4d5ef4f99f2-1b350d52094b9e4e-00",
+        "traceparent": "00-e1d071cced3c88499a74fd21606f4cfa-64358977f2e86947-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "aec54db5-42e5-40d5-f580-c19594b81104",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:03 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,29 +53,29 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:02 GMT",
-        "ETag": "\u00220x8D83D4F621E8932\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:03 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:08 GMT",
+        "ETag": "\u00220x8D863D83302AA6E\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "aec54db5-42e5-40d5-f580-c19594b81104",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "e0acbfa9-401f-0038-6838-6f52e1000000",
+        "x-ms-request-id": "49ae9a57-d01f-0077-15c1-9523b5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?resource=directory",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-60e2ff21b317544b8f3406e01cf31493-ea6370ae79bf384c-00",
+        "traceparent": "00-512478429d8b954693c8079fc28e6145-bfc965f62dea424e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4d12b505-de61-281a-c8ae-ea0693ecfda5",
         "x-ms-return-client-request-id": "true",
@@ -85,28 +85,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:03 GMT",
-        "ETag": "\u00220x8D83D4F629AF8D2\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:03 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "ETag": "\u00220x8D863D8335E754C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4d12b505-de61-281a-c8ae-ea0693ecfda5",
-        "x-ms-request-id": "e99145aa-101f-008c-1f38-6f9e2f000000",
+        "x-ms-request-id": "acae8c1f-a01f-0099-13c1-95899c000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70?resource=directory",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7b9a48a2bbe491449560d67b2ea5d50a-6c1cd6ece85c8143-00",
+        "traceparent": "00-dd2731b86f5b184786afaaed23a0bd1d-b54148d9959d8f47-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b6119204-15ad-c601-c5c5-4dacb2371d85",
         "x-ms-return-client-request-id": "true",
@@ -116,27 +116,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:03 GMT",
-        "ETag": "\u00220x8D83D4F62A8A1B1\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:03 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "ETag": "\u00220x8D863D8336BEEFE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b6119204-15ad-c601-c5c5-4dacb2371d85",
-        "x-ms-request-id": "e99145ab-101f-008c-2038-6f9e2f000000",
+        "x-ms-request-id": "acae8c20-a01f-0099-14c1-95899c000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70/test-file-f8957941-1f5c-bdff-7ad2-60a7a6f2cfb8?resource=file",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70/test-file-f8957941-1f5c-bdff-7ad2-60a7a6f2cfb8?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "04bc1361-84b1-e538-9254-3cdab45a1fd3",
         "x-ms-return-client-request-id": "true",
@@ -146,27 +146,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "ETag": "\u00220x8D83D4F62B73481\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "ETag": "\u00220x8D863D8338533DE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "04bc1361-84b1-e538-9254-3cdab45a1fd3",
-        "x-ms-request-id": "e99145ac-101f-008c-2138-6f9e2f000000",
+        "x-ms-request-id": "acae8c21-a01f-0099-15c1-95899c000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70/test-file-1a7295f5-a358-8b53-b63a-5e93061f4783?resource=file",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70/test-file-1a7295f5-a358-8b53-b63a-5e93061f4783?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "dfea45aa-3884-bd0b-c030-4d7725a5df72",
         "x-ms-return-client-request-id": "true",
@@ -176,28 +176,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "ETag": "\u00220x8D83D4F62C56021\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "ETag": "\u00220x8D863D83392F344\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "dfea45aa-3884-bd0b-c030-4d7725a5df72",
-        "x-ms-request-id": "e99145ae-101f-008c-2238-6f9e2f000000",
+        "x-ms-request-id": "acae8c22-a01f-0099-16c1-95899c000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce?resource=directory",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-bd753c7cc663cd49b75d3ae256b47616-c8b7235898d98047-00",
+        "traceparent": "00-660adbde3570ac4cbc9f6160e817a0bb-d892fbde836ed143-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c1d1741a-ef8d-1e2b-a7c0-50c67cac014a",
         "x-ms-return-client-request-id": "true",
@@ -207,27 +207,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "ETag": "\u00220x8D83D4F62D37483\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "ETag": "\u00220x8D863D833A010B7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c1d1741a-ef8d-1e2b-a7c0-50c67cac014a",
-        "x-ms-request-id": "e99145af-101f-008c-2338-6f9e2f000000",
+        "x-ms-request-id": "acae8c23-a01f-0099-17c1-95899c000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce/test-file-06e37e1f-1ebc-a43d-b912-c58bb898ac00?resource=file",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce/test-file-06e37e1f-1ebc-a43d-b912-c58bb898ac00?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ffe58887-88ab-fcfc-362d-087a2aa0650f",
         "x-ms-return-client-request-id": "true",
@@ -237,94 +237,321 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "ETag": "\u00220x8D83D4F62E5D54C\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "ETag": "\u00220x8D863D833ADC025\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ffe58887-88ab-fcfc-362d-087a2aa0650f",
-        "x-ms-request-id": "e99145b0-101f-008c-2438-6f9e2f000000",
+        "x-ms-request-id": "acae8c24-a01f-0099-18c1-95899c000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce/test-file-7b985013-b968-d0a6-3d3e-13f204c98c7f?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-e8d3fdebb1d9b642b457818903d7f3bd-ea83e9e68a62b646-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c7610964-4fa1-cedd-e115-c16c750af86d",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "ETag": "\u00220x8D83D4F62F6573E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:04 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "c7610964-4fa1-cedd-e115-c16c750af86d",
-        "x-ms-request-id": "e0acbfab-401f-0038-6a38-6f52e1000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?action=setAccessControlRecursive\u0026mode=modify",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-5a8607caa57f3446a2415c98d997d6d0-838df8224f31ae41-00",
+        "traceparent": "00-f725c2a44bbb7e4cb511f31993560f2e-db9b59f003684e43-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "fa8ec0c4-c467-f7de-a235-4d9cebe730fa",
+        "x-ms-client-request-id": "c7610964-4fa1-cedd-e115-c16c750af86d",
+        "x-ms-owner": "7b985013-b968-d0a6-3d3e-13f204c98c7f",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "ETag": "\u00220x8D863D8335E754C\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c7610964-4fa1-cedd-e115-c16c750af86d",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "acae8c25-a01f-0099-19c1-95899c000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "fa8ec0c4-c467-f7de-a235-4d9cebe730fa",
+        "x-ms-owner": "7b985013-b968-d0a6-3d3e-13f204c98c7f",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "ETag": "\u00220x8D863D8336BEEFE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:09 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fa8ec0c4-c467-f7de-a235-4d9cebe730fa",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "b202cefa-101f-0025-6bc1-955f5d000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70/test-file-f8957941-1f5c-bdff-7ad2-60a7a6f2cfb8?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b4a84b8c-fd7c-dc05-a93b-0866e8c07913",
+        "x-ms-owner": "7b985013-b968-d0a6-3d3e-13f204c98c7f",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "ETag": "\u00220x8D863D8338533DE\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b4a84b8c-fd7c-dc05-a93b-0866e8c07913",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "d239370f-201f-00ca-4dc1-95aaa8000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-fbd71d80-3f25-4def-ffb5-2ce30b436c70/test-file-1a7295f5-a358-8b53-b63a-5e93061f4783?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a0109c0f-7b3f-527d-9df8-1458c75045ec",
+        "x-ms-owner": "7b985013-b968-d0a6-3d3e-13f204c98c7f",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:11 GMT",
+        "ETag": "\u00220x8D863D83392F344\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a0109c0f-7b3f-527d-9df8-1458c75045ec",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "685c58af-401f-0017-53c1-955f2a000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4b57221c-d8af-47d4-fd7e-6662b78a2cb9",
+        "x-ms-owner": "7b985013-b968-d0a6-3d3e-13f204c98c7f",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:12 GMT",
+        "ETag": "\u00220x8D863D833A010B7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4b57221c-d8af-47d4-fd7e-6662b78a2cb9",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "9c8edb9c-a01f-001f-0cc1-954525000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce/test-file-06e37e1f-1ebc-a43d-b912-c58bb898ac00?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a53b9a15-faf8-a93d-e4a4-5f6cbbf309de",
+        "x-ms-owner": "7b985013-b968-d0a6-3d3e-13f204c98c7f",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:11 GMT",
+        "ETag": "\u00220x8D863D833ADC025\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:10 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a53b9a15-faf8-a93d-e4a4-5f6cbbf309de",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "9d86f2af-801f-0008-62c1-95ec2e000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9/test-directory-b75ab80c-8b14-2a9d-8fbd-bb5ebc7511ce/test-file-4e02f086-a3b0-5c34-2869-055fa048769c?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "e0055a47-535f-7153-65df-7c8ff5de089c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 17:59:12 GMT",
+        "ETag": "\u00220x8D863D83524B649\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 17:59:12 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e0055a47-535f-7153-65df-7c8ff5de089c",
+        "x-ms-request-id": "edab73b3-401f-00dc-15c1-955c7f000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-c042c6f603183c46b856188f6bf6aa25-b6377af199302a47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4618b237-9542-893d-0edb-b76e0a312a45",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T18:59:12Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 17:59:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "4618b237-9542-893d-0edb-b76e0a312a45",
+        "x-ms-request-id": "91e213b1-201e-00e5-2fc1-95a763000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T17:59:13Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T18:59:12Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003EU7Ax07GyBOwX\u002BLuf7WW8DeO8/7dQn434JI8XjSeyEuY=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be/test-directory-4d3edd78-652b-a0dd-36fd-2229b279d7f9?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T17%3A59%3A13Z\u0026ske=2020-09-28T18%3A59%3A12Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T16%3A59%3A12Z\u0026se=2020-09-28T18%3A59%3A12Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=7b985013-b968-d0a6-3d3e-13f204c98c7f\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "4258e1e4-c2c6-9959-8607-4acb3520f4fd",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 17:59:13 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "fa8ec0c4-c467-f7de-a235-4d9cebe730fa",
+        "x-ms-client-request-id": "4258e1e4-c2c6-9959-8607-4acb3520f4fd",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "e99145b1-101f-008c-2538-6f9e2f000000",
+        "x-ms-request-id": "edab73b4-401f-00dc-16c1-955c7f000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNGQzZWRkNzgtNjUyYi1hMGRkLTM2ZmQtMjIyOWIyNzlkN2Y5L3Rlc3QtZGlyZWN0b3J5LWI3NWFiODBjLThiMTQtMmE5ZC04ZmJkLWJiNWViYzc1MTFjZS90ZXN0LWZpbGUtN2I5ODUwMTMtYjk2OC1kMGE2LTNkM2UtMTNmMjA0Yzk4YzdmIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktNGQzZWRkNzgtNjUyYi1hMGRkLTM2ZmQtMjIyOWIyNzlkN2Y5L3Rlc3QtZGlyZWN0b3J5LWI3NWFiODBjLThiMTQtMmE5ZC04ZmJkLWJiNWViYzc1MTFjZS90ZXN0LWZpbGUtNGUwMmYwODYtYTNiMC01YzM0LTI4NjktMDU1ZmEwNDg3NjljIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-8846cf25-bdc5-3f50-7943-982415c707be?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-554e992cfd6f854b886011f41f9a20a2-b6d9585fa9a9ac4e-00",
+        "traceparent": "00-8abe4cb4dfd1354f82deb1f5d2257a72-d6a2d48c516c5a45-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "b4a84b8c-fd7c-dc05-a93b-0866e8c07913",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "x-ms-client-request-id": "298ae6b1-e7d9-757f-66d8-17f58fe025a9",
+        "x-ms-date": "Mon, 28 Sep 2020 17:59:14 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -332,20 +559,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:04 GMT",
+        "Date": "Mon, 28 Sep 2020 17:59:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "b4a84b8c-fd7c-dc05-a93b-0866e8c07913",
-        "x-ms-request-id": "58daccb6-601e-00b9-5138-6ff23b000000",
+        "x-ms-client-request-id": "298ae6b1-e7d9-757f-66d8-17f58fe025a9",
+        "x-ms-request-id": "49b8cb13-601e-0072-10c1-95f16e000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T10:59:12.9085011-07:00",
     "RandomSeed": "1066276978",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_WithProgressMonitoring_WithFailureAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/UpdateAccessControlRecursiveAsync_WithProgressMonitoring_WithFailureAsync.json
@@ -1,18 +1,18 @@
 {
   "Entries": [
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-63c07a0967126e40bcc8a897f3ae2536-61db34fe7d349d41-00",
+        "traceparent": "00-edeb5d7bd421584aabd7cb42cdc9cf06-5ff01d671bc87b4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e131de60-cdbd-1b8a-650a-76455e960ac2",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -20,32 +20,32 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
-        "ETag": "\u00220x8D83D4F65D71C99\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:45 GMT",
+        "ETag": "\u00220x8D863DC3210E6EA\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:45 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e131de60-cdbd-1b8a-650a-76455e960ac2",
-        "x-ms-request-id": "58dad0ed-601e-00b9-3738-6ff23b000000",
+        "x-ms-request-id": "ca918123-701e-00d7-37c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/?action=setAccessControl",
+      "RequestUri": "http://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b9ac4beb0df7c04a8f795846f00a3ca4-cd0c795698248441-00",
+        "traceparent": "00-447e7ee46e3e7046b41b73eeeca70940-6a9ab6eb4ee6174c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-acl": "user::--x,group::--x,other::--x",
         "x-ms-client-request-id": "4c1eb2ee-6579-c686-9d00-899dc6cb935a",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -53,29 +53,29 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
-        "ETag": "\u00220x8D83D4F65D85294\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:45 GMT",
+        "ETag": "\u00220x8D863DC3212655B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:45 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "4c1eb2ee-6579-c686-9d00-899dc6cb935a",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "e0acbfbd-401f-0038-7138-6f52e1000000",
+        "x-ms-request-id": "54c950d8-f01f-003d-03c5-95803a000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744?resource=directory",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8b2943b24466b44b9c3b26a6798e559d-b4e036676d5b5043-00",
+        "traceparent": "00-44a210032683c74eaad38fdb5aa65f59-b34d2247423f184d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ab575003-be77-5448-819a-cea164cd2aeb",
         "x-ms-return-client-request-id": "true",
@@ -85,28 +85,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
-        "ETag": "\u00220x8D83D4F66289E56\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "ETag": "\u00220x8D863DC32BE9C48\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:46 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ab575003-be77-5448-819a-cea164cd2aeb",
-        "x-ms-request-id": "c1098d8e-c01f-00ed-4d38-6fbd6c000000",
+        "x-ms-request-id": "98ba17b5-601f-005d-0ac5-95fca5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f?resource=directory",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-092881f3ed2bd146bdc1eaf5b4b96501-4f6de5d73bf7cb4c-00",
+        "traceparent": "00-ca678e23b383a3459d7ffe1dc1a4749d-fa63b93ca2cff74b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "60283e15-fdd1-e0ae-2cc9-dacbe40f1924",
         "x-ms-return-client-request-id": "true",
@@ -116,27 +116,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
-        "ETag": "\u00220x8D83D4F6635819E\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:09 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "ETag": "\u00220x8D863DC32CCB011\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:46 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "60283e15-fdd1-e0ae-2cc9-dacbe40f1924",
-        "x-ms-request-id": "c1098d8f-c01f-00ed-4e38-6fbd6c000000",
+        "x-ms-request-id": "98ba17b6-601f-005d-0bc5-95fca5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f/test-file-40b0bfbe-b334-1978-a73b-60c4c1bbfd91?resource=file",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f/test-file-40b0bfbe-b334-1978-a73b-60c4c1bbfd91?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d1a93dd9-cd8f-6270-c60f-b9969de91e71",
         "x-ms-return-client-request-id": "true",
@@ -146,27 +146,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
-        "ETag": "\u00220x8D83D4F664312CB\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "ETag": "\u00220x8D863DC32EF5057\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d1a93dd9-cd8f-6270-c60f-b9969de91e71",
-        "x-ms-request-id": "c1098d90-c01f-00ed-4f38-6fbd6c000000",
+        "x-ms-request-id": "98ba17b7-601f-005d-0cc5-95fca5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f/test-file-af2d49cb-1dec-43ef-81bc-cb7a69cd0c90?resource=file",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f/test-file-af2d49cb-1dec-43ef-81bc-cb7a69cd0c90?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c3ded89b-ece9-bcb5-4d66-50d302f6f8f9",
         "x-ms-return-client-request-id": "true",
@@ -176,28 +176,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:09 GMT",
-        "ETag": "\u00220x8D83D4F665F77D7\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "ETag": "\u00220x8D863DC32FD08B7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c3ded89b-ece9-bcb5-4d66-50d302f6f8f9",
-        "x-ms-request-id": "c1098d91-c01f-00ed-5038-6fbd6c000000",
+        "x-ms-request-id": "98ba17b8-601f-005d-0dc5-95fca5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da?resource=directory",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8147b30b7319da41a1b10329c93ace7a-9c08d5af8ee96544-00",
+        "traceparent": "00-94932c950a842240ab11a8de4b8c9107-9d7dbbce710fda41-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "98233cc8-77af-018c-783e-7c8c008ad482",
         "x-ms-return-client-request-id": "true",
@@ -207,27 +207,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:10 GMT",
-        "ETag": "\u00220x8D83D4F666C0B55\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "ETag": "\u00220x8D863DC330A4095\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "98233cc8-77af-018c-783e-7c8c008ad482",
-        "x-ms-request-id": "c1098d92-c01f-00ed-5138-6fbd6c000000",
+        "x-ms-request-id": "98ba17b9-601f-005d-0ec5-95fca5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da/test-file-c26d75e5-6717-b90a-8245-d6cf62b5c519?resource=file",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da/test-file-c26d75e5-6717-b90a-8245-d6cf62b5c519?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "65c5b45a-0cc0-60b6-3269-1669a1bd9ec3",
         "x-ms-return-client-request-id": "true",
@@ -237,94 +237,321 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:10 GMT",
-        "ETag": "\u00220x8D83D4F6681032A\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "ETag": "\u00220x8D863DC3318060B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "65c5b45a-0cc0-60b6-3269-1669a1bd9ec3",
-        "x-ms-request-id": "c1098d93-c01f-00ed-5238-6fbd6c000000",
+        "x-ms-request-id": "98ba17ba-601f-005d-0fc5-95fca5000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "http://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da/test-file-e2fd6278-2926-fcdb-497f-0e384e59ec67?resource=file",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-868a2c4ace5e2f42a2882ffdd7724a6f-d5c62f8c8d4d4949-00",
-        "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "6937553f-ce1e-3057-d9c9-1c41fd7d11d8",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:10 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-02-10"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:10 GMT",
-        "ETag": "\u00220x8D83D4F668E2835\u0022",
-        "Last-Modified": "Mon, 10 Aug 2020 17:04:10 GMT",
-        "Server": [
-          "Windows-Azure-HDFS/1.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-client-request-id": "6937553f-ce1e-3057-d9c9-1c41fd7d11d8",
-        "x-ms-request-id": "e0acbfbf-401f-0038-7238-6f52e1000000",
-        "x-ms-version": "2020-02-10"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://gen1gen2domain1.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744?action=setAccessControlRecursive\u0026mode=modify",
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744?action=setAccessControl",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-102c4fa75dc4254ba49dfb329a13126e-401dfb71cb235d4e-00",
+        "traceparent": "00-b7cbfb8a45be8d418be343ca417b1386-6b239a439c44414d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
-        "x-ms-client-request-id": "f9f91833-8221-c648-ff44-d426431785ea",
+        "x-ms-client-request-id": "6937553f-ce1e-3057-d9c9-1c41fd7d11d8",
+        "x-ms-owner": "e2fd6278-2926-fcdb-497f-0e384e59ec67",
+        "x-ms-permissions": "rwxrwxrwx",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Date": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "ETag": "\u00220x8D863DC32BE9C48\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6937553f-ce1e-3057-d9c9-1c41fd7d11d8",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "98ba17bb-601f-005d-10c5-95fca5000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f9f91833-8221-c648-ff44-d426431785ea",
+        "x-ms-owner": "e2fd6278-2926-fcdb-497f-0e384e59ec67",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "ETag": "\u00220x8D863DC32CCB011\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:46 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f9f91833-8221-c648-ff44-d426431785ea",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "56554afb-801f-0045-48c5-9523c2000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f/test-file-40b0bfbe-b334-1978-a73b-60c4c1bbfd91?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "e50d94a0-1884-fab6-660e-4b031cacd5f3",
+        "x-ms-owner": "e2fd6278-2926-fcdb-497f-0e384e59ec67",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:48 GMT",
+        "ETag": "\u00220x8D863DC32EF5057\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e50d94a0-1884-fab6-660e-4b031cacd5f3",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "7eef7c87-f01f-0094-5ac5-954148000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-11bc8901-23b7-8e23-d1ac-d9393b5ddc0f/test-file-af2d49cb-1dec-43ef-81bc-cb7a69cd0c90?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "ae8698c5-a009-d865-e8c6-bddeb6aa31d5",
+        "x-ms-owner": "e2fd6278-2926-fcdb-497f-0e384e59ec67",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:48 GMT",
+        "ETag": "\u00220x8D863DC32FD08B7\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ae8698c5-a009-d865-e8c6-bddeb6aa31d5",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "f4a5edff-101f-00c1-2fc5-9551c3000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "843e7e9b-2625-55e9-2b5b-281647bc7abf",
+        "x-ms-owner": "e2fd6278-2926-fcdb-497f-0e384e59ec67",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:48 GMT",
+        "ETag": "\u00220x8D863DC330A4095\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "843e7e9b-2625-55e9-2b5b-281647bc7abf",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "d1c8be1c-101f-0078-3bc5-9555d9000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da/test-file-c26d75e5-6717-b90a-8245-d6cf62b5c519?action=setAccessControl",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "3742fdf0-ad6c-21af-8259-97a34547533d",
+        "x-ms-owner": "e2fd6278-2926-fcdb-497f-0e384e59ec67",
+        "x-ms-permissions": "rwxrwxrwx",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:49 GMT",
+        "ETag": "\u00220x8D863DC3318060B\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:47 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3742fdf0-ad6c-21af-8259-97a34547533d",
+        "x-ms-namespace-enabled": "true",
+        "x-ms-request-id": "d1c8be1d-101f-0078-3cc5-9555d9000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744/test-directory-def72902-99fe-a060-475d-eb2be7ca81da/test-file-fe61bb61-1ff9-ebc9-b2e6-493a71bb2fa0?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "6acc7897-3829-d13b-3356-85866375b0c7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 28 Sep 2020 18:27:49 GMT",
+        "ETag": "\u00220x8D863DC3487FA5D\u0022",
+        "Last-Modified": "Mon, 28 Sep 2020 18:27:49 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6acc7897-3829-d13b-3356-85866375b0c7",
+        "x-ms-request-id": "9fba52a5-701f-006e-51c5-95a30e000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.blob.core.windows.net/?restype=service\u0026comp=userdelegationkey",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "56",
+        "Content-Type": "application/xml",
+        "traceparent": "00-67712a3e1111c4429310b5679eb21838-b42aa7307caf6d48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f9a256d4-c5ef-eb76-b755-1623bdcc677d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": "\u003CKeyInfo\u003E\u003CExpiry\u003E2020-09-28T19:27:49Z\u003C/Expiry\u003E\u003C/KeyInfo\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Mon, 28 Sep 2020 18:27:49 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "f9a256d4-c5ef-eb76-b755-1623bdcc677d",
+        "x-ms-request-id": "0eeabdb6-b01e-0003-61c5-951745000000",
+        "x-ms-version": "2020-02-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CUserDelegationKey\u003E\u003CSignedOid\u003Ec4f48289-bb84-4086-b250-6f94a8f64cee\u003C/SignedOid\u003E\u003CSignedTid\u003E72f988bf-86f1-41af-91ab-2d7cd011db47\u003C/SignedTid\u003E\u003CSignedStart\u003E2020-09-28T18:27:50Z\u003C/SignedStart\u003E\u003CSignedExpiry\u003E2020-09-28T19:27:49Z\u003C/SignedExpiry\u003E\u003CSignedService\u003Eb\u003C/SignedService\u003E\u003CSignedVersion\u003E2020-02-10\u003C/SignedVersion\u003E\u003CValue\u003ESwNierZf53WqRnvlX4ZwTqtqoxNHY/mrHuVVhtjg4LU=\u003C/Value\u003E\u003C/UserDelegationKey\u003E"
+    },
+    {
+      "RequestUri": "https://amandaadlscanary2.dfs.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13/test-directory-d486c72e-c846-f302-89ba-367e2aaa4744?skoid=c4f48289-bb84-4086-b250-6f94a8f64cee\u0026sktid=72f988bf-86f1-41af-91ab-2d7cd011db47\u0026skt=2020-09-28T18%3A27%3A50Z\u0026ske=2020-09-28T19%3A27%3A49Z\u0026sks=b\u0026skv=2020-02-10\u0026sv=2020-02-10\u0026st=2020-09-28T17%3A27%3A49Z\u0026se=2020-09-28T19%3A27%3A49Z\u0026sr=c\u0026sp=racwdlmeop\u0026suoid=e2fd6278-2926-fcdb-497f-0e384e59ec67\u0026sig=Sanitized\u0026action=setAccessControlRecursive\u0026mode=modify",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-acl": "user::rwx,group::r--,other::---,mask::rwx",
+        "x-ms-client-request-id": "0db1fb83-b6d2-64d7-8094-9acbf29e609b",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-02-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Date": "Mon, 28 Sep 2020 18:27:50 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "f9f91833-8221-c648-ff44-d426431785ea",
+        "x-ms-client-request-id": "0db1fb83-b6d2-64d7-8094-9acbf29e609b",
         "x-ms-namespace-enabled": "true",
-        "x-ms-request-id": "c1098d94-c01f-00ed-5338-6fbd6c000000",
+        "x-ms-request-id": "ea92b934-801f-0037-28c5-95248d000000",
         "x-ms-version": "2020-02-10"
       },
-      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktZDQ4NmM3MmUtYzg0Ni1mMzAyLTg5YmEtMzY3ZTJhYWE0NzQ0L3Rlc3QtZGlyZWN0b3J5LWRlZjcyOTAyLTk5ZmUtYTA2MC00NzVkLWViMmJlN2NhODFkYS90ZXN0LWZpbGUtZTJmZDYyNzgtMjkyNi1mY2RiLTQ5N2YtMGUzODRlNTllYzY3IiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
+      "ResponseBody": "eyJkaXJlY3Rvcmllc1N1Y2Nlc3NmdWwiOjMsImZhaWxlZEVudHJpZXMiOlt7ImVycm9yTWVzc2FnZSI6IlRoaXMgcmVxdWVzdCBpcyBub3QgYXV0aG9yaXplZCB0byBwZXJmb3JtIHRoaXMgb3BlcmF0aW9uIHVzaW5nIHRoaXMgcGVybWlzc2lvbi4iLCJuYW1lIjoidGVzdC1kaXJlY3RvcnktZDQ4NmM3MmUtYzg0Ni1mMzAyLTg5YmEtMzY3ZTJhYWE0NzQ0L3Rlc3QtZGlyZWN0b3J5LWRlZjcyOTAyLTk5ZmUtYTA2MC00NzVkLWViMmJlN2NhODFkYS90ZXN0LWZpbGUtZmU2MWJiNjEtMWZmOS1lYmM5LWIyZTYtNDkzYTcxYmIyZmEwIiwidHlwZSI6IkZJTEUifV0sImZhaWx1cmVDb3VudCI6MSwiZmlsZXNTdWNjZXNzZnVsIjozfQo="
     },
     {
-      "RequestUri": "http://gen1gen2domain1.blob.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13?restype=container",
+      "RequestUri": "http://amandaadlscanary2.blob.core.windows.net/test-filesystem-00fd68e4-95ff-3514-6d01-4df494bfdd13?restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-10989cb609e43242aa16e9634f177d48-55573a7e85bc074a-00",
+        "traceparent": "00-474c264a7d34f841a35f0d56771cf47a-a24108f7dc2fef43-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.DataLake/12.3.0-dev.20200810.1",
-          "(.NET Core 4.6.29017.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Storage.Files.DataLake/12.5.0-alpha.20200928.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": "e50d94a0-1884-fab6-660e-4b031cacd5f3",
-        "x-ms-date": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "x-ms-client-request-id": "c1a00f6e-591a-31aa-950f-a11525079b16",
+        "x-ms-date": "Mon, 28 Sep 2020 18:27:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-02-10"
       },
@@ -332,20 +559,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 10 Aug 2020 17:04:10 GMT",
+        "Date": "Mon, 28 Sep 2020 18:27:51 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-client-request-id": "e50d94a0-1884-fab6-660e-4b031cacd5f3",
-        "x-ms-request-id": "58dad276-601e-00b9-2038-6ff23b000000",
+        "x-ms-client-request-id": "c1a00f6e-591a-31aa-950f-a11525079b16",
+        "x-ms-request-id": "ca91826b-701e-00d7-54c5-95a714000000",
         "x-ms-version": "2020-02-10"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2020-09-28T11:27:49.8704525-07:00",
     "RandomSeed": "997275216",
-    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\ngen1gen2domain1\nU2FuaXRpemVk\nhttp://gen1gen2domain1.blob.core.windows.net\nhttp://gen1gen2domain1.file.core.windows.net\nhttp://gen1gen2domain1.queue.core.windows.net\nhttp://gen1gen2domain1.table.core.windows.net\n\n\n\n\nhttp://gen1gen2domain1-secondary.blob.core.windows.net\nhttp://gen1gen2domain1-secondary.file.core.windows.net\nhttp://gen1gen2domain1-secondary.queue.core.windows.net\n\nc6b5fe1a-9b59-4975-92c4-d9f728c3c371\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://gen1gen2domain1.blob.core.windows.net/;QueueEndpoint=http://gen1gen2domain1.queue.core.windows.net/;FileEndpoint=http://gen1gen2domain1.file.core.windows.net/;BlobSecondaryEndpoint=http://gen1gen2domain1-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://gen1gen2domain1-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://gen1gen2domain1-secondary.file.core.windows.net/;AccountName=gen1gen2domain1;AccountKey=Sanitized\n"
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary2\nU2FuaXRpemVk\nhttp://amandaadlscanary2.blob.core.windows.net\nhttp://amandaadlscanary2.file.core.windows.net\nhttp://amandaadlscanary2.queue.core.windows.net\nhttp://amandaadlscanary2.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary2-secondary.blob.core.windows.net\nhttp://amandaadlscanary2-secondary.file.core.windows.net\nhttp://amandaadlscanary2-secondary.queue.core.windows.net\n\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=http://amandaadlscanary2.blob.core.windows.net/;QueueEndpoint=http://amandaadlscanary2.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary2-secondary.file.core.windows.net/;AccountName=amandaadlscanary2;AccountKey=Sanitized\n"
   }
 }


### PR DESCRIPTION
by using a suoid sas and setting the guid set in the suoid as the owner for some datalake paths through `SetPermissions`