### PR TITLE
[Storage][Webjobs] reduce number of times azurite is created.

### DIFF
--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Azure.WebJobs.Extensions.Storage.Blobs.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Azure.WebJobs.Extensions.Storage.Blobs.Tests.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(AzureStorageWebjobsExtensionSharedTestSources)\**\*.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Azure.Storage.Webjobs.Extensions.Common\tests\Azure.WebJobs.Extensions.Storage.Common.Tests.csproj" />
     <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Host.TestCommon\Azure.WebJobs.Host.TestCommon.csproj" />
     <ProjectReference Include="..\src\Azure.WebJobs.Extensions.Storage.Blobs.csproj" />

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/HostCallTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/HostCallTests.cs
@@ -22,19 +22,21 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
     // Some tests in this class aren't as targeted as most other tests in this project.
     // (Look elsewhere for better examples to use as templates for new tests.)
-    public class HostCallTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class HostCallTests
     {
-        private const string ContainerName = "container";
+        private const string ContainerName = "container-hostcalltests";
         private const string BlobName = "blob";
         private const string BlobPath = ContainerName + "/" + BlobName;
         private const string OutputBlobName = "blob.out";
         private const string OutputBlobPath = ContainerName + "/" + OutputBlobName;
         private const int TestValue = Int32.MinValue;
-        private readonly AzuriteFixture azuriteFixture;
+        private readonly StorageAccount account;
 
         public HostCallTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
+            account.CreateBlobServiceClient().GetBlobContainerClient(ContainerName).DeleteIfExists();
         }
 
         [Theory]
