### PR TITLE
[Event Hub Client] EventData Body Update

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{797FF941-76FD-45FD-AC17-A73DFE2BA621}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{C1A4524B-CFFB-48C8-BA16-8E833DBAA1CD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,12 +37,17 @@ Global
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1A4524B-CFFB-48C8-BA16-8E833DBAA1CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1A4524B-CFFB-48C8-BA16-8E833DBAA1CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1A4524B-CFFB-48C8-BA16-8E833DBAA1CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1A4524B-CFFB-48C8-BA16-8E833DBAA1CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
+		{C1A4524B-CFFB-48C8-BA16-8E833DBAA1CD} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {44BD3BD5-61DF-464D-8627-E00B0BC4B3A3}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample03_BasicEventProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample03_BasicEventProcessing.cs
@@ -129,7 +129,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                     // token be passed to any asynchronous operations that are awaited in this handler.
 
                     ++eventIndex;
-                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                 }
                 catch (Exception ex)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_BasicCheckpointing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_BasicCheckpointing.cs
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                         Console.WriteLine();
                     }
 
-                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                 }
                 catch (Exception ex)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_InitializeAPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_InitializeAPartition.cs
@@ -98,7 +98,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
                 try
                 {
-                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                 }
                 catch (Exception ex)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample06_TrackWhenAPartitionIsClosed.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample06_TrackWhenAPartitionIsClosed.cs
@@ -145,7 +145,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                     ownedPartitions[eventArgs.Partition.PartitionId] = eventArgs;
 
                     ++eventsProcessed;
-                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                 }
                 catch (Exception ex)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample07_RestartProcessingOnError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample07_RestartProcessingOnError.cs
@@ -104,7 +104,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 try
                 {
                     ++eventIndex;
-                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                 }
                 catch (Exception ex)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
