### PR TITLE
Fix core CI - webjobs tests

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -42,3 +42,5 @@ extends:
       safeName: AzureCoreExperimental
     - name: Microsoft.Azure.Core.NewtonsoftJson
       safeName: MicrosoftAzureCoreNewtonsoftJson
+    TestSetupSteps:
+    - template: /sdk/storage/tests-install-azurite.yml


### PR DESCRIPTION
Turns out Core pipeline runs all service's tests. So adding storage test setup there as well.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/15529