### PR TITLE
[TA] Delete length property from library

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
 ## 5.1.0-beta.2 (Unreleased)
-
+### Breaking changes
+- Removed property `Length` from `CategorizedEntity`, `SentenceSentiment`, `LinkedEntityMatch`, `AspectSentiment`, `OpinionSentiment`, and `PiiEntity`.
 
 ## 5.1.0-beta.1 (2020-09-17)
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -194,7 +194,7 @@ CategorizedEntityCollection entities = client.RecognizeEntities(document);
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
     Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```
@@ -243,7 +243,7 @@ foreach (LinkedEntity linkedEntity in linkedEntities)
     Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
     {
-        Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+        Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
         Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
     }
 }
@@ -274,7 +274,7 @@ CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(docum
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
     Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -28,7 +28,6 @@ namespace Azure.AI.TextAnalytics
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public Azure.AI.TextAnalytics.SentimentConfidenceScores ConfidenceScores { get { throw null; } }
-        public int Length { get { throw null; } }
         public int Offset { get { throw null; } }
         public Azure.AI.TextAnalytics.TextSentiment Sentiment { get { throw null; } }
         public string Text { get { throw null; } }
@@ -40,7 +39,6 @@ namespace Azure.AI.TextAnalytics
         private readonly int _dummyPrimitive;
         public Azure.AI.TextAnalytics.EntityCategory Category { get { throw null; } }
         public double ConfidenceScore { get { throw null; } }
-        public int Length { get { throw null; } }
         public int Offset { get { throw null; } }
         public string SubCategory { get { throw null; } }
         public string Text { get { throw null; } }
@@ -155,7 +153,6 @@ namespace Azure.AI.TextAnalytics
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public double ConfidenceScore { get { throw null; } }
-        public int Length { get { throw null; } }
         public int Offset { get { throw null; } }
         public string Text { get { throw null; } }
     }
@@ -174,7 +171,6 @@ namespace Azure.AI.TextAnalytics
         private readonly int _dummyPrimitive;
         public Azure.AI.TextAnalytics.SentimentConfidenceScores ConfidenceScores { get { throw null; } }
         public bool IsNegated { get { throw null; } }
-        public int Length { get { throw null; } }
         public int Offset { get { throw null; } }
         public Azure.AI.TextAnalytics.TextSentiment Sentiment { get { throw null; } }
         public string Text { get { throw null; } }
@@ -186,7 +182,6 @@ namespace Azure.AI.TextAnalytics
         private readonly int _dummyPrimitive;
         public Azure.AI.TextAnalytics.EntityCategory Category { get { throw null; } }
         public double ConfidenceScore { get { throw null; } }
-        public int Length { get { throw null; } }
         public int Offset { get { throw null; } }
         public string SubCategory { get { throw null; } }
         public string Text { get { throw null; } }
@@ -245,7 +240,6 @@ namespace Azure.AI.TextAnalytics
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public Azure.AI.TextAnalytics.SentimentConfidenceScores ConfidenceScores { get { throw null; } }
-        public int Length { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Azure.AI.TextAnalytics.MinedOpinion> MinedOpinions { get { throw null; } }
         public int Offset { get { throw null; } }
         public Azure.AI.TextAnalytics.TextSentiment Sentiment { get { throw null; } }
@@ -380,10 +374,10 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.AnalyzeSentimentResult AnalyzeSentimentResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeSentimentResult AnalyzeSentimentResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.DocumentSentiment documentSentiment) { throw null; }
         public static Azure.AI.TextAnalytics.AnalyzeSentimentResultCollection AnalyzeSentimentResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.AnalyzeSentimentResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
-        public static Azure.AI.TextAnalytics.AspectSentiment AspectSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset, int length) { throw null; }
+        public static Azure.AI.TextAnalytics.AspectSentiment AspectSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.AI.TextAnalytics.CategorizedEntity CategorizedEntity(string text, string category, string subCategory, double score) { throw null; }
-        public static Azure.AI.TextAnalytics.CategorizedEntity CategorizedEntity(string text, string category, string subCategory, double score, int offset, int length) { throw null; }
+        public static Azure.AI.TextAnalytics.CategorizedEntity CategorizedEntity(string text, string category, string subCategory, double score, int offset) { throw null; }
         public static Azure.AI.TextAnalytics.CategorizedEntityCollection CategorizedEntityCollection(System.Collections.Generic.IList<Azure.AI.TextAnalytics.CategorizedEntity> entities, System.Collections.Generic.IList<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings = null) { throw null; }
         public static Azure.AI.TextAnalytics.DetectedLanguage DetectedLanguage(string name, string iso6391Name, double confidenceScore, System.Collections.Generic.IList<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings = null) { throw null; }
         public static Azure.AI.TextAnalytics.DetectLanguageResult DetectLanguageResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
@@ -400,10 +394,10 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.LinkedEntityCollection LinkedEntityCollection(System.Collections.Generic.IList<Azure.AI.TextAnalytics.LinkedEntity> entities, System.Collections.Generic.IList<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings = null) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.AI.TextAnalytics.LinkedEntityMatch LinkedEntityMatch(string text, double score) { throw null; }
-        public static Azure.AI.TextAnalytics.LinkedEntityMatch LinkedEntityMatch(string text, double score, int offset, int length) { throw null; }
+        public static Azure.AI.TextAnalytics.LinkedEntityMatch LinkedEntityMatch(string text, double score, int offset) { throw null; }
         public static Azure.AI.TextAnalytics.MinedOpinion MinedOpinion(Azure.AI.TextAnalytics.AspectSentiment aspect, System.Collections.Generic.IReadOnlyList<Azure.AI.TextAnalytics.OpinionSentiment> opinions) { throw null; }
-        public static Azure.AI.TextAnalytics.OpinionSentiment OpinionSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, double positiveScore, double negativeScore, string text, bool isNegated, int offset, int length) { throw null; }
-        public static Azure.AI.TextAnalytics.PiiEntity PiiEntity(string text, string category, string subCategory, double score, int offset, int length) { throw null; }
+        public static Azure.AI.TextAnalytics.OpinionSentiment OpinionSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, double positiveScore, double negativeScore, string text, bool isNegated, int offset) { throw null; }
+        public static Azure.AI.TextAnalytics.PiiEntity PiiEntity(string text, string category, string subCategory, double score, int offset) { throw null; }
         public static Azure.AI.TextAnalytics.PiiEntityCollection PiiEntityCollection(System.Collections.Generic.IList<Azure.AI.TextAnalytics.PiiEntity> entities, string redactedText, System.Collections.Generic.IList<Azure.AI.TextAnalytics.TextAnalyticsWarning> warnings = null) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeEntitiesResult RecognizeEntitiesResult(string id, Azure.AI.TextAnalytics.TextAnalyticsError error) { throw null; }
         public static Azure.AI.TextAnalytics.RecognizeEntitiesResult RecognizeEntitiesResult(string id, Azure.AI.TextAnalytics.TextDocumentStatistics statistics, Azure.AI.TextAnalytics.CategorizedEntityCollection entities) { throw null; }
@@ -416,7 +410,7 @@ namespace Azure.AI.TextAnalytics
         public static Azure.AI.TextAnalytics.RecognizePiiEntitiesResultCollection RecognizePiiEntitiesResultCollection(System.Collections.Generic.IEnumerable<Azure.AI.TextAnalytics.RecognizePiiEntitiesResult> list, Azure.AI.TextAnalytics.TextDocumentBatchStatistics statistics, string modelVersion) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static Azure.AI.TextAnalytics.SentenceSentiment SentenceSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore) { throw null; }
-        public static Azure.AI.TextAnalytics.SentenceSentiment SentenceSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, int length, System.Collections.Generic.IReadOnlyList<Azure.AI.TextAnalytics.MinedOpinion> minedOpinions) { throw null; }
+        public static Azure.AI.TextAnalytics.SentenceSentiment SentenceSentiment(Azure.AI.TextAnalytics.TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, System.Collections.Generic.IReadOnlyList<Azure.AI.TextAnalytics.MinedOpinion> minedOpinions) { throw null; }
         public static Azure.AI.TextAnalytics.SentimentConfidenceScores SentimentConfidenceScores(double positiveScore, double neutralScore, double negativeScore) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsError TextAnalyticsError(string code, string message, string target = null) { throw null; }
         public static Azure.AI.TextAnalytics.TextAnalyticsWarning TextAnalyticsWarning(string code, string message) { throw null; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -23,7 +23,7 @@ CategorizedEntityCollection entities = client.RecognizeEntities(document);
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
     Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -26,7 +26,7 @@ foreach (LinkedEntity linkedEntity in linkedEntities)
     Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
     {
-        Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+        Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
         Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AspectSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AspectSentiment.cs
@@ -17,13 +17,12 @@ namespace Azure.AI.TextAnalytics
     {
         private const double _neutralValue = 0d;
 
-        internal AspectSentiment(TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset, int length)
+        internal AspectSentiment(TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset)
         {
             Sentiment = sentiment;
             Text = text;
             ConfidenceScores = new SentimentConfidenceScores(positiveScore, _neutralValue, negativeScore);
             Offset = offset;
-            Length = length;
         }
 
         internal AspectSentiment(SentenceAspect sentenceAspect)
@@ -34,7 +33,6 @@ namespace Azure.AI.TextAnalytics
             ConfidenceScores = new SentimentConfidenceScores(sentenceAspect.ConfidenceScores.Positive, _neutralValue, sentenceAspect.ConfidenceScores.Negative);
             Sentiment = (TextSentiment)Enum.Parse(typeof(TextSentiment), sentenceAspect.Sentiment, ignoreCase: true);
             Offset = sentenceAspect.Offset;
-            Length = sentenceAspect.Length;
         }
 
         /// <summary>
@@ -59,10 +57,5 @@ namespace Azure.AI.TextAnalytics
         /// Gets the starting position (in UTF-16 code units) for the aspect text.
         /// </summary>
         public int Offset { get; }
-
-        /// <summary>
-        /// Gets the length (in UTF-16 code units) of the aspect text.
-        /// </summary>
-        public int Length { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntity.cs
@@ -22,7 +22,6 @@ namespace Azure.AI.TextAnalytics
             SubCategory = entity.Subcategory;
             ConfidenceScore = entity.ConfidenceScore;
             Offset = entity.Offset;
-            Length = entity.Length;
         }
 
         /// <summary>
@@ -57,10 +56,5 @@ namespace Azure.AI.TextAnalytics
         /// Gets the starting position (in UTF-16 code units) for the matching text in the input document.
         /// </summary>
         public int Offset { get; }
-
-        /// <summary>
-        /// Gets the length (in UTF-16 code units) of the matching text in the input document.
-        /// </summary>
-        public int Length { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityMatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityMatch.cs
@@ -13,14 +13,18 @@ namespace Azure.AI.TextAnalytics
     [CodeGenModel("Match")]
     public readonly partial struct LinkedEntityMatch
     {
+        // use for deserialization
         internal LinkedEntityMatch(double confidenceScore, string text, int offset, int length)
+            : this(confidenceScore, text, offset) => Length = length;
+
+        internal LinkedEntityMatch(double confidenceScore, string text, int offset)
         {
             // We shipped TA 5.0.0 Text == string.Empty if the service returned a null value for Text.
             // Because we don't want to introduce a breaking change, we are transforming that null to string.Empty
             Text = text ?? string.Empty;
             ConfidenceScore = confidenceScore;
             Offset = offset;
-            Length = length;
+            Length = default;
         }
 
         /// <summary>
@@ -40,8 +44,8 @@ namespace Azure.AI.TextAnalytics
         public int Offset { get; }
 
         /// <summary>
-        /// Gets the length (in UTF-16 code units) of the matching text in the document.
+        /// Gets the length (in UTF-16 code units) of the matching text in the sentence.
         /// </summary>
-        public int Length { get; }
+        private int Length { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/OpinionSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/OpinionSentiment.cs
@@ -15,14 +15,13 @@ namespace Azure.AI.TextAnalytics
     {
         private const double _neutralValue = 0d;
 
-        internal OpinionSentiment(TextSentiment sentiment, double positiveScore, double negativeScore, string text, bool isNegated, int offset, int length)
+        internal OpinionSentiment(TextSentiment sentiment, double positiveScore, double negativeScore, string text, bool isNegated, int offset)
         {
             Sentiment = sentiment;
             ConfidenceScores = new SentimentConfidenceScores(positiveScore, _neutralValue, negativeScore);
             Text = text;
             IsNegated = isNegated;
             Offset = offset;
-            Length = length;
         }
 
         internal OpinionSentiment(SentenceOpinion opinion)
@@ -34,7 +33,6 @@ namespace Azure.AI.TextAnalytics
             Sentiment = (TextSentiment)Enum.Parse(typeof(TextSentiment), opinion.Sentiment, ignoreCase: true);
             IsNegated = opinion.IsNegated;
             Offset = opinion.Offset;
-            Length = opinion.Length;
         }
 
         /// <summary>
@@ -66,10 +64,5 @@ namespace Azure.AI.TextAnalytics
         /// Gets the starting position (in UTF-16 code units) for the opinion text.
         /// </summary>
         public int Offset { get; }
-
-        /// <summary>
-        /// Gets the length (in UTF-16 code units) of the opinion text.
-        /// </summary>
-        public int Length { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntity.cs
@@ -20,7 +20,6 @@ namespace Azure.AI.TextAnalytics
             SubCategory = entity.Subcategory;
             ConfidenceScore = entity.ConfidenceScore;
             Offset = entity.Offset;
-            Length = entity.Length;
         }
 
         /// <summary>
@@ -55,10 +54,5 @@ namespace Azure.AI.TextAnalytics
         /// Gets the starting position (in UTF-16 code units) for the matching text in the input document.
         /// </summary>
         public int Offset { get; }
-
-        /// <summary>
-        /// Gets the length (in UTF-16 code units) of the matching text in the input document.
-        /// </summary>
-        public int Length { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
@@ -16,13 +16,12 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public readonly struct SentenceSentiment
     {
-        internal SentenceSentiment(TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, int length, IReadOnlyList<MinedOpinion> minedOpinions)
+        internal SentenceSentiment(TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, IReadOnlyList<MinedOpinion> minedOpinions)
         {
             Sentiment = sentiment;
             Text = text;
             ConfidenceScores = new SentimentConfidenceScores(positiveScore, neutralScore, negativeScore);
             Offset = offset;
-            Length = length;
             MinedOpinions = new List<MinedOpinion>(minedOpinions);
         }
 
@@ -36,7 +35,6 @@ namespace Azure.AI.TextAnalytics
             Sentiment = (TextSentiment)Enum.Parse(typeof(TextSentiment), sentenceSentiment.Sentiment, ignoreCase: true);
             MinedOpinions = ConvertToMinedOpinions(sentenceSentiment, allSentences);
             Offset = sentenceSentiment.Offset;
-            Length = sentenceSentiment.Length;
         }
 
         /// <summary>
@@ -65,11 +63,6 @@ namespace Azure.AI.TextAnalytics
         /// Gets the starting position (in UTF-16 code units) for the matching text in the sentence.
         /// </summary>
         public int Offset { get; }
-
-        /// <summary>
-        /// Gets the length (in UTF-16 code units) of the matching text in the sentence.
-        /// </summary>
-        public int Length { get; }
 
         private static IReadOnlyCollection<MinedOpinion> ConvertToMinedOpinions(SentenceSentimentInternal sentence, IReadOnlyList<SentenceSentimentInternal> allSentences)
         {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -105,7 +105,7 @@ namespace Azure.AI.TextAnalytics
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static SentenceSentiment SentenceSentiment(TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore)
         {
-            return new SentenceSentiment(sentiment, text, positiveScore, neutralScore, negativeScore, default, default, new List<MinedOpinion>());
+            return new SentenceSentiment(sentiment, text, positiveScore, neutralScore, negativeScore, default, new List<MinedOpinion>());
         }
 
         /// <summary>
@@ -117,13 +117,12 @@ namespace Azure.AI.TextAnalytics
         /// <param name="neutralScore">Sets the <see cref="SentimentConfidenceScores.Neutral"/> property.</param>
         /// <param name="negativeScore">Sets the <see cref="SentimentConfidenceScores.Negative"/> property.</param>
         /// <param name="offset">Sets the <see cref="SentenceSentiment.Offset"/> property.</param>
-        /// <param name="length">Sets the <see cref="SentenceSentiment.Length"/> property.</param>
         /// <param name="minedOpinions">Sets the <see cref="SentenceSentiment.MinedOpinions"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.SentenceSentiment"/> for mocking purposes.</returns>
-        public static SentenceSentiment SentenceSentiment(TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, int length, IReadOnlyList<MinedOpinion> minedOpinions)
+        public static SentenceSentiment SentenceSentiment(TextSentiment sentiment, string text, double positiveScore, double neutralScore, double negativeScore, int offset, IReadOnlyList<MinedOpinion> minedOpinions)
         {
             minedOpinions ??= new List<MinedOpinion>();
-            return new SentenceSentiment(sentiment, text, positiveScore, neutralScore, negativeScore, offset, length, minedOpinions);
+            return new SentenceSentiment(sentiment, text, positiveScore, neutralScore, negativeScore, offset, minedOpinions);
         }
 
         /// <summary>
@@ -134,11 +133,10 @@ namespace Azure.AI.TextAnalytics
         /// <param name="positiveScore">Sets the <see cref="SentimentConfidenceScores.Positive"/> property.</param>
         /// <param name="negativeScore">Sets the <see cref="SentimentConfidenceScores.Negative"/> property.</param>
         /// <param name="offset">Sets the <see cref="AspectSentiment.Offset"/> property.</param>
-        /// <param name="length">Sets the <see cref="AspectSentiment.Length"/> property.</param>
         /// <returns>>A new instance of <see cref="TextAnalytics.AspectSentiment"/> for mocking purposes.</returns>
-        public static AspectSentiment AspectSentiment(TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset, int length)
+        public static AspectSentiment AspectSentiment(TextSentiment sentiment, string text, double positiveScore, double negativeScore, int offset)
         {
-            return new AspectSentiment(sentiment, text, positiveScore, negativeScore, offset, length);
+            return new AspectSentiment(sentiment, text, positiveScore, negativeScore, offset);
         }
 
         /// <summary>
@@ -150,11 +148,10 @@ namespace Azure.AI.TextAnalytics
         /// <param name="text">Sets the <see cref="OpinionSentiment.Text"/> property.</param>
         /// <param name="isNegated">Sets the <see cref="OpinionSentiment.IsNegated"/> property.</param>
         /// <param name="offset">Sets the <see cref="OpinionSentiment.Offset"/> property.</param>
-        /// <param name="length">Sets the <see cref="OpinionSentiment.Length"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.OpinionSentiment"/> for mocking purposes.</returns>
-        public static OpinionSentiment OpinionSentiment(TextSentiment sentiment, double positiveScore, double negativeScore, string text, bool isNegated, int offset, int length)
+        public static OpinionSentiment OpinionSentiment(TextSentiment sentiment, double positiveScore, double negativeScore, string text, bool isNegated, int offset)
         {
-            return new OpinionSentiment(sentiment, positiveScore, negativeScore, text, isNegated, offset, length);
+            return new OpinionSentiment(sentiment, positiveScore, negativeScore, text, isNegated, offset);
         }
 
         /// <summary>
@@ -280,11 +277,10 @@ namespace Azure.AI.TextAnalytics
         /// <param name="subCategory">Sets the <see cref="CategorizedEntity.SubCategory"/> property.</param>
         /// <param name="score">Sets the <see cref="CategorizedEntity.ConfidenceScore"/> property.</param>
         /// <param name="offset">Sets the <see cref="CategorizedEntity.Offset"/> property.</param>
-        /// <param name="length">Sets the <see cref="CategorizedEntity.Length"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.CategorizedEntity"/> for mocking purposes.</returns>
-        public static CategorizedEntity CategorizedEntity(string text, string category, string subCategory, double score, int offset, int length)
+        public static CategorizedEntity CategorizedEntity(string text, string category, string subCategory, double score, int offset)
         {
-            return new CategorizedEntity(new Entity(text, category, subCategory, offset, length, score));
+            return new CategorizedEntity(new Entity(text, category, subCategory, offset, default, score));
         }
 
         /// <summary>
@@ -345,11 +341,10 @@ namespace Azure.AI.TextAnalytics
         /// <param name="subCategory">Sets the <see cref="PiiEntity.SubCategory"/> property.</param>
         /// <param name="score">Sets the <see cref="PiiEntity.ConfidenceScore"/> property.</param>
         /// /// <param name="offset">Sets the <see cref="PiiEntity.Offset"/> property.</param>
-        /// <param name="length">Sets the <see cref="PiiEntity.Length"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.PiiEntity"/> for mocking purposes.</returns>
-        public static PiiEntity PiiEntity(string text, string category, string subCategory, double score, int offset, int length)
+        public static PiiEntity PiiEntity(string text, string category, string subCategory, double score, int offset)
         {
-            return new PiiEntity(new Entity(text, category, subCategory, offset, length, score));
+            return new PiiEntity(new Entity(text, category, subCategory, offset, default, score));
         }
 
         /// <summary>
@@ -494,7 +489,7 @@ namespace Azure.AI.TextAnalytics
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static LinkedEntityMatch LinkedEntityMatch(string text, double score)
         {
-            return new LinkedEntityMatch(score, text, default, default);
+            return new LinkedEntityMatch(score, text, default);
         }
 
         /// <summary>
@@ -503,11 +498,10 @@ namespace Azure.AI.TextAnalytics
         /// <param name="text">Sets the <see cref="LinkedEntityMatch.Text"/> property.</param>
         /// <param name="score">Sets the <see cref="LinkedEntityMatch.ConfidenceScore"/> property.</param>
         /// <param name="offset">Sets the <see cref="LinkedEntityMatch.Offset"/> property.</param>
-        /// <param name="length">Sets the <see cref="LinkedEntityMatch.Length"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.LinkedEntityMatch"/> for mocking purposes.</returns>
-        public static LinkedEntityMatch LinkedEntityMatch(string text, double score, int offset, int length)
+        public static LinkedEntityMatch LinkedEntityMatch(string text, double score, int offset)
         {
-            return new LinkedEntityMatch(score, text, offset, length);
+            return new LinkedEntityMatch(score, text, offset);
         }
 
         /// <summary>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeSentimentTests.cs
@@ -426,7 +426,6 @@ namespace Azure.AI.TextAnalytics.Tests
                 Assert.IsNotNull(sentence.ConfidenceScores.Neutral);
                 Assert.IsNotNull(sentence.ConfidenceScores.Negative);
                 Assert.IsTrue(CheckTotalConfidenceScoreValue(sentence.ConfidenceScores));
-                Assert.Greater(sentence.Length, 0);
 
                 Assert.IsNotNull(sentence.MinedOpinions);
                 if (opinionMining)
@@ -443,8 +442,6 @@ namespace Azure.AI.TextAnalytics.Tests
                         Assert.AreEqual(0, minedOpinions.Aspect.ConfidenceScores.Neutral);
                         Assert.IsTrue(CheckTotalConfidenceScoreValue(minedOpinions.Aspect.ConfidenceScores));
                         Assert.IsNotNull(minedOpinions.Aspect.Offset);
-                        Assert.IsNotNull(minedOpinions.Aspect.Length);
-                        Assert.Greater(minedOpinions.Aspect.Length, 0);
 
                         // Opinions
                         Assert.IsNotNull(minedOpinions.Opinions);
@@ -459,8 +456,6 @@ namespace Azure.AI.TextAnalytics.Tests
                             Assert.IsTrue(CheckTotalConfidenceScoreValue(opinion.ConfidenceScores));
                             Assert.IsNotNull(opinion.IsNegated);
                             Assert.IsNotNull(opinion.Offset);
-                            Assert.IsNotNull(opinion.Length);
-                            Assert.Greater(opinion.Length, 0);
                         }
                     }
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -49,7 +49,6 @@ namespace Azure.AI.TextAnalytics.Tests
             {
                 Assert.IsTrue(entitiesList.Contains(entity.Text));
                 Assert.IsNotNull(entity.ConfidenceScore);
-                Assert.Greater(entity.Length, 0);
             }
         }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeLinkedEntitiesTests.cs
@@ -58,7 +58,6 @@ namespace Azure.AI.TextAnalytics.Tests
                 LinkedEntityMatch match = entity.Matches.First();
                 Assert.IsNotNull(match.ConfidenceScore);
                 Assert.IsNotNull(match.Text);
-                Assert.Greater(match.Length, 0);
             }
         }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizePiiEntitiesTests.cs
@@ -48,7 +48,6 @@ namespace Azure.AI.TextAnalytics.Tests
             foreach (PiiEntity entity in entities)
             {
                 Assert.IsTrue(entitiesList.Contains(entity.Text));
-                Assert.Greater(entity.Length, 0);
             }
         }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -23,7 +23,6 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(1, entities.Count);
             Assert.AreEqual("Microsoft", entities.FirstOrDefault().Text);
             Assert.AreEqual(3, entities.FirstOrDefault().Offset);
-            Assert.AreEqual(9, entities.FirstOrDefault().Length);
         }
 
         [Test]
@@ -37,7 +36,6 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(1, entities.Count);
             Assert.AreEqual("Microsoft", entities.FirstOrDefault().Text);
             Assert.AreEqual(4, entities.FirstOrDefault().Offset);
-            Assert.AreEqual(9, entities.FirstOrDefault().Length);
         }
 
         [Test]
@@ -51,7 +49,6 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(1, entities.Count);
             Assert.AreEqual("Bill Gates", entities.FirstOrDefault().Text);
             Assert.AreEqual(3, entities.FirstOrDefault().Offset);
-            Assert.AreEqual(10, entities.FirstOrDefault().Length);
         }
 
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -72,7 +72,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     foreach (SentenceSentiment sentenceSentiment in result.DocumentSentiment.Sentences)
                     {
                         Console.WriteLine($"    For sentence: \"{sentenceSentiment.Text}\"");
-                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}, Length (in UTF-16 code units): {sentenceSentiment.Length}");
+                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}");
                         Console.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
                         Console.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive}.");
                         Console.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
@@ -70,7 +70,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     foreach (SentenceSentiment sentenceSentiment in result.DocumentSentiment.Sentences)
                     {
                         Console.WriteLine($"    For sentence: \"{sentenceSentiment.Text}\"");
-                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}, Length (in UTF-16 code units): {sentenceSentiment.Length}");
+                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}");
                         Console.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
                         Console.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive}.");
                         Console.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
@@ -56,7 +56,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     foreach (SentenceSentiment sentenceSentiment in result.DocumentSentiment.Sentences)
                     {
                         Console.WriteLine($"    For sentence: \"{sentenceSentiment.Text}\"");
-                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}, Length (in UTF-16 code units): {sentenceSentiment.Length}");
+                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}");
                         Console.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
                         Console.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive}.");
                         Console.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.TextAnalytics.Samples
             Console.WriteLine($"Recognized {entities.Count} entities:");
             foreach (CategorizedEntity entity in entities)
             {
-                Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+                Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
                 Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
             }
             #endregion

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.TextAnalytics.Samples
             Console.WriteLine($"Recognized {entities.Count} entities:");
             foreach (CategorizedEntity entity in entities)
             {
-                Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+                Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
                 Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
             }
             #endregion

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -63,7 +63,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                     foreach (CategorizedEntity entity in result.Entities)
                     {
-                        Debug.WriteLine($"        Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+                        Debug.WriteLine($"        Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
                         Debug.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                     }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs
@@ -61,7 +61,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                     foreach (CategorizedEntity entity in result.Entities)
                     {
-                        Console.WriteLine($"        Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+                        Console.WriteLine($"        Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
                         Console.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                     }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 foreach (CategorizedEntity entity in result.Entities)
                 {
-                    Debug.WriteLine($"    Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+                    Debug.WriteLine($"    Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
                     Debug.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                 }
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs
@@ -40,7 +40,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 foreach (CategorizedEntity entity in result.Entities)
                 {
-                    Console.WriteLine($"    Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}, Length (in UTF-16 code units): {entity.Length}");
+                    Console.WriteLine($"    Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
                     Console.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                 }
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
                 foreach (LinkedEntityMatch match in linkedEntity.Matches)
                 {
-                    Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+                    Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
                     Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
                 }
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
@@ -29,7 +29,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
                 foreach (LinkedEntityMatch match in linkedEntity.Matches)
                 {
-                    Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+                    Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
                     Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
                 }
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -66,7 +66,7 @@ namespace Azure.AI.TextAnalytics.Samples
                         Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                         foreach (LinkedEntityMatch match in linkedEntity.Matches)
                         {
-                            Debug.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+                            Debug.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
                             Debug.WriteLine($"        Confidence score: {match.ConfidenceScore}");
                         }
                     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchAsync.cs
@@ -64,7 +64,7 @@ namespace Azure.AI.TextAnalytics.Samples
                         Console.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                         foreach (LinkedEntityMatch match in linkedEntity.Matches)
                         {
-                            Console.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+                            Console.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
                             Console.WriteLine($"        Confidence score: {match.ConfidenceScore}");
                         }
                     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -45,7 +45,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                     foreach (LinkedEntityMatch match in linkedEntity.Matches)
                     {
-                        Debug.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+                        Debug.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
                         Debug.WriteLine($"        Confidence score: {match.ConfidenceScore}");
                     }
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs
@@ -43,7 +43,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     Console.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                     foreach (LinkedEntityMatch match in linkedEntity.Matches)
                     {
-                        Console.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}, Length (in UTF-16 code units): {match.Length}");
+                        Console.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
                         Console.WriteLine($"        Confidence score: {match.ConfidenceScore}");
                     }
                 }


### PR DESCRIPTION
Currently we don't expose the encoding to the user, so the `Length` property can be calculated from the `Text` property by doing `Text.Length`. Because of that we decided to remove `Length` until we really need it.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/15498