### PR TITLE
Various API Renames

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -218,7 +218,6 @@ namespace Azure.Messaging.ServiceBus
         public bool AutoComplete { get { throw null; } set { } }
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
         public int MaxConcurrentCalls { get { throw null; } set { } }
-        public System.TimeSpan? MaxReceiveWaitTime { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ReceiveMode ReceiveMode { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -400,7 +399,6 @@ namespace Azure.Messaging.ServiceBus
         public System.TimeSpan MaxAutoLockRenewalDuration { get { throw null; } set { } }
         public int MaxConcurrentCallsPerSession { get { throw null; } set { } }
         public int MaxConcurrentSessions { get { throw null; } set { } }
-        public System.TimeSpan? MaxReceiveWaitTime { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ReceiveMode ReceiveMode { get { throw null; } set { } }
         public string[] SessionIds { get { throw null; } set { } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -92,9 +92,9 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusClientOptions
     {
         public ServiceBusClientOptions() { }
-        public System.Net.IWebProxy Proxy { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusRetryOptions RetryOptions { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } set { } }
+        public System.Net.IWebProxy WebProxy { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -160,7 +160,7 @@ namespace Azure.Messaging.ServiceBus
         public string Subject { get { throw null; } set { } }
         public System.TimeSpan TimeToLive { get { throw null; } set { } }
         public string To { get { throw null; } set { } }
-        public string ViaPartitionKey { get { throw null; } set { } }
+        public string TransactionPartitionKey { get { throw null; } set { } }
         public override string ToString() { throw null; }
     }
     public sealed partial class ServiceBusMessageBatch : System.IDisposable
@@ -333,7 +333,7 @@ namespace Azure.Messaging.ServiceBus
         public string EntityPath { get { throw null; } }
         public string FullyQualifiedNamespace { get { throw null; } }
         public bool IsClosed { get { throw null; } }
-        public string ViaEntityPath { get { throw null; } }
+        public string TransactionEntityPath { get { throw null; } }
         public virtual System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CancelScheduledMessagesAsync(System.Collections.Generic.IEnumerable<long> sequenceNumbers, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CloseAsync(Azure.Messaging.ServiceBus.LinkCloseMode closeMode = Azure.Messaging.ServiceBus.LinkCloseMode.Detach, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -355,7 +355,7 @@ namespace Azure.Messaging.ServiceBus
     public partial class ServiceBusSenderOptions
     {
         public ServiceBusSenderOptions() { }
-        public string ViaQueueOrTopicName { get { throw null; } set { } }
+        public string TransactionQueueOrTopicName { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
@@ -38,7 +38,7 @@ await senderA.SendMessageAsync(new ServiceBusMessage(Encoding.UTF8.GetBytes("Fir
 
 ServiceBusSender senderBViaA = client.CreateSender(queueB, new ServiceBusSenderOptions
 {
-    ViaQueueOrTopicName = queueA
+    TransactionQueueOrTopicName = queueA
 });
 
 ServiceBusReceiver receiverA = client.CreateReceiver(queueA);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -99,7 +99,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 ServiceEndpoint,
                 credential,
                 options.TransportType,
-                options.Proxy);
+                options.WebProxy);
 
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -111,10 +111,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     firstMessage.PartitionKey;
             }
 
-            if (firstMessage?.ViaPartitionKey != null)
+            if (firstMessage?.TransactionPartitionKey != null)
             {
                 batchEnvelope.MessageAnnotations.Map[AmqpMessageConstants.ViaPartitionKeyName] =
-                    firstMessage.ViaPartitionKey;
+                    firstMessage.TransactionPartitionKey;
             }
 
             batchEnvelope.Batchable = true;
@@ -179,9 +179,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 amqpMessage.MessageAnnotations.Map.Add(AmqpMessageConstants.PartitionKeyName, sbMessage.PartitionKey);
             }
 
-            if (sbMessage.ViaPartitionKey != null)
+            if (sbMessage.TransactionPartitionKey != null)
             {
-                amqpMessage.MessageAnnotations.Map.Add(AmqpMessageConstants.ViaPartitionKeyName, sbMessage.ViaPartitionKey);
+                amqpMessage.MessageAnnotations.Map.Add(AmqpMessageConstants.ViaPartitionKeyName, sbMessage.TransactionPartitionKey);
             }
 
             if (sbMessage.ApplicationProperties != null && sbMessage.ApplicationProperties.Count > 0)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -446,9 +446,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         entry[ManagementConstants.Properties.PartitionKey] = message.PartitionKey;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(message.ViaPartitionKey))
+                    if (!string.IsNullOrWhiteSpace(message.TransactionPartitionKey))
                     {
-                        entry[ManagementConstants.Properties.ViaPartitionKey] = message.ViaPartitionKey;
+                        entry[ManagementConstants.Properties.ViaPartitionKey] = message.TransactionPartitionKey;
                     }
 
                     entries.Add(entry);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -207,7 +207,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns>A <see cref="ServiceBusSender"/> scoped to the specified queue or topic.</returns>
         public virtual ServiceBusSender CreateSender(string queueOrTopicName, ServiceBusSenderOptions options)
         {
-            ValidateSendViaEntityName(queueOrTopicName, options?.ViaQueueOrTopicName);
+            ValidateSendViaEntityName(queueOrTopicName, options?.TransactionQueueOrTopicName);
 
             return new ServiceBusSender(
                 entityPath: queueOrTopicName,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -100,7 +100,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   Creates a new copy of the current <see cref="ServiceBusClientOptions" />, cloning its attributes into a new instance.
         /// </summary>
-        ///        ///
+        ///
         /// <returns>A new copy of <see cref="ServiceBusClientOptions" />.</returns>
         ///
         internal ServiceBusClientOptions Clone() =>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClientOptions.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.ServiceBus
         ///   use, specifying a proxy is an invalid option.
         /// </remarks>
         ///
-        public IWebProxy Proxy { get; set; } = null;
+        public IWebProxy WebProxy { get; set; } = null;
 
         /// <summary>
         /// The set of options to use for determining whether a failed operation should be retried and,
@@ -107,7 +107,7 @@ namespace Azure.Messaging.ServiceBus
             new ServiceBusClientOptions
             {
                 TransportType = TransportType,
-                Proxy = Proxy,
+                WebProxy = WebProxy,
                 RetryOptions = RetryOptions.Clone(),
                 Plugins = new List<ServiceBusPlugin>(Plugins)
             };

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusConnection.cs
@@ -327,7 +327,7 @@ namespace Azure.Messaging.ServiceBus
 
             // A proxy is only valid when web sockets is used as the transport.
 
-            if ((!connectionOptions.TransportType.IsWebSocketTransport()) && (connectionOptions.Proxy != null))
+            if ((!connectionOptions.TransportType.IsWebSocketTransport()) && (connectionOptions.WebProxy != null))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.ProxyMustUseWebSockets), nameof(connectionOptions));
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -138,7 +138,7 @@ namespace Azure.Messaging.ServiceBus
         ///    messages are kept together and in order as they are transferred.
         ///    See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-transactions#transfers-and-send-via">Transfers and Send Via</see>.
         /// </remarks>
-        public string ViaPartitionKey
+        public string TransactionPartitionKey
         {
             get
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -74,7 +74,7 @@ namespace Azure.Messaging.ServiceBus
         /// The maximum amount of time to wait for each Receive call using the processor's underlying receiver.
         /// If not specified, the <see cref="ServiceBusRetryOptions.TryTimeout"/> will be used.
         /// </summary>
-        public TimeSpan? MaxReceiveWaitTime
+        internal TimeSpan? MaxReceiveWaitTime
         {
             get => _maxReceiveWaitTime;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
@@ -72,7 +72,7 @@ namespace Azure.Messaging.ServiceBus
         /// Hence, if this value is set to be too low, it could cause new sessions to be requested
         /// more often than necessary.
         /// </remarks>
-        public TimeSpan? MaxReceiveWaitTime
+        internal TimeSpan? MaxReceiveWaitTime
         {
             get => _maxReceiveWaitTime;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -376,7 +376,7 @@ namespace Azure.Messaging.ServiceBus {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The connection string used for an Service Bus entity client must specify the Service Bus namespace host, and a Shared Access Signature (both the name and value) to be valid. The path to an Service Bus entity must be included in the connection string or specified separately..
+        ///   Looks up a localized string similar to The connection string used for an Service Bus client must specify the Service Bus namespace host and either a Shared Access Key (both the name and value) OR a Shard Access Signature to be valid..
         /// </summary>
         internal static string MissingConnectionInformation {
             get {
@@ -394,11 +394,20 @@ namespace Azure.Messaging.ServiceBus {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The path to an Service Bus entity may be specified as part of the connection string or as a separate value, but not both..
+        ///   Looks up a localized string similar to The queue or topic name provided does not match the EntityPath in the connection string passed to the ServiceBusClient constructor..
         /// </summary>
         internal static string OnlyOneEntityNameMayBeSpecified {
             get {
                 return ResourceManager.GetString("OnlyOneEntityNameMayBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The authorization for a connection string may specifiy a shared key or precomputed shared access signature, but not both.  Please verify that your connection string does not have the `SharedAccessSignature` token if you are passing the `SharedKeyName` and `SharedKey`..
+        /// </summary>
+        internal static string OnlyOneSharedAccessAuthorizationMayBeSpecified {
+            get {
+                return ResourceManager.GetString("OnlyOneSharedAccessAuthorizationMayBeSpecified", resourceCulture);
             }
         }
         
@@ -597,17 +606,6 @@ namespace Azure.Messaging.ServiceBus {
         internal static string UnsupportedTransportEventType {
             get {
                 return ResourceManager.GetString("UnsupportedTransportEventType", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The authorization for a connection string may specifiy a shared key or precomputed shared access signature, but not both.  Please verify that your connection string does not have the `SharedAccessSignature` token if you are passing the  `SharedKeyName` and `SharedKey`..
-        /// </summary>
-        internal static string OnlyOneSharedAccessAuthorizationMayBeSpecified
-        {
-            get
-            {
-                return ResourceManager.GetString("OnlyOneSharedAccessAuthorizationMayBeSpecified", resourceCulture);
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -259,7 +259,7 @@
     <value>The connection string used for an Service Bus client must specify the Service Bus namespace host and either a Shared Access Key (both the name and value) OR a Shard Access Signature to be valid.</value>
   </data>
   <data name="OnlyOneEntityNameMayBeSpecified" xml:space="preserve">
-    <value>The path to an Service Bus entity may be specified as part of the connection string or as a separate value, but not both.</value>
+    <value>The queue or topic name provided does not match the EntityPath in the connection string passed to the ServiceBusClient constructor.</value>
   </data>
   <data name="OperationNotSupported" xml:space="preserve">
     <value>The operation is only supported in 'PeekLock' receive mode.</value>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -65,7 +65,9 @@ namespace Azure.Messaging.ServiceBus
         internal ServiceBusEventSource Logger { get; set; } = ServiceBusEventSource.Log;
 
         /// <summary>
-        /// In the case of a via-sender, the message is sent to <see cref="EntityPath"/> via <see cref="TransactionEntityPath"/>; null otherwise.
+        /// If <see cref="ServiceBusSenderOptions.TransactionQueueOrTopicName"/> is set,
+        /// the message is sent to <see cref="EntityPath"/> via <see cref="TransactionEntityPath"/>;
+        /// null otherwise.
         /// </summary>
         public string TransactionEntityPath { get; }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -65,9 +65,9 @@ namespace Azure.Messaging.ServiceBus
         internal ServiceBusEventSource Logger { get; set; } = ServiceBusEventSource.Log;
 
         /// <summary>
-        /// In the case of a via-sender, the message is sent to <see cref="EntityPath"/> via <see cref="ViaEntityPath"/>; null otherwise.
+        /// In the case of a via-sender, the message is sent to <see cref="EntityPath"/> via <see cref="TransactionEntityPath"/>; null otherwise.
         /// </summary>
-        public string ViaEntityPath { get; }
+        public string TransactionEntityPath { get; }
 
         /// <summary>
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
@@ -122,13 +122,13 @@ namespace Azure.Messaging.ServiceBus
 
                 options = options?.Clone() ?? new ServiceBusSenderOptions();
                 EntityPath = entityPath;
-                ViaEntityPath = options.ViaQueueOrTopicName;
+                TransactionEntityPath = options.TransactionQueueOrTopicName;
                 Identifier = DiagnosticUtilities.GenerateIdentifier(EntityPath);
                 _connection = connection;
                 _retryPolicy = _connection.RetryOptions.ToRetryPolicy();
                 _innerSender = _connection.CreateTransportSender(
                     entityPath,
-                    ViaEntityPath,
+                    TransactionEntityPath,
                     _retryPolicy,
                     Identifier);
                 _scopeFactory = new EntityScopeFactory(EntityPath, FullyQualifiedNamespace);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
@@ -15,10 +15,10 @@ namespace Azure.Messaging.ServiceBus
         /// The queue or topic name to route the message through. This is useful when using transactions, in order
         /// to allow for completing a transaction involving multiple entities. For instance, if you want to
         /// settle a message on Entity A and send a message to Entity B as part of the same transaction,
-        /// you can use a <see cref="ServiceBusSender"/> for Entity B, with the <see cref="ViaQueueOrTopicName"/>
+        /// you can use a <see cref="ServiceBusSender"/> for Entity B, with the <see cref="TransactionQueueOrTopicName"/>
         /// property set to Entity A.
         /// </summary>
-        public string ViaQueueOrTopicName { get; set; }
+        public string TransactionQueueOrTopicName { get; set; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
@@ -56,7 +56,7 @@ namespace Azure.Messaging.ServiceBus
         internal ServiceBusSenderOptions Clone() =>
             new ServiceBusSenderOptions
             {
-                ViaQueueOrTopicName = ViaQueueOrTopicName
+                TransactionQueueOrTopicName = TransactionQueueOrTopicName
             };
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             {
                 MessageId = messageId,
                 PartitionKey = partitionKey,
-                ViaPartitionKey = viaPartitionKey,
+                TransactionPartitionKey = viaPartitionKey,
                 SessionId = sessionId,
                 CorrelationId = correlationId,
                 Subject = label,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             var options = new ServiceBusClientOptions
             {
                 TransportType = ServiceBusTransportType.AmqpWebSockets,
-                Proxy = Mock.Of<IWebProxy>()
+                WebProxy = Mock.Of<IWebProxy>()
             };
 
             yield return new object[] { new ReadableOptionsMock(fakeConnection, options), options, "connection string" };
@@ -170,7 +170,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set default options.");
             Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
             Assert.That(options.TransportType, Is.EqualTo(defaultOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
-            Assert.That(options.Proxy, Is.EqualTo(defaultOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
+            Assert.That(options.WebProxy, Is.EqualTo(defaultOptions.WebProxy), $"The { constructorDescription } constructor should have the correct proxy.");
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set the options.");
             Assert.That(options, Is.Not.SameAs(constructorOptions), $"The { constructorDescription } constructor should have cloned the options.");
             Assert.That(options.TransportType, Is.EqualTo(constructorOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
-            Assert.That(options.Proxy, Is.EqualTo(constructorOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
+            Assert.That(options.WebProxy, Is.EqualTo(constructorOptions.WebProxy), $"The { constructorDescription } constructor should have the correct proxy.");
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         public void ConstructorWithConnectionStringValidatesOptions()
         {
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
-            var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, WebProxy = Mock.Of<IWebProxy>() };
 
             Assert.That(() => new ServiceBusClient(fakeConnection, invalidOptions), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate client options");
         }
@@ -215,7 +215,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         public void ConstructorWithExpandedArgumentsValidatesOptions()
         {
             var token = new Mock<ServiceBusTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            var invalidOptions = new ServiceBusClientOptions { TransportType = ServiceBusTransportType.AmqpTcp, WebProxy = Mock.Of<IWebProxy>() };
             Assert.That(() => new ServiceBusClient("fullyQualifiedNamespace", Mock.Of<TokenCredential>(), invalidOptions), Throws.InstanceOf<ArgumentException>(), "The expanded argument constructor should validate client options");
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -140,7 +140,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                     Assert.AreEqual(received.SessionId, sentMessage.SessionId);
                     Assert.AreEqual(received.TimeToLive, sentMessage.TimeToLive);
                     Assert.AreEqual(received.To, sentMessage.To);
-                    Assert.AreEqual(received.ViaPartitionKey, sentMessage.ViaPartitionKey);
+                    Assert.AreEqual(received.ViaPartitionKey, sentMessage.TransactionPartitionKey);
                 }
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -39,7 +39,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     MaxConcurrentCalls = numThreads,
                     AutoComplete = autoComplete,
-                    MaxReceiveWaitTime = TimeSpan.FromSeconds(30)
+                    MaxReceiveWaitTime = TimeSpan.FromSeconds(30),
+                    PrefetchCount = 20
                 };
                 await using var processor = client.CreateProcessor(scope.QueueName, options);
                 int messageCt = 0;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -359,7 +359,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var options = new ServiceBusSessionProcessorOptions
                 {
                     MaxConcurrentSessions = numThreads,
-                    AutoComplete = autoComplete
+                    AutoComplete = autoComplete,
+                    PrefetchCount = 5
                 };
 
                 await using ServiceBusSessionProcessor processor = GetNoRetryClient().CreateSessionProcessor(scope.QueueName, options);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -270,7 +270,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(messages);
 
-                var receiver = client.CreateReceiver(scope.QueueName);
+                var receiver = client.CreateReceiver(scope.QueueName, new ServiceBusReceiverOptions
+                {
+                    PrefetchCount = 10
+                });
                 var remainingMessages = messageCount;
                 var messageEnum = messages.GetEnumerator();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -223,7 +223,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(
+                    scope.QueueName,
+                    new ServiceBusSessionReceiverOptions
+                {
+                    PrefetchCount = 100
+                });
 
                 var messageEnum = messages.GetEnumerator();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
@@ -97,7 +97,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 ServiceBusSender senderBViaA = client.CreateSender(queueB, new ServiceBusSenderOptions
                 {
-                    ViaQueueOrTopicName = queueA
+                    TransactionQueueOrTopicName = queueA
                 });
 
                 ServiceBusReceiver receiverA = client.CreateReceiver(queueA);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -57,7 +57,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var options = new ServiceBusClientOptions
                 {
                     TransportType = ServiceBusTransportType.AmqpWebSockets,
-                    Proxy = WebRequest.DefaultWebProxy,
+                    WebProxy = WebRequest.DefaultWebProxy,
                     RetryOptions = new ServiceBusRetryOptions()
                     {
                         Mode = ServiceBusRetryMode.Exponential
@@ -78,7 +78,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var options = new ServiceBusClientOptions
                 {
                     TransportType = ServiceBusTransportType.AmqpWebSockets,
-                    Proxy = WebRequest.DefaultWebProxy,
+                    WebProxy = WebRequest.DefaultWebProxy,
                     RetryOptions = new ServiceBusRetryOptions()
                     {
                         Mode = ServiceBusRetryMode.Exponential

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -129,7 +129,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var sender = client.CreateSender(queueName,
                 new ServiceBusSenderOptions
                 {
-                    ViaQueueOrTopicName = "sendViaName"
+                    TransactionQueueOrTopicName = "sendViaName"
                 });
         }
 
@@ -144,13 +144,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             Assert.That(() => client.CreateSender(queueName,
                 new ServiceBusSenderOptions
                 {
-                    ViaQueueOrTopicName = "sendViaName"
+                    TransactionQueueOrTopicName = "sendViaName"
                 }),
                 Throws.InstanceOf<ArgumentException>());
             Assert.That(() => client.CreateSender(queueName,
                new ServiceBusSenderOptions
                {
-                   ViaQueueOrTopicName = queueName
+                   TransactionQueueOrTopicName = queueName
                }),
                Throws.InstanceOf<ArgumentException>());
         }
@@ -165,7 +165,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             client.CreateSender("something",
                 new ServiceBusSenderOptions
                 {
-                    ViaQueueOrTopicName = "something"
+                    TransactionQueueOrTopicName = "something"
                 });
         }
 
@@ -192,7 +192,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var sender = client.CreateSender(queueName,
                 new ServiceBusSenderOptions
                 {
-                    ViaQueueOrTopicName = null
+                    TransactionQueueOrTopicName = null
                 });
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -434,19 +434,19 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
             var destination1Sender = client.CreateSender(destination1.TopicName);
             var destination1ViaSender = client.CreateSender(destination1.TopicName, new ServiceBusSenderOptions
             {
-                ViaQueueOrTopicName = intermediateQueue.QueueName
+                TransactionQueueOrTopicName = intermediateQueue.QueueName
             });
             var destination2ViaSender = client.CreateSender(destination2.QueueName, new ServiceBusSenderOptions
             {
-                ViaQueueOrTopicName = intermediateQueue.QueueName
+                TransactionQueueOrTopicName = intermediateQueue.QueueName
             });
             var destination1Receiver = client.CreateReceiver(destination1.TopicName, destination1.SubscriptionNames.First());
             var destination2Receiver = client.CreateReceiver(destination2.QueueName);
 
             var body = Encoding.Default.GetBytes(Guid.NewGuid().ToString("N"));
             var message1 = new ServiceBusMessage(body) { MessageId = "1", PartitionKey = "pk1" };
-            var message2 = new ServiceBusMessage(body) { MessageId = "2", PartitionKey = "pk2", ViaPartitionKey = "pk1" };
-            var message3 = new ServiceBusMessage(body) { MessageId = "3", PartitionKey = "pk3", ViaPartitionKey = "pk1" };
+            var message2 = new ServiceBusMessage(body) { MessageId = "2", PartitionKey = "pk2", TransactionPartitionKey = "pk1" };
+            var message3 = new ServiceBusMessage(body) { MessageId = "3", PartitionKey = "pk3", TransactionPartitionKey = "pk1" };
 
             await intermediateSender.SendMessageAsync(message1).ConfigureAwait(false);
             var receivedMessage = await intermediateReceiver.ReceiveMessageAsync();


### PR DESCRIPTION
- SendVia -> TransactionQueueOrTopicName
- ViaPartitionKey -> TransactionPartitionKey
- Proxy -> WebProxy

Make MaxReceiveTime internal within the ProcessorOptions.
Update entity name exception message.

Fixes https://github.com/azure/azure-sdk-for-net/issues/14986, https://github.com/azure/azure-sdk-for-net/issues/14975, https://github.com/azure/azure-sdk-for-net/issues/10646