@@ -84,7 +84,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
                     if (eventArgs.HasEvent)
                     {
-                        Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                        Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                     }
 
                     // Simulate sending a heartbeat using a simple helper that writes a status to the

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
@@ -287,7 +287,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
             foreach (EventData data in eventBatch)
             {
-                batchMessage.AppendLine($"\tEvent: { Encoding.UTF8.GetString(data.Body.ToArray()) }");
+                batchMessage.AppendLine($"\tEvent: { Encoding.UTF8.GetString(data.EventBody.ToBytes().ToArray()) }");
                 ++eventCount;
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample10_RunningWithDifferentStorageVersion.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample10_RunningWithDifferentStorageVersion.cs
@@ -91,7 +91,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 if (eventArgs.HasEvent)
                 {
                     ++eventsProcessed;
-                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
                 }
 
                 return Task.CompletedTask;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -12,7 +12,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.3.0-beta.3" /><!-- This override will be removed when v5.3.0 is released for GA -->
+
+    <!-- TEMP -->
+      <!--
+        Project reference is temporary, due to the changes to the EventData model. Don't forget to also remove the project reference in the
+        solution under the "External" folder.
+      -->
+      <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
+      <!--<PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.3.0-beta.4" /> --><!-- This override will be removed when v5.3.0 is released for GA -->
+    <!--END TEMP-->
+
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventDataExtensions.cs
@@ -47,8 +47,8 @@ namespace Azure.Messaging.EventHubs.Tests
             // If the contents of each body is not equal, the events are not
             // equal.
 
-            var instanceBody = instance.Body.ToArray();
-            var otherBody = other.Body.ToArray();
+            var instanceBody = instance.EventBody.ToBytes().ToArray();
+            var otherBody = other.EventBody.ToBytes().ToArray();
 
             if (instanceBody.Length != otherBody.Length)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
@@ -359,7 +359,7 @@ private async Task ProcessUntilCanceled(CancellationToken cancellationToken)
 
     async Task processEventHandler(ProcessEventArgs eventArgs)
     {
-        Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+        Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.EventBody.ToBytes().ToArray()) }");
         return Task.CompletedTask;
     }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -3,12 +3,16 @@ namespace Azure.Messaging.EventHubs
     public partial class EventData
     {
         public EventData(Azure.BinaryData eventBody) { }
+        protected EventData(Azure.BinaryData eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(System.ReadOnlyMemory<byte> eventBody) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected EventData(System.ReadOnlyMemory<byte> eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.ReadOnlyMemory<byte> Body { get { throw null; } }
-        public Azure.BinaryData BodyAsBinaryData { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.IO.Stream BodyAsStream { get { throw null; } }
         public System.DateTimeOffset EnqueuedTime { get { throw null; } }
+        public Azure.BinaryData EventBody { get { throw null; } }
         public long Offset { get { throw null; } }
         public string PartitionKey { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadEvents.cs
@@ -90,7 +90,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 await foreach (PartitionEvent partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
                 {
-                    Console.WriteLine($"Event Read: { Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Read: { Encoding.UTF8.GetString(partitionEvent.Data.EventBody.ToBytes().ToArray()) }");
                     eventsRead++;
 
                     if (eventsRead >= maximumEvents)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ReadOnlyNewEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ReadOnlyNewEvents.cs
@@ -129,7 +129,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 foreach (EventData currentEvent in receivedEvents)
                 {
-                    string message = Encoding.UTF8.GetString(currentEvent.Body.ToArray());
+                    string message = Encoding.UTF8.GetString(currentEvent.EventBody.ToBytes().ToArray());
                     Console.WriteLine($"\tEvent Message: \"{ message }\"");
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ReadEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ReadEventsFromAKnownPosition.cs
@@ -149,7 +149,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     // The body of our event was an encoded string; we'll recover the
                     // message by reversing the encoding process.
 
-                    string message = Encoding.UTF8.GetString(eventData.Body.ToArray());
+                    string message = Encoding.UTF8.GetString(eventData.EventBody.ToBytes().ToArray());
                     Console.WriteLine($"\tEvent Message: \"{ message }\"");
                 }
 
@@ -198,7 +198,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     // The body of our event was an encoded string; we'll recover the
                     // message by reversing the encoding process.
 
-                    string message = Encoding.UTF8.GetString(eventData.Body.ToArray());
+                    string message = Encoding.UTF8.GetString(eventData.EventBody.ToBytes().ToArray());
                     Console.WriteLine($"\tEvent Message: \"{ message }\"");
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_AuthenticateWithClientSecretCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_AuthenticateWithClientSecretCredential.cs
@@ -100,7 +100,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 await foreach (PartitionEvent partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
                 {
-                    Console.WriteLine($"Event Read: { Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray()) }");
+                    Console.WriteLine($"Event Read: { Encoding.UTF8.GetString(partitionEvent.Data.EventBody.ToBytes().ToArray()) }");
                     eventsRead++;
 
                     if (eventsRead >= eventsPublished)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample13_ReadEventsWithSerialization.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample13_ReadEventsWithSerialization.cs
@@ -141,7 +141,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 await foreach (PartitionEvent partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
                 {
-                    BinaryData binaryData = partitionEvent.Data.BodyAsBinaryData;
+                    BinaryData binaryData = partitionEvent.Data.EventBody;
                     GenericRecord eventRecord = binaryData.ToObject<GenericRecord>(avroSerializer);
                     string messageText = (string)eventRecord["Message"];
                     Console.WriteLine($"Event Read: { messageText }");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -304,7 +304,8 @@ namespace Azure.Messaging.EventHubs.Amqp
         private static AmqpMessage BuildAmqpMessageFromEvent(EventData source,
                                                              string partitionKey)
         {
-            var body = new ArraySegment<byte>((source.Body.IsEmpty) ? Array.Empty<byte>() : source.Body.ToArray());
+            var bodyBytes = source.EventBody.ToBytes();
+            var body = new ArraySegment<byte>((bodyBytes.IsEmpty) ? Array.Empty<byte>() : bodyBytes.ToArray());
             var message = AmqpMessage.Create(new Data { Value = body });
 
             if (source.Properties?.Count > 0)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/PartitionEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/PartitionEvent.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// </value>
         ///
         /// <remarks>
-        ///   Ownership of this data, including the memory that holds its <see cref="EventData.Body" />,
+        ///   Ownership of this data, including the memory that holds its <see cref="EventData.EventBody" />,
         ///   is assumed to transfer to consumers of the <see cref="PartitionEvent" />.  It may be considered
         ///   immutable and is safe to access so long as the reference is held.
         /// </remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -18,45 +18,20 @@ namespace Azure.Messaging.EventHubs
     public class EventData
     {
         /// <summary>
-        ///   The data associated with the event.
-        /// </summary>
-        ///
-        /// <remarks>
-        ///   If the means for deserializing the raw data is not apparent to consumers, a
-        ///   common technique is to make use of <see cref="EventData.Properties" /> to associate serialization hints
-        ///   as an aid to consumers who wish to deserialize the binary data.
-        /// </remarks>
-        ///
-        /// <seealso cref="EventData.Properties" />
-        ///
-        public ReadOnlyMemory<byte> Body => BodyAsBinaryData.ToBytes();
-
-        /// <summary>
-        ///   The <see cref="Body" /> data associated with the event, in <see cref="BinaryData" /> form, providing support
+        ///   The data associated with the event, in <see cref="BinaryData" /> form, providing support
         ///   for a variety of data transformations and <see cref="ObjectSerializer" /> integration.
         /// </summary>
         ///
-        public BinaryData BodyAsBinaryData { get; }
-
-        /// <summary>
-        ///   The data associated with the event, in stream form.
-        /// </summary>
-        ///
-        /// <value>
-        ///   A <see cref="Stream" /> containing the raw data representing the <see cref="Body" />
-        ///   of the event.  The caller is assumed to have ownership of the stream, including responsibility
-        ///   for managing its lifespan and ensuring proper disposal.
-        /// </value>
-        ///
         /// <remarks>
-        ///   If the means for deserializing the raw data is not apparent to consumers, a
+        ///   <para>If the means for deserializing the raw data is not apparent to consumers, a
         ///   common technique is to make use of <see cref="EventData.Properties" /> to associate serialization hints
-        ///   as an aid to consumers who wish to deserialize the binary data.
+        ///   as an aid to consumers who wish to deserialize the binary data.</para>
         /// </remarks>
         ///
+        /// <seealso cref="BinaryData" />
         /// <seealso cref="EventData.Properties" />
         ///
-        public Stream BodyAsStream => BodyAsBinaryData.ToStream();
+        public BinaryData EventBody { get; }
 
         /// <summary>
         ///   The set of free-form event properties which may be used for passing metadata associated with the event body
@@ -64,7 +39,7 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   A common use case for <see cref="EventData.Properties" /> is to associate serialization hints for the <see cref="EventData.Body" />
+        ///   A common use case for <see cref="EventData.Properties" /> is to associate serialization hints for the <see cref="EventData.EventBody" />
         ///   as an aid to consumers who wish to deserialize the binary data.
         /// </remarks>
         ///
@@ -149,6 +124,43 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         public string PartitionKey { get; }
+
+        /// <summary>
+        ///   The data associated with the event.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   This member exists only to preserve backward compatibility.  It is recommended to
+        ///   prefer the <see cref="EventBody" /> where possible in order to take advantage of
+        ///   additional functionality and improved usability for common scenarios.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventData.EventBody" />
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ReadOnlyMemory<byte> Body => EventBody.ToBytes();
+
+        /// <summary>
+        ///   The data associated with the event, in stream form.
+        /// </summary>
+        ///
+        /// <value>
+        ///   A <see cref="Stream" /> containing the raw data representing the <see cref="EventBody" />
+        ///   of the event.  The caller is assumed to have ownership of the stream, including responsibility
+        ///   for managing its lifespan and ensuring proper disposal.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   This member exists only to preserve backward compatibility.  It is recommended to
+        ///   prefer the <see cref="EventBody" /> where possible in order to take advantage of
+        ///   additional functionality and improved usability for common scenarios.
+        /// </remarks>
+        ///
+        /// <seealso cref="BinaryData.ToStream" />
+        /// <seealso cref="EventData.EventBody" />
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Stream BodyAsStream => EventBody.ToStream();
 
         /// <summary>
         ///   The sequence number of the event that was last enqueued into the Event Hub partition from which this
@@ -342,7 +354,7 @@ namespace Azure.Messaging.EventHubs
                            long? pendingProducerGroupId = null,
                            short? pendingOwnerLevel = null)
         {
-            BodyAsBinaryData = eventBody;
+            EventBody = eventBody;
             Properties = properties ?? new Dictionary<string, object>();
             SystemProperties = systemProperties ?? new Dictionary<string, object>();
             SequenceNumber = sequenceNumber;
@@ -371,13 +383,36 @@ namespace Azure.Messaging.EventHubs
         /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
         /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
         ///
-        protected EventData(ReadOnlyMemory<byte> eventBody,
+        protected EventData(BinaryData eventBody,
                             IDictionary<string, object> properties = null,
                             IReadOnlyDictionary<string, object> systemProperties = null,
                             long sequenceNumber = long.MinValue,
                             long offset = long.MinValue,
                             DateTimeOffset enqueuedTime = default,
                             string partitionKey = null) : this(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The raw data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected EventData(ReadOnlyMemory<byte> eventBody,
+                            IDictionary<string, object> properties = null,
+                            IReadOnlyDictionary<string, object> systemProperties = null,
+                            long sequenceNumber = long.MinValue,
+                            long offset = long.MinValue,
+                            DateTimeOffset enqueuedTime = default,
+                            string partitionKey = null) : this(new BinaryData(eventBody), properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
         {
         }
 
@@ -440,7 +475,7 @@ namespace Azure.Messaging.EventHubs
         internal EventData Clone() =>
             new EventData
             (
-                BodyAsBinaryData,
+                EventBody,
                 new Dictionary<string, object>(Properties),
                 SystemProperties,
                 SequenceNumber,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.EventHubs.Processor
         /// </summary>
         ///
         /// <remarks>
-        ///   Ownership of this data, including the memory that holds its <see cref="EventData.Body" />,
+        ///   Ownership of this data, including the memory that holds its <see cref="EventData.EventBody" />,
         ///   is assumed to transfer to consumers of the <see cref="ProcessEventArgs" />.  It may be considered
         ///   immutable and is safe to access so long as the reference is held.
         /// </remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -126,7 +126,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var messageData = message.DataBody.ToList();
             Assert.That(messageData.Count, Is.EqualTo(1), "The AMQP message should a single data body.");
-            Assert.That(messageData[0].Value, Is.EqualTo(eventData.Body.ToArray()), "The AMQP message data should match the event body.");
+            Assert.That(messageData[0].Value, Is.EqualTo(eventData.EventBody.ToBytes().ToArray()), "The AMQP message data should match the event body.");
         }
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var messageData = message.DataBody.ToList();
             Assert.That(messageData.Count, Is.EqualTo(1), "The batch envelope should a single data body.");
-            Assert.That(messageData[0].Value, Is.EqualTo(eventData.Body.ToArray()), "The batch envelope data should match the event body.");
+            Assert.That(messageData[0].Value, Is.EqualTo(eventData.EventBody.ToBytes().ToArray()), "The batch envelope data should match the event body.");
 
             Assert.That(message.ApplicationProperties.Map.TryGetValue(nameof(property), out object propertyValue), Is.True, "The application property should exist in the batch.");
             Assert.That(propertyValue, Is.EqualTo(property), "The application property value should match.");
@@ -676,7 +676,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var messageData = batchEnvelope.DataBody.ToList();
             Assert.That(messageData.Count, Is.EqualTo(1), "The batch envelope should a single data body.");
-            Assert.That(messageData[0].Value, Is.EqualTo(eventData.Body.ToArray()), "The batch envelope data should match the event body.");
+            Assert.That(messageData[0].Value, Is.EqualTo(eventData.EventBody.ToBytes().ToArray()), "The batch envelope data should match the event body.");
 
             Assert.That(batchEnvelope.ApplicationProperties.Map.TryGetValue(nameof(property), out object propertyValue), Is.True, "The application property should exist in the batch.");
             Assert.That(propertyValue, Is.EqualTo(property), "The application property value should match.");
@@ -806,8 +806,8 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
-            Assert.That(eventData.Body.ToArray(), Is.EqualTo(body), "The body contents should match.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody.ToBytes().ToArray(), Is.EqualTo(body), "The body contents should match.");
         }
 
         /// <summary>
@@ -852,7 +852,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Any(), Is.True, "The event should have a set of application properties.");
 
             // The collection comparisons built into the test assertions do not recognize
@@ -889,7 +889,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Any(), Is.True, "The event should have a set of application properties.");
 
             var containsValue = eventData.Properties.TryGetValue(typeDescriptor.ToString(), out object value);
@@ -916,7 +916,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Any(), Is.True, "The event should have a set of application properties.");
 
             var containsValue = eventData.Properties.TryGetValue(propertyKey, out var eventValue);
@@ -943,7 +943,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Any(), Is.True, "The event should have a set of application properties.");
 
             var containsValue = eventData.Properties.TryGetValue(propertyKey, out var eventValue);
@@ -970,7 +970,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Any(), Is.True, "The event should have a set of application properties.");
 
             var containsValue = eventData.Properties.TryGetValue(propertyKey, out var eventValue);
@@ -997,7 +997,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Any(), Is.False, "The event should not have a set of application properties.");
 
             var containsValue = eventData.Properties.TryGetValue(typeDescriptor.ToString(), out var _);
@@ -1032,7 +1032,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Count, Is.EqualTo(message.ApplicationProperties.Map.Count()), "The event should have a set of properties.");
             Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should match.");
             Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should match.");
@@ -1071,7 +1071,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Count, Is.EqualTo(message.ApplicationProperties.Map.Count()), "The event should have a set of properties.");
             Assert.That(eventData.SystemProperties.ContainsKey(nameof(firstMessageAnnotation)), Is.True, "The first annotation should be in the system properties.");
             Assert.That(eventData.SystemProperties.ContainsKey(nameof(secondMessageAnnotation)), Is.True, "The second annotation should be in the system properties.");
@@ -1118,7 +1118,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData eventData = converter.CreateEventFromMessage(message);
 
             Assert.That(eventData, Is.Not.Null, "The event should have been created.");
-            Assert.That(eventData.Body, Is.Not.Null, "The event should have a body.");
+            Assert.That(eventData.EventBody, Is.Not.Null, "The event should have a body.");
             Assert.That(eventData.Properties.Count, Is.EqualTo(message.ApplicationProperties.Map.Count()), "The event should have a set of properties.");
             Assert.That(eventData.Offset, Is.EqualTo(offset), "The offset should match.");
             Assert.That(eventData.SequenceNumber, Is.EqualTo(sequenceNumber), "The sequence number should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -1630,7 +1630,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     if (partitionEvent.Partition.PartitionId == partitions[0])
                     {
-                        receivedEvents.Add(Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray()));
+                        receivedEvents.Add(Encoding.UTF8.GetString(partitionEvent.Data.EventBody.ToBytes().ToArray()));
                     }
 
                     ++actualCount;
@@ -1646,7 +1646,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actualCount, Is.EqualTo(expectedEventCount), "The received event count should match the published events.");
 
             var expectedEvents = events
-              .Select(item => Encoding.UTF8.GetString(item.Body.ToArray()))
+              .Select(item => Encoding.UTF8.GetString(item.EventBody.ToBytes().ToArray()))
               .OrderBy(item => item);
 
             Assert.That(receivedEvents.OrderBy(item => item), Is.EquivalentTo(expectedEvents), "The received events should match the published events.");
@@ -1687,7 +1687,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         if (partitionEvent.Partition.PartitionId == partitions[0])
                         {
-                            firstSubscriberEvents.Add(Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray()));
+                            firstSubscriberEvents.Add(Encoding.UTF8.GetString(partitionEvent.Data.EventBody.ToBytes().ToArray()));
                         }
 
                         ++firstSubscriberCount;
@@ -1711,7 +1711,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         if (partitionEvent.Partition.PartitionId == partitions[0])
                         {
-                            secondSubscriberEvents.Add(Encoding.UTF8.GetString(partitionEvent.Data.Body.ToArray()));
+                            secondSubscriberEvents.Add(Encoding.UTF8.GetString(partitionEvent.Data.EventBody.ToBytes().ToArray()));
                         }
 
                         ++secondSubcriberCount;
@@ -1741,7 +1741,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ToList();
 
             var expectedEvents = events
-              .Select(item => Encoding.UTF8.GetString(item.Body.ToArray()))
+              .Select(item => Encoding.UTF8.GetString(item.EventBody.ToBytes().ToArray()))
               .OrderBy(item => item)
               .ToList();
 
@@ -1799,12 +1799,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var receivedEventMessages = new HashSet<string>();
 
-            foreach (var message in receivedEvents.Where(item => item != null).Select(item => Encoding.UTF8.GetString(item.Body.ToArray())))
+            foreach (var message in receivedEvents.Where(item => item != null).Select(item => Encoding.UTF8.GetString(item.EventBody.ToBytes().ToArray())))
             {
                 receivedEventMessages.Add(message);
             }
 
-            foreach (var sourceMessage in events.Select(item => Encoding.UTF8.GetString(item.Body.ToArray())))
+            foreach (var sourceMessage in events.Select(item => Encoding.UTF8.GetString(item.EventBody.ToBytes().ToArray())))
             {
                 Assert.That(receivedEventMessages.Contains(sourceMessage), $"The message: { sourceMessage } was not received.");
             }
@@ -2153,7 +2153,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < events.Count; ++index)
             {
-                Assert.That(events[index].Body.ToArray().Single(), Is.EqualTo(publishedEvents[index].Body.ToArray().Single()), $"The payload for index: { index } should match the event source.");
+                Assert.That(events[index].EventBody.ToBytes().ToArray().Single(), Is.EqualTo(publishedEvents[index].EventBody.ToBytes().ToArray().Single()), $"The payload for index: { index } should match the event source.");
             }
         }
 
@@ -2233,7 +2233,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < forceErrorAt; ++index)
             {
-                Assert.That(events[index].Body.ToArray().Single(), Is.EqualTo(publishedEvents[index].Body.ToArray().Single()), $"The payload for index: { index } should match the event source.");
+                Assert.That(events[index].EventBody.ToBytes().ToArray().Single(), Is.EqualTo(publishedEvents[index].EventBody.ToBytes().ToArray().Single()), $"The payload for index: { index } should match the event source.");
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var streamData = bodyStream.ToArray();
             Assert.That(streamData, Is.Not.Null, "There should have been data in the stream.");
-            Assert.That(streamData, Is.EqualTo(eventData.Body.ToArray()), "The body data and the data read from the stream should agree.");
+            Assert.That(streamData, Is.EqualTo(eventData.EventBody.ToBytes().ToArray()), "The body data and the data read from the stream should agree.");
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to refactor the `EventData` class to promote the `BinaryData` representation of the payload as the primary interaction point, and deprecate the former `Body` and `BodyAsStream` members in favor.

**Note:** These changes have been reviewed and approved by the language architect. Marking with the corresponding tag for tracking purposes.

# Last Upstream Rebase

Monday, October 5, 2:28pm (EST)