@@ -49,7 +51,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task Blob_IfBoundToTypeAndBlobIsMissing_DoesNotCreate(string methodName)
         {
             // Arrange
-            var account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetBlockBlobClient(BlobName);
@@ -71,7 +72,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task Blob_IfBoundToTypeAndBlobIsMissing_Creates(string methodName)
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetBlockBlobClient(BlobName);
@@ -87,7 +87,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfHasUnboundParameter_CanCall()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             const string inputBlobName = "note-monday.csv";
@@ -119,7 +118,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task Blob_IfBoundToCloudBlockBlob_CanCall()
         {
             // Arrange
-            var account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var inputBlob = container.GetBlockBlobClient(BlobName);
@@ -134,7 +132,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task Blob_IfBoundToString_CanCall()
         {
             // Arrange
-            var account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var inputBlob = container.GetBlockBlobClient(BlobName);
@@ -148,7 +145,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task Blob_IfCopiedViaString_CanCall()
         {
             // Arrange
-            var account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var inputBlob = container.GetBlockBlobClient(BlobName);
@@ -169,7 +165,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfCopiedViaTextReaderTextWriter_CanCall()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var inputBlob = container.GetBlockBlobClient(BlobName);
@@ -196,7 +191,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfBoundToICloudBlob_CanCallWithBlockBlob()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetBlockBlobClient(BlobName);
@@ -222,7 +216,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfBoundToICloudBlob_CanCallWithPageBlob()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetPageBlobClient(BlobName);
@@ -247,9 +240,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task BlobTrigger_IfBoundToICloudBlobAndTriggerArgumentIsMissing_CallThrows()
         {
-            // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
-
             // Act
             Exception exception = await CallFailureAsync(account, typeof(BlobTriggerBindToICloudBlobProgram), "Call");
 
@@ -262,7 +252,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfBoundToCloudBlockBlob_CanCall()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetBlockBlobClient(BlobName);
@@ -286,9 +275,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task BlobTrigger_IfBoundToCloudBLockBlobAndTriggerArgumentIsMissing_CallThrows()
         {
-            // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
-
             // Act
             Exception exception = await CallFailureAsync(account, typeof(BlobTriggerBindToCloudBlockBlobProgram), "Call");
 
@@ -311,7 +297,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfBoundToCloudPageBlob_CanCall()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetPageBlobClient(BlobName);
@@ -335,9 +320,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task BlobTrigger_IfBoundToCloudPageBlobAndTriggerArgumentIsMissing_CallThrows()
         {
-            // Arrange
-            var account = CreateFakeStorageAccount();
-
             // Act
             Exception exception = await CallFailureAsync(account, typeof(BlobTriggerBindToCloudPageBlobProgram), "Call");
 
@@ -360,7 +342,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfBoundToCloudAppendBlob_CanCall()
         {
             // Arrange
-            var account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var blob = container.GetAppendBlobClient(BlobName);
@@ -384,9 +365,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task BlobTrigger_IfBoundToCloudAppendBlobAndTriggerArgumentIsMissing_CallThrows()
         {
-            // Arrange
-            var account = CreateFakeStorageAccount();
-
             // Act
             Exception exception = await CallFailureAsync(account, typeof(BlobTriggerBindToCloudAppendBlobProgram), "Call");
 
@@ -408,8 +386,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task Int32Argument_CanCallViaStringParse()
         {
-            // Arrange
-            var account = CreateFakeStorageAccount();
             IDictionary<string, object> arguments = new Dictionary<string, object>
             {
                 { "value", "15" }
@@ -436,9 +412,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         [Fact]
         public async Task Binder_IfBindingBlobToTextWriter_CanCall()
         {
-            // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
-
             // Act
             await CallAsync(account, typeof(BindToBinderBlobTextWriterProgram), "Call");
 
@@ -465,7 +438,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task BlobTrigger_IfCopiedViaPoco_CanCall()
         {
             // Arrange
-            StorageAccount account = CreateFakeStorageAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(ContainerName);
             var inputBlob = container.GetBlockBlobClient(BlobName);
@@ -521,11 +493,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         private static async Task<Exception> CallFailureAsync(StorageAccount account, Type programType, string methodName)
         {
             return await FunctionalTest.CallFailureAsync(account, programType, programType.GetMethod(methodName), null);
-        }
-
-        private StorageAccount CreateFakeStorageAccount()
-        {
-            return azuriteFixture.GetAccount();
         }
 
         private struct CustomDataValue

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Listeners/BlobQueueTriggerExecutorTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Listeners/BlobQueueTriggerExecutorTests.cs
@@ -25,10 +25,11 @@ using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
 {
-    public class BlobQueueTriggerExecutorTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class BlobQueueTriggerExecutorTests
     {
         private const string TestBlobName = "TestBlobName";
-        private const string TestContainerName = "container";
+        private const string TestContainerName = "container-blobqueuetriggerexecutortests";
         private const string TestQueueMessageId = "abc123";
 
         private readonly TestLoggerProvider _loggerProvider = new TestLoggerProvider();
@@ -36,17 +37,16 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
         private readonly BlobServiceClient blobServiceClient;
         private readonly BlobContainerClient blobContainer;
 
-        private readonly AzuriteFixture azuriteFixture;
-
         public BlobQueueTriggerExecutorTests(AzuriteFixture azuriteFixture)
         {
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
             _logger = loggerFactory.CreateLogger<BlobListener>();
 
-            this.azuriteFixture = azuriteFixture;
-            blobServiceClient = azuriteFixture.GetAccount().CreateBlobServiceClient();
+            var account = azuriteFixture.GetAccount();
+            blobServiceClient = account.CreateBlobServiceClient();
             blobContainer = blobServiceClient.GetBlobContainerClient(TestContainerName);
+            blobContainer.DeleteIfExists();
             blobContainer.CreateIfNotExists();
         }
 

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Listeners/ScanContainersStrategyTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Listeners/ScanContainersStrategyTests.cs
@@ -14,22 +14,23 @@ using Azure.WebJobs.Extensions.Storage.Common.Tests;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
 {
-    public class ScanContainersStrategyTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class ScanContainersStrategyTests
     {
-        private readonly AzuriteFixture azuriteFixture;
+        private const string ContainerName = "container-scancontainersstrategytests";
+        private readonly StorageAccount account;
 
         public ScanContainersStrategyTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
+            account.CreateBlobServiceClient().GetBlobContainerClient(ContainerName).DeleteIfExists();
         }
 
         [Fact]
         public async Task TestBlobListener()
         {
-            const string containerName = "container";
-            var account = CreateFakeStorageAccount();
             var blobServiceClient = account.CreateBlobServiceClient();
-            var container = blobServiceClient.GetBlobContainerClient(containerName);
+            var container = blobServiceClient.GetBlobContainerClient(ContainerName);
             IBlobListenerStrategy product = new ScanContainersStrategy();
             LambdaBlobTriggerExecutor executor = new LambdaBlobTriggerExecutor();
             product.Register(blobServiceClient, container, executor);
@@ -62,11 +63,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
                 throw new InvalidOperationException("shouldn't retrigger the same blob");
             };
             product.Execute();
-        }
-
-        private StorageAccount CreateFakeStorageAccount()
-        {
-            return azuriteFixture.GetAccount();
         }
 
         private class LambdaBlobTriggerExecutor : ITriggerExecutor<BlobTriggerExecutorContext>

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Listeners/StorageBlobScanInfoManagerTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Listeners/StorageBlobScanInfoManagerTests.cs
@@ -14,13 +14,14 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
 {
-    public class StorageBlobScanInfoManagerTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class StorageBlobScanInfoManagerTests
     {
-        private readonly AzuriteFixture azuriteFixture;
+        private readonly StorageAccount account;
 
         public StorageBlobScanInfoManagerTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
         }
 
         [Fact]
@@ -30,7 +31,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string storageAccountName = Guid.NewGuid().ToString();
             string containerName = Guid.NewGuid().ToString();
 
-            var account = azuriteFixture.GetAccount();
             var client = account.CreateBlobServiceClient();
 
             // by default there is no table in this client
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string storageAccountName = Guid.NewGuid().ToString();
             string containerName = Guid.NewGuid().ToString();
 
-            var account = azuriteFixture.GetAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(HostContainerNames.Hosts);
             await container.CreateIfNotExistsAsync();
@@ -67,7 +66,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string storageAccountName = "account=" + Guid.NewGuid().ToString();
             string containerName = "container-" + Guid.NewGuid().ToString();
 
-            var account = azuriteFixture.GetAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(HostContainerNames.Hosts);
             await container.CreateIfNotExistsAsync();
@@ -89,7 +87,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string storageAccountName = Guid.NewGuid().ToString();
             string containerName = Guid.NewGuid().ToString();
 
-            var account = azuriteFixture.GetAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(HostContainerNames.Hosts);
             await container.CreateIfNotExistsAsync();
@@ -114,7 +111,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests.Blobs.Listeners
             string storageAccountName = Guid.NewGuid().ToString();
             string containerName = Guid.NewGuid().ToString();
 
-            var account = azuriteFixture.GetAccount();
             var client = account.CreateBlobServiceClient();
             var container = client.GetBlobContainerClient(HostContainerNames.Hosts);
             await container.CreateIfNotExistsAsync();

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Properties/AssemblyInfo.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/tests/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Xunit;
 
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerClass)]

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Common/tests/Azure.WebJobs.Extensions.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Common/tests/Azure.WebJobs.Extensions.Storage.Common.Tests.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="Shared\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\src\Azure.WebJobs.Extensions.Storage.Common.csproj" />
   </ItemGroup>
 

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Common/tests/AzuriteFixture.cs
@@ -36,7 +36,6 @@ namespace Azure.WebJobs.Extensions.Storage.Common.Tests
         private StringBuilder azuriteOutput = new StringBuilder();
         private int blobsPort;
         private int queuesPort;
-        private static readonly object obj = new object();
 
         public AzuriteFixture()
         {
@@ -101,13 +100,6 @@ namespace Azure.WebJobs.Extensions.Storage.Common.Tests
             }
             account.BlobsPort = blobsPort;
             account.QueuesPort = queuesPort;
-            lock (obj)
-            {
-                using (var writer = File.AppendText("C:\\tmp\\azurite.txt"))
-                {
-                    writer.WriteLine("azurite created");
-                }
-            }
         }
 
         private int ParseAzuritePort(string outputLine)

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Common/tests/Shared/AzuriteCollection.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Common/tests/Shared/AzuriteCollection.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Azure.WebJobs.Extensions.Storage.Common.Tests
+{
+    [CollectionDefinition(Name)]
+    public class AzuriteCollection : ICollectionFixture<AzuriteFixture>
+    {
+        public const string Name = nameof(AzuriteCollection);
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+        // It has to be compiled into assembly using it.
+    }
+}

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/Azure.WebJobs.Extensions.Storage.Queues.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/Azure.WebJobs.Extensions.Storage.Queues.Tests.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(AzureStorageWebjobsExtensionSharedTestSources)\**\*.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Host.TestCommon\Azure.WebJobs.Host.TestCommon.csproj" />
     <ProjectReference Include="..\src\Azure.WebJobs.Extensions.Storage.Queues.csproj" />
   </ItemGroup>

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/BinderTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/BinderTests.cs
@@ -11,14 +11,16 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
-    public class BinderTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class BinderTests
     {
-        private const string QueueName = "input";
-        private readonly AzuriteFixture azuriteFixture;
+        private const string QueueName = "input-bindertests";
+        private readonly StorageAccount account;
 
         public BinderTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
+            account.CreateQueueServiceClient().GetQueueClient(QueueName).DeleteIfExists();
         }
 
         [Fact]
@@ -26,7 +28,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         {
             // Arrange
             const string expectedContents = "abc";
-            var account = CreateFakeStorageAccount();
             QueueClient queue = CreateQueue(account, QueueName);
             await queue.SendMessageAsync(expectedContents);
 
@@ -36,11 +37,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 
             // Assert
             Assert.Equal("No binding found for attribute 'Microsoft.Azure.WebJobs.QueueTriggerAttribute'.", exception.Message);
-        }
-
-        private StorageAccount CreateFakeStorageAccount()
-        {
-            return azuriteFixture.GetAccount();
         }
 
         private static QueueClient CreateQueue(StorageAccount account, string queueName)

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/DataBindingFunctionalTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/DataBindingFunctionalTests.cs
@@ -13,13 +13,16 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
 {
-    public class DataBindingFunctionalTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class DataBindingFunctionalTests
     {
-        private readonly AzuriteFixture azuriteFixture;
+        private const string QueueName = "queue-databindingfunctionaltests";
+        private readonly StorageAccount account;
 
         public DataBindingFunctionalTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
+            account.CreateQueueServiceClient().GetQueueClient(QueueName).DeleteIfExists();
         }
 
         [Fact]
@@ -29,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
             var builder = new HostBuilder()
                 .ConfigureDefaultTestHost<TestFunctions>(b =>
                 {
-                    b.UseStorage(azuriteFixture.GetAccount());
+                    b.UseStorage(account);
                 });
 
 
@@ -64,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Bindings.Data
         {
             public static string Result { get; set; }
 
-            public static void BindStringableParameter([QueueTrigger("ignore")] MessageWithStringableProperty message,
+            public static void BindStringableParameter([QueueTrigger(QueueName)] MessageWithStringableProperty message,
                 string guidValue)
             {
                 Result = guidValue;

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/HostStartTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/HostStartTests.cs
@@ -13,13 +13,14 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
-    public class HostStartTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class HostStartTests
     {
-        private readonly AzuriteFixture azuriteFixture;
+        private readonly StorageAccount account;
 
         public HostStartTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
         }
 
         [Fact]
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                 .ConfigureDefaultTestHost<InvalidQueueNameProgram>(b =>
                 {
                     b.AddAzureStorageBlobs().AddAzureStorageQueues()
-                    .UseStorage(azuriteFixture.GetAccount());
+                    .UseStorage(account);
                 })
                 .Build();
 

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/HostStopTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/HostStopTests.cs
@@ -13,23 +13,24 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
-    public class HostStopTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class HostStopTests
     {
-        private const string QueueName = "input";
+        private const string QueueName = "input-hoststoptests";
         private static readonly TaskCompletionSource<object> _functionStarted = new TaskCompletionSource<object>();
         private static readonly TaskCompletionSource<object> _stopHostCalled = new TaskCompletionSource<object>();
         private static readonly TaskCompletionSource<bool> _testTaskSource = new TaskCompletionSource<bool>();
-        private readonly AzuriteFixture azuriteFixture;
+        private readonly StorageAccount account;
 
         public HostStopTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
+            account.CreateQueueServiceClient().GetQueueClient(QueueName).DeleteIfExists();
         }
 
         [Fact]
         public async Task Stop_TriggersCancellationToken()
         {
-            StorageAccount account = azuriteFixture.GetAccount();
             QueueClient queue = await CreateQueueAsync(account, QueueName);
             await queue.SendMessageAsync("ignore");
 

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/InstanceTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/InstanceTests.cs
@@ -13,14 +13,16 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 
 namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
 {
-    public class InstanceTests : IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class InstanceTests
     {
-        private const string QueueName = "input";
-        private readonly AzuriteFixture azuriteFixture;
+        private const string QueueName = "input-instancetests";
+        private readonly StorageAccount account;
 
         public InstanceTests(AzuriteFixture azuriteFixture)
         {
-            this.azuriteFixture = azuriteFixture;
+            account = azuriteFixture.GetAccount();
+            account.CreateQueueServiceClient().GetQueueClient(QueueName).DeleteIfExists();
         }
 
         [Fact]
@@ -28,7 +30,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         {
             // Arrange
             string expectedGuid = Guid.NewGuid().ToString();
-            var account = azuriteFixture.GetAccount();
             await account.AddQueueMessageAsync(expectedGuid, QueueName);
 
             var prog = new InstanceProgram();
@@ -64,7 +65,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         {
             // Arrange
             string expectedGuid = Guid.NewGuid().ToString();
-            var account = azuriteFixture.GetAccount();
             await account.AddQueueMessageAsync(expectedGuid, QueueName);
 
             var prog = new InstanceAsyncProgram();
@@ -100,7 +100,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         public async Task Trigger_IfClassIsDisposable_Disposes()
         {
             // Arrange
-            var account = azuriteFixture.GetAccount();
             await account.AddQueueMessageAsync("ignore", QueueName);
 
             IHost host = new HostBuilder()
@@ -145,7 +144,6 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
                          .Returns(() => new InstanceCustomActivatorProgram(resultFactory));
             IJobActivator activator = activatorMock.Object;
 
-            var account = azuriteFixture.GetAccount();
             await account.AddQueueMessageAsync("ignore", QueueName);
 
             IHost host = new HostBuilder()

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/Properties/AssemblyInfo.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Xunit;
 
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerClass)]

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/QueueTriggerBindingIntegrationTests.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Queues/tests/QueueTriggerBindingIntegrationTests.cs
@@ -16,7 +16,8 @@ using Azure.WebJobs.Extensions.Storage.Common.Tests;
 
 namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
 {
-    public class QueueTriggerBindingIntegrationTests : IClassFixture<InvariantCultureFixture>, IClassFixture<AzuriteFixture>
+    [Collection(AzuriteCollection.Name)]
+    public class QueueTriggerBindingIntegrationTests : IClassFixture<InvariantCultureFixture>
     {
         private ITriggerBinding _binding;
 
@@ -28,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Host.UnitTests.Queues
 
             var fakeAccount = azuriteFixture.GetAccount();
             QueueServiceClient queueServiceClient = fakeAccount.CreateQueueServiceClient();
-            QueueClient queue = queueServiceClient.GetQueueClient("queueName");
+            QueueClient queue = queueServiceClient.GetQueueClient("queueName-queuetriggerbindingintegrationtests");
 
             IWebJobsExceptionHandler exceptionHandler = new WebJobsExceptionHandler(new Mock<IHost>().Object);
             var enqueueWatcher = new Host.Queues.Listeners.SharedQueueWatcher();

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -83,5 +83,6 @@
   <PropertyGroup>
     <AzureStorageSharedSources>$(MSBuildThisFileDirectory)\Azure.Storage.Common\src\Shared\</AzureStorageSharedSources>
     <AzureStorageWebjobsExtensionSharedSources>$(MSBuildThisFileDirectory)\Azure.Storage.Webjobs.Extensions.Common\src\Shared\</AzureStorageWebjobsExtensionSharedSources>
+    <AzureStorageWebjobsExtensionSharedTestSources>$(MSBuildThisFileDirectory)\Azure.Storage.Webjobs.Extensions.Common\tests\Shared\</AzureStorageWebjobsExtensionSharedTestSources>
   </PropertyGroup>
 </Project>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Host.EndToEndTests/tests/Azure.WebJobs.Host.EndToEnd.Tests.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Host.EndToEndTests/tests/Azure.WebJobs.Host.EndToEnd.Tests.csproj
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(AzureStorageWebjobsExtensionSharedTestSources)\**\*.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 


### PR DESCRIPTION
In this PR:
- changes in tests to assure isolation through storage resources naming
- AzuriteFixture creates just one account
- Changed collection behavior to per class (more parallelism - faster run)
- azurite is created once per test assembly instead of once per test class (from 34 to 6 in local run)

Note: lot of binding tests rely on attributes that can only take constant strings, so the options for isolating through resource names are somewhat limited. 