### PR TITLE
[Service Bus] Run live tests in the canary region

### DIFF
--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -6,3 +6,4 @@ extends:
     MaxParallel: 4
     ServiceDirectory: servicebus
     TimeoutInMinutes: 120
+    TestCanary: true


### PR DESCRIPTION
Similar to what we did for event-hubs... https://github.com/Azure/azure-sdk-for-js/pull/11318