### PR TITLE
[CODEOWNERS]  Adding Metrics Advisor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,9 @@
 # PRLabel: %KeyVault
 /sdk/keyvault/                                  @schaabs @heaths
 
+# PRLabel: %Cognitive - Metrics Advisor
+sdk/metricsadvisor/                             @kinelski
+
 # PRLabel: %Search
 /sdk/search/                                    @brjohnstmsft @arv100kri @bleroy @tg-msft @heaths
 /sdk/search/Microsoft.*/                        @brjohnstmsft @arv100kri @bleroy


### PR DESCRIPTION
# Summary

The focus of these changes is to add an entry for the Cognitive Metrics Advisor libraries.

# Last Upstream Rebase

Wednesday, October 1, 3:38pm (EDT)