### PR TITLE
Update test environment and add AssemblyInfo

### DIFF
--- a/sdk/api-learn/Azure.Learn.AppConfig/src/Azure.Learn.AppConfig.csproj
+++ b/sdk/api-learn/Azure.Learn.AppConfig/src/Azure.Learn.AppConfig.csproj
@@ -23,6 +23,7 @@
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" Link="Shared\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" />
   </ItemGroup>
 
   <!-- The following line enables switching between project and package references. -->

--- a/sdk/api-learn/Azure.Learn.AppConfig/src/properties/AssemblyInfo.cs
+++ b/sdk/api-learn/Azure.Learn.AppConfig/src/properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+// Replace with test project/test project public key and uncomment to make internal members visible to
+// your test project. If not needed, this can be deleted.
+// [assembly: InternalsVisibleTo("Azure.Template.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
+
+// Replace Microsoft.Test with the correct resource provider namepace for your service and uncomment.
+// See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-services-resource-providers
+// for the list of possible values.
+[assembly: Azure.Core.AzureResourceProviderNamespace("Microsoft.AppConfiguration")]

--- a/sdk/api-learn/Azure.Learn.AppConfig/tests/LearnAppConfigEnvironment.cs
+++ b/sdk/api-learn/Azure.Learn.AppConfig/tests/LearnAppConfigEnvironment.cs
@@ -1,14 +1,14 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Core.TestFramework;
 
-namespace Azure.Learn.AppConfig.Samples
+namespace Azure.Learn.AppConfig.Tests
 {
     // To learn more about TestEnvironment classes, please see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core.TestFramework/README.md
-    public class AppConfigClientTestEnvironment : TestEnvironment
+    public class LearnAppConfigEnvironment : TestEnvironment
     {
-        public AppConfigClientTestEnvironment() : base("api-learn")
+        public LearnAppConfigEnvironment() : base("api-learn")
         {
         }
     }

--- a/sdk/api-learn/Azure.Learn.AppConfig/tests/LearnAppConfigTestEnvironment.cs
+++ b/sdk/api-learn/Azure.Learn.AppConfig/tests/LearnAppConfigTestEnvironment.cs
@@ -6,9 +6,9 @@ using Azure.Core.TestFramework;
 namespace Azure.Learn.AppConfig.Tests
 {
     // To learn more about TestEnvironment classes, please see: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core.TestFramework/README.md
-    public class LearnAppConfigEnvironment : TestEnvironment
+    public class LearnAppConfigTestEnvironment : TestEnvironment
     {
-        public LearnAppConfigEnvironment() : base("api-learn")
+        public LearnAppConfigTestEnvironment() : base("api-learn")
         {
         }
     }


### PR DESCRIPTION
AssemblyInfo is now included as part of the Template solution, and is needed for tests.