### PR TITLE
[ServiceBus] Change CreateSession to AcceptSession + overloads

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -73,6 +73,10 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace { get { throw null; } }
         public bool IsClosed { get { throw null; } }
         public Azure.Messaging.ServiceBus.ServiceBusTransportType TransportType { get { throw null; } }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> AcceptNextSessionAsync(string queueName, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> AcceptNextSessionAsync(string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> AcceptSessionAsync(string queueName, string sessionId, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> AcceptSessionAsync(string topicName, string subscriptionName, string sessionId, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusProcessor CreateProcessor(string queueName) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusProcessor CreateProcessor(string queueName, Azure.Messaging.ServiceBus.ServiceBusProcessorOptions options) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusProcessor CreateProcessor(string topicName, string subscriptionName) { throw null; }
@@ -85,8 +89,6 @@ namespace Azure.Messaging.ServiceBus
         public virtual Azure.Messaging.ServiceBus.ServiceBusSender CreateSender(string queueOrTopicName, Azure.Messaging.ServiceBus.ServiceBusSenderOptions options) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusSessionProcessor CreateSessionProcessor(string queueName, Azure.Messaging.ServiceBus.ServiceBusSessionProcessorOptions options = null) { throw null; }
         public virtual Azure.Messaging.ServiceBus.ServiceBusSessionProcessor CreateSessionProcessor(string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusSessionProcessorOptions options = null) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> CreateSessionReceiverAsync(string queueName, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Messaging.ServiceBus.ServiceBusSessionReceiver> CreateSessionReceiverAsync(string topicName, string subscriptionName, Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
     }
     public partial class ServiceBusClientOptions
@@ -423,7 +425,6 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusSessionReceiverOptions() { }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ReceiveMode ReceiveMode { get { throw null; } set { } }
-        public string SessionId { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample03_SendReceiveSessions.md
@@ -26,7 +26,7 @@ await sender.SendMessageAsync(message);
 
 // create a session receiver that we can use to receive the message. Since we don't specify a
 // particular session, we will get the next available session from the service.
-ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
+ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(queueName);
 
 // the received message is a different type as it contains some service set properties
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -44,12 +44,9 @@ byte[] state = await receiver.GetSessionStateAsync();
 
 ```C# Snippet:ServiceBusReceiveFromSpecificSession
 // create a receiver specifying a particular session
-ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
+ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
     queueName,
-    new ServiceBusSessionReceiverOptions
-    {
-        SessionId = "Session2"
-    });
+    "Session2");
 
 // the received message is a different type as it contains some service set properties
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample06_Transactions.md
@@ -61,7 +61,7 @@ await using var client = new ServiceBusClient(connectionString);
 ServiceBusSender sender = client.CreateSender(queueName);
 
 await sender.SendMessageAsync(new ServiceBusMessage("my message") { SessionId = "sessionId" });
-ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
+ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(queueName);
 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
 var state = Encoding.UTF8.GetBytes("some state");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -328,9 +328,8 @@ namespace Azure.Messaging.ServiceBus
         /// <see cref="ServiceBusSessionReceiver"/>.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        /// <remarks>Because this is establishing a session lock, this method performs a service call. If the
-        /// sessionId parameter is not specified, and there are no available messages in the queue, this will
-        /// throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
+        /// <remarks>Because this is establishing a session lock, this method performs a service call. If there are no available messages in the queue,
+        /// this will throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
         /// </remarks>
         ///
         /// <returns>A <see cref="ServiceBusSessionReceiver"/> scoped to the specified queue and a specific session.</returns>
@@ -361,9 +360,8 @@ namespace Azure.Messaging.ServiceBus
         /// <see cref="ServiceBusSessionReceiver"/>.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        /// <remarks>Because this is establishing a session lock, this method performs a service call. If the
-        /// sessionId parameter is not specified, and there are no available messages in the queue, this will
-        /// throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
+        /// <remarks>Because this is establishing a session lock, this method performs a service call. If there are no available messages in the queue,
+        /// this will throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
         /// </remarks>
         ///
         /// <returns>A <see cref="ServiceBusSessionReceiver"/> scoped to the specified queue and a specific session.</returns>
@@ -396,7 +394,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>Because this is establishing a session lock, this method performs a service call. If the
-        /// sessionId parameter is not specified, and there are no available messages in the queue, this will
+        /// sessionId parameter is null, and there are no available messages in the queue, this will
         /// throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
         /// </remarks>
         ///
@@ -433,7 +431,7 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>Because this is establishing a session lock, this method performs a service call. If the
-        /// sessionId parameter is not specified, and there are no available messages in the queue, this will
+        /// sessionId parameter is null, and there are no available messages in the queue, this will
         /// throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
         /// </remarks>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -334,7 +334,7 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         /// <returns>A <see cref="ServiceBusSessionReceiver"/> scoped to the specified queue and a specific session.</returns>
-        public virtual async Task<ServiceBusSessionReceiver> CreateSessionReceiverAsync(
+        public virtual async Task<ServiceBusSessionReceiver> AcceptNextSessionAsync(
             string queueName,
             ServiceBusSessionReceiverOptions options = default,
             CancellationToken cancellationToken = default)
@@ -367,13 +367,87 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         /// <returns>A <see cref="ServiceBusSessionReceiver"/> scoped to the specified queue and a specific session.</returns>
-        public virtual async Task<ServiceBusSessionReceiver> CreateSessionReceiverAsync(
+        public virtual async Task<ServiceBusSessionReceiver> AcceptNextSessionAsync(
             string topicName,
             string subscriptionName,
             ServiceBusSessionReceiverOptions options = default,
             CancellationToken cancellationToken = default)
         {
             ValidateEntityName(topicName);
+
+            return await ServiceBusSessionReceiver.CreateSessionReceiverAsync(
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                connection: Connection,
+                plugins: Plugins,
+                options: options,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
+        /// and settling messages from a specific session-enabled queue. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
+        /// </summary>
+        ///
+        /// <param name="queueName">The session-enabled queue to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
+        /// <param name="sessionId">Gets or sets a session ID to scope the <see cref="ServiceBusSessionReceiver"/> to.</param>
+        /// <param name="options">The set of <see cref="ServiceBusReceiverOptions"/> to use for configuring the
+        /// <see cref="ServiceBusSessionReceiver"/>.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <remarks>Because this is establishing a session lock, this method performs a service call. If the
+        /// sessionId parameter is not specified, and there are no available messages in the queue, this will
+        /// throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
+        /// </remarks>
+        ///
+        /// <returns>A <see cref="ServiceBusSessionReceiver"/> scoped to the specified queue and a specific session.</returns>
+        public virtual async Task<ServiceBusSessionReceiver> AcceptSessionAsync(
+            string queueName,
+            string sessionId,
+            ServiceBusSessionReceiverOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            ValidateEntityName(queueName);
+            options ??= new ServiceBusSessionReceiverOptions();
+            options.SessionId = sessionId;
+
+            return await ServiceBusSessionReceiver.CreateSessionReceiverAsync(
+                entityPath: queueName,
+                connection: Connection,
+                plugins: Plugins,
+                options: options,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
+        /// and settling messages from a specific session-enabled subscription. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
+        /// </summary>
+        ///
+        /// <param name="topicName">The topic to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
+        /// <param name="subscriptionName">The session-enabled subscription to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
+        /// <param name="sessionId">Gets or sets a session ID to scope the <see cref="ServiceBusSessionReceiver"/> to.</param>
+        /// <param name="options">The set of <see cref="ServiceBusReceiverOptions"/> to use for configuring the
+        /// <see cref="ServiceBusSessionReceiver"/>.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <remarks>Because this is establishing a session lock, this method performs a service call. If the
+        /// sessionId parameter is not specified, and there are no available messages in the queue, this will
+        /// throw a <see cref="ServiceBusException"/> with <see cref="ServiceBusException.Reason"/> of <see cref="ServiceBusFailureReason.ServiceTimeout"/>.
+        /// </remarks>
+        ///
+        /// <returns>A <see cref="ServiceBusSessionReceiver"/> scoped to the specified queue and a specific session.</returns>
+        public virtual async Task<ServiceBusSessionReceiver> AcceptSessionAsync(
+            string topicName,
+            string subscriptionName,
+            string sessionId,
+            ServiceBusSessionReceiverOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            ValidateEntityName(topicName);
+            options ??= new ServiceBusSessionReceiverOptions();
+            options.SessionId = sessionId;
 
             return await ServiceBusSessionReceiver.CreateSessionReceiverAsync(
                 entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -2,21 +2,21 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.ServiceBus.Core;
 using Azure.Core;
-using Azure.Messaging.ServiceBus.Diagnostics;
 using Azure.Core.Pipeline;
+using Azure.Messaging.ServiceBus.Core;
+using Azure.Messaging.ServiceBus.Diagnostics;
 using Azure.Messaging.ServiceBus.Plugins;
-using System.Collections.Generic;
 
 namespace Azure.Messaging.ServiceBus
 {
     /// <summary>
     /// The <see cref="ServiceBusSessionReceiver" /> is responsible for receiving <see cref="ServiceBusReceivedMessage" />
     ///  and settling messages from session-enabled Queues and Subscriptions. It is constructed by calling
-    ///  <see cref="ServiceBusClient.CreateSessionReceiverAsync(string, string, ServiceBusSessionReceiverOptions, CancellationToken)"/>.
+    ///  <see cref="ServiceBusClient.AcceptNextSessionAsync(string,string,Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions,System.Threading.CancellationToken)"/>.
     /// </summary>
     public class ServiceBusSessionReceiver : ServiceBusReceiver
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -16,7 +16,7 @@ namespace Azure.Messaging.ServiceBus
     /// <summary>
     /// The <see cref="ServiceBusSessionReceiver" /> is responsible for receiving <see cref="ServiceBusReceivedMessage" />
     ///  and settling messages from session-enabled Queues and Subscriptions. It is constructed by calling
-    ///  <see cref="ServiceBusClient.AcceptNextSessionAsync(string,string,Azure.Messaging.ServiceBus.ServiceBusSessionReceiverOptions,System.Threading.CancellationToken)"/>.
+    ///  <see cref="ServiceBusClient.AcceptNextSessionAsync(string, string, ServiceBusSessionReceiverOptions, CancellationToken)"/>.
     /// </summary>
     public class ServiceBusSessionReceiver : ServiceBusReceiver
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiverOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiverOptions.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets or sets an optional session ID to scope the <see cref="ServiceBusSessionReceiver"/> to. If left blank,
         /// the next available session returned from the service will be used.
         /// </summary>
-        public string SessionId { get; set; }
+        internal string SessionId { get; set; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using Azure.Core;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Client
@@ -66,7 +63,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 }
                 else
                 {
-                    receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                    receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                 }
                 var receivedMessage = await receiver.ReceiveMessageAsync().ConfigureAwait(false);
                 Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
@@ -81,10 +78,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 }
                 else
                 {
-                    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.CreateSessionReceiverAsync(scope.QueueName));
-                    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.CreateSessionReceiverAsync(
+                    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.AcceptNextSessionAsync(scope.QueueName));
+                    Assert.ThrowsAsync<ObjectDisposedException>(async () => await client.AcceptSessionAsync(
                         scope.QueueName,
-                        new ServiceBusSessionReceiverOptions { SessionId = "sessionId" }));
+                        "sessionId"));
                 }
                 Assert.Throws<ObjectDisposedException>(() => client.CreateProcessor(scope.QueueName));
             }
@@ -110,7 +107,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 }
                 else
                 {
-                    receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                    receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                 }
                 var receivedMessage = await receiver.ReceiveMessageAsync().ConfigureAwait(false);
                 Assert.AreEqual(message.Body.ToString(), receivedMessage.Body.ToString());
@@ -125,7 +122,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 {
                     // close old receiver so we can get session lock
                     await receiver.DisposeAsync();
-                    await client.CreateSessionReceiverAsync(scope.QueueName);
+                    await client.AcceptNextSessionAsync(scope.QueueName);
                 }
                 client.CreateProcessor(scope.QueueName);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 ServiceBusReceiver receiver = null;
                 if (useSessions)
                 {
-                    receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                    receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                 }
                 else
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -56,7 +56,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageCompleteEvent, e => e.Payload.Contains(sender.Identifier));
 
                 Assert.That(
-                    async () => await client.CreateSessionReceiverAsync(scope.QueueName),
+                    async () => await client.AcceptNextSessionAsync(scope.QueueName),
                     Throws.InstanceOf<InvalidOperationException>());
                 _listener.SingleEventById(ServiceBusEventSource.ClientCreateStartEvent, e => e.Payload.Contains(nameof(ServiceBusSessionReceiver)) && e.Payload.Contains(client.FullyQualifiedNamespace) && e.Payload.Contains(scope.QueueName));
                 _listener.SingleEventById(ServiceBusEventSource.ClientCreateExceptionEvent, e => e.Payload.Contains(nameof(ServiceBusSessionReceiver)) && e.Payload.Contains(client.FullyQualifiedNamespace) && e.Payload.Contains(scope.QueueName));
@@ -161,7 +161,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 _listener.SingleEventById(ServiceBusEventSource.ReceiveMessageStartEvent, e => e.Payload.Contains(receiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.ReceiveMessageExceptionEvent, e => e.Payload.Contains(receiver.Identifier));
 
-                var sessionReceiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                var sessionReceiver = await client.AcceptNextSessionAsync(scope.QueueName);
                 _listener.EventsById(ServiceBusEventSource.ClientCreateStartEvent).Where(e => e.Payload.Contains(nameof(ServiceBusSessionReceiver)) && e.Payload.Contains(client.FullyQualifiedNamespace)).Any();
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkStartEvent, e => e.Payload.Contains(sessionReceiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkCompleteEvent, e => e.Payload.Contains(sessionReceiver.Identifier));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -112,7 +112,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 msg.To = "to";
                 await sender.SendMessageAsync(msg);
 
-                var receiver = await client.CreateSessionReceiverAsync(
+                var receiver = await client.AcceptNextSessionAsync(
                     scope.QueueName,
                     new ServiceBusSessionReceiverOptions
                     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Plugins/PluginLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Plugins/PluginLiveTests.cs
@@ -125,7 +125,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Plugins
 
                 await sender.SendMessageAsync(GetMessage("sessionId"));
                 Assert.True(plugin.WasCalled);
-                var receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                var receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                 var receivedMessage = await receiver.ReceiveMessageAsync();
 
                 Assert.AreEqual("received", receivedMessage.Body.ToString());
@@ -148,7 +148,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Plugins
 
                 await sender.SendMessageAsync(GetMessage("sessionId"));
                 Assert.True(plugin.WasCalled);
-                var receiver = await client.CreateSessionReceiverAsync(scope.TopicName, scope.SubscriptionNames.First());
+                var receiver = await client.AcceptNextSessionAsync(scope.TopicName, scope.SubscriptionNames.First());
                 var receivedMessage = await receiver.ReceiveMessageAsync();
 
                 Assert.AreEqual("received", receivedMessage.Body.ToString());

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -410,7 +409,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 if (!autoComplete)
                 {
                     Assert.That(async () =>
-                        await GetNoRetryClient().CreateSessionReceiverAsync(scope.QueueName),
+                        await GetNoRetryClient().AcceptNextSessionAsync(scope.QueueName),
                         Throws.Exception);
                 }
             }
@@ -778,7 +777,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await tcs.Task;
                 await processor.StopProcessingAsync();
                 Assert.That(
-                    async () => await GetNoRetryClient().CreateSessionReceiverAsync(scope.QueueName),
+                    async () => await GetNoRetryClient().AcceptNextSessionAsync(scope.QueueName),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.ServiceTimeout));
             }
         }
@@ -844,7 +843,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 if (settleMethod == "" || settleMethod == "Abandon")
                 {
-                    var receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                    var receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                     var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
                     Assert.IsNotNull(msg);
                 }
@@ -852,7 +851,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     try
                     {
-                        await GetNoRetryClient().CreateSessionReceiverAsync(scope.QueueName);
+                        await GetNoRetryClient().AcceptNextSessionAsync(scope.QueueName);
                     }
                     catch (ServiceBusException ex)
                     when (ex.Reason == ServiceBusFailureReason.ServiceTimeout ||
@@ -1247,12 +1246,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 if (errorSource == ServiceBusErrorSource.AcceptMessageSession)
                 {
-                    var receiver = await client.CreateSessionReceiverAsync(
+                    var receiver = await client.AcceptSessionAsync(
                         scope.QueueName,
-                        new ServiceBusSessionReceiverOptions
-                        {
-                            SessionId = sessionId
-                        });
+                        sessionId);
                 }
 
                 sessions.TryAdd(sessionId, true);
@@ -1367,13 +1363,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                                 await Task.Delay(delayDuration);
                                 // lock the session so we can trigger
                                 // an error on the processor receive
-                                await client.CreateSessionReceiverAsync(
+                                await client.AcceptSessionAsync(
                                     scope.QueueName,
-                                    new ServiceBusSessionReceiverOptions
-                                    {
-                                        SessionId = args.SessionId
-                                    },
-                                    args.CancellationToken);
+                                    args.SessionId,
+                                    cancellationToken: args.CancellationToken);
                                 break;
                             case ServiceBusErrorSource.UserCallback:
                                 await Task.Delay(delayDuration);
@@ -1604,9 +1597,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 Assert.IsFalse(processor.IsProcessing);
 
                 Assert.That(
-                    async () => await GetNoRetryClient().CreateSessionReceiverAsync(
+                    async () => await GetNoRetryClient().AcceptSessionAsync(
                         scope.QueueName,
-                        new ServiceBusSessionReceiverOptions { SessionId = "sessionId" }),
+                        "sessionId"),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).
                     EqualTo(ServiceBusFailureReason.SessionCannotBeLocked));
 
@@ -1622,10 +1615,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await processor.DisposeAsync();
                 Assert.IsTrue(processor.IsClosed);
                 await sender.SendMessageAsync(GetMessage("sessionId"));
-                var receiver = await client.CreateSessionReceiverAsync(scope.QueueName, new ServiceBusSessionReceiverOptions
-                {
-                    SessionId = "sessionId"
-                });
+                var receiver = await client.AcceptSessionAsync(scope.QueueName, "sessionId");
                 var msg = await receiver.ReceiveMessageAsync();
                 Assert.IsNotNull(msg);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -40,12 +39,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     sentMessageIdToMsg.Add(message.MessageId, message);
                 }
 
-                var receiver = await client.CreateSessionReceiverAsync(
+                var receiver = await client.AcceptNextSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = sessionId
-                    });
+                    sessionId);
 
                 sequenceNumber ??= 1;
 
@@ -86,19 +82,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, messageCt, sessionId);
 
                 await sender.SendMessagesAsync(messageBatch);
-                var options = new ServiceBusSessionReceiverOptions
-                {
-                    SessionId = sessionId
-                };
-                ServiceBusReceiver receiver1 = await client.CreateSessionReceiverAsync(
+                ServiceBusReceiver receiver1 = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    options);
+                    sessionId);
 
                 Assert.That(
                     async () =>
-                    await GetNoRetryClient().CreateSessionReceiverAsync(
+                    await GetNoRetryClient().AcceptSessionAsync(
                         scope.QueueName,
-                        options),
+                        sessionId),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.SessionCannotBeLocked));
             }
         }
@@ -121,7 +113,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 ServiceBusMessageBatch messagebatch = AddMessages(batch, messageCt, sessionId);
 
                 await sender.SendMessagesAsync(messagebatch);
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                ServiceBusReceiver receiver = await client.AcceptNextSessionAsync(scope.QueueName);
 
                 long seq = 0;
                 for (int i = 0; i < messageCt / peekCt; i++)
@@ -156,7 +148,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(messagebatch);
 
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                ServiceBusReceiver receiver = await client.AcceptNextSessionAsync(scope.QueueName);
 
                 long seq = 0;
                 for (int i = 0; i < messageCt; i++)
@@ -193,7 +185,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 // create receiver not scoped to a specific session
                 for (int i = 0; i < 10; i++)
                 {
-                    ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                    ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                     foreach (ServiceBusReceivedMessage peekedMessage in await receiver.PeekMessagesAsync(
                         fromSequenceNumber: 1,
                         maxMessages: 10))
@@ -223,12 +215,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusReceiver receiver = await client.AcceptNextSessionAsync(
                     scope.QueueName,
                     new ServiceBusSessionReceiverOptions
-                {
-                    PrefetchCount = 100
-                });
+                    {
+                        PrefetchCount = 100
+                    });
 
                 var messageEnum = messages.GetEnumerator();
 
@@ -265,14 +257,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                var clientOptions = new ServiceBusSessionReceiverOptions()
+                var clientOptions = new ServiceBusSessionReceiverOptions
                 {
-                    ReceiveMode = ReceiveMode.ReceiveAndDelete,
-                    SessionId = sessionId
+                    ReceiveMode = ReceiveMode.ReceiveAndDelete
                 };
 
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusReceiver receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
+                    sessionId,
                     clientOptions);
 
                 var remainingMessages = messageCount;
@@ -312,12 +304,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusReceiver receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = useSpecificSession ? sessionId : null
-                    });
+                    useSpecificSession ? sessionId : null);
                 var messageEnum = messages.GetEnumerator();
                 var remainingMessages = messageCount;
 
@@ -356,12 +345,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                ServiceBusReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusReceiver receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = useSpecificSession ? sessionId : null
-                    });
+                    useSpecificSession ? sessionId : null);
                 var messageEnum = messages.GetEnumerator();
                 var remainingMessages = messageCount;
                 IList<ServiceBusReceivedMessage> receivedMessages = new List<ServiceBusReceivedMessage>();
@@ -416,12 +402,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                var receiver = await client.CreateSessionReceiverAsync(
+                var receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = useSpecificSession ? sessionId : null
-                    });
+                    useSpecificSession ? sessionId : null);
                 var remainingMessages = messageCount;
                 var messageEnum = messages.GetEnumerator();
 
@@ -486,13 +469,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var topicName = scope.TopicName;
                 var subscriptionName = scope.SubscriptionNames.First();
 
-                var receiver = await client.CreateSessionReceiverAsync(
+                var receiver = await client.AcceptSessionAsync(
                     topicName: topicName,
                     subscriptionName: subscriptionName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = useSpecificSession ? sessionId : null
-                    });
+                    useSpecificSession ? sessionId : null);
                 var remainingMessages = messageCount;
                 var messageEnum = messages.GetEnumerator();
 
@@ -563,12 +543,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 await sender.SendMessagesAsync(batch);
 
-                var receiver = await client.CreateSessionReceiverAsync(
+                var receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = useSpecificSession ? sessionId : null
-                    });
+                    useSpecificSession ? sessionId : null);
                 var remainingMessages = messageCount;
                 var messageEnum = messages.GetEnumerator();
                 IList<long> sequenceNumbers = new List<long>();
@@ -613,12 +590,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await sender.SendMessageAsync(GetMessage("sessionId2"));
                 await sender.SendMessageAsync(message);
 
-                ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = isSessionSpecified ? sessionId1 : null
-                    });
+                    isSessionSpecified ? sessionId1 : null);
                 if (isSessionSpecified)
                 {
                     Assert.AreEqual(sessionId1, receiver.SessionId);
@@ -663,12 +637,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 // send another session message before the one we are interested in to make sure that when isSessionSpecified=true, it is being respected
                 await sender.SendMessagesAsync(GetMessages(3, "sessionId2"));
 
-                ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = isSessionSpecified ? "sessionId1" : null
-                    });
+                    isSessionSpecified ? "sessionId1" : null);
                 if (isSessionSpecified)
                 {
                     Assert.AreEqual("sessionId1", receiver.SessionId);
@@ -687,18 +658,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 // received before we reconnected, the message won't be able to be settled. This is analogous
                 // to the case of reconnecting a regular non-session link and getting a MessageLockLost error.
                 Assert.That(
-                    async() => await receiver.CompleteMessageAsync(firstMessage),
+                    async () => await receiver.CompleteMessageAsync(firstMessage),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.SessionLockLost));
                 await Task.Delay((receiver.SessionLockedUntil - DateTime.UtcNow) + TimeSpan.FromSeconds(5));
 
                 // If another receiver accepts the session after the lock is lost, we expect a SessionCannotBeLocked error,
                 // when we try to receive again with our initial receiver.
-                ServiceBusSessionReceiver secondReceiver = await client.CreateSessionReceiverAsync(
+                ServiceBusSessionReceiver secondReceiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = sessionId
-                    });
+                    sessionId);
 
                 try
                 {
@@ -724,22 +692,16 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = GetClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var sessionId = "sessionId";
-                var options = new ServiceBusSessionReceiverOptions
-                {
-                    SessionId = sessionId
-                };
-                var receiver = await client.CreateSessionReceiverAsync(scope.QueueName, options);
+                var receiver = await client.AcceptSessionAsync(scope.QueueName, sessionId);
 
                 // should not throw when using different session
-                options.SessionId = "sessionId2";
-                await client.CreateSessionReceiverAsync(scope.QueueName, options);
+                await client.AcceptSessionAsync(scope.QueueName, "sessionId2");
 
                 // for some reason, using Throws.InstanceOf and Assert.ThrowsAsync always end up coming back
                 // as a timeout exception.
                 try
                 {
-                    options.SessionId = sessionId;
-                    await client.CreateSessionReceiverAsync(scope.QueueName, options);
+                    await client.AcceptSessionAsync(scope.QueueName, sessionId);
                 }
                 catch (ServiceBusException ex)
                 when (ex.Reason == ServiceBusFailureReason.SessionCannotBeLocked)
@@ -765,7 +727,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await sender.SendMessageAsync(sentMessage);
 
                 Assert.That(
-                    async () => await client.CreateSessionReceiverAsync(scope.QueueName),
+                    async () => await client.AcceptNextSessionAsync(scope.QueueName),
                     Throws.InstanceOf<InvalidOperationException>());
             }
         }
@@ -784,12 +746,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 ServiceBusMessage message = GetMessage(sessionId);
                 await sender.SendMessageAsync(message);
 
-                ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = isSessionSpecified ? sessionId : null
-                    });
+                    isSessionSpecified ? sessionId : null);
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
                 Assert.AreEqual(message.MessageId, receivedMessage.MessageId);
                 Assert.AreEqual(message.SessionId, receivedMessage.SessionId);
@@ -835,7 +794,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 _ = Task.Delay(TimeSpan.FromSeconds(30)).ContinueWith(
                     async _ => await sender.SendMessagesAsync(secondSet));
 
-                var receiver = await client.CreateSessionReceiverAsync(scope.QueueName);
+                var receiver = await client.AcceptNextSessionAsync(scope.QueueName);
                 var cts = new CancellationTokenSource();
                 cts.CancelAfter(TimeSpan.FromMinutes(1));
                 messages.AddRange(secondSet);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample03_SendReceiveSessions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
-using Azure.Core;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples
@@ -38,7 +37,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 // create a session receiver that we can use to receive the message. Since we don't specify a
                 // particular session, we will get the next available session from the service.
-                ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
+                ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(queueName);
 
                 // the received message is a different type as it contains some service set properties
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -89,12 +88,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 #region Snippet:ServiceBusReceiveFromSpecificSession
                 // create a receiver specifying a particular session
-                ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(
+                ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
                     queueName,
-                    new ServiceBusSessionReceiverOptions
-                    {
-                        SessionId = "Session2"
-                    });
+                    "Session2");
 
                 // the received message is a different type as it contains some service set properties
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample06_Transactions.cs
@@ -58,7 +58,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 ServiceBusSender sender = client.CreateSender(queueName);
 
                 await sender.SendMessageAsync(new ServiceBusMessage("my message") { SessionId = "sessionId" });
-                ServiceBusSessionReceiver receiver = await client.CreateSessionReceiverAsync(queueName);
+                ServiceBusSessionReceiver receiver = await client.AcceptNextSessionAsync(queueName);
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
 
                 var state = Encoding.UTF8.GetBytes("some state");


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/15579

Updated client surface to have AcceptSession overloads that take in session ID. Changed CreateSession to AcceptSession. Made SessionId internal in ServiceBusSessionReceiverOptions.