### PR TITLE
Update archetype-sdk-client.yml : Do not pack test projects

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -34,6 +34,7 @@ jobs:
       - script: >-
           dotnet pack eng/service.proj -warnaserror
           /p:ServiceDirectory=${{parameters.ServiceToBuild}}
+          /p:IncludeTests=false
           /p:PublicSign=false $(VersioningProperties)
           /p:Configuration=$(BuildConfiguration)
           /p:CommitSHA=$(Build.SourceVersion)


### PR DESCRIPTION
## Proposed Change
Hello, I'm proposing a change to the following yml pipeline to exclude test projects from being packed (nupkg).
In my opinion, there's no value to this and these projects could be omitted.

For context; this step in the yml calls `eng/service.proj`. `IncludeTests` defaults to `true`.
https://github.com/Azure/azure-sdk-for-net/blob/6166b0194f7fb77e4787327ad829ffef4571a5ed/eng/service.proj#L5

## How I found this
I'm using the[ ASP.NET Integration test](https://docs.microsoft.com/aspnet/core/test/integration-tests) library to build tests for the Azure Monitor Exporter.
This consists of two new projects; a unit test project and an aspnetcore web app project.

My PR has been failing because the build system was trying to pack my web project. #15545.
`Microsoft.NET.Sdk.Web` sets a property `WarnOnPackingNonPackableProject`.
https://github.com/dotnet/websdk/blob/4a4ae15f4c78cb3dfeffdf05ca12094b7e8a72a7/src/ProjectSystem/Targets/Microsoft.NET.Sdk.Web.ProjectSystem.props#L22

The Azure SDK Pipeline treats all warnings as errors, as it should :)

@pakrym, this is the issue I was discussing with you.