### PR TITLE
Add title where there are multiple Swagger files as inputs

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/autorest.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/autorest.md
@@ -33,6 +33,7 @@ directive:
       }
     }
 
+title: EventGridClient
 input-file:
     -  https://github.com/ellismg/azure-rest-api-specs/blob/4bb5b76cb8401896b15f1be3fdaac6bd5d299b17/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2018-01-01/EventGrid.json
     -  https://github.com/Azure/azure-rest-api-specs/blob/3e974736d767fd714b4fb0570aa352e774582ecd/specification/eventgrid/data-plane/Microsoft.Storage/stable/2018-01-01/Storage.json

--- a/sdk/resources/Azure.ResourceManager.Resources/src/autorest.md
+++ b/sdk/resources/Azure.ResourceManager.Resources/src/autorest.md
@@ -4,6 +4,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 
 ``` yaml
 azure-arm: true
+title: ResourceManagementClient
 input-file:
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f9d1625a69e739f362dd16e32f8f9e8fa01abd37/specification/resources/resource-manager/Microsoft.Resources/stable/2019-10-01/resources.json
     - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f9d1625a69e739f362dd16e32f8f9e8fa01abd37/specification/resources/resource-manager/Microsoft.Resources/stable/2019-11-01/subscriptions.json

--- a/sdk/search/Azure.Search.Documents/src/autorest.md
+++ b/sdk/search/Azure.Search.Documents/src/autorest.md
@@ -11,6 +11,7 @@ however merge two local swagger files together automagically.  At some point,
 we should merge the Service and Index swagger files together but for now we
 copy them locally in `/sdk/search/generate.ps1` and reference them here.
 ```yaml
+title: SearchServiceClient
 input-file:
 - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/0bc7853cb4d824bb6c310344dcc1b5f77cbe6bdd/specification/search/data-plane/Azure.Search/preview/2020-06-30/searchindex.json
 - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/0bc7853cb4d824bb6c310344dcc1b5f77cbe6bdd/specification/search/data-plane/Azure.Search/preview/2020-06-30/searchservice.json


### PR DESCRIPTION
When you're generating a service that has multiple Swagger files as inputs, it doesn't know which title to pick because each file has a title that's why we need to define a title explicitly in the configuration file. 