### PR TITLE
Set version artificially for the test template runs

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -5,6 +5,13 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
+      - task: PowerShell@2
+        displayName: Prep template pipeline for release
+        condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
+        inputs:
+          pwsh: true
+          workingDirectory: $(Build.SourcesDirectory)
+          filePath: eng/scripts/SetTestPipelineVersion.ps1
       - pwsh: |
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -54,6 +54,13 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
+                    - task: PowerShell@2
+                      displayName: Prep template pipeline for release
+                      condition: and(succeeded(),eq(variables['TestPipeline'],'true'))
+                      inputs:
+                        pwsh: true
+                        workingDirectory: $(Build.SourcesDirectory)
+                        filePath: eng/scripts/SetTestPipelineVersion.ps1
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -1,0 +1,28 @@
+# Overides the project file and CHANGELOG.md for the template project using the next publishable version
+# This is to help with testing the release pipeline.
+. "${PSScriptRoot}\..\common\scripts\common.ps1"
+$latestTags = git tag -l "Azure.Template_*"
+$semVars = @()
+
+$changeLogFile = "${PSScriptRoot}\..\..\sdk\template\Azure.Template\CHANGELOG.md"
+
+Foreach ($tags in $latestTags)
+{
+  $semVars += $tags.Replace("Azure.Template_", "")
+}
+
+$semVarsSorted = [AzureEngSemanticVersion]::SortVersionStrings($semVars)
+LogDebug "Last Published Version $($semVarsSorted[0])"
+
+$newVersion = [AzureEngSemanticVersion]::ParseVersionString($semVarsSorted[0])
+$newVersion.IncrementAndSetToPrerelease()
+LogDebug "Version to publish [ $($newVersion.ToString()) ]"
+
+&"${PSScriptRoot}/Update-PkgVersion.ps1" -ServiceDirectory "template" `
+-PackageName 'Azure.Template' -PackageDirName "Azure.Template" -NewVersionString $newVersion.ToString() `
+-ReleaseDate (Get-Date -f "yyyy-MM-dd")
+Set-Content -Path $changeLogFile -Value @"
+# Release History
+## $($newVersion.ToString()) ($(Get-Date -f "yyyy-MM-dd"))
+- Test Release Pipeline
+"@


### PR DESCRIPTION
This allows template (Test) run to go all the way to release with artificially generated versions.
Sample run https://dev.azure.com/azure-sdk/internal/_build/results?buildId=559264&view=results