### PR TITLE
ShouldSerialize isn't working as Expected in PolymorphicConvertor

### DIFF
--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/JsonConverterHelper.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/JsonConverterHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Rest.Serialization
                 // Skipping properties with JsonIgnore attribute, non-readable, and 
                 // ShouldSerialize returning false when set
                 if (!property.Ignored && property.Readable &&
-                    (property.ShouldSerialize == null || property.ShouldSerialize(memberValue)))
+                    (property.ShouldSerialize == null || property.ShouldSerialize(value)))
                 {
                     string propertyName = property.PropertyName;
                     if (property.PropertyName.StartsWith("properties.", StringComparison.OrdinalIgnoreCase))

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/JsonSerializationTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/JsonSerializationTests.cs
@@ -211,6 +211,49 @@ namespace Microsoft.Rest.ClientRuntime.Tests
         }
 
         [Fact]
+        public void PolymorphicShouldSerializeWorks()
+        {
+            Zoo zoo = new Zoo() { Id = 1 };
+            zoo.Animals.Add(new Dog()
+            {
+                Name = "Fido",
+                LikesDogfood = true,
+                NeedVaccine = true
+            });
+
+            zoo.Animals.Add(new Cat()
+            {
+                Name = "Felix",
+                LikesMice = false,
+                Dislikes = new Dog()
+                {
+                    Name = "Angry",
+                    LikesDogfood = true
+                },
+                BestFriend = new Animal()
+                {
+                    Name = "Rudy the Rabbit",
+                    BestFriend = new Cat()
+                    {
+                        Name = "Jango",
+                        LikesMice = true
+                    }
+                }
+            });
+            var serializeSettings = new JsonSerializerSettings();
+            serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            serializeSettings.Converters.Add(new PolymorphicSerializeJsonConverter<Animal>("dType"));
+
+            var deserializeSettings = new JsonSerializerSettings();
+            deserializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            deserializeSettings.Converters.Add(new PolymorphicDeserializeJsonConverter<Animal>("dType"));
+
+            var serializedJson = JsonConvert.SerializeObject(zoo, Formatting.Indented, serializeSettings);
+           
+            Assert.DoesNotContain("needVaccine", serializedJson);
+        }
+
+        [Fact]
         public void RawJsonIsSerialized()
         {
             var serializeSettings = new JsonSerializerSettings();

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Resources/Animal.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/Resources/Animal.cs
@@ -25,6 +25,14 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
 
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalProperties { get; set; }
+
+        [JsonProperty("needVaccine")]
+        public bool NeedVaccine { get; set; }
+
+        public bool ShouldSerializeNeedVaccine()
+        {
+            return false;
+        }
     }
 
     [JsonObject("dog")]


### PR DESCRIPTION
ShouldSerialize is throwing an error as we have to provide targetobject instead of the property value to the function.

Issue : https://github.com/Azure/azure-sdk-for-net/issues/15470