### PR TITLE
Fix KeyVaultProxy sample README

### DIFF
--- a/sdk/keyvault/samples/keyvaultproxy/src/README.md
+++ b/sdk/keyvault/samples/keyvaultproxy/src/README.md
@@ -5,7 +5,6 @@ languages:
 products:
 - azure
 - azure-key-vault
-urlFragment: keyvaultproxy
 name: Cache certain responses from Key Vault
 description: Shows how to implement a pipeline policy to cache certain responses from Key Vault to mitigate rate limiting.
 ---


### PR DESCRIPTION
This was an ask from the Docs / Samples team that may have an issue validating the `urlFragment` in a new sample.