### PR TITLE
Add staging step to stage artifacts before signing

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -38,12 +38,18 @@ jobs:
           /p:PublicSign=false $(VersioningProperties)
           /p:Configuration=$(BuildConfiguration)
           /p:CommitSHA=$(Build.SourceVersion)
-          /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)
+          /p:ArtifactsPackagesDir=$(Build.SourcesDirectory)/packages
         displayName: "Build and Package"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
+      - ${{ each artifact in parameters.Artifacts }}:
+        - pwsh: |
+            Copy-Item $(Build.SourcesDirectory)/packages/${{artifact.name}} $(Build.ArtifactStagingDirectory) -Recurse
+            Get-ChildItem $(Build.ArtifactStagingDirectory)
+            Get-ChildItem $(Build.ArtifactStagingDirectory)/${{artifact.name}}
+          displayName: Copying ${{artifact.name}} to artifact staging directory
       - template: ../steps/archetype-sdk-docs.yml
         parameters:
           ServiceDirectory: ${{parameters.ServiceDirectory}}

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -33,23 +33,17 @@ jobs:
           versionSpec: '3.6'
       - script: >-
           dotnet pack eng/service.proj -warnaserror
-          /p:ServiceDirectory=${{parameters.ServiceToBuild}}
+          /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeTests=false
           /p:PublicSign=false $(VersioningProperties)
           /p:Configuration=$(BuildConfiguration)
           /p:CommitSHA=$(Build.SourceVersion)
-          /p:ArtifactsPackagesDir=$(Build.SourcesDirectory)/packages
+          /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)
         displayName: "Build and Package"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
-      - ${{ each artifact in parameters.Artifacts }}:
-        - pwsh: |
-            Copy-Item $(Build.SourcesDirectory)/packages/${{artifact.name}} $(Build.ArtifactStagingDirectory) -Recurse
-            Get-ChildItem $(Build.ArtifactStagingDirectory)
-            Get-ChildItem $(Build.ArtifactStagingDirectory)/${{artifact.name}}
-          displayName: Copying ${{artifact.name}} to artifact staging directory
       - template: ../steps/archetype-sdk-docs.yml
         parameters:
           ServiceDirectory: ${{parameters.ServiceDirectory}}
@@ -96,7 +90,7 @@ jobs:
           DOTNET_MULTILEVEL_LOOKUP: 0
         inputs:
           filePath: "eng/scripts/CodeChecks.ps1"
-          arguments: -ServiceDirectory ${{parameters.ServiceToBuild}}
+          arguments: -ServiceDirectory ${{parameters.ServiceDirectory}}
           pwsh: true
           failOnStderr:  false
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -145,7 +139,7 @@ jobs:
       - script: >-
           dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework)
           --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
-          /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false
+          /p:ServiceDirectory=${{parameters.ServiceToTest}} /p:IncludeSrc=false /p:IncludeSamples=false
           /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption) /p:CollectCoverage=$(CollectCoverage)
         displayName: "Build & Test ($(TestTargetFramework))"
         env:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -15,7 +15,7 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
-- name: ServiceToBuild
+- name: ServiceToTest
   type: string
   default: ''
 - name: TargetDocRepoOwner
@@ -33,7 +33,7 @@ stages:
     jobs:
     - template: ../jobs/archetype-sdk-client.yml
       parameters:
-        ServiceToBuild: ${{ coalesce(parameters.ServiceToBuild, parameters.ServiceDirectory) }}
+        ServiceToTest: ${{ coalesce(parameters.ServiceToTest, parameters.ServiceDirectory) }}
         ServiceDirectory: ${{parameters.ServiceDirectory}}
         Artifacts: ${{parameters.Artifacts}}
         ArtifactName: packages

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -33,7 +33,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: core
-    ServiceToBuild: '*'
+    ServiceToTest: '*'
     ArtifactName: packages
     Artifacts:
     - name: Azure.Core


### PR DESCRIPTION
This Fixes a bug in the release stage.
Stage artifacts such that only packages present in `ci.yml` are signed.