### PR TITLE
[Event Hubs Client] October Republish Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
-## 5.3.0-beta.3 (Unreleased)
+## 5.3.0-beta.3 (2020-09-30)
+
+### Changes
+
+#### Key Bug Fixes
+
+- An issue with package publishing which blocked referencing and use has been fixed.
 
 ## 5.3.0-beta.2 (2020-09-28)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release History
 
-## 5.3.0-beta.3 (Unreleased)
+## 5.3.0-beta.3 (2020-09-30)
+
+### Changes
+
+#### Key Bug Fixes
+
+- An issue with package publishing which blocked referencing and use has been fixed.
 
 ## 5.3.0-beta.2 (2020-09-28)
 


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare for republishing the October packages to correct a build pipeline issue that exposed an internal dependency, blocking customer use.

# Last Upstream Rebase

Wednesday, September 30, 11:36am (EDT)