### PR TITLE
[Messaging Clients] Fix Multi-Cloud Auth Support

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -77,7 +77,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public async Task<string> AquireManagementTokenAsync()
         {
-            ManagementToken token = s_managementToken;
+            var token = s_managementToken;
+            var authority = new Uri(new Uri(EventHubsTestEnvironment.Instance.AuthorityHostUrl), EventHubsTestEnvironment.Instance.TenantId).ToString();
 
             // If there was no current token, or it is within the buffer for expiration, request a new token.
             // There is a benign race condition here, where there may be multiple requests in-flight for a new token.  Since
@@ -86,8 +87,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
+                var context = new AuthenticationContext(authority);
                 var credential = new ClientCredential(EventHubsTestEnvironment.Instance.ClientId, EventHubsTestEnvironment.Instance.ClientSecret);
-                var context = new AuthenticationContext($"{ EventHubsTestEnvironment.Instance.AuthorityHostUrl }{ EventHubsTestEnvironment.Instance.TenantId }");
                 var result = await context.AcquireTokenAsync(EventHubsTestEnvironment.Instance.ServiceManagementUrl, credential).ConfigureAwait(false);
 
                 if ((string.IsNullOrEmpty(result?.AccessToken)))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
@@ -254,7 +254,8 @@ namespace Azure.Messaging.ServiceBus.Tests
         ///
         private static async Task<string> AquireManagementTokenAsync()
         {
-            ManagementToken token = s_managementToken;
+            var token = s_managementToken;
+            var authority = new Uri(new Uri(ServiceBusTestEnvironment.Instance.AuthorityHostUrl), ServiceBusTestEnvironment.Instance.TenantId).ToString();
 
             // If there was no current token, or it is within the buffer for expiration, request a new token.
             // There is a benign race condition here, where there may be multiple requests in-flight for a new token.  Since
@@ -263,8 +264,8 @@ namespace Azure.Messaging.ServiceBus.Tests
 
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
+                var context = new AuthenticationContext(authority);
                 var credential = new ClientCredential(ServiceBusTestEnvironment.Instance.ClientId, ServiceBusTestEnvironment.Instance.ClientSecret);
-                var context = new AuthenticationContext($"{ ServiceBusTestEnvironment.Instance.AuthorityHostUrl }{ ServiceBusTestEnvironment.Instance.TenantId }");
                 var result = await context.AcquireTokenAsync(ServiceBusTestEnvironment.Instance.ServiceManagementUrl, credential);
 
                 if ((string.IsNullOrEmpty(result?.AccessToken)))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestEnvironment.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestEnvironment.cs
@@ -24,9 +24,7 @@ namespace Azure.Messaging.ServiceBus.Tests
         /// <summary>The name of the shared access key to be used for accessing an Service Bus namespace.</summary>
         public const string ServiceBusDefaultSharedAccessKey = "RootManageSharedAccessKey";
 
-        /// <summary>
-        /// A shared instance of <see cref="ServiceBusTestEnvironment"/>.
-        /// </summary>
+        /// <summary>A shared instance of <see cref="ServiceBusTestEnvironment"/>. </summary>
         public static ServiceBusTestEnvironment Instance { get; } = new ServiceBusTestEnvironment();
 
         /// <summary>The active Service Bus namespace for this test run, lazily created.</summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a URL formation issue for the authority used when requesting management tokens.  Because the format of the fragment differs between Azure clouds, no assumptions can be made about the format, specifically around trailing slashes.

# Last Upstream Rebase

Tuesday, September 29, 11:24am (EDT)

# References and Related Issues

- [[Event Hubs Client] Tests fail while authorityhost from environment doesn't end with "/"](https://github.com/Azure/azure-sdk-for-net/issues/https://github.com/Azure/azure-sdk-for-net/issues/15009) ([#15009](https://github.com/Azure/azure-sdk-for-net/issues/https://github.com/Azure/azure-sdk-for-net/issues/15009))