### PR TITLE
Fixes integration tests hanging on CreateIfNotExistsAsync and DeleteIfExistsAsync

### DIFF
--- a/sdk/batch/Microsoft.Azure.Batch/src/Common/RetryPolicyCommon.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/src/Common/RetryPolicyCommon.cs
@@ -14,12 +14,11 @@
 
             if (currentRetryCount < maxRetries)
             {
-                BatchException batchException = exception as BatchException;
-                if (batchException != null)
+                if (exception is BatchException batchException)
                 {
                     int statusCode = (int)batchException.RequestInformation.HttpStatusCode;
 
-                    if ((statusCode >= 400 && statusCode < 500 
+                    if ((statusCode >= 400 && statusCode < 500
                         && statusCode != 408 // Timeout
                         && statusCode != 429 // Too many reqeuests
                         )

--- a/sdk/batch/Microsoft.Azure.Batch/src/JobOperations.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/src/JobOperations.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Batch
 
         internal JobOperations(BatchClient parentBatchClient, IEnumerable<BatchClientBehavior> inheritedBehaviors)
         {
-            this.ParentBatchClient = parentBatchClient;
+            ParentBatchClient = parentBatchClient;
 
             // set up the behavior inheritance
             InheritUtil.InheritClientBehaviorsAndSetPublicProperty(this, inheritedBehaviors);
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Batch
                 () =>
                 {
                     // here is the actual strongly typed enumerator
-                    AsyncListJobsEnumerator typedEnumerator = new AsyncListJobsEnumerator(this.ParentBatchClient, bhMgr, detailLevel);
+                    AsyncListJobsEnumerator typedEnumerator = new AsyncListJobsEnumerator(ParentBatchClient, bhMgr, detailLevel);
 
                     // here is the base
                     PagedEnumeratorBase<CloudJob> enumeratorBase = typedEnumerator;
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Batch
         public IPagedEnumerable<CloudJob> ListJobs(DetailLevel detailLevel = null, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
             
             IPagedEnumerable<CloudJob> enumerable = ListJobsImpl(bhMgr, detailLevel);
 
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Batch
 
         internal async Task<CloudJob> GetJobAsyncImpl(string jobId, BehaviorManager bhMgr, CancellationToken cancellationToken)
         {
-            Task<AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>> asyncTask = this.ParentBatchClient.ProtocolLayer.GetJob(jobId, bhMgr, cancellationToken);
+            Task<AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>> asyncTask = ParentBatchClient.ProtocolLayer.GetJob(jobId, bhMgr, cancellationToken);
 
             AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders> response = await asyncTask.ConfigureAwait(continueOnCapturedContext: false);
 
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Batch
             Models.CloudJob protoJob = response.Body;
 
             // convert to bound object layer equiv
-            CloudJob openedJob = new CloudJob(this.ParentBatchClient, protoJob, bhMgr.BaseBehaviors);
+            CloudJob openedJob = new CloudJob(ParentBatchClient, protoJob, bhMgr.BaseBehaviors);
 
             return openedJob;
         }
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Batch
             CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors, detailLevel);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors, detailLevel);
 
             Task<CloudJob> asyncTask = GetJobAsyncImpl(jobId, bhMgr, cancellationToken);
 
@@ -177,14 +177,14 @@ namespace Microsoft.Azure.Batch
         public CloudJob GetJob(string jobId, DetailLevel detailLevel = null, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task<CloudJob> asyncTask = GetJobAsync(jobId, detailLevel, additionalBehaviors);
-            CloudJob newJob = asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            CloudJob newJob = asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
 
             return newJob;
         }
 
         internal async Task<TaskCountsResult> GetJobTaskCountsAsyncImpl(string jobId, BehaviorManager bhMgr, CancellationToken cancellationToken)
         {
-            AzureOperationResponse<Models.TaskCountsResult, Models.JobGetTaskCountsHeaders> response = await this.ParentBatchClient.ProtocolLayer.GetJobTaskCounts(
+            AzureOperationResponse<Models.TaskCountsResult, Models.JobGetTaskCountsHeaders> response = await ParentBatchClient.ProtocolLayer.GetJobTaskCounts(
                 jobId,
                 bhMgr,
                 cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Batch
             CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors, detailLevel: null);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors, detailLevel: null);
             TaskCountsResult counts = await GetJobTaskCountsAsyncImpl(jobId, bhMgr, cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
 
             return counts;
@@ -238,9 +238,9 @@ namespace Microsoft.Azure.Batch
         public async Task EnableJobAsync(string jobId, IEnumerable<BatchClientBehavior> additionalBehaviors = null, CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.EnableJob(jobId, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.EnableJob(jobId, bhMgr, cancellationToken);
 
             await asyncTask.ConfigureAwait(continueOnCapturedContext: false);
         }
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Batch
         public void EnableJob(string jobId, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task asyncTask = EnableJobAsync(jobId, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         /// <summary>
@@ -273,9 +273,9 @@ namespace Microsoft.Azure.Batch
             CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.DisableJob(jobId, disableJobOption, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.DisableJob(jobId, disableJobOption, bhMgr, cancellationToken);
 
             await asyncTask.ConfigureAwait(continueOnCapturedContext: false);
         }
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Batch
         public void DisableJob(string jobId, Common.DisableJobOption disableJobOption, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task asyncTask = DisableJobAsync(jobId, disableJobOption, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Batch
             // set up behavior manager
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.TerminateJob(jobId, terminateReason, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.TerminateJob(jobId, terminateReason, bhMgr, cancellationToken);
 
             await asyncTask.ConfigureAwait(continueOnCapturedContext: false);
         }
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Batch
         public void TerminateJob(string jobId, string terminateReason = null, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task asyncTask = TerminateJobAsync(jobId, terminateReason, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         /// <summary>
@@ -344,9 +344,9 @@ namespace Microsoft.Azure.Batch
         public async Task DeleteJobAsync(string jobId, IEnumerable<BatchClientBehavior> additionalBehaviors = null, CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.DeleteJob(jobId, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.DeleteJob(jobId, bhMgr, cancellationToken);
 
             await asyncTask.ConfigureAwait(continueOnCapturedContext: false);
         }
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.Batch
         public void DeleteJob(string jobId, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task asyncTask = DeleteJobAsync(jobId, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         internal IPagedEnumerable<CloudTask> ListTasksImpl(string jobId, BehaviorManager bhMgr, DetailLevel detailLevel)
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.Batch
                                                         IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
             // get the enumerable
             IPagedEnumerable<CloudTask> enumerable = ListTasksImpl(jobId, bhMgr, detailLevel);
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Batch
                                                                     CancellationToken cancellationToken)
         {
             Task<AzureOperationResponse<Models.CloudTask, Models.TaskGetHeaders>> asyncTask =
-                this.ParentBatchClient.ProtocolLayer.GetTask(
+                ParentBatchClient.ProtocolLayer.GetTask(
                     jobId,
                     taskId,
                     bhMgr,
@@ -427,7 +427,7 @@ namespace Microsoft.Azure.Batch
             Models.CloudTask protoTask = response.Body;
 
             // bind CloudTask to protocol task
-            CloudTask newTask = new CloudTask(this.ParentBatchClient, jobId, protoTask, bhMgr.BaseBehaviors);
+            CloudTask newTask = new CloudTask(ParentBatchClient, jobId, protoTask, bhMgr.BaseBehaviors);
 
             return newTask;
         }
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Batch
             CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors, detailLevel);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors, detailLevel);
 
             Task<CloudTask> asyncTask = GetTaskAsyncImpl(jobId, taskId, bhMgr, cancellationToken);
 
@@ -469,7 +469,7 @@ namespace Microsoft.Azure.Batch
         public CloudTask GetTask(string jobId, string taskId, DetailLevel detailLevel = null, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task<CloudTask> asyncTask = GetTaskAsync(jobId, taskId, detailLevel, additionalBehaviors);
-            CloudTask newTask = asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            CloudTask newTask = asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
 
             return newTask;
         }
@@ -490,7 +490,7 @@ namespace Microsoft.Azure.Batch
                                                         IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
             // get the enumerable
             IPagedEnumerable<SubtaskInformation> enumerable = ListSubtasksImpl(jobId, taskId, bhMgr, detailLevel);
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.Batch
             implTask.Freeze(); //Mark the underlying task readonly
 
             // start the AddTask request
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.AddTask(jobId, protoTask, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.AddTask(jobId, protoTask, bhMgr, cancellationToken);
 
             await asyncTask.ConfigureAwait(continueOnCapturedContext: false);
         }
@@ -590,9 +590,9 @@ namespace Microsoft.Azure.Batch
         {
             ConcurrentDictionary<Type, IFileStagingArtifact> artifacts = new ConcurrentDictionary<Type,IFileStagingArtifact>();
 
-            Task asyncTask = this.AddTaskAsync(jobId, taskToAdd, artifacts, additionalBehaviors);
+            Task asyncTask = AddTaskAsync(jobId, taskToAdd, artifacts, additionalBehaviors);
 
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
 
             return artifacts;
         }
@@ -659,10 +659,10 @@ namespace Microsoft.Azure.Batch
                                                         IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
             // get the enumerable
-            IPagedEnumerable<NodeFile> enumerable = this.ListNodeFilesImpl(jobId, taskId, recursive, bhMgr, detailLevel);
+            IPagedEnumerable<NodeFile> enumerable = ListNodeFilesImpl(jobId, taskId, recursive, bhMgr, detailLevel);
 
             return enumerable;
         }
@@ -685,7 +685,7 @@ namespace Microsoft.Azure.Batch
             // set up behavior manager
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.TerminateTask(jobId, taskId, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.TerminateTask(jobId, taskId, bhMgr, cancellationToken);
 
             return asyncTask;
         }
@@ -704,7 +704,7 @@ namespace Microsoft.Azure.Batch
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task asyncTask = TerminateTaskAsync(jobId, taskId, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
 
         }
 
@@ -726,7 +726,7 @@ namespace Microsoft.Azure.Batch
             // set up behavior manager
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.DeleteTask(jobId, taskId, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.DeleteTask(jobId, taskId, bhMgr, cancellationToken);
 
             return asyncTask;
         }
@@ -776,7 +776,7 @@ namespace Microsoft.Azure.Batch
             // set up behavior manager
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task asyncTask = this.ParentBatchClient.ProtocolLayer.ReactivateTask(jobId, taskId, bhMgr, cancellationToken);
+            Task asyncTask = ParentBatchClient.ProtocolLayer.ReactivateTask(jobId, taskId, bhMgr, cancellationToken);
             
             return asyncTask;
         }
@@ -805,7 +805,7 @@ namespace Microsoft.Azure.Batch
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             Task asyncTask = ReactivateTaskAsync(jobId, taskId, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         internal async Task<NodeFile> GetNodeFileAsyncImpl(
@@ -815,7 +815,7 @@ namespace Microsoft.Azure.Batch
             BehaviorManager bhMgr,
             CancellationToken cancellationToken)
         {
-            var getNodeFilePropertiesTask = await this.ParentBatchClient.ProtocolLayer.GetNodeFilePropertiesByTask(
+            var getNodeFilePropertiesTask = await ParentBatchClient.ProtocolLayer.GetNodeFilePropertiesByTask(
                 jobId, 
                 taskId, 
                 filePath, 
@@ -850,7 +850,7 @@ namespace Microsoft.Azure.Batch
             // set up behavior manager
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            Task<NodeFile> asyncTask = this.GetNodeFileAsyncImpl(jobId, taskId, filePath, bhMgr, cancellationToken);
+            Task<NodeFile> asyncTask = GetNodeFileAsyncImpl(jobId, taskId, filePath, bhMgr, cancellationToken);
 
             return asyncTask;
         }
@@ -870,8 +870,8 @@ namespace Microsoft.Azure.Batch
             string filePath,
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
-            Task<NodeFile> asyncTask = this.GetNodeFileAsync(jobId, taskId, filePath, additionalBehaviors);
-            NodeFile file = asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            Task<NodeFile> asyncTask = GetNodeFileAsync(jobId, taskId, filePath, additionalBehaviors);
+            NodeFile file = asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
             return file;
         }
 
@@ -884,7 +884,7 @@ namespace Microsoft.Azure.Batch
             BehaviorManager bhMgr,
             CancellationToken cancellationToken)
         {
-            await this.ParentBatchClient.ProtocolLayer.GetNodeFileByTask(
+            await ParentBatchClient.ProtocolLayer.GetNodeFileByTask(
                 jobId,
                 taskId,
                 filePath,
@@ -916,7 +916,7 @@ namespace Microsoft.Azure.Batch
         {
             // set up behavior manager
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
-            return this.CopyNodeFileContentToStreamAsyncImpl(jobId, taskId, filePath, stream, byteRange, bhMgr, cancellationToken);
+            return CopyNodeFileContentToStreamAsyncImpl(jobId, taskId, filePath, stream, byteRange, bhMgr, cancellationToken);
         }
 
         /// <summary>
@@ -937,8 +937,8 @@ namespace Microsoft.Azure.Batch
             GetFileRequestByteRange byteRange = null,
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
-            Task asyncTask = this.CopyNodeFileContentToStreamAsync(jobId, taskId, filePath, stream, byteRange, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            Task asyncTask = CopyNodeFileContentToStreamAsync(jobId, taskId, filePath, stream, byteRange, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         internal Task<string> CopyNodeFileContentToStringAsyncImpl(
@@ -952,7 +952,7 @@ namespace Microsoft.Azure.Batch
         {
             return UtilitiesInternal.ReadNodeFileAsStringAsync(
                 // Note that behaviors is purposefully dropped in the below call since it's already managed by the bhMgr
-                (stream, bRange, behaviors, ct) => this.CopyNodeFileContentToStreamAsyncImpl(jobId, taskId, filePath, stream, bRange, bhMgr, ct),
+                (stream, bRange, behaviors, ct) => CopyNodeFileContentToStreamAsyncImpl(jobId, taskId, filePath, stream, bRange, bhMgr, ct),
                 encoding,
                 byteRange,
                 additionalBehaviors: null,
@@ -980,7 +980,7 @@ namespace Microsoft.Azure.Batch
             CancellationToken cancellationToken = default)
         {
             // set up behavior manager
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
             return CopyNodeFileContentToStringAsyncImpl(jobId, taskId, filePath, encoding, byteRange, bhMgr, cancellationToken);
         }
 
@@ -1002,8 +1002,8 @@ namespace Microsoft.Azure.Batch
             GetFileRequestByteRange byteRange = null,
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
-            Task<string> asyncTask = this.CopyNodeFileContentToStringAsync(jobId, taskId, filePath, encoding, byteRange, additionalBehaviors);
-            return asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            Task<string> asyncTask = CopyNodeFileContentToStringAsync(jobId, taskId, filePath, encoding, byteRange, additionalBehaviors);
+            return asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         /// <summary>
@@ -1032,7 +1032,7 @@ namespace Microsoft.Azure.Batch
             // craft the behavior manager for this call
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            var asyncTask = this.ParentBatchClient.ProtocolLayer.DeleteNodeFileByTask(
+            var asyncTask = ParentBatchClient.ProtocolLayer.DeleteNodeFileByTask(
                 jobId,
                 taskId, 
                 filePath, 
@@ -1064,8 +1064,8 @@ namespace Microsoft.Azure.Batch
             bool? recursive = null,
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
-            Task asyncTask = this.DeleteNodeFileAsync(jobId, taskId, filePath, recursive, additionalBehaviors);
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            Task asyncTask = DeleteNodeFileAsync(jobId, taskId, filePath, recursive, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         internal Task AddTaskAsyncImpl(
@@ -1129,9 +1129,9 @@ namespace Microsoft.Azure.Batch
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             // craft the behavior manager for this call
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
-            await this.AddTaskAsyncImpl(
+            await AddTaskAsyncImpl(
                 jobId,
                 tasksToAdd,
                 parallelOptions,
@@ -1181,7 +1181,7 @@ namespace Microsoft.Azure.Batch
             TimeSpan? timeout = null,
             IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
-            Task asyncTask = this.AddTaskAsync(
+            Task asyncTask = AddTaskAsync(
                 jobId,
                 tasksToAdd,
                 parallelOptions,
@@ -1189,7 +1189,7 @@ namespace Microsoft.Azure.Batch
                 timeout,
                 additionalBehaviors);
 
-            asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
         }
 
         /// <summary>
@@ -1209,7 +1209,7 @@ namespace Microsoft.Azure.Batch
             BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
             Task<AzureOperationResponse<Models.JobStatistics, Models.JobGetAllLifetimeStatisticsHeaders>> asyncTask = 
-                this.ParentBatchClient.ProtocolLayer.GetAllJobLifetimeStats(
+                ParentBatchClient.ProtocolLayer.GetAllJobLifetimeStats(
                     bhMgr,
                     cancellationToken);
 
@@ -1230,8 +1230,8 @@ namespace Microsoft.Azure.Batch
         /// <remarks>This is a blocking operation; for a non-blocking equivalent, see <see cref="GetAllLifetimeStatisticsAsync(IEnumerable{BatchClientBehavior}, CancellationToken)"/>.</remarks>
         public JobStatistics GetAllLifetimeStatistics(IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
-            Task<JobStatistics> asyncTask = this.GetAllLifetimeStatisticsAsync(additionalBehaviors);
-            JobStatistics statistics = asyncTask.WaitAndUnaggregateException(this.CustomBehaviors, additionalBehaviors);
+            Task<JobStatistics> asyncTask = GetAllLifetimeStatisticsAsync(additionalBehaviors);
+            JobStatistics statistics = asyncTask.WaitAndUnaggregateException(CustomBehaviors, additionalBehaviors);
 
             return statistics;
         }
@@ -1248,7 +1248,7 @@ namespace Microsoft.Azure.Batch
         public IPagedEnumerable<JobPreparationAndReleaseTaskExecutionInformation> ListJobPreparationAndReleaseTaskStatus(string jobId, DetailLevel detailLevel = null, IEnumerable<BatchClientBehavior> additionalBehaviors = null)
         {
             // craft the behavior manager for this call
-            BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
+            BehaviorManager bhMgr = new BehaviorManager(CustomBehaviors, additionalBehaviors);
 
             PagedEnumerable<JobPreparationAndReleaseTaskExecutionInformation> enumerable = new PagedEnumerable<JobPreparationAndReleaseTaskExecutionInformation>( // the lamda will be the enumerator factory
                 () =>

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTestCommon/Helpers/CertificateCredentialsNetCore.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTestCommon/Helpers/CertificateCredentialsNetCore.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Batch.IntegrationTestCommon.Tests.Helpers
     /// </summary>
     class CertificateCredentialsNetCore : ServiceClientCredentials
     {
-        private X509Certificate2 cert;
+        private readonly X509Certificate2 cert;
         public CertificateCredentialsNetCore(X509Certificate2 cert)
         {
             this.cert = cert;
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Batch.IntegrationTestCommon.Tests.Helpers
         public override void InitializeServiceClient<T>(ServiceClient<T> client)
         {
             HttpClientHandler handler = client.HttpMessageHandlers.FirstOrDefault(h => h is HttpClientHandler) as HttpClientHandler;
-            handler.ClientCertificates.Add(this.cert);
+            handler.ClientCertificates.Add(cert);
         }
     }
 #endif

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
@@ -21,6 +21,7 @@
     using Xunit;
     using Xunit.Abstractions;
     using Xunit.Sdk;
+    using Microsoft.Azure.Batch.Protocol.BatchRequests;
 
     public class AddTaskCollectionIntegrationTests
     {
@@ -237,7 +238,7 @@
 
             BatchClientBehavior customBehavior = new Protocol.RequestInterceptor(request =>
             {
-                var typedRequest = request as Protocol.BatchRequests.TaskAddCollectionBatchRequest;
+                TaskAddCollectionBatchRequest typedRequest = request as TaskAddCollectionBatchRequest;
 
                 if (typedRequest != null)
                 {
@@ -303,7 +304,7 @@
                                     CancellationToken = source.Token
                                 };
 
-                            System.Threading.Tasks.Task t = this.AddTasksSimpleTestAsync(
+                            Task t = this.AddTasksSimpleTestAsync(
                                 batchCli,
                                 testName,
                                 taskCount,
@@ -517,7 +518,7 @@
             int degreesOfParallelism = 2;
             BatchClientBehavior customBehavior = new Protocol.RequestInterceptor(request =>
             {
-                var typedRequest = request as Protocol.BatchRequests.TaskAddCollectionBatchRequest;
+                var typedRequest = request as TaskAddCollectionBatchRequest;
                 if (typedRequest != null)
                 {
                     if(typedRequest.Parameters.Count > 50)
@@ -595,7 +596,7 @@
         /// Performs a simple AddTask test, adding the specified task count using the specified parallelOptions and resultHandlerFunc
         /// </summary>
         /// <returns></returns>
-        private async System.Threading.Tasks.Task AddTasksSimpleTestAsync(
+        private async Task AddTasksSimpleTestAsync(
             BatchClient batchCli,
             string testName,
             int taskCount,

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
@@ -44,10 +44,8 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
                 {
-                    using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
-                    {
-                        await AddTasksSimpleTestAsync(batchCli, testName, 50, useJobOperations: useJobOperations).ConfigureAwait(false);
-                    }
+                    using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                    await AddTasksSimpleTestAsync(batchCli, testName, 50, useJobOperations: useJobOperations).ConfigureAwait(false);
                 },
                 TestTimeout);
         }
@@ -61,10 +59,8 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
                 {
-                    using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
-                    {
-                        await AddTasksSimpleTestAsync(batchCli, testName, 550, useJobOperations: useJobOperations).ConfigureAwait(false);
-                    }
+                    using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                    await AddTasksSimpleTestAsync(batchCli, testName, 550, useJobOperations: useJobOperations).ConfigureAwait(false);
                 },
                 TestTimeout);
         }
@@ -78,15 +74,13 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                 {
-                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                                                                 {
-                                                                     MaxDegreeOfParallelism = 25
-                                                                 };
+                    MaxDegreeOfParallelism = 25
+                };
 
-                    await AddTasksSimpleTestAsync(batchCli, testName, 5025, parallelOptions).ConfigureAwait(false);
-                }
+                await AddTasksSimpleTestAsync(batchCli, testName, 5025, parallelOptions).ConfigureAwait(false);
             },
             LongTestTimeout);
         }
@@ -131,23 +125,21 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                 {
-                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                    {
-                        MaxDegreeOfParallelism = 2
-                    };
+                    MaxDegreeOfParallelism = 2
+                };
 
-                    var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
-                        async () => await AddTasksSimpleTestAsync(
-                            batchCli,
-                            testName,
-                            taskCount,
-                            parallelOptions,
-                            resultHandlerFunc,
-                            useJobOperations: useJobOperations).ConfigureAwait(false)).ConfigureAwait(false);
-                    Assert.IsType<HttpRequestException>(exception.InnerException);
-                }
+                var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
+                    async () => await AddTasksSimpleTestAsync(
+                        batchCli,
+                        testName,
+                        taskCount,
+                        parallelOptions,
+                        resultHandlerFunc,
+                        useJobOperations: useJobOperations).ConfigureAwait(false)).ConfigureAwait(false);
+                Assert.IsType<HttpRequestException>(exception.InnerException);
             },
             TestTimeout);
         }
@@ -199,23 +191,21 @@
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
                 StagingStorageAccount storageCredentials = TestUtilities.GetStorageCredentialsFromEnvironment();
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                 {
-                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                    {
-                        MaxDegreeOfParallelism = 2
-                    };
+                    MaxDegreeOfParallelism = 2
+                };
 
-                    await AddTasksSimpleTestAsync(
-                        batchCli,
-                        testName,
-                        1281,
-                        parallelOptions,
-                        resultHandlerFunc,
-                        storageCredentials,
-                        new List<string> { "TestResources\\Data.txt" },
-                        useJobOperations: useJobOperations).ConfigureAwait(false);
-                }
+                await AddTasksSimpleTestAsync(
+                    batchCli,
+                    testName,
+                    1281,
+                    parallelOptions,
+                    resultHandlerFunc,
+                    storageCredentials,
+                    new List<string> { "TestResources\\Data.txt" },
+                    useJobOperations: useJobOperations).ConfigureAwait(false);
             },
             LongTestTimeout);
 
@@ -262,21 +252,19 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
+                batchCli.JobOperations.CustomBehaviors.Add(customBehavior);
+
+                BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                 {
-                    batchCli.JobOperations.CustomBehaviors.Add(customBehavior);
+                    MaxDegreeOfParallelism = 2
+                };
 
-                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                    {
-                        MaxDegreeOfParallelism = 2
-                    };
+                var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(async () =>
+                    await AddTasksSimpleTestAsync(batchCli, testName, 397, parallelOptions, useJobOperations: useJobOperations).ConfigureAwait(false)
+                    ).ConfigureAwait(false);
 
-                    var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(async () => 
-                        await AddTasksSimpleTestAsync(batchCli, testName, 397, parallelOptions, useJobOperations: useJobOperations).ConfigureAwait(false)
-                        ).ConfigureAwait(false);
-
-                    Assert.IsType<HttpRequestException>(exception.InnerException);
-                }
+                Assert.IsType<HttpRequestException>(exception.InnerException);
             },
             TestTimeout);
         }
@@ -292,40 +280,35 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
                 {
-                    using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                    using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                    using CancellationTokenSource source = new CancellationTokenSource();
+                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                     {
-                        using (CancellationTokenSource source = new CancellationTokenSource())
+                        MaxDegreeOfParallelism = 2,
+                        CancellationToken = source.Token
+                    };
+
+                    Task t = AddTasksSimpleTestAsync(
+                        batchCli,
+                        testName,
+                        taskCount,
+                        parallelOptions,
+                        useJobOperations: useJobOperations);
+                    Thread.Sleep(TimeSpan.FromSeconds(.3)); //Wait till we get into the workflow
+                    testOutputHelper.WriteLine("Canceling the work flow");
+
+                    source.Cancel();
+
+                    try
+                    {
+                        await t.ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        //This is expected to throw one of two possible exception types...
+                        if (!(e is TaskCanceledException) && !(e is OperationCanceledException))
                         {
-                            BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                                {
-                                    MaxDegreeOfParallelism = 2,
-                                    CancellationToken = source.Token
-                                };
-
-                            Task t = AddTasksSimpleTestAsync(
-                                batchCli,
-                                testName,
-                                taskCount,
-                                parallelOptions,
-                                useJobOperations: useJobOperations);
-                            Thread.Sleep(TimeSpan.FromSeconds(.3)); //Wait till we get into the workflow
-                            testOutputHelper.WriteLine("Canceling the work flow");
-
-                            source.Cancel();
-
-                            try
-                            {
-                                await t.ConfigureAwait(false);
-                            }
-                            catch (Exception e)
-                            {
-                                //This is expected to throw one of two possible exception types...
-                                if (!(e is TaskCanceledException) && !(e is OperationCanceledException))
-                                {
-                                    throw new ThrowsException(typeof (TaskCanceledException), e);
-                                }
-                            }
-
+                            throw new ThrowsException(typeof(TaskCanceledException), e);
                         }
                     }
                 },
@@ -344,53 +327,49 @@
             ConcurrentBag<ConcurrentDictionary<Type, IFileStagingArtifact>> artifacts = new ConcurrentBag<ConcurrentDictionary<Type, IFileStagingArtifact>>();
 
             List<int> legArtifactsCountList = new List<int>();
-            using(CancellationTokenSource cts = new CancellationTokenSource())
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            //Spawn a thread to monitor the files to stage as we go - we should observe that
+            Task t = Task.Factory.StartNew(() =>
             {
-                //Spawn a thread to monitor the files to stage as we go - we should observe that
-                Task t = Task.Factory.StartNew(() =>
+                while (!cts.Token.IsCancellationRequested)
                 {
-                    while (!cts.Token.IsCancellationRequested)
-                    {
-                        legArtifactsCountList.Add(artifacts.Count);
-                        Thread.Sleep(TimeSpan.FromSeconds(1));
-                    }
-                });
+                    legArtifactsCountList.Add(artifacts.Count);
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                }
+            });
 
-                await SynchronizationContextHelper.RunTestAsync(async () =>
+            await SynchronizationContextHelper.RunTestAsync(async () =>
+            {
+                StagingStorageAccount storageCredentials = TestUtilities.GetStorageCredentialsFromEnvironment();
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                await AddTasksSimpleTestAsync(
+                        batchCli,
+                        testName,
+                        taskCount,
+                        parallelOptions: new BatchClientParallelOptions() { MaxDegreeOfParallelism = 2 },
+                        storageCredentials: storageCredentials,
+                        localFilesToStage: localFilesToStage,
+                        fileStagingArtifacts: artifacts,
+                        useJobOperations: useJobOperations).ConfigureAwait(false);
+
+                cts.Cancel();
+
+                await t.ConfigureAwait(false); //Wait for the spawned thread to exit
+
+                    testOutputHelper.WriteLine("File staging leg count: [");
+                foreach (int fileStagingArtifactsCount in legArtifactsCountList)
                 {
-                    StagingStorageAccount storageCredentials = TestUtilities.GetStorageCredentialsFromEnvironment();
-                    using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
-                    {
-                        await AddTasksSimpleTestAsync(
-                            batchCli,
-                            testName,
-                            taskCount,
-                            parallelOptions: new BatchClientParallelOptions() { MaxDegreeOfParallelism = 2 },
-                            storageCredentials: storageCredentials,
-                            localFilesToStage: localFilesToStage,
-                            fileStagingArtifacts: artifacts,
-                            useJobOperations: useJobOperations).ConfigureAwait(false);
+                    testOutputHelper.WriteLine(fileStagingArtifactsCount + ", ");
+                }
+                testOutputHelper.WriteLine("]");
 
-                        cts.Cancel();
+                const int expectedFinalFileStagingArtifactsCount = taskCount / 100 + 1;
+                const int expectedInitialFileStagingArtifactsCount = 0;
 
-                        await t.ConfigureAwait(false); //Wait for the spawned thread to exit
-
-                        testOutputHelper.WriteLine("File staging leg count: [");
-                        foreach (int fileStagingArtifactsCount in legArtifactsCountList)
-                        {
-                            testOutputHelper.WriteLine(fileStagingArtifactsCount + ", ");
-                        }
-                        testOutputHelper.WriteLine("]");
-
-                        const int expectedFinalFileStagingArtifactsCount = taskCount / 100 + 1;
-                        const int expectedInitialFileStagingArtifactsCount = 0;
-
-                        Assert.Equal(expectedInitialFileStagingArtifactsCount, legArtifactsCountList.First());
-                        Assert.Equal(expectedFinalFileStagingArtifactsCount, legArtifactsCountList.Last());
-                    }
-                },
-                TestTimeout);
-            }
+                Assert.Equal(expectedInitialFileStagingArtifactsCount, legArtifactsCountList.First());
+                Assert.Equal(expectedFinalFileStagingArtifactsCount, legArtifactsCountList.Last());
+            },
+            TestTimeout);
         }
 
         [Fact]
@@ -429,20 +408,18 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                 {
-                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                    {
-                        MaxDegreeOfParallelism = 2
-                    };
+                    MaxDegreeOfParallelism = 2
+                };
 
-                    await AddTasksSimpleTestAsync(
-                        batchCli,
-                        testName,
-                        55,
-                        parallelOptions,
-                        resultHandlerFunc).ConfigureAwait(false);
-                }
+                await AddTasksSimpleTestAsync(
+                    batchCli,
+                    testName,
+                    55,
+                    parallelOptions,
+                    resultHandlerFunc).ConfigureAwait(false);
             },
             TestTimeout);
 
@@ -457,18 +434,16 @@
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
-                {
-                    var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
-                        async () => await AddTasksSimpleTestAsync(
-                            batchCli,
-                            testName,
-                            311,
-                            timeout: TimeSpan.FromSeconds(-1),
-                            useJobOperations: useJobOperations).ConfigureAwait(false)).ConfigureAwait(false);
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
+                    async () => await AddTasksSimpleTestAsync(
+                        batchCli,
+                        testName,
+                        311,
+                        timeout: TimeSpan.FromSeconds(-1),
+                        useJobOperations: useJobOperations).ConfigureAwait(false)).ConfigureAwait(false);
 
-                    Assert.IsType<TimeoutException>(exception.InnerException);
-                }
+                Assert.IsType<TimeoutException>(exception.InnerException);
             },
             TestTimeout);
         }
@@ -489,14 +464,12 @@
             }
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
-                {
-                    var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
-                        async () => await AddTasksSimpleTestAsync(batchCli, testName, 1, resourceFiles:resourceFiles).ConfigureAwait(false)).ConfigureAwait(false);
-                    var innerException = exception.InnerException;
-                    Assert.IsType<BatchException>(innerException);
-                    Assert.Equal(((BatchException) innerException).RequestInformation.BatchError.Code, BatchErrorCodeStrings.RequestBodyTooLarge);
-                }
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
+                    async () => await AddTasksSimpleTestAsync(batchCli, testName, 1, resourceFiles: resourceFiles).ConfigureAwait(false)).ConfigureAwait(false);
+                var innerException = exception.InnerException;
+                Assert.IsType<BatchException>(innerException);
+                Assert.Equal(((BatchException)innerException).RequestInformation.BatchError.Code, BatchErrorCodeStrings.RequestBodyTooLarge);
             },
             TestTimeout);
         }
@@ -531,15 +504,13 @@
             }
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
+                batchCli.JobOperations.CustomBehaviors.Add(customBehavior);
+                BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
                 {
-                    batchCli.JobOperations.CustomBehaviors.Add(customBehavior);
-                    BatchClientParallelOptions parallelOptions = new BatchClientParallelOptions()
-                    {
-                        MaxDegreeOfParallelism = degreesOfParallelism
-                    };
-                    await AddTasksSimpleTestAsync(batchCli, testName, numTasks, parallelOptions, resourceFiles: resourceFiles).ConfigureAwait(false);
-                }
+                    MaxDegreeOfParallelism = degreesOfParallelism
+                };
+                await AddTasksSimpleTestAsync(batchCli, testName, numTasks, parallelOptions, resourceFiles: resourceFiles).ConfigureAwait(false);
             },
             TestTimeout);
             Assert.True(countChunksOf100 <= Math.Min(Math.Ceiling(numTasks/100.0), degreesOfParallelism));

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
@@ -46,7 +46,7 @@
                 {
                     using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
                     {
-                        await this.AddTasksSimpleTestAsync(batchCli, testName, 50, useJobOperations: useJobOperations).ConfigureAwait(false);
+                        await AddTasksSimpleTestAsync(batchCli, testName, 50, useJobOperations: useJobOperations).ConfigureAwait(false);
                     }
                 },
                 TestTimeout);
@@ -63,7 +63,7 @@
                 {
                     using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
                     {
-                        await this.AddTasksSimpleTestAsync(batchCli, testName, 550, useJobOperations: useJobOperations).ConfigureAwait(false);
+                        await AddTasksSimpleTestAsync(batchCli, testName, 550, useJobOperations: useJobOperations).ConfigureAwait(false);
                     }
                 },
                 TestTimeout);
@@ -85,7 +85,7 @@
                                                                      MaxDegreeOfParallelism = 25
                                                                  };
 
-                    await this.AddTasksSimpleTestAsync(batchCli, testName, 5025, parallelOptions).ConfigureAwait(false);
+                    await AddTasksSimpleTestAsync(batchCli, testName, 5025, parallelOptions).ConfigureAwait(false);
                 }
             },
             LongTestTimeout);
@@ -103,7 +103,7 @@
             HashSet<string> taskIdsExpectedToFail = new HashSet<string>();
             Func<AddTaskResult, CancellationToken, AddTaskResultStatus> resultHandlerFunc = (result, token) =>
             {
-                this.testOutputHelper.WriteLine("Task: {0} got status code: {1}", result.TaskId, result.Status);
+                testOutputHelper.WriteLine("Task: {0} got status code: {1}", result.TaskId, result.Status);
                 ++count;
 
                 if (taskIdsExpectedToFail.Contains(result.TaskId))
@@ -116,7 +116,7 @@
                     {
                         taskIdsExpectedToFail.Add(result.TaskId);
 
-                        this.testOutputHelper.WriteLine("Forcing a failure");
+                        testOutputHelper.WriteLine("Forcing a failure");
 
                         //Throw an exception to cause a failure from the customers result handler -- this is a supported scenario which will
                         //terminate the add task operation
@@ -139,7 +139,7 @@
                     };
 
                     var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
-                        async () => await this.AddTasksSimpleTestAsync(
+                        async () => await AddTasksSimpleTestAsync(
                             batchCli,
                             testName,
                             taskCount,
@@ -167,7 +167,7 @@
 
             Func<AddTaskResult, CancellationToken, AddTaskResultStatus> resultHandlerFunc = (result, token) =>
             {
-                this.testOutputHelper.WriteLine("Task: {0} got status code: {1}", result.TaskId, result.Status);
+                testOutputHelper.WriteLine("Task: {0} got status code: {1}", result.TaskId, result.Status);
                 AddTaskResultStatus resultAction;
 
                 if (result.Status == AddTaskStatus.ClientError)
@@ -182,7 +182,7 @@
 
                     if (d > 0.8)
                     {
-                        this.testOutputHelper.WriteLine("Forcing retry for task: {0}", result.TaskId);
+                        testOutputHelper.WriteLine("Forcing retry for task: {0}", result.TaskId);
 
                         resultAction = AddTaskResultStatus.Retry;
                         ++numberOfTasksWhichWereForcedToRetry;
@@ -206,7 +206,7 @@
                         MaxDegreeOfParallelism = 2
                     };
 
-                    await this.AddTasksSimpleTestAsync(
+                    await AddTasksSimpleTestAsync(
                         batchCli,
                         testName,
                         1281,
@@ -220,7 +220,7 @@
             LongTestTimeout);
 
             //Ensure that we forced some tasks to retry
-            this.testOutputHelper.WriteLine("Forced a total of {0} tasks to retry", numberOfTasksWhichWereForcedToRetry);
+            testOutputHelper.WriteLine("Forced a total of {0} tasks to retry", numberOfTasksWhichWereForcedToRetry);
 
             Assert.True(numberOfTasksWhichWereForcedToRetry > 0);
             Assert.Equal(numberOfTasksWhichWereForcedToRetry, numberOfTasksWhichHitClientError);
@@ -238,9 +238,7 @@
 
             BatchClientBehavior customBehavior = new Protocol.RequestInterceptor(request =>
             {
-                TaskAddCollectionBatchRequest typedRequest = request as TaskAddCollectionBatchRequest;
-
-                if (typedRequest != null)
+                if (request is TaskAddCollectionBatchRequest typedRequest)
                 {
                     var originalServiceRequestFunction = typedRequest.ServiceRequestFunc;
 
@@ -274,7 +272,7 @@
                     };
 
                     var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(async () => 
-                        await this.AddTasksSimpleTestAsync(batchCli, testName, 397, parallelOptions, useJobOperations: useJobOperations).ConfigureAwait(false)
+                        await AddTasksSimpleTestAsync(batchCli, testName, 397, parallelOptions, useJobOperations: useJobOperations).ConfigureAwait(false)
                         ).ConfigureAwait(false);
 
                     Assert.IsType<HttpRequestException>(exception.InnerException);
@@ -304,14 +302,14 @@
                                     CancellationToken = source.Token
                                 };
 
-                            Task t = this.AddTasksSimpleTestAsync(
+                            Task t = AddTasksSimpleTestAsync(
                                 batchCli,
                                 testName,
                                 taskCount,
                                 parallelOptions,
                                 useJobOperations: useJobOperations);
                             Thread.Sleep(TimeSpan.FromSeconds(.3)); //Wait till we get into the workflow
-                            this.testOutputHelper.WriteLine("Canceling the work flow");
+                            testOutputHelper.WriteLine("Canceling the work flow");
 
                             source.Cancel();
 
@@ -341,9 +339,7 @@
         {
             const string testName = "Bug1360227_AddTasksBatchWithFilesToStage";
             const int taskCount = 499;
-            List<string> localFilesToStage = new List<string>();
-
-            localFilesToStage.Add("TestResources\\Data.txt");
+            List<string> localFilesToStage = new List<string> { "TestResources\\Data.txt" };
 
             ConcurrentBag<ConcurrentDictionary<Type, IFileStagingArtifact>> artifacts = new ConcurrentBag<ConcurrentDictionary<Type, IFileStagingArtifact>>();
 
@@ -365,7 +361,7 @@
                     StagingStorageAccount storageCredentials = TestUtilities.GetStorageCredentialsFromEnvironment();
                     using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
                     {
-                        await this.AddTasksSimpleTestAsync(
+                        await AddTasksSimpleTestAsync(
                             batchCli,
                             testName,
                             taskCount,
@@ -379,12 +375,12 @@
 
                         await t.ConfigureAwait(false); //Wait for the spawned thread to exit
 
-                        this.testOutputHelper.WriteLine("File staging leg count: [");
+                        testOutputHelper.WriteLine("File staging leg count: [");
                         foreach (int fileStagingArtifactsCount in legArtifactsCountList)
                         {
-                            this.testOutputHelper.WriteLine(fileStagingArtifactsCount + ", ");
+                            testOutputHelper.WriteLine(fileStagingArtifactsCount + ", ");
                         }
-                        this.testOutputHelper.WriteLine("]");
+                        testOutputHelper.WriteLine("]");
 
                         const int expectedFinalFileStagingArtifactsCount = taskCount / 100 + 1;
                         const int expectedInitialFileStagingArtifactsCount = 0;
@@ -440,7 +436,7 @@
                         MaxDegreeOfParallelism = 2
                     };
 
-                    await this.AddTasksSimpleTestAsync(
+                    await AddTasksSimpleTestAsync(
                         batchCli,
                         testName,
                         55,
@@ -464,7 +460,7 @@
                 using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
                 {
                     var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
-                        async () => await this.AddTasksSimpleTestAsync(
+                        async () => await AddTasksSimpleTestAsync(
                             batchCli,
                             testName,
                             311,
@@ -496,7 +492,7 @@
                 using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
                 {
                     var exception = await TestUtilities.AssertThrowsAsync<ParallelOperationsException>(
-                        async () => await this.AddTasksSimpleTestAsync(batchCli, testName, 1, resourceFiles:resourceFiles).ConfigureAwait(false)).ConfigureAwait(false);
+                        async () => await AddTasksSimpleTestAsync(batchCli, testName, 1, resourceFiles:resourceFiles).ConfigureAwait(false)).ConfigureAwait(false);
                     var innerException = exception.InnerException;
                     Assert.IsType<BatchException>(innerException);
                     Assert.Equal(((BatchException) innerException).RequestInformation.BatchError.Code, BatchErrorCodeStrings.RequestBodyTooLarge);
@@ -518,10 +514,9 @@
             int degreesOfParallelism = 2;
             BatchClientBehavior customBehavior = new Protocol.RequestInterceptor(request =>
             {
-                var typedRequest = request as TaskAddCollectionBatchRequest;
-                if (typedRequest != null)
+                if (request is TaskAddCollectionBatchRequest typedRequest)
                 {
-                    if(typedRequest.Parameters.Count > 50)
+                    if (typedRequest.Parameters.Count > 50)
                     {
                         Interlocked.Increment(ref countChunksOf100);
                     }
@@ -617,7 +612,7 @@
             {
                 CloudJob unboundJob = jobOperations.CreateJob();
 
-                this.testOutputHelper.WriteLine("Initial job commit for job: {0}", jobId);
+                testOutputHelper.WriteLine("Initial job commit for job: {0}", jobId);
                 unboundJob.PoolInformation = new PoolInformation()
                     {
                         PoolId = "DummyPool"
@@ -667,7 +662,7 @@
 
                 //Add the tasks
                 Stopwatch stopwatch = new Stopwatch();
-                this.testOutputHelper.WriteLine("Starting task add");
+                testOutputHelper.WriteLine("Starting task add");
                 stopwatch.Start();
 
                 if (useJobOperations)
@@ -691,7 +686,7 @@
                 }
 
                 stopwatch.Stop();
-                this.testOutputHelper.WriteLine("Task add finished, took: {0}", stopwatch.Elapsed);
+                testOutputHelper.WriteLine("Task add finished, took: {0}", stopwatch.Elapsed);
 
                 if (lastFilesToStageList != null)
                 {
@@ -704,7 +699,7 @@
             }
             catch (Exception e)
             {
-                this.testOutputHelper.WriteLine("Exception: {0}", e.ToString());
+                testOutputHelper.WriteLine("Exception: {0}", e.ToString());
                 throw;
             }
             finally

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationManagementIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationManagementIntegrationTests.cs
@@ -43,50 +43,46 @@
             Func<Task> test = async () =>
                 {
                     var poolId = "app-ref-test" + Guid.NewGuid();
-                    using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                    using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                    using var mgmtClient = IntegrationTestCommon.OpenBatchManagementClient();
+                    // Give the application a display name
+                    await mgmtClient.Application.UpdateAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId, new UpdateApplicationParameters
                     {
-                        using (var mgmtClient = IntegrationTestCommon.OpenBatchManagementClient())
-                        {
-                            // Give the application a display name
-                            await mgmtClient.Application.UpdateAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId, new UpdateApplicationParameters
-                            {
-                                AllowUpdates = true,
-                                DefaultVersion = ApplicationIntegrationCommon.Version,
-                                DisplayName = DisplayName
-                            }).ConfigureAwait(false);
+                        AllowUpdates = true,
+                        DefaultVersion = ApplicationIntegrationCommon.Version,
+                        DisplayName = DisplayName
+                    }).ConfigureAwait(false);
 
-                            List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
+                    List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
 
-                            ApplicationSummary applicationSummary = applicationSummaries.First();
-                            Assert.Equal(ApplicationIntegrationCommon.Version, applicationSummary.Versions.First());
-                            Assert.Equal(ApplicationId, applicationSummary.Id);
-                            Assert.Equal(DisplayName, applicationSummary.DisplayName);
+                    ApplicationSummary applicationSummary = applicationSummaries.First();
+                    Assert.Equal(ApplicationIntegrationCommon.Version, applicationSummary.Versions.First());
+                    Assert.Equal(ApplicationId, applicationSummary.Id);
+                    Assert.Equal(DisplayName, applicationSummary.DisplayName);
 
 
-                            ApplicationSummary getApplicationSummary = await client.ApplicationOperations.GetApplicationSummaryAsync(applicationSummary.Id).ConfigureAwait(false);
+                    ApplicationSummary getApplicationSummary = await client.ApplicationOperations.GetApplicationSummaryAsync(applicationSummary.Id).ConfigureAwait(false);
 
-                            Assert.Equal(getApplicationSummary.Id, applicationSummary.Id);
-                            Assert.Equal(getApplicationSummary.Versions.Count(), applicationSummary.Versions.Count());
-                            Assert.Equal(getApplicationSummary.DisplayName, applicationSummary.DisplayName);
+                    Assert.Equal(getApplicationSummary.Id, applicationSummary.Id);
+                    Assert.Equal(getApplicationSummary.Versions.Count(), applicationSummary.Versions.Count());
+                    Assert.Equal(getApplicationSummary.DisplayName, applicationSummary.DisplayName);
 
-                            var appPackage = await mgmtClient.ApplicationPackage.GetAsync(
-                                    TestCommon.Configuration.BatchAccountResourceGroup,
-                                    accountName,
-                                    ApplicationId,
-                                    ApplicationIntegrationCommon.Version).ConfigureAwait(false);
+                    var appPackage = await mgmtClient.ApplicationPackage.GetAsync(
+                            TestCommon.Configuration.BatchAccountResourceGroup,
+                            accountName,
+                            ApplicationId,
+                            ApplicationIntegrationCommon.Version).ConfigureAwait(false);
 
-                            Assert.Equal(PackageState.Active, appPackage.State);
-                            Assert.Equal(ApplicationIntegrationCommon.Version, appPackage.Version);
-                            Assert.Equal(ApplicationId, appPackage.Id);
+                    Assert.Equal(PackageState.Active, appPackage.State);
+                    Assert.Equal(ApplicationIntegrationCommon.Version, appPackage.Version);
+                    Assert.Equal(ApplicationId, appPackage.Id);
 
-                            var application = await mgmtClient.Application.GetAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId).ConfigureAwait(false);
+                    var application = await mgmtClient.Application.GetAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId).ConfigureAwait(false);
 
-                            Assert.Equal(ApplicationIntegrationCommon.Version, application.DefaultVersion);
-                            Assert.Equal(ApplicationId, application.Id);
+                    Assert.Equal(ApplicationIntegrationCommon.Version, application.DefaultVersion);
+                    Assert.Equal(ApplicationId, application.Id);
 
-                            await AssertPoolWasCreatedWithApplicationReferences(client, poolId, ApplicationId).ConfigureAwait(false);
-                        }
-                    }
+                    await AssertPoolWasCreatedWithApplicationReferences(client, poolId, ApplicationId).ConfigureAwait(false);
                 };
 
             await SynchronizationContextHelper.RunTestAsync(test, LongRunningTestTimeout);

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesIntegrationTests.cs
@@ -40,19 +40,17 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
-                {
-                    List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
-                    var application = applicationSummaries.First(app => app.Id == ApplicationId);
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
+                var application = applicationSummaries.First(app => app.Id == ApplicationId);
 
-                    Assert.Equal(ApplicationId, application.Id);
-                    Assert.Equal(ApplicationIntegrationCommon.Version, application.Versions.FirstOrDefault());
+                Assert.Equal(ApplicationId, application.Id);
+                Assert.Equal(ApplicationIntegrationCommon.Version, application.Versions.FirstOrDefault());
 
-                    ApplicationSummary getApplicationSummary = await client.ApplicationOperations.GetApplicationSummaryAsync(application.Id).ConfigureAwait(false);
+                ApplicationSummary getApplicationSummary = await client.ApplicationOperations.GetApplicationSummaryAsync(application.Id).ConfigureAwait(false);
 
-                    Assert.Equal(ApplicationId, getApplicationSummary.Id);
-                    Assert.Equal(ApplicationIntegrationCommon.Version, getApplicationSummary.Versions.First());
-                }
+                Assert.Equal(ApplicationId, getApplicationSummary.Id);
+                Assert.Equal(ApplicationIntegrationCommon.Version, getApplicationSummary.Versions.First());
             };
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesIntegrationTests.cs
@@ -33,34 +33,32 @@
 
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                CloudPool newPool = null;
+                try
                 {
-                    CloudPool newPool = null;
-                    try
+                    List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
+
+                    foreach (var applicationSummary in applicationSummaries.Where(app => app.Id == ApplicationId))
                     {
-                        List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
-
-                        foreach (var applicationSummary in applicationSummaries.Where(app => app.Id == ApplicationId))
-                        {
-                            Assert.True(true, string.Format("{0} was found.", applicationSummary.Id));
-                        }
-                        CloudPool pool = client.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
-
-                        pool.ApplicationPackageReferences = new[] { new ApplicationPackageReference { ApplicationId = ApplicationId, Version = Version } };
-
-                        await pool.CommitAsync().ConfigureAwait(false);
-
-                        newPool = await client.PoolOperations.GetPoolAsync(poolId).ConfigureAwait(false);
-
-                        ApplicationPackageReference apr = newPool.ApplicationPackageReferences.First();
-
-                        Assert.Equal(ApplicationId, apr.ApplicationId);
-                        Assert.Equal(Version, apr.Version);
+                        Assert.True(true, string.Format("{0} was found.", applicationSummary.Id));
                     }
-                    finally
-                    {
-                        TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
-                    }
+                    CloudPool pool = client.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
+
+                    pool.ApplicationPackageReferences = new[] { new ApplicationPackageReference { ApplicationId = ApplicationId, Version = Version } };
+
+                    await pool.CommitAsync().ConfigureAwait(false);
+
+                    newPool = await client.PoolOperations.GetPoolAsync(poolId).ConfigureAwait(false);
+
+                    ApplicationPackageReference apr = newPool.ApplicationPackageReferences.First();
+
+                    Assert.Equal(ApplicationId, apr.ApplicationId);
+                    Assert.Equal(Version, apr.Version);
+                }
+                finally
+                {
+                    TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
                 }
             };
 
@@ -76,31 +74,29 @@
 
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                try
                 {
-                    try
-                    {
-                        CloudPool pool = client.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
-                        await pool.CommitAsync().ConfigureAwait(false);
+                    CloudPool pool = client.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
+                    await pool.CommitAsync().ConfigureAwait(false);
 
-                        pool = await client.PoolOperations.GetPoolAsync(poolId).ConfigureAwait(false);
-                        Assert.Null(pool.ApplicationPackageReferences);
+                    pool = await client.PoolOperations.GetPoolAsync(poolId).ConfigureAwait(false);
+                    Assert.Null(pool.ApplicationPackageReferences);
 
-                        pool.ApplicationPackageReferences = new[] { new ApplicationPackageReference { ApplicationId = ApplicationId, Version = Version } };
+                    pool.ApplicationPackageReferences = new[] { new ApplicationPackageReference { ApplicationId = ApplicationId, Version = Version } };
 
-                        await pool.CommitAsync().ConfigureAwait(false);
+                    await pool.CommitAsync().ConfigureAwait(false);
 
-                        CloudPool updatedPool = await client.PoolOperations.GetPoolAsync(poolId).ConfigureAwait(false);
+                    CloudPool updatedPool = await client.PoolOperations.GetPoolAsync(poolId).ConfigureAwait(false);
 
-                        ApplicationPackageReference apr = updatedPool.ApplicationPackageReferences.First();
+                    ApplicationPackageReference apr = updatedPool.ApplicationPackageReferences.First();
 
-                        Assert.Equal(ApplicationId, apr.ApplicationId);
-                        Assert.Equal(Version, apr.Version);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
-                    }
+                    Assert.Equal(ApplicationId, apr.ApplicationId);
+                    Assert.Equal(Version, apr.Version);
+                }
+                finally
+                {
+                    TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
                 }
             };
 
@@ -115,14 +111,12 @@
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
                 var poolId = "app-ref-test-3-" + Guid.NewGuid();
-                using (BatchClient client = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
-                {
-                    CloudPool pool = client.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
+                using BatchClient client = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                CloudPool pool = client.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
 
-                    pool.ApplicationPackageReferences = new[] { new ApplicationPackageReference { ApplicationId = "dud", Version = Version } };
+                pool.ApplicationPackageReferences = new[] { new ApplicationPackageReference { ApplicationId = "dud", Version = Version } };
 
-                    await TestUtilities.AssertThrowsAsync<BatchException>(() => pool.CommitAsync()).ConfigureAwait(false);
-                }
+                await TestUtilities.AssertThrowsAsync<BatchException>(() => pool.CommitAsync()).ConfigureAwait(false);
             }, LongTestTimeout);
         }
 
@@ -160,54 +154,52 @@
             Schedule schedule = new Schedule { DoNotRunAfter = DateTime.UtcNow.AddMinutes(5), RecurrenceInterval = TimeSpan.FromMinutes(2) };
             JobSpecification jobSpecification = new JobSpecification(poolInformation);
 
-            using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
-            {
-                CloudJobSchedule cloudJobSchedule = client.JobScheduleOperations.CreateJobSchedule(jobId, schedule, jobSpecification);
+            using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+            CloudJobSchedule cloudJobSchedule = client.JobScheduleOperations.CreateJobSchedule(jobId, schedule, jobSpecification);
 
-                Func<Task> test = async () =>
+            Func<Task> test = async () =>
+                {
+                    CloudJobSchedule updatedBoundJobSchedule = null;
+
+                    try
                     {
-                        CloudJobSchedule updatedBoundJobSchedule = null;
+                        await cloudJobSchedule.CommitAsync().ConfigureAwait(false);
 
-                        try
+                        CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(client.JobScheduleOperations, jobId);
+
+                        ApplicationPackageReference apr = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
+
+                        Assert.Equal(ApplicationId, apr.ApplicationId);
+                        Assert.Equal(Version, apr.Version);
+
+                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences = new[]
                         {
-                            await cloudJobSchedule.CommitAsync().ConfigureAwait(false);
-
-                            CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(client.JobScheduleOperations, jobId);
-
-                            ApplicationPackageReference apr = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
-
-                            Assert.Equal(ApplicationId, apr.ApplicationId);
-                            Assert.Equal(Version, apr.Version);
-
-                            boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences = new []
-                            {
                                 new ApplicationPackageReference()
                                 {
                                     ApplicationId = ApplicationId,
                                     Version = newVersion
                                 }
-                            };
+                        };
 
-                            await boundJobSchedule.CommitAsync().ConfigureAwait(false);
-                            await boundJobSchedule.RefreshAsync().ConfigureAwait(false);
+                        await boundJobSchedule.CommitAsync().ConfigureAwait(false);
+                        await boundJobSchedule.RefreshAsync().ConfigureAwait(false);
 
-                            updatedBoundJobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync(jobId).ConfigureAwait(false);
+                        updatedBoundJobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync(jobId).ConfigureAwait(false);
 
-                            ApplicationPackageReference updatedApr =
-                                updatedBoundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences
-                                                       .First();
+                        ApplicationPackageReference updatedApr =
+                            updatedBoundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences
+                                                   .First();
 
-                            Assert.Equal(ApplicationId, updatedApr.ApplicationId);
-                            Assert.Equal(newVersion, updatedApr.Version);
-                        }
-                        finally
-                        {
-                            TestUtilities.DeleteJobScheduleIfExistsAsync(client, jobId).Wait();
-                        }
-                    };
+                        Assert.Equal(ApplicationId, updatedApr.ApplicationId);
+                        Assert.Equal(newVersion, updatedApr.Version);
+                    }
+                    finally
+                    {
+                        TestUtilities.DeleteJobScheduleIfExistsAsync(client, jobId).Wait();
+                    }
+                };
 
-                await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
-            }
+            await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
         }
 
         [Fact]
@@ -240,25 +232,23 @@
 
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                try
                 {
-                    try
-                    {
-                        var job = client.JobOperations.CreateJob(jobId, poolInformation);
+                    var job = client.JobOperations.CreateJob(jobId, poolInformation);
 
-                        await job.CommitAsync().ConfigureAwait(false);
+                    await job.CommitAsync().ConfigureAwait(false);
 
-                        CloudJob jobResponse = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
+                    CloudJob jobResponse = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
 
-                        ApplicationPackageReference apr = jobResponse.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
+                    ApplicationPackageReference apr = jobResponse.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
 
-                        Assert.Equal(ApplicationId, apr.ApplicationId);
-                        Assert.Equal(Version, apr.Version);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+                    Assert.Equal(ApplicationId, apr.ApplicationId);
+                    Assert.Equal(Version, apr.Version);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesOnTasksIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesOnTasksIntegrationTests.cs
@@ -31,51 +31,49 @@
 
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                var poolInfo = new PoolInformation
                 {
-                    var poolInfo = new PoolInformation
+                    AutoPoolSpecification = new AutoPoolSpecification
                     {
-                        AutoPoolSpecification = new AutoPoolSpecification
+                        PoolSpecification = new PoolSpecification
                         {
-                            PoolSpecification = new PoolSpecification
-                            {
-                                CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
-                                VirtualMachineSize = PoolFixture.VMSize,
-                            },
-                            PoolLifetimeOption = PoolLifetimeOption.Job
-                        }
-                    };
+                            CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
+                            VirtualMachineSize = PoolFixture.VMSize,
+                        },
+                        PoolLifetimeOption = PoolLifetimeOption.Job
+                    }
+                };
 
-                    try
+                try
+                {
+                    CloudJob job = client.JobOperations.CreateJob(jobId, poolInfo);
+                    await job.CommitAsync().ConfigureAwait(false);
+
+                    var boundJob = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
+
+                    CloudTask cloudTask = new CloudTask(taskId, "cmd /c ping 127.0.0.1")
                     {
-                        CloudJob job = client.JobOperations.CreateJob(jobId, poolInfo);
-                        await job.CommitAsync().ConfigureAwait(false);
-
-                        var boundJob = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
-
-                        CloudTask cloudTask = new CloudTask(taskId, "cmd /c ping 127.0.0.1")
+                        ApplicationPackageReferences = new[]
                         {
-                            ApplicationPackageReferences = new[]
-                            {
                                 new ApplicationPackageReference
                                 {
                                     ApplicationId = applicationId,
                                     Version = applicationVerson
                                 }
                             }
-                        };
+                    };
 
-                        await boundJob.AddTaskAsync(cloudTask).ConfigureAwait(false);
+                    await boundJob.AddTaskAsync(cloudTask).ConfigureAwait(false);
 
-                        CloudTask boundCloudTask = await boundJob.GetTaskAsync(taskId).ConfigureAwait(false);
-                        Assert.Equal(applicationId, boundCloudTask.ApplicationPackageReferences.Single().ApplicationId);
-                        Assert.Equal(applicationVerson, boundCloudTask.ApplicationPackageReferences.Single().Version);
+                    CloudTask boundCloudTask = await boundJob.GetTaskAsync(taskId).ConfigureAwait(false);
+                    Assert.Equal(applicationId, boundCloudTask.ApplicationPackageReferences.Single().ApplicationId);
+                    Assert.Equal(applicationVerson, boundCloudTask.ApplicationPackageReferences.Single().Version);
 
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 
@@ -93,47 +91,45 @@
 
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                var poolInfo = new PoolInformation
                 {
-                    var poolInfo = new PoolInformation
+                    AutoPoolSpecification = new AutoPoolSpecification
                     {
-                        AutoPoolSpecification = new AutoPoolSpecification
+                        PoolSpecification = new PoolSpecification
                         {
-                            PoolSpecification = new PoolSpecification
-                            {
-                                CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
-                                VirtualMachineSize = PoolFixture.VMSize,
-                            },
-                            PoolLifetimeOption = PoolLifetimeOption.Job
-                        }
-                    };
+                            CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
+                            VirtualMachineSize = PoolFixture.VMSize,
+                        },
+                        PoolLifetimeOption = PoolLifetimeOption.Job
+                    }
+                };
 
-                    try
+                try
+                {
+                    CloudJob job = client.JobOperations.CreateJob(jobId, poolInfo);
+                    job.JobManagerTask = new JobManagerTask
                     {
-                        CloudJob job = client.JobOperations.CreateJob(jobId, poolInfo);
-                        job.JobManagerTask = new JobManagerTask
-                        {
-                            Id = jobId,
-                            CommandLine = "cmd /c ping 127.0.0.1",
-                            ApplicationPackageReferences = new[]{ new ApplicationPackageReference
+                        Id = jobId,
+                        CommandLine = "cmd /c ping 127.0.0.1",
+                        ApplicationPackageReferences = new[]{ new ApplicationPackageReference
                             {
                                 ApplicationId = applicationId,
                                 Version = applicationVersion
                             }}
-                        };
+                    };
 
-                        await job.CommitAsync().ConfigureAwait(false);
+                    await job.CommitAsync().ConfigureAwait(false);
 
-                        var boundJob = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
+                    var boundJob = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
 
-                        Assert.Equal(applicationId, boundJob.JobManagerTask.ApplicationPackageReferences.Single().ApplicationId);
-                        Assert.Equal(applicationVersion, boundJob.JobManagerTask.ApplicationPackageReferences.Single().Version);
+                    Assert.Equal(applicationId, boundJob.JobManagerTask.ApplicationPackageReferences.Single().ApplicationId);
+                    Assert.Equal(applicationVersion, boundJob.JobManagerTask.ApplicationPackageReferences.Single().Version);
 
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/JobWithApplicationPackageReferencesIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/JobWithApplicationPackageReferencesIntegrationTests.cs
@@ -31,45 +31,43 @@
 
             Func<Task> test = async () =>
             {
-                using (BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                var poolInfo = new PoolInformation
                 {
-                    var poolInfo = new PoolInformation
+                    AutoPoolSpecification = new AutoPoolSpecification
                     {
-                        AutoPoolSpecification = new AutoPoolSpecification
+                        PoolSpecification = new PoolSpecification
                         {
-                            PoolSpecification = new PoolSpecification
+                            ApplicationPackageReferences = new[]
                             {
-                                ApplicationPackageReferences = new[]
-                                {
                                     new ApplicationPackageReference
                                     {
                                         ApplicationId = applicationId,
                                         Version = PoolFixture.VMSize,
                                     }
                                 },
-                                CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
-                                VirtualMachineSize = PoolFixture.VMSize,
-                            },
-                            PoolLifetimeOption = PoolLifetimeOption.Job
-                        }
-                    };
-
-                    CloudJob response = null;
-                    try
-                    {
-                        CloudJob job = client.JobOperations.CreateJob(jobId, poolInfo);
-                        await job.CommitAsync().ConfigureAwait(false);
-
-                        response = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
-
-                        Assert.Equal(response.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().ApplicationId, applicationId);
+                            CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
+                            VirtualMachineSize = PoolFixture.VMSize,
+                        },
+                        PoolLifetimeOption = PoolLifetimeOption.Job
                     }
-                    finally
+                };
+
+                CloudJob response = null;
+                try
+                {
+                    CloudJob job = client.JobOperations.CreateJob(jobId, poolInfo);
+                    await job.CommitAsync().ConfigureAwait(false);
+
+                    response = await client.JobOperations.GetJobAsync(jobId).ConfigureAwait(false);
+
+                    Assert.Equal(response.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().ApplicationId, applicationId);
+                }
+                finally
+                {
+                    if (response != null)
                     {
-                        if (response != null)
-                        {
-                            TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                        }
+                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                     }
                 }
             };

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AuthenticationTest.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AuthenticationTest.cs
@@ -27,10 +27,8 @@ namespace BatchClientIntegrationTests
         {
             Func<Task<string>> tokenProvider = () => IntegrationTestCommon.GetAuthenticationTokenAsync("https://batch.core.windows.net/");
 
-            using (var client = BatchClient.Open(new BatchTokenCredentials(TestCommon.Configuration.BatchAccountUrl, tokenProvider)))
-            {
-                await client.JobOperations.ListJobs().ToListAsync();
-            }
+            using var client = BatchClient.Open(new BatchTokenCredentials(TestCommon.Configuration.BatchAccountUrl, tokenProvider));
+            await client.JobOperations.ListJobs().ToListAsync();
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AutoScaleIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AutoScaleIntegrationTests.cs
@@ -37,79 +37,77 @@
         {
             await SynchronizationContextHelper.RunTestAsync(async () =>
                 {
-                    using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false))
-                    {
-                        const string poolASFormulaOrig = "$TargetDedicated = 0;";
-                        TimeSpan evalInterval = TimeSpan.FromMinutes(6);
-                        string poolId0 = "AutoScaleEvalInterval0-" + TestUtilities.GetMyName();
+                    using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
+                    const string poolASFormulaOrig = "$TargetDedicated = 0;";
+                    TimeSpan evalInterval = TimeSpan.FromMinutes(6);
+                    string poolId0 = "AutoScaleEvalInterval0-" + TestUtilities.GetMyName();
 
+                    try
+                    {
+                        // create an empty pool with autoscale and an eval interval
+                        CloudServiceConfiguration cloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
+                        CloudPool ubPool = batchCli.PoolOperations.CreatePool(
+                            poolId0,
+                            cloudServiceConfiguration: cloudServiceConfiguration,
+                            virtualMachineSize: PoolFixture.VMSize);
+                        ubPool.AutoScaleEnabled = true;
+                        ubPool.AutoScaleEvaluationInterval = evalInterval;
+                        ubPool.AutoScaleFormula = poolASFormulaOrig;
+
+                        ubPool.Commit();
+
+                        // confirm values are returned
+                        CloudPool bndPool = batchCli.PoolOperations.GetPool(poolId0);
+
+                        Assert.True(bndPool.AutoScaleEnabled.HasValue && bndPool.AutoScaleEnabled.Value);
+                        Assert.Equal(evalInterval, bndPool.AutoScaleEvaluationInterval);
+
+                        // change eval interval
+                        TimeSpan newEvalInterval = evalInterval + TimeSpan.FromMinutes(1);
+
+                        bndPool.EnableAutoScale(autoscaleEvaluationInterval: newEvalInterval);
+
+                        int enableCallCounter = 1; // count these to validate server throttle
+                        const int expectedEnableCallToFail = 2;
+
+                        bndPool.Refresh();
+
+                        Assert.True(bndPool.AutoScaleEnabled.HasValue && bndPool.AutoScaleEnabled.Value);
+                        Assert.True(bndPool.AutoScaleEvaluationInterval.HasValue);
+                        Assert.Equal(newEvalInterval, bndPool.AutoScaleEvaluationInterval.Value);
+
+                        // check the interval floor assert
+                        var batchException = TestUtilities.AssertThrows<BatchException>(
+                            () => bndPool.EnableAutoScale(autoscaleEvaluationInterval: TimeSpan.FromMinutes(1)));
+                        Assert.Equal(Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.InvalidPropertyValue, batchException.RequestInformation.BatchError.Code);
+
+                        // check for AutoScaleTooManyRequestsToEnable
                         try
                         {
-                            // create an empty pool with autoscale and an eval interval
-                            CloudServiceConfiguration cloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
-                            CloudPool ubPool = batchCli.PoolOperations.CreatePool(
-                                poolId0, 
-                                cloudServiceConfiguration: cloudServiceConfiguration, 
-                                virtualMachineSize: PoolFixture.VMSize);
-                            ubPool.AutoScaleEnabled = true;
-                            ubPool.AutoScaleEvaluationInterval = evalInterval;
-                            ubPool.AutoScaleFormula = poolASFormulaOrig;
-
-                            ubPool.Commit();
-
-                            // confirm values are returned
-                            CloudPool bndPool = batchCli.PoolOperations.GetPool(poolId0);
-
-                            Assert.True(bndPool.AutoScaleEnabled.HasValue && bndPool.AutoScaleEnabled.Value);
-                            Assert.Equal(evalInterval, bndPool.AutoScaleEvaluationInterval);
-
-                            // change eval interval
-                            TimeSpan newEvalInterval = evalInterval + TimeSpan.FromMinutes(1);
-
-                            bndPool.EnableAutoScale(autoscaleEvaluationInterval: newEvalInterval);
-
-                            int enableCallCounter = 1; // count these to validate server throttle
-                            const int expectedEnableCallToFail = 2;
-
-                            bndPool.Refresh();
-
-                            Assert.True(bndPool.AutoScaleEnabled.HasValue && bndPool.AutoScaleEnabled.Value);
-                            Assert.True(bndPool.AutoScaleEvaluationInterval.HasValue);
-                            Assert.Equal(newEvalInterval, bndPool.AutoScaleEvaluationInterval.Value);
-
-                            // check the interval floor assert
-                            var batchException = TestUtilities.AssertThrows<BatchException>(
-                                () => bndPool.EnableAutoScale(autoscaleEvaluationInterval: TimeSpan.FromMinutes(1)));
-                            Assert.Equal(Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.InvalidPropertyValue, batchException.RequestInformation.BatchError.Code);
-
-                            // check for AutoScaleTooManyRequestsToEnable
-                            try
+                            // spam the server
+                            for (int i = 0; i < 99; i++)  // remember there was already one (1) call made above
                             {
-                                // spam the server
-                                for (int i = 0; i < 99; i++)  // remember there was already one (1) call made above
-                                {
-                                    enableCallCounter++; // one more call
-                                    bndPool.EnableAutoScale(autoscaleEvaluationInterval: newEvalInterval + TimeSpan.FromSeconds(i));
-                                }
-
-                                // server never pushed back on the spam.  this is a bug
-                                throw new Exception("AutoScaleEvaluationIntervalTest: unable to force AutoScaleTooManyRequestsToEnable");
+                                enableCallCounter++; // one more call
+                                bndPool.EnableAutoScale(autoscaleEvaluationInterval: newEvalInterval + TimeSpan.FromSeconds(i));
                             }
-                            catch (Exception ex)
-                            {
-                                TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.AutoScaleTooManyRequestsToEnable, testOutputHelper);
 
-                                // if we get here the exception passed.
-
-                                // confirm that the expected call fails
-                                Assert.Equal(expectedEnableCallToFail, enableCallCounter);
-                            }
+                            // server never pushed back on the spam.  this is a bug
+                            throw new Exception("AutoScaleEvaluationIntervalTest: unable to force AutoScaleTooManyRequestsToEnable");
                         }
-                        finally
+                        catch (Exception ex)
                         {
-                            // cleanup
-                            TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId0).Wait();
+                            TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.AutoScaleTooManyRequestsToEnable, testOutputHelper);
+
+                            // if we get here the exception passed.
+
+                            // confirm that the expected call fails
+                            Assert.Equal(expectedEnableCallToFail, enableCallCounter);
                         }
+                    }
+                    finally
+                    {
+                        // cleanup
+                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId0).Wait();
                     }
                 },
                 TestTimeout);

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AutoScaleIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AutoScaleIntegrationTests.cs
@@ -22,7 +22,6 @@
     public class AutoScaleIntegrationTests
     {
         private readonly ITestOutputHelper testOutputHelper;
-        private static readonly TimeSpan LongTestTimeout = TimeSpan.FromMinutes(5);
         private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(1);
 
         public AutoScaleIntegrationTests(ITestOutputHelper testOutputHelper)
@@ -98,7 +97,7 @@
                             }
                             catch (Exception ex)
                             {
-                                TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.AutoScaleTooManyRequestsToEnable, this.testOutputHelper);
+                                TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.AutoScaleTooManyRequestsToEnable, testOutputHelper);
 
                                 // if we get here the exception passed.
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/BatchRequestIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/BatchRequestIntegrationTests.cs
@@ -77,7 +77,7 @@
                             req.Timeout = TimeSpan.FromMilliseconds(25);
 
                             var castRequest = (JobGetBatchRequest)req;
-                            Func<CancellationToken, Task<AzureOperationResponse<Microsoft.Azure.Batch.Protocol.Models.CloudJob, Microsoft.Azure.Batch.Protocol.Models.JobGetHeaders>>> oldFunc = castRequest.ServiceRequestFunc;
+                            Func<CancellationToken, Task<AzureOperationResponse<Microsoft.Azure.Batch.Protocol.Models.CloudJob, JobGetHeaders>>> oldFunc = castRequest.ServiceRequestFunc;
                             castRequest.ServiceRequestFunc = async (token) =>
                                                                    {
                                                                        actualRequestCount++; //Count the number of calls to the func

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CertificateUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CertificateUnitTests.cs
@@ -78,17 +78,15 @@ namespace BatchClientIntegrationTests
 
             try
             {
-                using (BatchClient batchClient = CreateDummyClient())
-                {
-                    X509Certificate2 x509Certificate = password == null ? new X509Certificate2(certificateFileLocation) : new X509Certificate2(certificateFileLocation, password);
-                    byte[] cerBytes = x509Certificate.Export(X509ContentType.Cert);
+                using BatchClient batchClient = CreateDummyClient();
+                X509Certificate2 x509Certificate = password == null ? new X509Certificate2(certificateFileLocation) : new X509Certificate2(certificateFileLocation, password);
+                byte[] cerBytes = x509Certificate.Export(X509ContentType.Cert);
 
-                    Certificate certificate = batchClient.CertificateOperations.CreateCertificateFromCer(cerBytes);
+                Certificate certificate = batchClient.CertificateOperations.CreateCertificateFromCer(cerBytes);
 
-                    Assert.Equal(x509Certificate.Thumbprint.ToUpper(), certificate.Thumbprint.ToUpper());
-                    Assert.Equal("sha1", certificate.ThumbprintAlgorithm);
-                    Assert.Equal(expectedSignatureAlgorithm, x509Certificate.SignatureAlgorithm.FriendlyName);
-                }
+                Assert.Equal(x509Certificate.Thumbprint.ToUpper(), certificate.Thumbprint.ToUpper());
+                Assert.Equal("sha1", certificate.ThumbprintAlgorithm);
+                Assert.Equal(expectedSignatureAlgorithm, x509Certificate.SignatureAlgorithm.FriendlyName);
             }
             finally
             {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudCertificateIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudCertificateIntegrationTests.cs
@@ -35,71 +35,69 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                //Generate the certificates
+                const string certificatePrefix = "testcertificatecrud";
+
+                string cerFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.cer", certificatePrefix));
+                string pfxFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.pfx", certificatePrefix));
+
+                IEnumerable<Certificate> certificates = GenerateCertificates(batchCli, cerFilePath, pfxFilePath);
+
+                try
                 {
-                    //Generate the certificates
-                    const string certificatePrefix = "testcertificatecrud";
-
-                    string cerFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.cer", certificatePrefix));
-                    string pfxFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.pfx", certificatePrefix));
-
-                    IEnumerable<Certificate> certificates = GenerateCertificates(batchCli, cerFilePath, pfxFilePath);
-
-                    try
+                    foreach (Certificate certificate in certificates)
                     {
-                        foreach (Certificate certificate in certificates)
-                        {
-                            testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
-                            await certificate.CommitAsync().ConfigureAwait(false);
+                        testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
+                        await certificate.CommitAsync().ConfigureAwait(false);
 
-                            Certificate boundCert = await batchCli.CertificateOperations.GetCertificateAsync(
-                                certificate.ThumbprintAlgorithm,
-                                certificate.Thumbprint).ConfigureAwait(false);
+                        Certificate boundCert = await batchCli.CertificateOperations.GetCertificateAsync(
+                            certificate.ThumbprintAlgorithm,
+                            certificate.Thumbprint).ConfigureAwait(false);
 
-                            Assert.Equal(certificate.Thumbprint, boundCert.Thumbprint);
-                            Assert.Equal(certificate.ThumbprintAlgorithm, boundCert.ThumbprintAlgorithm);
-                            Assert.NotNull(boundCert.Url);
+                        Assert.Equal(certificate.Thumbprint, boundCert.Thumbprint);
+                        Assert.Equal(certificate.ThumbprintAlgorithm, boundCert.ThumbprintAlgorithm);
+                        Assert.NotNull(boundCert.Url);
 
-                            Certificate certLowerDetail = await batchCli.CertificateOperations.GetCertificateAsync(
-                                certificate.ThumbprintAlgorithm,
-                                certificate.Thumbprint,
-                                new ODATADetailLevel() { SelectClause = "thumbprint, thumbprintAlgorithm" }).ConfigureAwait(false);
+                        Certificate certLowerDetail = await batchCli.CertificateOperations.GetCertificateAsync(
+                            certificate.ThumbprintAlgorithm,
+                            certificate.Thumbprint,
+                            new ODATADetailLevel() { SelectClause = "thumbprint, thumbprintAlgorithm" }).ConfigureAwait(false);
 
-                            // confirm lower detail level
-                            Assert.Null(certLowerDetail.Url);
-                            //test refresh to higher detail level
-                            await certLowerDetail.RefreshAsync();
-                            // confirm higher detail level
-                            Assert.NotNull(certLowerDetail.Url);
-                            // test refresh can lower detail level
-                            await certLowerDetail.RefreshAsync(new ODATADetailLevel() { SelectClause = "thumbprint, thumbprintAlgorithm" });
-                            // confirm lower detail level via refresh
-                            Assert.Null(certLowerDetail.Url);
-                        }
-
-                        List<CertificateReference> certificateReferences = certificates.Select(cer => new CertificateReference(cer)
-                            {
-                                StoreLocation = CertStoreLocation.LocalMachine,
-                                StoreName = "My",
-                                Visibility = CertificateVisibility.RemoteUser
-                            }).ToList();
-
-                        await TestCancelDeleteCertificateAsync(batchCli, certificateReferences, certificates.First()).ConfigureAwait(false);
+                        // confirm lower detail level
+                        Assert.Null(certLowerDetail.Url);
+                        //test refresh to higher detail level
+                        await certLowerDetail.RefreshAsync();
+                        // confirm higher detail level
+                        Assert.NotNull(certLowerDetail.Url);
+                        // test refresh can lower detail level
+                        await certLowerDetail.RefreshAsync(new ODATADetailLevel() { SelectClause = "thumbprint, thumbprintAlgorithm" });
+                        // confirm lower detail level via refresh
+                        Assert.Null(certLowerDetail.Url);
                     }
-                    finally
+
+                    List<CertificateReference> certificateReferences = certificates.Select(cer => new CertificateReference(cer)
                     {
-                        File.Delete(pfxFilePath);
-                        File.Delete(cerFilePath);
+                        StoreLocation = CertStoreLocation.LocalMachine,
+                        StoreName = "My",
+                        Visibility = CertificateVisibility.RemoteUser
+                    }).ToList();
 
-                        foreach (Certificate certificate in certificates)
-                        {
-                            TestUtilities.DeleteCertificateIfExistsAsync(batchCli, certificate.ThumbprintAlgorithm, certificate.Thumbprint).Wait();
-                        }
+                    await TestCancelDeleteCertificateAsync(batchCli, certificateReferences, certificates.First()).ConfigureAwait(false);
+                }
+                finally
+                {
+                    File.Delete(pfxFilePath);
+                    File.Delete(cerFilePath);
 
-                        foreach (Certificate certificate in certificates)
-                        {
-                            TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
-                        }
+                    foreach (Certificate certificate in certificates)
+                    {
+                        TestUtilities.DeleteCertificateIfExistsAsync(batchCli, certificate.ThumbprintAlgorithm, certificate.Thumbprint).Wait();
+                    }
+
+                    foreach (Certificate certificate in certificates)
+                    {
+                        TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
                     }
                 }
             };
@@ -114,48 +112,46 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                //Generate the certificates
+                const string certificatePrefix = "poolwithcertificatereferences";
+
+                string cerFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.cer", certificatePrefix));
+                string pfxFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.pfx", certificatePrefix));
+
+                IEnumerable<Certificate> certificates = GenerateCertificates(batchCli, cerFilePath, pfxFilePath);
+
+                try
                 {
-                    //Generate the certificates
-                    const string certificatePrefix = "poolwithcertificatereferences";
-
-                    string cerFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.cer", certificatePrefix));
-                    string pfxFilePath = IntegrationTestCommon.GetTemporaryCertificateFilePath(string.Format("{0}.pfx", certificatePrefix));
-
-                    IEnumerable<Certificate> certificates = GenerateCertificates(batchCli, cerFilePath, pfxFilePath);
-
-                    try
+                    foreach (Certificate certificate in certificates)
                     {
-                        foreach (Certificate certificate in certificates)
-                        {
-                            testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
-                            await certificate.CommitAsync().ConfigureAwait(false);
-                        }
-
-                        List<CertificateReference> certificateReferences = certificates.Select(cer => new CertificateReference(cer)
-                            {
-                                StoreLocation = CertStoreLocation.LocalMachine,
-                                StoreName = "My",
-                                Visibility = CertificateVisibility.RemoteUser
-                            }).ToList();
-
-                        await TestPoolCreateAndUpdateWithCertificateReferencesAsync(batchCli, certificateReferences).ConfigureAwait(false);
-                        await TestAutoPoolCreateAndUpdateWithCertificateReferencesAsync(batchCli, certificateReferences).ConfigureAwait(false);
+                        testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
+                        await certificate.CommitAsync().ConfigureAwait(false);
                     }
-                    finally
+
+                    List<CertificateReference> certificateReferences = certificates.Select(cer => new CertificateReference(cer)
                     {
-                        File.Delete(pfxFilePath);
-                        File.Delete(cerFilePath);
+                        StoreLocation = CertStoreLocation.LocalMachine,
+                        StoreName = "My",
+                        Visibility = CertificateVisibility.RemoteUser
+                    }).ToList();
 
-                        foreach (Certificate certificate in certificates)
-                        {
-                            TestUtilities.DeleteCertificateIfExistsAsync(batchCli, certificate.ThumbprintAlgorithm, certificate.Thumbprint).Wait();
-                        }
+                    await TestPoolCreateAndUpdateWithCertificateReferencesAsync(batchCli, certificateReferences).ConfigureAwait(false);
+                    await TestAutoPoolCreateAndUpdateWithCertificateReferencesAsync(batchCli, certificateReferences).ConfigureAwait(false);
+                }
+                finally
+                {
+                    File.Delete(pfxFilePath);
+                    File.Delete(cerFilePath);
 
-                        foreach (Certificate certificate in certificates)
-                        {
-                            TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
-                        }
+                    foreach (Certificate certificate in certificates)
+                    {
+                        TestUtilities.DeleteCertificateIfExistsAsync(batchCli, certificate.ThumbprintAlgorithm, certificate.Thumbprint).Wait();
+                    }
+
+                    foreach (Certificate certificate in certificates)
+                    {
+                        TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
                     }
                 }
             };

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudCertificateIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudCertificateIntegrationTests.cs
@@ -49,7 +49,7 @@
                     {
                         foreach (Certificate certificate in certificates)
                         {
-                            this.testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
+                            testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
                             await certificate.CommitAsync().ConfigureAwait(false);
 
                             Certificate boundCert = await batchCli.CertificateOperations.GetCertificateAsync(
@@ -98,7 +98,7 @@
 
                         foreach (Certificate certificate in certificates)
                         {
-                            TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, this.testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
+                            TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
                         }
                     }
                 }
@@ -128,7 +128,7 @@
                     {
                         foreach (Certificate certificate in certificates)
                         {
-                            this.testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
+                            testOutputHelper.WriteLine("Adding certificate with thumbprint: {0}", certificate.Thumbprint);
                             await certificate.CommitAsync().ConfigureAwait(false);
                         }
 
@@ -154,7 +154,7 @@
 
                         foreach (Certificate certificate in certificates)
                         {
-                            TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, this.testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
+                            TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
                         }
                     }
                 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
@@ -45,7 +45,7 @@
                     try
                     {
                         CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
                         unboundJob.Commit();
 
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
@@ -66,7 +66,7 @@
 
                             while (repeat)
                             {
-                                CloudPool boundPool = batchCli.PoolOperations.GetPool(this.poolFixture.PoolId);
+                                CloudPool boundPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
                                 repeat = false;
 
@@ -76,13 +76,13 @@
                                     {
                                         repeat = true;
 
-                                        this.testOutputHelper.WriteLine("Manual Wait Task Id: " + curTask.Id + ", state = " + curTask.State);
-                                        this.testOutputHelper.WriteLine("   poolstate: " + boundPool.State + ", currentdedicated: " + boundPool.CurrentDedicatedComputeNodes);
-                                        this.testOutputHelper.WriteLine("      compute nodes:");
+                                        testOutputHelper.WriteLine("Manual Wait Task Id: " + curTask.Id + ", state = " + curTask.State);
+                                        testOutputHelper.WriteLine("   poolstate: " + boundPool.State + ", currentdedicated: " + boundPool.CurrentDedicatedComputeNodes);
+                                        testOutputHelper.WriteLine("      compute nodes:");
 
                                         foreach (ComputeNode curComputeNode in boundPool.ListComputeNodes())
                                         {
-                                            this.testOutputHelper.WriteLine("           computeNode.Id: " + curComputeNode.Id + ", state: " + curComputeNode.State);
+                                            testOutputHelper.WriteLine("           computeNode.Id: " + curComputeNode.Id + ", state: " + curComputeNode.State);
                                         }
                                     }
                                 }
@@ -91,7 +91,7 @@
 
                         // add some longer running tasks
 
-                        this.testOutputHelper.WriteLine("Adding longer running tasks");
+                        testOutputHelper.WriteLine("Adding longer running tasks");
 
                         for (int i = 0; i < 15; i++)
                         {
@@ -111,7 +111,7 @@
                         // confirm the floor is enforced
                         Assert.Equal(500, odmc.DelayBetweenDataFetch.Milliseconds);
 
-                        this.testOutputHelper.WriteLine("Calling TaskStateMonitor.WaitAll().  This will take a while.");
+                        testOutputHelper.WriteLine("Calling TaskStateMonitor.WaitAll().  This will take a while.");
 
                         TimeSpan timeToWait = TimeSpan.FromMinutes(5);
                         Task whenAll = tsm.WhenAll(taskList, Microsoft.Azure.Batch.Common.TaskState.Completed, timeToWait, controlParams: odmc);
@@ -153,7 +153,7 @@
                         CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
                         cloudJob.PoolInformation = new PoolInformation()
                         {
-                            PoolId = this.poolFixture.PoolId
+                            PoolId = poolFixture.PoolId
                         };
                         cloudJob.Commit();
 
@@ -166,7 +166,7 @@
                         //Check the job state
 
                         CloudJob disabledJob = batchCli.JobOperations.GetJob(jobId);
-                        this.testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
+                        testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
                         Assert.True(disabledJob.State == JobState.Disabled || disabledJob.State == JobState.Disabling);
 
                         //Enable the job (via instance)
@@ -174,14 +174,14 @@
 
                         //Check the job state
                         CloudJob enabledJob = batchCli.JobOperations.GetJob(jobId);
-                        this.testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
+                        testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
                         Assert.Equal(JobState.Active, JobState.Active);
 
                         //Disable the job (via operations)
                         batchCli.JobOperations.DisableJob(jobId, DisableJobOption.Terminate);
 
                         disabledJob = batchCli.JobOperations.GetJob(jobId);
-                        this.testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
+                        testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
                         Assert.True(disabledJob.State == JobState.Disabled || disabledJob.State == JobState.Disabling);
 
                         //Enable the job (via operations)
@@ -189,7 +189,7 @@
 
                         //Check the job state
                         enabledJob = batchCli.JobOperations.GetJob(jobId);
-                        this.testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
+                        testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
                         Assert.Equal(JobState.Active, JobState.Active);
 
                         //Terminate the job
@@ -197,7 +197,7 @@
 
                         //Check the job state
                         CloudJob terminatedJob = batchCli.JobOperations.GetJob(jobId);
-                        this.testOutputHelper.WriteLine("TerminatedJob state: {0}", terminatedJob.State);
+                        testOutputHelper.WriteLine("TerminatedJob state: {0}", terminatedJob.State);
                         Assert.True(terminatedJob.State == JobState.Terminating || terminatedJob.State == JobState.Completed);
 
                         if (terminatedJob.State == JobState.Terminating)
@@ -212,7 +212,7 @@
 
                         try
                         {
-                            this.testOutputHelper.WriteLine("Expected Exception: testing that job does NOT exist.");
+                            testOutputHelper.WriteLine("Expected Exception: testing that job does NOT exist.");
 
                             CloudJob deletedJob = batchCli.JobOperations.GetJob(jobId);
                             Assert.Equal(JobState.Deleting, deletedJob.State);
@@ -225,7 +225,7 @@
                             Assert.NotNull(be.RequestInformation.BatchError);
                             Assert.Equal(BatchErrorCodeStrings.JobNotFound, be.RequestInformation.BatchError.Code);
 
-                            this.testOutputHelper.WriteLine("Job was deleted successfully");
+                            testOutputHelper.WriteLine("Job was deleted successfully");
                         }
                     }
                     finally
@@ -256,10 +256,10 @@
                         CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
                         cloudJob.PoolInformation = new PoolInformation()
                         {
-                            PoolId = this.poolFixture.PoolId
+                            PoolId = poolFixture.PoolId
                         };
 
-                        this.testOutputHelper.WriteLine("Initial job schedule commit()");
+                        testOutputHelper.WriteLine("Initial job schedule commit()");
                         cloudJob.Commit();
 
                         //Get the job
@@ -269,12 +269,12 @@
                         const int newJobPriority = 5;
                         OnAllTasksComplete newOnAllTasksComplete = OnAllTasksComplete.NoAction;
 
-                        this.testOutputHelper.WriteLine("Job priority is: {0}", refreshableJob.Priority);
+                        testOutputHelper.WriteLine("Job priority is: {0}", refreshableJob.Priority);
                         refreshableJob.Priority = newJobPriority;
                         refreshableJob.OnAllTasksComplete = newOnAllTasksComplete;
                         refreshableJob.Commit();
 
-                        AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, this.poolFixture.PoolId, newJobPriority, null);
+                        AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, poolFixture.PoolId, newJobPriority, null);
 
                         //Update the bound job pool name
                         //Must disable the job first before updating its pool
@@ -286,7 +286,7 @@
                         TimeSpan jobDisabledTimeout = TimeSpan.FromSeconds(120);
                         while (refreshableJob.State != JobState.Disabled)
                         {
-                            this.testOutputHelper.WriteLine("Bug1433069TestBoundJobCommit: sleeping for (refreshableJob.State != JobState.Disabled)");
+                            testOutputHelper.WriteLine("Bug1433069TestBoundJobCommit: sleeping for (refreshableJob.State != JobState.Disabled)");
                             Thread.Sleep(TimeSpan.FromSeconds(10));
                             refreshableJob = batchCli.JobOperations.GetJob(jobId);
 
@@ -340,7 +340,7 @@
                         {
                             // need a bound job/task for the tests so set one up
                             CloudJob tsh = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                            tsh.PoolInformation.PoolId = this.poolFixture.PoolId;
+                            tsh.PoolInformation.PoolId = poolFixture.PoolId;
                             tsh.Commit();
 
                             boundJob = batchCli.JobOperations.GetJob(jobId);
@@ -579,7 +579,7 @@
         private CloudJob CreateBoundJob(BatchClient client, string jobId, Action<CloudJob> jobSetup = null)
         {
             CloudJob cloudJob = client.JobOperations.CreateJob(jobId, new PoolInformation());
-            cloudJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+            cloudJob.PoolInformation.PoolId = poolFixture.PoolId;
             jobSetup?.Invoke(cloudJob);
             cloudJob.Commit();
 
@@ -655,12 +655,14 @@
 
                     const int originalPriority = 0;
                     unboundJob.Priority = originalPriority;
-                    List<MetadataItem> originalMetadata = new List<MetadataItem>();
-                    originalMetadata.Add(new MetadataItem("meta1", "value1"));
-                    originalMetadata.Add(new MetadataItem("meta2", "value2"));
+                    List<MetadataItem> originalMetadata = new List<MetadataItem>
+                    {
+                        new MetadataItem("meta1", "value1"),
+                        new MetadataItem("meta2", "value2")
+                    };
                     unboundJob.Metadata = originalMetadata;
 
-                    this.testOutputHelper.WriteLine("Creating job {0}", jobId);
+                    testOutputHelper.WriteLine("Creating job {0}", jobId);
                     unboundJob.Commit();
 
                     try
@@ -672,12 +674,11 @@
                         Assert.NotEqual(JobState.Disabled, createdJob.State);
 
                         int updatedPriority = originalPriority + 1;
-                        List<MetadataItem> updatedMetadata = new List<MetadataItem>();
-                        updatedMetadata.Add(new MetadataItem("updatedMeta1", "value1"));
+                        List<MetadataItem> updatedMetadata = new List<MetadataItem> { new MetadataItem("updatedMeta1", "value1") };
                         createdJob.Priority = updatedPriority;
                         createdJob.Metadata = updatedMetadata;
 
-                        this.testOutputHelper.WriteLine("Updating job {0} without altering PoolInformation", jobId);
+                        testOutputHelper.WriteLine("Updating job {0} without altering PoolInformation", jobId);
 
                         createdJob.Commit();
 
@@ -691,7 +692,7 @@
 
                         // Verify that updating the PoolInformation works.
                         // PoolInformation can only be changed in the Disabled state.
-                        this.testOutputHelper.WriteLine("Disabling job {0}", jobId);
+                        testOutputHelper.WriteLine("Disabling job {0}", jobId);
                         updatedJob.Disable(DisableJobOption.Terminate);
                         while (updatedJob.State != JobState.Disabled)
                         {
@@ -705,7 +706,7 @@
                         updatedJob.PoolInformation.AutoPoolSpecification.KeepAlive = updatedKeepAlive;
                         int updatedAgainPriority = updatedPriority + 1;
                         updatedJob.Priority = updatedAgainPriority;
-                        this.testOutputHelper.WriteLine("Updating job {0} properties, including PoolInformation", jobId);
+                        testOutputHelper.WriteLine("Updating job {0} properties, including PoolInformation", jobId);
                         updatedJob.Commit();
 
                         CloudJob updatedPoolInfoJob = batchCli.JobOperations.GetJob(jobId);
@@ -715,13 +716,13 @@
                     }
                     finally
                     {
-                        this.testOutputHelper.WriteLine("Deleting job {0}", jobId);
+                        testOutputHelper.WriteLine("Deleting job {0}", jobId);
                         TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
 
                         // Explicitly delete auto pool
                         foreach (CloudPool pool in batchCli.PoolOperations.ListPools(new ODATADetailLevel(filterClause: string.Format("startswith(id,'{0}')", autoPoolPrefix))))
                         {
-                            this.testOutputHelper.WriteLine("Deleting pool {0}", pool.Id);
+                            testOutputHelper.WriteLine("Deleting pool {0}", pool.Id);
                             TestUtilities.DeletePoolIfExistsAsync(batchCli, pool.Id).Wait();
                         }
                     }
@@ -760,14 +761,14 @@
 
                         CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
 
-                        this.testOutputHelper.WriteLine("Commiting quickjob");
+                        testOutputHelper.WriteLine("Commiting quickjob");
                         unboundJob.Commit();
 
                         CloudTask task = new CloudTask("Bug1965363Wat7OSVersionFeaturesQuickJobWithAutoPoolTask", "cmd /c echo Bug1965363");
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
                         boundJob.AddTask(task);
 
-                        this.testOutputHelper.WriteLine("Getting pool name: {0}", boundJob.ExecutionInformation.PoolId);
+                        testOutputHelper.WriteLine("Getting pool name: {0}", boundJob.ExecutionInformation.PoolId);
 
                         CloudPool boundPool = batchCli.PoolOperations.GetPool(boundJob.ExecutionInformation.PoolId);
                         TaskStateMonitor tsm = batchCli.Utilities.CreateTaskStateMonitor();
@@ -776,7 +777,7 @@
                         // we know that the autopool compute nodes will take a long time to become scheduleable so we slow down polling/spam
                         odControl.DelayBetweenDataFetch = TimeSpan.FromSeconds(5);
 
-                        this.testOutputHelper.WriteLine("Invoking TaskStateMonitor");
+                        testOutputHelper.WriteLine("Invoking TaskStateMonitor");
 
                         tsm.WaitAll(
                             boundJob.ListTasks(),
@@ -787,14 +788,14 @@
                                 // spam/logging interceptor
                                 new Protocol.RequestInterceptor((x) =>
                                 {
-                                    this.testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
+                                    testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
 
                                     // print out the compute node states... we are actually waiting on the compute nodes
                                     List<ComputeNode> allComputeNodes = boundPool.ListComputeNodes().ToList();
-                                    this.testOutputHelper.WriteLine("    #comnpute nodes: " + allComputeNodes.Count);
+                                    testOutputHelper.WriteLine("    #comnpute nodes: " + allComputeNodes.Count);
 
-                                    allComputeNodes.ForEach((icn) => { this.testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State); });
-                                    this.testOutputHelper.WriteLine("");
+                                    allComputeNodes.ForEach((icn) => { testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State); });
+                                    testOutputHelper.WriteLine("");
                                 })
                             });
 
@@ -836,20 +837,18 @@
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
                         string capturedEtag1 = boundJob.ETag;
-                        this.testOutputHelper.WriteLine("Etag is: {0}", capturedEtag1);
+                        testOutputHelper.WriteLine("Etag is: {0}", capturedEtag1);
                         Assert.NotNull(capturedEtag1);
 
                         boundJob.Constraints = new JobConstraints(TimeSpan.FromMinutes(60), 0);
 
-                        BatchClientBehavior updateInterceptor = new Protocol.RequestInterceptor(
-                            (req) =>
-                                {
-                                    var typedParams = req.Options as Protocol.Models.JobUpdateOptions;
-                                    if (typedParams != null)
-                                    {
-                                        typedParams.IfMatch = capturedEtag1;
-                                    }
-                                });
+                        BatchClientBehavior updateInterceptor = new Protocol.RequestInterceptor(req =>
+                        {
+                            if (req.Options is Protocol.Models.JobUpdateOptions typedParams)
+                            {
+                                typedParams.IfMatch = capturedEtag1;
+                            }
+                        });
 
                         //Update bound job with if-match header, it should succeed
                         boundJob.Commit(additionalBehaviors: new[] { updateInterceptor });
@@ -860,7 +859,7 @@
 
                         //Update bound job with if-match header, it should fail
                         Exception e = TestUtilities.AssertThrows<BatchException>(() => boundJob.Commit(additionalBehaviors: new[] { updateInterceptor }));
-                        TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, this.testOutputHelper);
+                        TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, testOutputHelper);
                     }
                     finally
                     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
@@ -785,7 +785,7 @@
                             odControl,
                             new[] {
                                 // spam/logging interceptor
-                                new Microsoft.Azure.Batch.Protocol.RequestInterceptor((x) =>
+                                new Protocol.RequestInterceptor((x) =>
                                 {
                                     this.testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
@@ -38,97 +38,95 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1665834Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1665834Job-" + TestUtilities.GetMyName();
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+                    unboundJob.Commit();
 
-                    try
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                    // add some noise tasks
+                    for (int j = 0; j < 5; j++)
                     {
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
-                        unboundJob.Commit();
+                        CloudTask unboundTaskQuick = new CloudTask((10 + j).ToString(), "cmd /c hostname");
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                        boundJob.AddTask(unboundTaskQuick);
+                    }
 
-                        // add some noise tasks
-                        for (int j = 0; j < 5; j++)
+                    System.Threading.Thread.Sleep(5000);
+
+                    // wait for fast tasks to complete
+                    {
+                        bool repeat = true;
+
+                        while (repeat)
                         {
-                            CloudTask unboundTaskQuick = new CloudTask((10 + j).ToString(), "cmd /c hostname");
+                            CloudPool boundPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                            boundJob.AddTask(unboundTaskQuick);
-                        }
+                            repeat = false;
 
-                        System.Threading.Thread.Sleep(5000);
-
-                        // wait for fast tasks to complete
-                        {
-                            bool repeat = true;
-
-                            while (repeat)
+                            foreach (CloudTask curTask in boundJob.ListTasks())
                             {
-                                CloudPool boundPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
-
-                                repeat = false;
-
-                                foreach (CloudTask curTask in boundJob.ListTasks())
+                                if (curTask.State != Microsoft.Azure.Batch.Common.TaskState.Completed)
                                 {
-                                    if (curTask.State != Microsoft.Azure.Batch.Common.TaskState.Completed)
+                                    repeat = true;
+
+                                    testOutputHelper.WriteLine("Manual Wait Task Id: " + curTask.Id + ", state = " + curTask.State);
+                                    testOutputHelper.WriteLine("   poolstate: " + boundPool.State + ", currentdedicated: " + boundPool.CurrentDedicatedComputeNodes);
+                                    testOutputHelper.WriteLine("      compute nodes:");
+
+                                    foreach (ComputeNode curComputeNode in boundPool.ListComputeNodes())
                                     {
-                                        repeat = true;
-
-                                        testOutputHelper.WriteLine("Manual Wait Task Id: " + curTask.Id + ", state = " + curTask.State);
-                                        testOutputHelper.WriteLine("   poolstate: " + boundPool.State + ", currentdedicated: " + boundPool.CurrentDedicatedComputeNodes);
-                                        testOutputHelper.WriteLine("      compute nodes:");
-
-                                        foreach (ComputeNode curComputeNode in boundPool.ListComputeNodes())
-                                        {
-                                            testOutputHelper.WriteLine("           computeNode.Id: " + curComputeNode.Id + ", state: " + curComputeNode.State);
-                                        }
+                                        testOutputHelper.WriteLine("           computeNode.Id: " + curComputeNode.Id + ", state: " + curComputeNode.State);
                                     }
                                 }
                             }
                         }
-
-                        // add some longer running tasks
-
-                        testOutputHelper.WriteLine("Adding longer running tasks");
-
-                        for (int i = 0; i < 15; i++)
-                        {
-                            CloudTask unboundTask = new CloudTask(i.ToString() + "_a234567890a234567890a234567890a234567890a234567890a234567890", "cmd /c ping 127.0.0.1 -n 4");
-
-                            boundJob.AddTask(unboundTask);
-                        }
-
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor tsm = utilities.CreateTaskStateMonitor();
-
-                        IPagedEnumerable<CloudTask> taskList = boundJob.ListTasks();
-                        
-                        // try to set really low delay
-                        ODATAMonitorControl odmc = new ODATAMonitorControl { DelayBetweenDataFetch = new TimeSpan(0) };
-
-                        // confirm the floor is enforced
-                        Assert.Equal(500, odmc.DelayBetweenDataFetch.Milliseconds);
-
-                        testOutputHelper.WriteLine("Calling TaskStateMonitor.WaitAll().  This will take a while.");
-
-                        TimeSpan timeToWait = TimeSpan.FromMinutes(5);
-                        Task whenAll = tsm.WhenAll(taskList, Microsoft.Azure.Batch.Common.TaskState.Completed, timeToWait, controlParams: odmc);
-
-                        //This could throw, if it does the test will fail, which is what we want
-                        whenAll.Wait();
-
-                        foreach (CloudTask curTask in boundJob.ListTasks())
-                        {
-                            Assert.Equal(TaskState.Completed, curTask.State);
-                        }
                     }
-                    finally
+
+                    // add some longer running tasks
+
+                    testOutputHelper.WriteLine("Adding longer running tasks");
+
+                    for (int i = 0; i < 15; i++)
                     {
-                        // cleanup
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        CloudTask unboundTask = new CloudTask(i.ToString() + "_a234567890a234567890a234567890a234567890a234567890a234567890", "cmd /c ping 127.0.0.1 -n 4");
+
+                        boundJob.AddTask(unboundTask);
                     }
+
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor tsm = utilities.CreateTaskStateMonitor();
+
+                    IPagedEnumerable<CloudTask> taskList = boundJob.ListTasks();
+
+                    // try to set really low delay
+                    ODATAMonitorControl odmc = new ODATAMonitorControl { DelayBetweenDataFetch = new TimeSpan(0) };
+
+                    // confirm the floor is enforced
+                    Assert.Equal(500, odmc.DelayBetweenDataFetch.Milliseconds);
+
+                    testOutputHelper.WriteLine("Calling TaskStateMonitor.WaitAll().  This will take a while.");
+
+                    TimeSpan timeToWait = TimeSpan.FromMinutes(5);
+                    Task whenAll = tsm.WhenAll(taskList, Microsoft.Azure.Batch.Common.TaskState.Completed, timeToWait, controlParams: odmc);
+
+                    //This could throw, if it does the test will fail, which is what we want
+                    whenAll.Wait();
+
+                    foreach (CloudTask curTask in boundJob.ListTasks())
+                    {
+                        Assert.Equal(TaskState.Completed, curTask.State);
+                    }
+                }
+                finally
+                {
+                    // cleanup
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -142,96 +140,94 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                {
-                    //Create a job
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                //Create a job
 
-                    string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobVerbs";
+                string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobVerbs";
+
+                try
+                {
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    cloudJob.PoolInformation = new PoolInformation()
+                    {
+                        PoolId = poolFixture.PoolId
+                    };
+                    cloudJob.Commit();
+
+                    //Get the bound job
+                    CloudJob job = batchCli.JobOperations.GetJob(jobId);
+
+                    //Disable the job (via instance)
+                    job.Disable(DisableJobOption.Terminate);
+
+                    //Check the job state
+
+                    CloudJob disabledJob = batchCli.JobOperations.GetJob(jobId);
+                    testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
+                    Assert.True(disabledJob.State == JobState.Disabled || disabledJob.State == JobState.Disabling);
+
+                    //Enable the job (via instance)
+                    job.Enable();
+
+                    //Check the job state
+                    CloudJob enabledJob = batchCli.JobOperations.GetJob(jobId);
+                    testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
+                    Assert.Equal(JobState.Active, JobState.Active);
+
+                    //Disable the job (via operations)
+                    batchCli.JobOperations.DisableJob(jobId, DisableJobOption.Terminate);
+
+                    disabledJob = batchCli.JobOperations.GetJob(jobId);
+                    testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
+                    Assert.True(disabledJob.State == JobState.Disabled || disabledJob.State == JobState.Disabling);
+
+                    //Enable the job (via operations)
+                    batchCli.JobOperations.EnableJob(jobId);
+
+                    //Check the job state
+                    enabledJob = batchCli.JobOperations.GetJob(jobId);
+                    testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
+                    Assert.Equal(JobState.Active, JobState.Active);
+
+                    //Terminate the job
+                    job.Terminate("need some reason");
+
+                    //Check the job state
+                    CloudJob terminatedJob = batchCli.JobOperations.GetJob(jobId);
+                    testOutputHelper.WriteLine("TerminatedJob state: {0}", terminatedJob.State);
+                    Assert.True(terminatedJob.State == JobState.Terminating || terminatedJob.State == JobState.Completed);
+
+                    if (terminatedJob.State == JobState.Terminating)
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(5)); //Sleep and wait for the job to finish terminating before we issue a delete
+                    }
+
+                    //Delete the job
+                    job.Delete();
+
+                    //Check that the job doesn't exist anymore
 
                     try
                     {
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation()
-                        {
-                            PoolId = poolFixture.PoolId
-                        };
-                        cloudJob.Commit();
+                        testOutputHelper.WriteLine("Expected Exception: testing that job does NOT exist.");
 
-                        //Get the bound job
-                        CloudJob job = batchCli.JobOperations.GetJob(jobId);
-
-                        //Disable the job (via instance)
-                        job.Disable(DisableJobOption.Terminate);
-
-                        //Check the job state
-
-                        CloudJob disabledJob = batchCli.JobOperations.GetJob(jobId);
-                        testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
-                        Assert.True(disabledJob.State == JobState.Disabled || disabledJob.State == JobState.Disabling);
-
-                        //Enable the job (via instance)
-                        job.Enable();
-
-                        //Check the job state
-                        CloudJob enabledJob = batchCli.JobOperations.GetJob(jobId);
-                        testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
-                        Assert.Equal(JobState.Active, JobState.Active);
-
-                        //Disable the job (via operations)
-                        batchCli.JobOperations.DisableJob(jobId, DisableJobOption.Terminate);
-
-                        disabledJob = batchCli.JobOperations.GetJob(jobId);
-                        testOutputHelper.WriteLine("DisabledJob State: {0}", disabledJob.State);
-                        Assert.True(disabledJob.State == JobState.Disabled || disabledJob.State == JobState.Disabling);
-
-                        //Enable the job (via operations)
-                        batchCli.JobOperations.EnableJob(jobId);
-
-                        //Check the job state
-                        enabledJob = batchCli.JobOperations.GetJob(jobId);
-                        testOutputHelper.WriteLine("EnabledJob state: {0}", enabledJob.State);
-                        Assert.Equal(JobState.Active, JobState.Active);
-
-                        //Terminate the job
-                        job.Terminate("need some reason");
-
-                        //Check the job state
-                        CloudJob terminatedJob = batchCli.JobOperations.GetJob(jobId);
-                        testOutputHelper.WriteLine("TerminatedJob state: {0}", terminatedJob.State);
-                        Assert.True(terminatedJob.State == JobState.Terminating || terminatedJob.State == JobState.Completed);
-
-                        if (terminatedJob.State == JobState.Terminating)
-                        {
-                            Thread.Sleep(TimeSpan.FromSeconds(5)); //Sleep and wait for the job to finish terminating before we issue a delete
-                        }
-
-                        //Delete the job
-                        job.Delete();
-
-                        //Check that the job doesn't exist anymore
-
-                        try
-                        {
-                            testOutputHelper.WriteLine("Expected Exception: testing that job does NOT exist.");
-
-                            CloudJob deletedJob = batchCli.JobOperations.GetJob(jobId);
-                            Assert.Equal(JobState.Deleting, deletedJob.State);
-                        }
-                        catch (Exception e)
-                        {
-                            Assert.IsAssignableFrom<BatchException>(e);
-                            BatchException be = e as BatchException;
-                            Assert.NotNull(be.RequestInformation);
-                            Assert.NotNull(be.RequestInformation.BatchError);
-                            Assert.Equal(BatchErrorCodeStrings.JobNotFound, be.RequestInformation.BatchError.Code);
-
-                            testOutputHelper.WriteLine("Job was deleted successfully");
-                        }
+                        CloudJob deletedJob = batchCli.JobOperations.GetJob(jobId);
+                        Assert.Equal(JobState.Deleting, deletedJob.State);
                     }
-                    finally
+                    catch (Exception e)
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        Assert.IsAssignableFrom<BatchException>(e);
+                        BatchException be = e as BatchException;
+                        Assert.NotNull(be.RequestInformation);
+                        Assert.NotNull(be.RequestInformation.BatchError);
+                        Assert.Equal(BatchErrorCodeStrings.JobNotFound, be.RequestInformation.BatchError.Code);
+
+                        testOutputHelper.WriteLine("Job was deleted successfully");
                     }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -245,77 +241,75 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobCommit";
+                try
                 {
-                    string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobCommit";
-                    try
+                    //
+                    // Create the job
+                    //
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    cloudJob.PoolInformation = new PoolInformation()
                     {
-                        //
-                        // Create the job
-                        //
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation()
+                        PoolId = poolFixture.PoolId
+                    };
+
+                    testOutputHelper.WriteLine("Initial job schedule commit()");
+                    cloudJob.Commit();
+
+                    //Get the job
+                    CloudJob refreshableJob = batchCli.JobOperations.GetJob(jobId);
+
+                    //Update the bound job priority
+                    const int newJobPriority = 5;
+                    OnAllTasksComplete newOnAllTasksComplete = OnAllTasksComplete.NoAction;
+
+                    testOutputHelper.WriteLine("Job priority is: {0}", refreshableJob.Priority);
+                    refreshableJob.Priority = newJobPriority;
+                    refreshableJob.OnAllTasksComplete = newOnAllTasksComplete;
+                    refreshableJob.Commit();
+
+                    AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, poolFixture.PoolId, newJobPriority, null);
+
+                    //Update the bound job pool name
+                    //Must disable the job first before updating its pool
+                    refreshableJob.Disable(DisableJobOption.Terminate);
+
+                    //Wait for job to reach disabled state (could go to Disabling for a bit)
+                    //TODO: Use a uBtilities wait helper here
+                    DateTime jobDisabledStateWaitStartTime = DateTime.UtcNow;
+                    TimeSpan jobDisabledTimeout = TimeSpan.FromSeconds(120);
+                    while (refreshableJob.State != JobState.Disabled)
+                    {
+                        testOutputHelper.WriteLine("Bug1433069TestBoundJobCommit: sleeping for (refreshableJob.State != JobState.Disabled)");
+                        Thread.Sleep(TimeSpan.FromSeconds(10));
+                        refreshableJob = batchCli.JobOperations.GetJob(jobId);
+
+                        if (DateTime.UtcNow > jobDisabledStateWaitStartTime.Add(jobDisabledTimeout))
                         {
-                            PoolId = poolFixture.PoolId
-                        };
-
-                        testOutputHelper.WriteLine("Initial job schedule commit()");
-                        cloudJob.Commit();
-
-                        //Get the job
-                        CloudJob refreshableJob = batchCli.JobOperations.GetJob(jobId);
-
-                        //Update the bound job priority
-                        const int newJobPriority = 5;
-                        OnAllTasksComplete newOnAllTasksComplete = OnAllTasksComplete.NoAction;
-
-                        testOutputHelper.WriteLine("Job priority is: {0}", refreshableJob.Priority);
-                        refreshableJob.Priority = newJobPriority;
-                        refreshableJob.OnAllTasksComplete = newOnAllTasksComplete;
-                        refreshableJob.Commit();
-
-                        AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, poolFixture.PoolId, newJobPriority, null);
-
-                        //Update the bound job pool name
-                        //Must disable the job first before updating its pool
-                        refreshableJob.Disable(DisableJobOption.Terminate);
-
-                        //Wait for job to reach disabled state (could go to Disabling for a bit)
-                        //TODO: Use a uBtilities wait helper here
-                        DateTime jobDisabledStateWaitStartTime = DateTime.UtcNow;
-                        TimeSpan jobDisabledTimeout = TimeSpan.FromSeconds(120);
-                        while (refreshableJob.State != JobState.Disabled)
-                        {
-                            testOutputHelper.WriteLine("Bug1433069TestBoundJobCommit: sleeping for (refreshableJob.State != JobState.Disabled)");
-                            Thread.Sleep(TimeSpan.FromSeconds(10));
-                            refreshableJob = batchCli.JobOperations.GetJob(jobId);
-
-                            if (DateTime.UtcNow > jobDisabledStateWaitStartTime.Add(jobDisabledTimeout))
-                            {
-                                Assert.False(true, "Timed out waiting for job to go to disabled state");
-                            }
+                            Assert.False(true, "Timed out waiting for job to go to disabled state");
                         }
-
-                        const string newPoolId = "testPool";
-                        refreshableJob.PoolInformation.PoolId = newPoolId;
-                        refreshableJob.Commit();
-
-                        AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, newPoolId, newJobPriority, null);
-
-                        //Enable the job again
-                        refreshableJob.Enable();
-
-                        //Update the bound job constraints
-                        JobConstraints newJobConstraints = new JobConstraints(TimeSpan.FromSeconds(200), 19);
-                        refreshableJob.Constraints = newJobConstraints;
-                        refreshableJob.Commit();
-
-                        AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, newPoolId, newJobPriority, newJobConstraints);
                     }
-                    finally
-                    {
-                        batchCli.JobOperations.DeleteJob(jobId);
-                    }
+
+                    const string newPoolId = "testPool";
+                    refreshableJob.PoolInformation.PoolId = newPoolId;
+                    refreshableJob.Commit();
+
+                    AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, newPoolId, newJobPriority, null);
+
+                    //Enable the job again
+                    refreshableJob.Enable();
+
+                    //Update the bound job constraints
+                    JobConstraints newJobConstraints = new JobConstraints(TimeSpan.FromSeconds(200), 19);
+                    refreshableJob.Constraints = newJobConstraints;
+                    refreshableJob.Commit();
+
+                    AssertJobCorrectness(batchCli.JobOperations, jobId, ref refreshableJob, newPoolId, newJobPriority, newJobConstraints);
+                }
+                finally
+                {
+                    batchCli.JobOperations.DeleteJob(jobId);
                 }
             };
 
@@ -329,67 +323,65 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1996130Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1996130Job-" + TestUtilities.GetMyName();
-
-                    try
+                    // get a job/task to test. use workflow
+                    CloudJob boundJob = null;
                     {
-                        // get a job/task to test. use workflow
-                        CloudJob boundJob = null;
-                        {
-                            // need a bound job/task for the tests so set one up
-                            CloudJob tsh = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                            tsh.PoolInformation.PoolId = poolFixture.PoolId;
-                            tsh.Commit();
+                        // need a bound job/task for the tests so set one up
+                        CloudJob tsh = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                        tsh.PoolInformation.PoolId = poolFixture.PoolId;
+                        tsh.Commit();
 
-                            boundJob = batchCli.JobOperations.GetJob(jobId);
+                        boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                            boundJob.AddTask(new CloudTask("Bug1996130_task", "cmd /c hostname"));
-                        }
-
-                        // test task double refresh
-                        {
-                            // get the task
-                            CloudTask boundTask = batchCli.JobOperations.ListTasks(jobId).First();
-
-                            // double refresh
-                            boundTask.Refresh();
-                            boundTask.Refresh(); // this branch of the bug actually fixed in the other doublerefesh checkin by matthchr
-
-                            // do verbs
-                            boundTask.Refresh();
-                            boundTask.Delete();
-
-                            Thread.Sleep(5000);  // give server time to do its deed
-
-                            List<CloudTask> tasks = batchCli.JobOperations.ListTasks(jobId).ToList();
-
-                            // confirm delete suceeded
-                            Assert.Empty(tasks);
-                        }
-
-                        // test job double refresh and verbs
-                        {
-                            boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                            // double refresh to taint the instance... lost path variable
-                            boundJob.Refresh();
-                            boundJob.Refresh();  // this used to fail/throw
-
-                            boundJob.Refresh();  // this should fail but does not
-                            boundJob.Delete();   // yet another verb that suceeds
-
-                            CloudJob job = batchCli.JobOperations.ListJobs().ToList().FirstOrDefault(j => j.Id == jobId);
-
-                            // confirm job delete suceeded
-                            Assert.True(job == null || (JobState.Deleting == job.State));
-                        }
+                        boundJob.AddTask(new CloudTask("Bug1996130_task", "cmd /c hostname"));
                     }
-                    finally
+
+                    // test task double refresh
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        // get the task
+                        CloudTask boundTask = batchCli.JobOperations.ListTasks(jobId).First();
+
+                        // double refresh
+                        boundTask.Refresh();
+                        boundTask.Refresh(); // this branch of the bug actually fixed in the other doublerefesh checkin by matthchr
+
+                        // do verbs
+                        boundTask.Refresh();
+                        boundTask.Delete();
+
+                        Thread.Sleep(5000);  // give server time to do its deed
+
+                        List<CloudTask> tasks = batchCli.JobOperations.ListTasks(jobId).ToList();
+
+                        // confirm delete suceeded
+                        Assert.Empty(tasks);
                     }
+
+                    // test job double refresh and verbs
+                    {
+                        boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                        // double refresh to taint the instance... lost path variable
+                        boundJob.Refresh();
+                        boundJob.Refresh();  // this used to fail/throw
+
+                        boundJob.Refresh();  // this should fail but does not
+                        boundJob.Delete();   // yet another verb that suceeds
+
+                        CloudJob job = batchCli.JobOperations.ListJobs().ToList().FirstOrDefault(j => j.Id == jobId);
+
+                        // confirm job delete suceeded
+                        Assert.True(job == null || (JobState.Deleting == job.State));
+                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
 
             };
@@ -404,38 +396,36 @@
         {
             Action test = () =>
             {
-                using (BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                //Create a job
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestJobCompletesWhenAllItsTasksComplete";
+                string taskIdPrefix = "task-id";
+
+                try
                 {
-                    //Create a job
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestJobCompletesWhenAllItsTasksComplete";
-                    string taskIdPrefix = "task-id";
+                    CloudJob boundJob = CreateBoundJob(client, jobId);
 
-                    try
+                    var cloudTasks = new List<CloudTask>();
+                    for (var i = 0; i < 4; i++)
                     {
-                        CloudJob boundJob = CreateBoundJob(client, jobId);
-
-                        var cloudTasks = new List<CloudTask>();
-                        for (var i = 0; i < 4; i++)
-                        {
-                            cloudTasks.Add(new CloudTask(taskIdPrefix + "-" + i, "cmd /c ping 127.0.0.1"));
-                        }
-
-                        boundJob.AddTask(cloudTasks);
-
-                        boundJob.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
-                        boundJob.Commit();
-
-                        boundJob.Refresh();
-
-                        TestUtilities.WaitForJobStateAsync(boundJob, TimeSpan.FromMinutes(2), JobState.Completed).Wait();
-
-                        Assert.Equal(JobState.Completed, boundJob.State);
-                        Assert.Equal("AllTasksCompleted", boundJob.ExecutionInformation.TerminateReason);
+                        cloudTasks.Add(new CloudTask(taskIdPrefix + "-" + i, "cmd /c ping 127.0.0.1"));
                     }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+
+                    boundJob.AddTask(cloudTasks);
+
+                    boundJob.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
+                    boundJob.Commit();
+
+                    boundJob.Refresh();
+
+                    TestUtilities.WaitForJobStateAsync(boundJob, TimeSpan.FromMinutes(2), JobState.Completed).Wait();
+
+                    Assert.Equal(JobState.Completed, boundJob.State);
+                    Assert.Equal("AllTasksCompleted", boundJob.ExecutionInformation.TerminateReason);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 
@@ -449,44 +439,42 @@
         {
             Action test = () =>
             {
-                using (BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                //Create a job
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-IfJobSetsOnTaskFailedJobCompletesWhenAnyTaskFail";
+                string taskId = "task-id-1";
+
+                try
                 {
-                    //Create a job
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-IfJobSetsOnTaskFailedJobCompletesWhenAnyTaskFail";
-                    string taskId = "task-id-1";
-
-                    try
+                    CloudJob boundJob = null;
                     {
-                        CloudJob boundJob = null;
+                        // need a bound job/task for the tests so set one up
+                        boundJob = CreateBoundJob(client, jobId, j => { j.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction; });
+
+                        Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJob.OnTaskFailure);
+
+                        CloudTask cloudTask = new CloudTask(taskId, "cmd /c exit 3")
                         {
-                            // need a bound job/task for the tests so set one up
-                            boundJob = CreateBoundJob(client, jobId, j => { j.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction; });
-
-                            Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJob.OnTaskFailure);
-
-                            CloudTask cloudTask = new CloudTask(taskId, "cmd /c exit 3")
+                            ExitConditions = new ExitConditions
                             {
-                                ExitConditions = new ExitConditions
-                                {
-                                    ExitCodeRanges = new List<ExitCodeRangeMapping>
+                                ExitCodeRanges = new List<ExitCodeRangeMapping>
                                     {
                                         new ExitCodeRangeMapping(2, 4, new ExitOptions { JobAction = JobAction.Terminate})
                                     }
-                                }
-                            };
+                            }
+                        };
 
-                            boundJob.AddTask(cloudTask);
-                            boundJob.Refresh();
+                        boundJob.AddTask(cloudTask);
+                        boundJob.Refresh();
 
-                            TestUtilities.WaitForJobStateAsync(boundJob, TimeSpan.FromMinutes(2), JobState.Completed).Wait();
-                            Assert.Equal(JobState.Completed, boundJob.State);
-                            Assert.Equal("TaskFailed", boundJob.ExecutionInformation.TerminateReason);
-                        }
+                        TestUtilities.WaitForJobStateAsync(boundJob, TimeSpan.FromMinutes(2), JobState.Completed).Wait();
+                        Assert.Equal(JobState.Completed, boundJob.State);
+                        Assert.Equal("TaskFailed", boundJob.ExecutionInformation.TerminateReason);
                     }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 
@@ -499,54 +487,52 @@
         public void TestExitConditionsAreBeingRoundTrippedCorrectly()
         {
             Action test = () => 
-            { 
-                using (BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+            {
+                using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                //Create a job
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestExitConditionsAreBeingRoundTrippedCorrectly";
+                string taskId = "task-id-1";
+                try
                 {
-                    //Create a job
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestExitConditionsAreBeingRoundTrippedCorrectly";
-                    string taskId = "task-id-1";
-                    try
+                    CloudJob boundJob = null;
                     {
-                        CloudJob boundJob = null;
-                        {
-                            // need a bound job/task for the tests so set one up
-                            boundJob = CreateBoundJob(client, jobId, j => { j.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction; });
-                            CloudTask cloudTask = new CloudTask(taskId, "cmd /c exit 2");
+                        // need a bound job/task for the tests so set one up
+                        boundJob = CreateBoundJob(client, jobId, j => { j.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction; });
+                        CloudTask cloudTask = new CloudTask(taskId, "cmd /c exit 2");
 
-                            cloudTask.ExitConditions = new ExitConditions
-                            {
-                                ExitCodes = new List<ExitCodeMapping> { new ExitCodeMapping(1, new ExitOptions { JobAction = JobAction.None }) },
-                                ExitCodeRanges = new List<ExitCodeRangeMapping>
+                        cloudTask.ExitConditions = new ExitConditions
+                        {
+                            ExitCodes = new List<ExitCodeMapping> { new ExitCodeMapping(1, new ExitOptions { JobAction = JobAction.None }) },
+                            ExitCodeRanges = new List<ExitCodeRangeMapping>
                                 {
                                     new ExitCodeRangeMapping(2, 4, new ExitOptions { JobAction = JobAction.Disable })
                                 },
-                                PreProcessingError = new ExitOptions { JobAction = JobAction.Terminate },
-                                FileUploadError = new ExitOptions { JobAction = JobAction.Terminate },
-                                Default = new ExitOptions { JobAction = JobAction.Terminate },
-                            };
+                            PreProcessingError = new ExitOptions { JobAction = JobAction.Terminate },
+                            FileUploadError = new ExitOptions { JobAction = JobAction.Terminate },
+                            Default = new ExitOptions { JobAction = JobAction.Terminate },
+                        };
 
-                            boundJob.AddTask(cloudTask);
-                            boundJob.Refresh();
+                        boundJob.AddTask(cloudTask);
+                        boundJob.Refresh();
 
-                            Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJob.OnTaskFailure);
-                            CloudTask boundTask = client.JobOperations.GetTask(jobId, taskId);
+                        Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJob.OnTaskFailure);
+                        CloudTask boundTask = client.JobOperations.GetTask(jobId, taskId);
 
-                            Assert.Equal(JobAction.None, boundTask.ExitConditions.ExitCodes.First().ExitOptions.JobAction);
-                            Assert.Equal(1, boundTask.ExitConditions.ExitCodes.First().Code);
+                        Assert.Equal(JobAction.None, boundTask.ExitConditions.ExitCodes.First().ExitOptions.JobAction);
+                        Assert.Equal(1, boundTask.ExitConditions.ExitCodes.First().Code);
 
-                            var exitCodeRangeMappings = boundTask.ExitConditions.ExitCodeRanges;
-                            Assert.Equal(2, exitCodeRangeMappings.First().Start);
-                            Assert.Equal(4, exitCodeRangeMappings.First().End);
-                            Assert.Equal(JobAction.Disable, exitCodeRangeMappings.First().ExitOptions.JobAction);
-                            Assert.Equal(JobAction.Terminate, boundTask.ExitConditions.PreProcessingError.JobAction);
-                            Assert.Equal(JobAction.Terminate, boundTask.ExitConditions.FileUploadError.JobAction);
-                            Assert.Equal(JobAction.Terminate, boundTask.ExitConditions.Default.JobAction);
-                        }
+                        var exitCodeRangeMappings = boundTask.ExitConditions.ExitCodeRanges;
+                        Assert.Equal(2, exitCodeRangeMappings.First().Start);
+                        Assert.Equal(4, exitCodeRangeMappings.First().End);
+                        Assert.Equal(JobAction.Disable, exitCodeRangeMappings.First().ExitOptions.JobAction);
+                        Assert.Equal(JobAction.Terminate, boundTask.ExitConditions.PreProcessingError.JobAction);
+                        Assert.Equal(JobAction.Terminate, boundTask.ExitConditions.FileUploadError.JobAction);
+                        Assert.Equal(JobAction.Terminate, boundTask.ExitConditions.Default.JobAction);
                     }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 
@@ -626,105 +612,103 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                {
-                    const string testName = "TestJobUpdateWithAndWithoutPoolInfo";
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string testName = "TestJobUpdateWithAndWithoutPoolInfo";
 
-                    // Create a job
-                    string jobId = testName + "_" + TestUtilities.GetMyName();
-                    CloudJob unboundJob = batchCli.JobOperations.CreateJob();
-                    unboundJob.Id = jobId;
+                // Create a job
+                string jobId = testName + "_" + TestUtilities.GetMyName();
+                CloudJob unboundJob = batchCli.JobOperations.CreateJob();
+                unboundJob.Id = jobId;
 
-                    // Use an auto pool with the job, since PoolInformation can't be updated otherwise.
-                    PoolSpecification poolSpec = new PoolSpecification();
-                    
-                    poolSpec.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily, "*");
+                // Use an auto pool with the job, since PoolInformation can't be updated otherwise.
+                PoolSpecification poolSpec = new PoolSpecification();
 
-                    poolSpec.TargetDedicatedComputeNodes = 0;
-                    poolSpec.VirtualMachineSize = PoolFixture.VMSize;
-                    AutoPoolSpecification autoPoolSpec = new AutoPoolSpecification();
-                    string autoPoolPrefix = "UpdPIAuto_" + TestUtilities.GetMyName();
-                    autoPoolSpec.AutoPoolIdPrefix = autoPoolPrefix;
-                    const bool originalKeepAlive = false;
-                    autoPoolSpec.KeepAlive = originalKeepAlive;
-                    autoPoolSpec.PoolLifetimeOption = PoolLifetimeOption.Job;
-                    autoPoolSpec.PoolSpecification = poolSpec;
-                    PoolInformation poolInfo = new PoolInformation();
-                    poolInfo.AutoPoolSpecification = autoPoolSpec;
-                    unboundJob.PoolInformation = poolInfo;
+                poolSpec.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily, "*");
 
-                    const int originalPriority = 0;
-                    unboundJob.Priority = originalPriority;
-                    List<MetadataItem> originalMetadata = new List<MetadataItem>
+                poolSpec.TargetDedicatedComputeNodes = 0;
+                poolSpec.VirtualMachineSize = PoolFixture.VMSize;
+                AutoPoolSpecification autoPoolSpec = new AutoPoolSpecification();
+                string autoPoolPrefix = "UpdPIAuto_" + TestUtilities.GetMyName();
+                autoPoolSpec.AutoPoolIdPrefix = autoPoolPrefix;
+                const bool originalKeepAlive = false;
+                autoPoolSpec.KeepAlive = originalKeepAlive;
+                autoPoolSpec.PoolLifetimeOption = PoolLifetimeOption.Job;
+                autoPoolSpec.PoolSpecification = poolSpec;
+                PoolInformation poolInfo = new PoolInformation();
+                poolInfo.AutoPoolSpecification = autoPoolSpec;
+                unboundJob.PoolInformation = poolInfo;
+
+                const int originalPriority = 0;
+                unboundJob.Priority = originalPriority;
+                List<MetadataItem> originalMetadata = new List<MetadataItem>
                     {
                         new MetadataItem("meta1", "value1"),
                         new MetadataItem("meta2", "value2")
                     };
-                    unboundJob.Metadata = originalMetadata;
+                unboundJob.Metadata = originalMetadata;
 
-                    testOutputHelper.WriteLine("Creating job {0}", jobId);
-                    unboundJob.Commit();
+                testOutputHelper.WriteLine("Creating job {0}", jobId);
+                unboundJob.Commit();
 
-                    try
+                try
+                {
+                    // Get bound job
+                    CloudJob createdJob = batchCli.JobOperations.GetJob(jobId);
+
+                    // Verify that we can update something besides PoolInformation without getting an error for not being in the Disabled state.
+                    Assert.NotEqual(JobState.Disabled, createdJob.State);
+
+                    int updatedPriority = originalPriority + 1;
+                    List<MetadataItem> updatedMetadata = new List<MetadataItem> { new MetadataItem("updatedMeta1", "value1") };
+                    createdJob.Priority = updatedPriority;
+                    createdJob.Metadata = updatedMetadata;
+
+                    testOutputHelper.WriteLine("Updating job {0} without altering PoolInformation", jobId);
+
+                    createdJob.Commit();
+
+                    // Verify update occurred
+                    CloudJob updatedJob = batchCli.JobOperations.GetJob(jobId);
+
+                    Assert.Equal(updatedPriority, updatedJob.Priority);
+                    Assert.Equal(updatedJob.Metadata.Count, updatedJob.Priority);
+                    Assert.Equal(updatedJob.Metadata[0].Name, updatedMetadata[0].Name);
+                    Assert.Equal(updatedJob.Metadata[0].Value, updatedMetadata[0].Value);
+
+                    // Verify that updating the PoolInformation works.
+                    // PoolInformation can only be changed in the Disabled state.
+                    testOutputHelper.WriteLine("Disabling job {0}", jobId);
+                    updatedJob.Disable(DisableJobOption.Terminate);
+                    while (updatedJob.State != JobState.Disabled)
                     {
-                        // Get bound job
-                        CloudJob createdJob = batchCli.JobOperations.GetJob(jobId);
-
-                        // Verify that we can update something besides PoolInformation without getting an error for not being in the Disabled state.
-                        Assert.NotEqual(JobState.Disabled, createdJob.State);
-
-                        int updatedPriority = originalPriority + 1;
-                        List<MetadataItem> updatedMetadata = new List<MetadataItem> { new MetadataItem("updatedMeta1", "value1") };
-                        createdJob.Priority = updatedPriority;
-                        createdJob.Metadata = updatedMetadata;
-
-                        testOutputHelper.WriteLine("Updating job {0} without altering PoolInformation", jobId);
-
-                        createdJob.Commit();
-
-                        // Verify update occurred
-                        CloudJob updatedJob = batchCli.JobOperations.GetJob(jobId);
-
-                        Assert.Equal(updatedPriority, updatedJob.Priority);
-                        Assert.Equal(updatedJob.Metadata.Count, updatedJob.Priority);
-                        Assert.Equal(updatedJob.Metadata[0].Name, updatedMetadata[0].Name);
-                        Assert.Equal(updatedJob.Metadata[0].Value, updatedMetadata[0].Value);
-
-                        // Verify that updating the PoolInformation works.
-                        // PoolInformation can only be changed in the Disabled state.
-                        testOutputHelper.WriteLine("Disabling job {0}", jobId);
-                        updatedJob.Disable(DisableJobOption.Terminate);
-                        while (updatedJob.State != JobState.Disabled)
-                        {
-                            Thread.Sleep(500);
-                            updatedJob.Refresh();
-                        }
-
-                        Assert.Equal(JobState.Disabled, updatedJob.State);
-
-                        bool updatedKeepAlive = !originalKeepAlive;
-                        updatedJob.PoolInformation.AutoPoolSpecification.KeepAlive = updatedKeepAlive;
-                        int updatedAgainPriority = updatedPriority + 1;
-                        updatedJob.Priority = updatedAgainPriority;
-                        testOutputHelper.WriteLine("Updating job {0} properties, including PoolInformation", jobId);
-                        updatedJob.Commit();
-
-                        CloudJob updatedPoolInfoJob = batchCli.JobOperations.GetJob(jobId);
-
-                        Assert.Equal(updatedKeepAlive, updatedPoolInfoJob.PoolInformation.AutoPoolSpecification.KeepAlive);
-                        Assert.Equal(updatedAgainPriority, updatedPoolInfoJob.Priority);
+                        Thread.Sleep(500);
+                        updatedJob.Refresh();
                     }
-                    finally
-                    {
-                        testOutputHelper.WriteLine("Deleting job {0}", jobId);
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
 
-                        // Explicitly delete auto pool
-                        foreach (CloudPool pool in batchCli.PoolOperations.ListPools(new ODATADetailLevel(filterClause: string.Format("startswith(id,'{0}')", autoPoolPrefix))))
-                        {
-                            testOutputHelper.WriteLine("Deleting pool {0}", pool.Id);
-                            TestUtilities.DeletePoolIfExistsAsync(batchCli, pool.Id).Wait();
-                        }
+                    Assert.Equal(JobState.Disabled, updatedJob.State);
+
+                    bool updatedKeepAlive = !originalKeepAlive;
+                    updatedJob.PoolInformation.AutoPoolSpecification.KeepAlive = updatedKeepAlive;
+                    int updatedAgainPriority = updatedPriority + 1;
+                    updatedJob.Priority = updatedAgainPriority;
+                    testOutputHelper.WriteLine("Updating job {0} properties, including PoolInformation", jobId);
+                    updatedJob.Commit();
+
+                    CloudJob updatedPoolInfoJob = batchCli.JobOperations.GetJob(jobId);
+
+                    Assert.Equal(updatedKeepAlive, updatedPoolInfoJob.PoolInformation.AutoPoolSpecification.KeepAlive);
+                    Assert.Equal(updatedAgainPriority, updatedPoolInfoJob.Priority);
+                }
+                finally
+                {
+                    testOutputHelper.WriteLine("Deleting job {0}", jobId);
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+
+                    // Explicitly delete auto pool
+                    foreach (CloudPool pool in batchCli.PoolOperations.ListPools(new ODATADetailLevel(filterClause: string.Format("startswith(id,'{0}')", autoPoolPrefix))))
+                    {
+                        testOutputHelper.WriteLine("Deleting pool {0}", pool.Id);
+                        TestUtilities.DeletePoolIfExistsAsync(batchCli, pool.Id).Wait();
                     }
                 }
             };
@@ -739,52 +723,51 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1965363Job-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "Bug1965363Job-" + TestUtilities.GetMyName();
-                    try
+
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-
-                        PoolInformation poolInfo = new PoolInformation()
+                        AutoPoolSpecification = new AutoPoolSpecification()
                         {
-                            AutoPoolSpecification = new AutoPoolSpecification()
+                            PoolLifetimeOption = PoolLifetimeOption.Job,
+                            PoolSpecification = new PoolSpecification()
                             {
-                                PoolLifetimeOption = PoolLifetimeOption.Job,
-                                PoolSpecification = new PoolSpecification()
-                                {
-                                    CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
-                                    VirtualMachineSize = PoolFixture.VMSize,
-                                    TargetDedicatedComputeNodes = 1
-                                }
+                                CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
+                                VirtualMachineSize = PoolFixture.VMSize,
+                                TargetDedicatedComputeNodes = 1
                             }
-                        };
+                        }
+                    };
 
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
 
-                        testOutputHelper.WriteLine("Commiting quickjob");
-                        unboundJob.Commit();
+                    testOutputHelper.WriteLine("Commiting quickjob");
+                    unboundJob.Commit();
 
-                        CloudTask task = new CloudTask("Bug1965363Wat7OSVersionFeaturesQuickJobWithAutoPoolTask", "cmd /c echo Bug1965363");
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        boundJob.AddTask(task);
+                    CloudTask task = new CloudTask("Bug1965363Wat7OSVersionFeaturesQuickJobWithAutoPoolTask", "cmd /c echo Bug1965363");
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    boundJob.AddTask(task);
 
-                        testOutputHelper.WriteLine("Getting pool name: {0}", boundJob.ExecutionInformation.PoolId);
+                    testOutputHelper.WriteLine("Getting pool name: {0}", boundJob.ExecutionInformation.PoolId);
 
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(boundJob.ExecutionInformation.PoolId);
-                        TaskStateMonitor tsm = batchCli.Utilities.CreateTaskStateMonitor();
-                        ODATAMonitorControl odControl = new ODATAMonitorControl();
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(boundJob.ExecutionInformation.PoolId);
+                    TaskStateMonitor tsm = batchCli.Utilities.CreateTaskStateMonitor();
+                    ODATAMonitorControl odControl = new ODATAMonitorControl();
 
-                        // we know that the autopool compute nodes will take a long time to become scheduleable so we slow down polling/spam
-                        odControl.DelayBetweenDataFetch = TimeSpan.FromSeconds(5);
+                    // we know that the autopool compute nodes will take a long time to become scheduleable so we slow down polling/spam
+                    odControl.DelayBetweenDataFetch = TimeSpan.FromSeconds(5);
 
-                        testOutputHelper.WriteLine("Invoking TaskStateMonitor");
+                    testOutputHelper.WriteLine("Invoking TaskStateMonitor");
 
-                        tsm.WaitAll(
-                            boundJob.ListTasks(),
-                            TaskState.Completed,
-                            TimeSpan.FromMinutes(15),
-                            odControl,
-                            new[] {
+                    tsm.WaitAll(
+                        boundJob.ListTasks(),
+                        TaskState.Completed,
+                        TimeSpan.FromMinutes(15),
+                        odControl,
+                        new[] {
                                 // spam/logging interceptor
                                 new Protocol.RequestInterceptor((x) =>
                                 {
@@ -797,17 +780,16 @@
                                     allComputeNodes.ForEach((icn) => { testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State); });
                                     testOutputHelper.WriteLine("");
                                 })
-                            });
+                        });
 
-                        // confirm the task ran by inspecting the stdOut
-                        string stdOut = boundJob.ListTasks().ToList()[0].GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                    // confirm the task ran by inspecting the stdOut
+                    string stdOut = boundJob.ListTasks().ToList()[0].GetNodeFile(Constants.StandardOutFileName).ReadAsString();
 
-                        Assert.Contains("Bug1965363", stdOut);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.Contains("Bug1965363", stdOut);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -821,50 +803,48 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string jobId = "JobConditionalHeaders-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "JobConditionalHeaders-" + TestUtilities.GetMyName();
-                    try
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-                        PoolInformation poolInfo = new PoolInformation()
-                            {
-                                PoolId = "Fake"
-                            };
+                        PoolId = "Fake"
+                    };
 
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
-                        unboundJob.Commit();
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
+                    unboundJob.Commit();
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                        string capturedEtag1 = boundJob.ETag;
-                        testOutputHelper.WriteLine("Etag is: {0}", capturedEtag1);
-                        Assert.NotNull(capturedEtag1);
+                    string capturedEtag1 = boundJob.ETag;
+                    testOutputHelper.WriteLine("Etag is: {0}", capturedEtag1);
+                    Assert.NotNull(capturedEtag1);
 
-                        boundJob.Constraints = new JobConstraints(TimeSpan.FromMinutes(60), 0);
+                    boundJob.Constraints = new JobConstraints(TimeSpan.FromMinutes(60), 0);
 
-                        BatchClientBehavior updateInterceptor = new Protocol.RequestInterceptor(req =>
+                    BatchClientBehavior updateInterceptor = new Protocol.RequestInterceptor(req =>
+                    {
+                        if (req.Options is Protocol.Models.JobUpdateOptions typedParams)
                         {
-                            if (req.Options is Protocol.Models.JobUpdateOptions typedParams)
-                            {
-                                typedParams.IfMatch = capturedEtag1;
-                            }
-                        });
+                            typedParams.IfMatch = capturedEtag1;
+                        }
+                    });
 
-                        //Update bound job with if-match header, it should succeed
-                        boundJob.Commit(additionalBehaviors: new[] { updateInterceptor });
+                    //Update bound job with if-match header, it should succeed
+                    boundJob.Commit(additionalBehaviors: new[] { updateInterceptor });
 
-                        boundJob = batchCli.JobOperations.GetJob(jobId);
+                    boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                        boundJob.Constraints = new JobConstraints(TimeSpan.FromMinutes(30), 1);
+                    boundJob.Constraints = new JobConstraints(TimeSpan.FromMinutes(30), 1);
 
-                        //Update bound job with if-match header, it should fail
-                        Exception e = TestUtilities.AssertThrows<BatchException>(() => boundJob.Commit(additionalBehaviors: new[] { updateInterceptor }));
-                        TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, testOutputHelper);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    //Update bound job with if-match header, it should fail
+                    Exception e = TestUtilities.AssertThrows<BatchException>(() => boundJob.Commit(additionalBehaviors: new[] { updateInterceptor }));
+                    TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, testOutputHelper);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -878,30 +858,28 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string jobId = "TestJobWithLowPriJobManager-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "TestJobWithLowPriJobManager-" + TestUtilities.GetMyName();
-                    try
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-                        PoolInformation poolInfo = new PoolInformation()
-                        {
-                            PoolId = "Fake"
-                        };
+                        PoolId = "Fake"
+                    };
 
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
-                        unboundJob.JobManagerTask = new JobManagerTask("foo", "cmd /c echo hi")
-                        {
-                            AllowLowPriorityNode = true
-                        };
-                        await unboundJob.CommitAsync().ConfigureAwait(false);
-                        await unboundJob.RefreshAsync().ConfigureAwait(false);
-
-                        Assert.True(unboundJob.JobManagerTask.AllowLowPriorityNode);
-                    }
-                    finally
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
+                    unboundJob.JobManagerTask = new JobManagerTask("foo", "cmd /c echo hi")
                     {
-                        await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
-                    }
+                        AllowLowPriorityNode = true
+                    };
+                    await unboundJob.CommitAsync().ConfigureAwait(false);
+                    await unboundJob.RefreshAsync().ConfigureAwait(false);
+
+                    Assert.True(unboundJob.JobManagerTask.AllowLowPriorityNode);
+                }
+                finally
+                {
+                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
                 }
             };
 
@@ -915,36 +893,34 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string jobId = "TestJobGetTaskCounts-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "TestJobGetTaskCounts-" + TestUtilities.GetMyName();
-                    try
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-                        PoolInformation poolInfo = new PoolInformation()
-                        {
-                            PoolId = "Fake"
-                        };
+                        PoolId = "Fake"
+                    };
 
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
-                        await unboundJob.CommitAsync().ConfigureAwait(false);
-                        await unboundJob.RefreshAsync().ConfigureAwait(false);
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
+                    await unboundJob.CommitAsync().ConfigureAwait(false);
+                    await unboundJob.RefreshAsync().ConfigureAwait(false);
 
-                        CloudTask t1 = new CloudTask("t1", "cmd /c dir");
-                        CloudTask t2 = new CloudTask("t2", "cmd /c ping 127.0.0.1 -n 4");
+                    CloudTask t1 = new CloudTask("t1", "cmd /c dir");
+                    CloudTask t2 = new CloudTask("t2", "cmd /c ping 127.0.0.1 -n 4");
 
-                        await unboundJob.AddTaskAsync(new[] {t1, t2}).ConfigureAwait(false);
+                    await unboundJob.AddTaskAsync(new[] { t1, t2 }).ConfigureAwait(false);
 
-                        await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false); // Give the service some time to get the counts
+                    await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false); // Give the service some time to get the counts
 
-                        var counts = await unboundJob.GetTaskCountsAsync().ConfigureAwait(false);
+                    var counts = await unboundJob.GetTaskCountsAsync().ConfigureAwait(false);
 
-                        Assert.Equal(2, counts.TaskCounts.Active);
-                        Assert.Equal(2, counts.TaskSlotCounts.Active);
-                    }
-                    finally
-                    {
-                        await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
-                    }
+                    Assert.Equal(2, counts.TaskCounts.Active);
+                    Assert.Equal(2, counts.TaskSlotCounts.Active);
+                }
+                finally
+                {
+                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
                 }
             };
 
@@ -959,44 +935,42 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string jobId = "NonZeroTaskSlots-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "NonZeroTaskSlots-" + TestUtilities.GetMyName();
-                    try
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-                        PoolInformation poolInfo = new PoolInformation()
-                        {
-                            PoolId = "Fake"
-                        };
+                        PoolId = "Fake"
+                    };
 
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
-                        await unboundJob.CommitAsync().ConfigureAwait(false);
-                        await unboundJob.RefreshAsync().ConfigureAwait(false);
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
+                    await unboundJob.CommitAsync().ConfigureAwait(false);
+                    await unboundJob.RefreshAsync().ConfigureAwait(false);
 
-                        CloudTask t1 = new CloudTask("t1", "cmd /c dir");
-                        t1.RequiredSlots = 2;
-                        CloudTask t2 = new CloudTask("t2", "cmd /c ping 127.0.0.1 -n 4");
-                        t2.RequiredSlots = 3;
+                    CloudTask t1 = new CloudTask("t1", "cmd /c dir");
+                    t1.RequiredSlots = 2;
+                    CloudTask t2 = new CloudTask("t2", "cmd /c ping 127.0.0.1 -n 4");
+                    t2.RequiredSlots = 3;
 
-                        await unboundJob.AddTaskAsync(new[] { t1, t2 }).ConfigureAwait(false);
+                    await unboundJob.AddTaskAsync(new[] { t1, t2 }).ConfigureAwait(false);
 
-                        await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false); // Give the service some time to get the counts
+                    await Task.Delay(TimeSpan.FromSeconds(5)).ConfigureAwait(false); // Give the service some time to get the counts
 
-                        var counts = await unboundJob.GetTaskCountsAsync().ConfigureAwait(false);
+                    var counts = await unboundJob.GetTaskCountsAsync().ConfigureAwait(false);
 
-                        var retTask1 = await unboundJob.GetTaskAsync(t1.Id);
-                        Assert.Equal(t1.RequiredSlots, retTask1.RequiredSlots);
-                        var retTask2 = await unboundJob.GetTaskAsync(t1.Id);
-                        Assert.Equal(t1.RequiredSlots, retTask2.RequiredSlots);
+                    var retTask1 = await unboundJob.GetTaskAsync(t1.Id);
+                    Assert.Equal(t1.RequiredSlots, retTask1.RequiredSlots);
+                    var retTask2 = await unboundJob.GetTaskAsync(t1.Id);
+                    Assert.Equal(t1.RequiredSlots, retTask2.RequiredSlots);
 
-                        Assert.Equal(2, counts.TaskCounts.Active);
-                        // Task slots counts is currently broken
-                        // Assert.Equal(5, counts.TaskSlotCounts.Active);
-                    }
-                    finally
-                    {
-                        await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
-                    }
+                    Assert.Equal(2, counts.TaskCounts.Active);
+                    // Task slots counts is currently broken
+                    // Assert.Equal(5, counts.TaskSlotCounts.Active);
+                }
+                finally
+                {
+                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
                 }
             };
 
@@ -1005,49 +979,47 @@
 
         private static async Task MutateJobAsync(string jobId, Func<CloudJob, Task> jobAction)
         {
-            using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+            using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+            const string newPoolId = "Bar";
+            const string metadataKey = "Foo";
+            const string metadataValue = "Bar";
+            TimeSpan newMaxWallClockTime = TimeSpan.FromDays(1);
+            try
             {
-                const string newPoolId = "Bar";
-                const string metadataKey = "Foo";
-                const string metadataValue = "Bar";
-                TimeSpan newMaxWallClockTime = TimeSpan.FromDays(1);
-                try
-                {
-                    CloudJob job = batchCli.JobOperations.CreateJob(
-                        jobId,
-                        new PoolInformation()
-                        {
-                            PoolId = "Temp"
-                        });
+                CloudJob job = batchCli.JobOperations.CreateJob(
+                    jobId,
+                    new PoolInformation()
+                    {
+                        PoolId = "Temp"
+                    });
 
-                    await job.CommitAsync().ConfigureAwait(false);
-                    await job.RefreshAsync().ConfigureAwait(false);
+                await job.CommitAsync().ConfigureAwait(false);
+                await job.RefreshAsync().ConfigureAwait(false);
 
-                    //Disable the job so that we can update the pool info
-                    await job.DisableAsync(DisableJobOption.Requeue).ConfigureAwait(false);
+                //Disable the job so that we can update the pool info
+                await job.DisableAsync(DisableJobOption.Requeue).ConfigureAwait(false);
 
-                    await TestUtilities.WaitForJobStateAsync(job, TimeSpan.FromMinutes(1), JobState.Disabled).ConfigureAwait(false);
+                await TestUtilities.WaitForJobStateAsync(job, TimeSpan.FromMinutes(1), JobState.Disabled).ConfigureAwait(false);
 
-                    job.Constraints = new JobConstraints(maxWallClockTime: newMaxWallClockTime);
-                    job.Metadata = new List<MetadataItem>()
+                job.Constraints = new JobConstraints(maxWallClockTime: newMaxWallClockTime);
+                job.Metadata = new List<MetadataItem>()
                             {
                                 new MetadataItem(metadataKey, metadataValue)
                             };
-                    job.PoolInformation.PoolId = newPoolId;
+                job.PoolInformation.PoolId = newPoolId;
 
-                    await jobAction(job).ConfigureAwait(false);
+                await jobAction(job).ConfigureAwait(false);
 
-                    await job.RefreshAsync().ConfigureAwait(false);
+                await job.RefreshAsync().ConfigureAwait(false);
 
-                    Assert.Equal(newMaxWallClockTime, job.Constraints.MaxWallClockTime);
-                    Assert.Equal(newPoolId, job.PoolInformation.PoolId);
-                    Assert.Equal(metadataKey, job.Metadata.Single().Name);
-                    Assert.Equal(metadataValue, job.Metadata.Single().Value);
-                }
-                finally
-                {
-                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).ConfigureAwait(false);
-                }
+                Assert.Equal(newMaxWallClockTime, job.Constraints.MaxWallClockTime);
+                Assert.Equal(newPoolId, job.PoolInformation.PoolId);
+                Assert.Equal(metadataKey, job.Metadata.Single().Name);
+                Assert.Equal(metadataValue, job.Metadata.Single().Value);
+            }
+            finally
+            {
+                await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).ConfigureAwait(false);
             }
         }
     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobScheduleIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobScheduleIntegrationTests.cs
@@ -54,7 +54,7 @@
                         jobSchedule.Schedule = new Schedule() { RecurrenceInterval = firstRecurrenceInterval };
                         PoolInformation poolInfo = new PoolInformation()
                             {
-                                PoolId = this.poolFixture.PoolId
+                                PoolId = poolFixture.PoolId
                             };
 
                         jobSchedule.JobSpecification = new JobSpecification(poolInfo)
@@ -65,14 +65,14 @@
 
                         jobSchedule.Metadata = metadata;
 
-                        this.testOutputHelper.WriteLine("Initial job schedule commit()");
+                        testOutputHelper.WriteLine("Initial job schedule commit()");
                         jobSchedule.Commit();
 
                         //Get the bound job schedule
                         CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
 
                         //Ensure the job schedule is structured as expected
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, this.poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, firstRecurrenceInterval, metadata);
+                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, firstRecurrenceInterval, metadata);
 
                         //Update the bound job schedule schedule
                         TimeSpan recurrenceInterval = TimeSpan.FromMinutes(5);
@@ -81,38 +81,38 @@
                             RecurrenceInterval = recurrenceInterval
                         };
 
-                        this.testOutputHelper.WriteLine("Updating JobSchedule Schedule");
+                        testOutputHelper.WriteLine("Updating JobSchedule Schedule");
                         boundJobSchedule.Commit();
 
                         //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, this.poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
+                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
 
                         //Update the bound job schedule priority
                         const int newJobSchedulePriority = 1;
                         boundJobSchedule.JobSpecification.Priority = newJobSchedulePriority;
 
-                        this.testOutputHelper.WriteLine("Updating JobSpecification.Priority");
+                        testOutputHelper.WriteLine("Updating JobSpecification.Priority");
                         boundJobSchedule.Commit();
 
                         //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, this.poolFixture.PoolId, newJobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
+                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
 
                         //Update the bound job schedule job manager commandline
                         const string newJobManagerCommandLine = "ping 127.0.0.1 -n 150";
                         boundJobSchedule.JobSpecification.JobManagerTask.CommandLine = newJobManagerCommandLine;
 
-                        this.testOutputHelper.WriteLine("Updating JobSpecification.JobManagerTask.CommandLine");
+                        testOutputHelper.WriteLine("Updating JobSpecification.JobManagerTask.CommandLine");
                         boundJobSchedule.Commit();
 
                         //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, this.poolFixture.PoolId, newJobSchedulePriority, jobManagerId, newJobManagerCommandLine, recurrenceInterval, metadata);
+                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, newJobManagerCommandLine, recurrenceInterval, metadata);
 
                         //Update the bound job schedule PoolInformation
                         const string newPoolId = "TestPool";
 
                         boundJobSchedule.JobSpecification.PoolInformation = new PoolInformation() { PoolId = newPoolId };
 
-                        this.testOutputHelper.WriteLine("Updating PoolInformation");
+                        testOutputHelper.WriteLine("Updating PoolInformation");
                         boundJobSchedule.Commit();
 
                         //Ensure the job schedule is correct after commit
@@ -130,7 +130,7 @@
                         IList<MetadataItem> newMetadata = new List<MetadataItem> { new MetadataItem("Object", "Model") };
                         boundJobSchedule.Metadata = newMetadata;
 
-                        this.testOutputHelper.WriteLine("Updating Metadata");
+                        testOutputHelper.WriteLine("Updating Metadata");
                         boundJobSchedule.Commit();
 
                         //Ensure the job schedule is correct after commit
@@ -323,7 +323,7 @@
 
                         CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
                         {
-                            TestUtilities.DisplayJobScheduleLong(this.testOutputHelper, jobSchedule);
+                            TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
 
                             List<MetadataItem> mdi = new List<MetadataItem>(jobSchedule.Metadata);
 
@@ -357,7 +357,7 @@
 
                             jobSchedule.Refresh();
 
-                            TestUtilities.DisplayJobScheduleLong(this.testOutputHelper, jobSchedule);
+                            TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
                         }
                     }
                     finally
@@ -417,7 +417,7 @@
                         CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
 
                         // confirm that the original value(s) are set
-                        TestUtilities.DisplayJobScheduleLong(this.testOutputHelper, jobSchedule);
+                        TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
 
                         Assert.Equal(unboundDNRU, jobSchedule.Schedule.DoNotRunUntil);
 
@@ -432,7 +432,7 @@
                         jobSchedule.Refresh();
 
                         // confirm that the new value(s) are set
-                        TestUtilities.DisplayJobScheduleLong(this.testOutputHelper, jobSchedule);
+                        TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
 
                         Assert.Equal(boundDNRU, jobSchedule.Schedule.DoNotRunUntil);
                     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobScheduleIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobScheduleIntegrationTests.cs
@@ -36,118 +36,116 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobScheduleCommit";
+                try
                 {
-                    string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobScheduleCommit";
-                    try
+                    //
+                    // Create the job schedule
+                    //
+                    const int jobSchedulePriority = 5;
+                    const string jobManagerId = "TestBoundJobScheduleCommit";
+                    const string jobManagerCommandLine = "ping 127.0.0.1 -n 500";
+
+                    IList<MetadataItem> metadata = new List<MetadataItem> { new MetadataItem("key1", "test1"), new MetadataItem("key2", "test2") };
+                    CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
+                    TimeSpan firstRecurrenceInterval = TimeSpan.FromMinutes(2);
+                    jobSchedule.Schedule = new Schedule() { RecurrenceInterval = firstRecurrenceInterval };
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-                        //
-                        // Create the job schedule
-                        //
-                        const int jobSchedulePriority = 5;
-                        const string jobManagerId = "TestBoundJobScheduleCommit";
-                        const string jobManagerCommandLine = "ping 127.0.0.1 -n 500";
+                        PoolId = poolFixture.PoolId
+                    };
 
-                        IList<MetadataItem> metadata = new List<MetadataItem> { new MetadataItem("key1", "test1"), new MetadataItem("key2", "test2") };
-                        CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
-                        TimeSpan firstRecurrenceInterval = TimeSpan.FromMinutes(2);
-                        jobSchedule.Schedule = new Schedule() { RecurrenceInterval = firstRecurrenceInterval };
-                        PoolInformation poolInfo = new PoolInformation()
-                            {
-                                PoolId = poolFixture.PoolId
-                            };
-
-                        jobSchedule.JobSpecification = new JobSpecification(poolInfo)
-                            {
-                                Priority = jobSchedulePriority,
-                                JobManagerTask = new JobManagerTask(jobManagerId, jobManagerCommandLine)
-                            };
-
-                        jobSchedule.Metadata = metadata;
-
-                        testOutputHelper.WriteLine("Initial job schedule commit()");
-                        jobSchedule.Commit();
-
-                        //Get the bound job schedule
-                        CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
-
-                        //Ensure the job schedule is structured as expected
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, firstRecurrenceInterval, metadata);
-
-                        //Update the bound job schedule schedule
-                        TimeSpan recurrenceInterval = TimeSpan.FromMinutes(5);
-                        boundJobSchedule.Schedule = new Schedule()
-                        {
-                            RecurrenceInterval = recurrenceInterval
-                        };
-
-                        testOutputHelper.WriteLine("Updating JobSchedule Schedule");
-                        boundJobSchedule.Commit();
-
-                        //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
-
-                        //Update the bound job schedule priority
-                        const int newJobSchedulePriority = 1;
-                        boundJobSchedule.JobSpecification.Priority = newJobSchedulePriority;
-
-                        testOutputHelper.WriteLine("Updating JobSpecification.Priority");
-                        boundJobSchedule.Commit();
-
-                        //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
-
-                        //Update the bound job schedule job manager commandline
-                        const string newJobManagerCommandLine = "ping 127.0.0.1 -n 150";
-                        boundJobSchedule.JobSpecification.JobManagerTask.CommandLine = newJobManagerCommandLine;
-
-                        testOutputHelper.WriteLine("Updating JobSpecification.JobManagerTask.CommandLine");
-                        boundJobSchedule.Commit();
-
-                        //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, newJobManagerCommandLine, recurrenceInterval, metadata);
-
-                        //Update the bound job schedule PoolInformation
-                        const string newPoolId = "TestPool";
-
-                        boundJobSchedule.JobSpecification.PoolInformation = new PoolInformation() { PoolId = newPoolId };
-
-                        testOutputHelper.WriteLine("Updating PoolInformation");
-                        boundJobSchedule.Commit();
-
-                        //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(
-                            batchCli.JobScheduleOperations,
-                            boundJobSchedule,
-                            newPoolId,
-                            newJobSchedulePriority,
-                            jobManagerId,
-                            newJobManagerCommandLine,
-                            recurrenceInterval,
-                            metadata);
-
-                        //Update the bound job schedule Metadata
-                        IList<MetadataItem> newMetadata = new List<MetadataItem> { new MetadataItem("Object", "Model") };
-                        boundJobSchedule.Metadata = newMetadata;
-
-                        testOutputHelper.WriteLine("Updating Metadata");
-                        boundJobSchedule.Commit();
-
-                        //Ensure the job schedule is correct after commit
-                        AssertJobScheduleCorrectness(
-                            batchCli.JobScheduleOperations,
-                            boundJobSchedule,
-                            newPoolId,
-                            newJobSchedulePriority,
-                            jobManagerId,
-                            newJobManagerCommandLine,
-                            recurrenceInterval,
-                            newMetadata);
-                    }
-                    finally
+                    jobSchedule.JobSpecification = new JobSpecification(poolInfo)
                     {
-                        batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
-                    }
+                        Priority = jobSchedulePriority,
+                        JobManagerTask = new JobManagerTask(jobManagerId, jobManagerCommandLine)
+                    };
+
+                    jobSchedule.Metadata = metadata;
+
+                    testOutputHelper.WriteLine("Initial job schedule commit()");
+                    jobSchedule.Commit();
+
+                    //Get the bound job schedule
+                    CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
+
+                    //Ensure the job schedule is structured as expected
+                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, firstRecurrenceInterval, metadata);
+
+                    //Update the bound job schedule schedule
+                    TimeSpan recurrenceInterval = TimeSpan.FromMinutes(5);
+                    boundJobSchedule.Schedule = new Schedule()
+                    {
+                        RecurrenceInterval = recurrenceInterval
+                    };
+
+                    testOutputHelper.WriteLine("Updating JobSchedule Schedule");
+                    boundJobSchedule.Commit();
+
+                    //Ensure the job schedule is correct after commit
+                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
+
+                    //Update the bound job schedule priority
+                    const int newJobSchedulePriority = 1;
+                    boundJobSchedule.JobSpecification.Priority = newJobSchedulePriority;
+
+                    testOutputHelper.WriteLine("Updating JobSpecification.Priority");
+                    boundJobSchedule.Commit();
+
+                    //Ensure the job schedule is correct after commit
+                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
+
+                    //Update the bound job schedule job manager commandline
+                    const string newJobManagerCommandLine = "ping 127.0.0.1 -n 150";
+                    boundJobSchedule.JobSpecification.JobManagerTask.CommandLine = newJobManagerCommandLine;
+
+                    testOutputHelper.WriteLine("Updating JobSpecification.JobManagerTask.CommandLine");
+                    boundJobSchedule.Commit();
+
+                    //Ensure the job schedule is correct after commit
+                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, newJobManagerCommandLine, recurrenceInterval, metadata);
+
+                    //Update the bound job schedule PoolInformation
+                    const string newPoolId = "TestPool";
+
+                    boundJobSchedule.JobSpecification.PoolInformation = new PoolInformation() { PoolId = newPoolId };
+
+                    testOutputHelper.WriteLine("Updating PoolInformation");
+                    boundJobSchedule.Commit();
+
+                    //Ensure the job schedule is correct after commit
+                    AssertJobScheduleCorrectness(
+                        batchCli.JobScheduleOperations,
+                        boundJobSchedule,
+                        newPoolId,
+                        newJobSchedulePriority,
+                        jobManagerId,
+                        newJobManagerCommandLine,
+                        recurrenceInterval,
+                        metadata);
+
+                    //Update the bound job schedule Metadata
+                    IList<MetadataItem> newMetadata = new List<MetadataItem> { new MetadataItem("Object", "Model") };
+                    boundJobSchedule.Metadata = newMetadata;
+
+                    testOutputHelper.WriteLine("Updating Metadata");
+                    boundJobSchedule.Commit();
+
+                    //Ensure the job schedule is correct after commit
+                    AssertJobScheduleCorrectness(
+                        batchCli.JobScheduleOperations,
+                        boundJobSchedule,
+                        newPoolId,
+                        newJobSchedulePriority,
+                        jobManagerId,
+                        newJobManagerCommandLine,
+                        recurrenceInterval,
+                        newMetadata);
+                }
+                finally
+                {
+                    batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
                 }
             };
 
@@ -212,49 +210,47 @@
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string jobScheduleId = "TestPatchJobSchedule-" + TestUtilities.GetMyName();
+                const string newJobManagerCommandLine = "cmd /c dir";
+                const string metadataKey = "Foo";
+                const string metadataValue = "Bar";
+                TimeSpan newRecurrenceInterval = TimeSpan.FromDays(2);
+                try
                 {
-                    string jobScheduleId = "TestPatchJobSchedule-" + TestUtilities.GetMyName();
-                    const string newJobManagerCommandLine = "cmd /c dir";
-                    const string metadataKey = "Foo";
-                    const string metadataValue = "Bar";
-                    TimeSpan newRecurrenceInterval = TimeSpan.FromDays(2);
-                    try
-                    {
-                        CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(
-                            jobScheduleId,
-                            new Schedule()
-                                {
-                                    RecurrenceInterval = TimeSpan.FromDays(1)
-                                },
-                            new JobSpecification(new PoolInformation() { PoolId = "DummyPool" })
-                                {
-                                    JobManagerTask = new JobManagerTask(id: "Foo", commandLine: "Foo")
-                                });
+                    CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(
+                        jobScheduleId,
+                        new Schedule()
+                        {
+                            RecurrenceInterval = TimeSpan.FromDays(1)
+                        },
+                        new JobSpecification(new PoolInformation() { PoolId = "DummyPool" })
+                        {
+                            JobManagerTask = new JobManagerTask(id: "Foo", commandLine: "Foo")
+                        });
 
-                        await jobSchedule.CommitAsync().ConfigureAwait(false);
-                        await jobSchedule.RefreshAsync().ConfigureAwait(false);
+                    await jobSchedule.CommitAsync().ConfigureAwait(false);
+                    await jobSchedule.RefreshAsync().ConfigureAwait(false);
 
-                        jobSchedule.JobSpecification.JobManagerTask.CommandLine = newJobManagerCommandLine;
-                        jobSchedule.Metadata = new List<MetadataItem>()
+                    jobSchedule.JobSpecification.JobManagerTask.CommandLine = newJobManagerCommandLine;
+                    jobSchedule.Metadata = new List<MetadataItem>()
                             {
                                 new MetadataItem(metadataKey, metadataValue)
                             };
-                        jobSchedule.Schedule.RecurrenceInterval = newRecurrenceInterval;
+                    jobSchedule.Schedule.RecurrenceInterval = newRecurrenceInterval;
 
-                        await jobSchedule.CommitChangesAsync().ConfigureAwait(false);
+                    await jobSchedule.CommitChangesAsync().ConfigureAwait(false);
 
-                        await jobSchedule.RefreshAsync().ConfigureAwait(false);
+                    await jobSchedule.RefreshAsync().ConfigureAwait(false);
 
-                        Assert.Equal(newRecurrenceInterval, jobSchedule.Schedule.RecurrenceInterval);
-                        Assert.Equal(newJobManagerCommandLine, jobSchedule.JobSpecification.JobManagerTask.CommandLine);
-                        Assert.Equal(metadataKey, jobSchedule.Metadata.Single().Name);
-                        Assert.Equal(metadataValue, jobSchedule.Metadata.Single().Value);
-                    }
-                    finally
-                    {
-                        await TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).ConfigureAwait(false);
-                    }
+                    Assert.Equal(newRecurrenceInterval, jobSchedule.Schedule.RecurrenceInterval);
+                    Assert.Equal(newJobManagerCommandLine, jobSchedule.JobSpecification.JobManagerTask.CommandLine);
+                    Assert.Equal(metadataKey, jobSchedule.Metadata.Single().Name);
+                    Assert.Equal(metadataValue, jobSchedule.Metadata.Single().Value);
+                }
+                finally
+                {
+                    await TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).ConfigureAwait(false);
                 }
             };
 
@@ -268,103 +264,101 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jsId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-CreateWiAutoPoolTest";
+                try
                 {
-                    string jsId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-CreateWiAutoPoolTest";
-                    try
+                    CloudJobSchedule newJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jsId, null, null);
                     {
-                        CloudJobSchedule newJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jsId, null, null);
+                        newJobSchedule.Metadata = MakeMetaData("onCreateName", "onCreateValue");
+
+                        PoolInformation poolInformation = new PoolInformation();
+                        AutoPoolSpecification iaps = new AutoPoolSpecification();
+                        Schedule schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(18) };
+                        poolInformation.AutoPoolSpecification = iaps;
+
+                        iaps.AutoPoolIdPrefix = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName();
+                        iaps.PoolLifetimeOption = Microsoft.Azure.Batch.Common.PoolLifetimeOption.Job;
+                        iaps.KeepAlive = false;
+
+                        PoolSpecification ps = new PoolSpecification();
+
+                        iaps.PoolSpecification = ps;
+
+                        ps.TargetDedicatedComputeNodes = 1;
+                        ps.VirtualMachineSize = PoolFixture.VMSize;
+
+                        ps.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
+
+                        ps.Metadata = MakeMetaData("pusMDIName", "pusMDIValue");
+
+                        JobSpecification jobSpec = newJobSchedule.JobSpecification;
+                        Assert.Null(jobSpec);
+
+                        jobSpec = new JobSpecification(poolInformation);
+
+                        JobManagerTask jobMgr = jobSpec.JobManagerTask;
+
+                        Assert.Null(jobMgr);
+
+                        jobMgr = new JobManagerTask(TestUtilities.GetMyName() + "-JobManagerTest", "hostname");
+
+                        jobMgr.KillJobOnCompletion = false;
+
+                        // set the JobManagerTask on the JobSpecification
+                        jobSpec.JobManagerTask = jobMgr;
+
+                        // set the JobSpecifcation on the Job Schedule
+                        newJobSchedule.JobSpecification = jobSpec;
+
+                        newJobSchedule.Schedule = schedule;
+
+                        newJobSchedule.Commit();
+                    }
+
+                    CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
+                    {
+                        TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
+
+                        List<MetadataItem> mdi = new List<MetadataItem>(jobSchedule.Metadata);
+
+                        // check the values specified for AddJobSchedule are correct.
+                        foreach (MetadataItem curIMDI in mdi)
                         {
-                            newJobSchedule.Metadata = MakeMetaData("onCreateName", "onCreateValue");
-
-                            PoolInformation poolInformation = new PoolInformation();
-                            AutoPoolSpecification iaps = new AutoPoolSpecification();
-                            Schedule schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(18) };
-                            poolInformation.AutoPoolSpecification = iaps;
-
-                            iaps.AutoPoolIdPrefix = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName();
-                            iaps.PoolLifetimeOption = Microsoft.Azure.Batch.Common.PoolLifetimeOption.Job;
-                            iaps.KeepAlive = false;
-
-                            PoolSpecification ps = new PoolSpecification();
-
-                            iaps.PoolSpecification = ps;
-
-                            ps.TargetDedicatedComputeNodes = 1;
-                            ps.VirtualMachineSize = PoolFixture.VMSize;
-                            
-                            ps.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
-
-                            ps.Metadata = MakeMetaData("pusMDIName", "pusMDIValue");
-
-                            JobSpecification jobSpec = newJobSchedule.JobSpecification;
-                            Assert.Null(jobSpec);
-
-                            jobSpec = new JobSpecification(poolInformation);
-
-                            JobManagerTask jobMgr = jobSpec.JobManagerTask;
-
-                            Assert.Null(jobMgr);
-
-                            jobMgr = new JobManagerTask(TestUtilities.GetMyName() + "-JobManagerTest", "hostname");
-
-                            jobMgr.KillJobOnCompletion = false;
-
-                            // set the JobManagerTask on the JobSpecification
-                            jobSpec.JobManagerTask = jobMgr;
-
-                            // set the JobSpecifcation on the Job Schedule
-                            newJobSchedule.JobSpecification = jobSpec;
-
-                            newJobSchedule.Schedule = schedule;
-
-                            newJobSchedule.Commit();
+                            Assert.Equal("onCreateName", curIMDI.Name);
+                            Assert.Equal("onCreateValue", curIMDI.Value);
                         }
 
-                        CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
+                        // add metadata items
+                        mdi.Add(new MetadataItem("modifiedName", "modifiedValue"));
+
+                        jobSchedule.Metadata = mdi;
+
+                        jobSchedule.Commit();
+
+                        // confirm metadata updated correctly
+                        CloudJobSchedule jsUpdated = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
                         {
-                            TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
+                            List<MetadataItem> updatedMDI = new List<MetadataItem>(jsUpdated.Metadata);
 
-                            List<MetadataItem> mdi = new List<MetadataItem>(jobSchedule.Metadata);
+                            Assert.Equal(2, updatedMDI.Count);
 
-                            // check the values specified for AddJobSchedule are correct.
-                            foreach (MetadataItem curIMDI in mdi)
-                            {
-                                Assert.Equal("onCreateName", curIMDI.Name);
-                                Assert.Equal("onCreateValue", curIMDI.Value);
-                            }
+                            Assert.Equal("onCreateName", updatedMDI[0].Name);
+                            Assert.Equal("onCreateValue", updatedMDI[0].Value);
 
-                            // add metadata items
-                            mdi.Add(new MetadataItem("modifiedName", "modifiedValue"));
-
-                            jobSchedule.Metadata = mdi;
-
-                            jobSchedule.Commit();
-
-                            // confirm metadata updated correctly
-                            CloudJobSchedule jsUpdated = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
-                            {
-                                List<MetadataItem> updatedMDI = new List<MetadataItem>(jsUpdated.Metadata);
-
-                                Assert.Equal(2, updatedMDI.Count);
-
-                                Assert.Equal("onCreateName", updatedMDI[0].Name);
-                                Assert.Equal("onCreateValue", updatedMDI[0].Value);
-
-                                Assert.Equal("modifiedName", updatedMDI[1].Name);
-                                Assert.Equal("modifiedValue", updatedMDI[1].Value);
-                            }
-
-                            jobSchedule.Refresh();
-
-                            TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
+                            Assert.Equal("modifiedName", updatedMDI[1].Name);
+                            Assert.Equal("modifiedValue", updatedMDI[1].Value);
                         }
+
+                        jobSchedule.Refresh();
+
+                        TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
                     }
-                    finally
-                    {
-                        // clean up
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
-                    }
+                }
+                finally
+                {
+                    // clean up
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
                 }
             };
 
@@ -378,69 +372,67 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jsId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-Bug1433008JobScheduleScheduleNewable";
+
+                try
                 {
-                    string jsId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-Bug1433008JobScheduleScheduleNewable";
+                    DateTime unboundDNRU = DateTime.UtcNow.AddYears(1);
 
-                    try
+                    CloudJobSchedule newJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jsId, null, null);
                     {
-                        DateTime unboundDNRU = DateTime.UtcNow.AddYears(1);
+                        AutoPoolSpecification iaps = new AutoPoolSpecification();
+                        PoolSpecification ips = new PoolSpecification();
+                        JobSpecification jobSpecification = new JobSpecification(new PoolInformation() { AutoPoolSpecification = iaps });
+                        iaps.PoolSpecification = ips;
 
-                        CloudJobSchedule newJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jsId, null, null);
-                        {
-                            AutoPoolSpecification iaps = new AutoPoolSpecification();
-                            PoolSpecification ips = new PoolSpecification();
-                            JobSpecification jobSpecification = new JobSpecification(new PoolInformation() { AutoPoolSpecification = iaps });
-                            iaps.PoolSpecification = ips;
+                        iaps.AutoPoolIdPrefix = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName();
+                        iaps.PoolLifetimeOption = Microsoft.Azure.Batch.Common.PoolLifetimeOption.Job;
+                        iaps.KeepAlive = false;
 
-                            iaps.AutoPoolIdPrefix = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName();
-                            iaps.PoolLifetimeOption = Microsoft.Azure.Batch.Common.PoolLifetimeOption.Job;
-                            iaps.KeepAlive = false;
+                        PoolSpecification ps = iaps.PoolSpecification;
 
-                            PoolSpecification ps = iaps.PoolSpecification;
+                        ps.TargetDedicatedComputeNodes = 1;
+                        ps.VirtualMachineSize = PoolFixture.VMSize;
 
-                            ps.TargetDedicatedComputeNodes = 1;
-                            ps.VirtualMachineSize = PoolFixture.VMSize;
-                            
-                            ps.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
+                        ps.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
 
-                            Schedule sched = new Schedule();
+                        Schedule sched = new Schedule();
 
-                            sched.DoNotRunUntil = unboundDNRU;
+                        sched.DoNotRunUntil = unboundDNRU;
 
-                            newJobSchedule.Schedule = sched;
-                            newJobSchedule.JobSpecification = jobSpecification;
+                        newJobSchedule.Schedule = sched;
+                        newJobSchedule.JobSpecification = jobSpecification;
 
-                            newJobSchedule.Commit();
-                        }
-
-                        CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
-
-                        // confirm that the original value(s) are set
-                        TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
-
-                        Assert.Equal(unboundDNRU, jobSchedule.Schedule.DoNotRunUntil);
-
-                        // now update the schedule and confirm
-
-                        DateTime boundDNRU = DateTime.UtcNow.AddYears(2);
-
-                        jobSchedule.Schedule.DoNotRunUntil = boundDNRU;
-
-                        jobSchedule.Commit();
-
-                        jobSchedule.Refresh();
-
-                        // confirm that the new value(s) are set
-                        TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
-
-                        Assert.Equal(boundDNRU, jobSchedule.Schedule.DoNotRunUntil);
+                        newJobSchedule.Commit();
                     }
-                    finally
-                    {
-                        // clean up
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
-                    }
+
+                    CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
+
+                    // confirm that the original value(s) are set
+                    TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
+
+                    Assert.Equal(unboundDNRU, jobSchedule.Schedule.DoNotRunUntil);
+
+                    // now update the schedule and confirm
+
+                    DateTime boundDNRU = DateTime.UtcNow.AddYears(2);
+
+                    jobSchedule.Schedule.DoNotRunUntil = boundDNRU;
+
+                    jobSchedule.Commit();
+
+                    jobSchedule.Refresh();
+
+                    // confirm that the new value(s) are set
+                    TestUtilities.DisplayJobScheduleLong(testOutputHelper, jobSchedule);
+
+                    Assert.Equal(boundDNRU, jobSchedule.Schedule.DoNotRunUntil);
+                }
+                finally
+                {
+                    // clean up
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
                 }
             };
 
@@ -454,51 +446,49 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestListJobsByJobSchedule";
+
+                try
                 {
-                    string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestListJobsByJobSchedule";
-
-                    try
+                    Schedule schedule = new Schedule()
                     {
-                        Schedule schedule = new Schedule()
-                        {
-                            DoNotRunAfter = DateTime.UtcNow.Add(TimeSpan.FromDays(1)),
-                            RecurrenceInterval = TimeSpan.FromMinutes(1)
-                        };
+                        DoNotRunAfter = DateTime.UtcNow.Add(TimeSpan.FromDays(1)),
+                        RecurrenceInterval = TimeSpan.FromMinutes(1)
+                    };
 
-                        JobSpecification jobSpecification = new JobSpecification(new PoolInformation()
-                            {
-                                PoolId = "DummyPool"
-                            });
-
-                        CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, schedule, jobSpecification);
-                        unboundJobSchedule.Commit();
-
-                        //List the jobs under this JobSchedule
-                        for (int i = 1; i <= 3; i++)
-                        {
-                            string expectedJobId = string.Format("{0}:job-{1}", jobScheduleId, i);
-                            CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(
-                                batchCli.JobScheduleOperations,
-                                jobScheduleId, 
-                                expectedJobId: expectedJobId, 
-                                timeout: TimeSpan.FromSeconds(70));
-
-                            List<CloudJob> jobs = boundJobSchedule.ListJobs().ToList();
-                            Assert.Equal(i, jobs.Count);
-
-                            jobs = batchCli.JobScheduleOperations.ListJobs(jobScheduleId).ToList();
-                            Assert.Equal(i, jobs.Count);
-
-                            //Terminate the current job to force a new job to be created
-                            batchCli.JobOperations.TerminateJob(expectedJobId);
-                        }
-                    }
-                    finally
+                    JobSpecification jobSpecification = new JobSpecification(new PoolInformation()
                     {
-                        // clean up
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
+                        PoolId = "DummyPool"
+                    });
+
+                    CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, schedule, jobSpecification);
+                    unboundJobSchedule.Commit();
+
+                    //List the jobs under this JobSchedule
+                    for (int i = 1; i <= 3; i++)
+                    {
+                        string expectedJobId = string.Format("{0}:job-{1}", jobScheduleId, i);
+                        CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(
+                            batchCli.JobScheduleOperations,
+                            jobScheduleId,
+                            expectedJobId: expectedJobId,
+                            timeout: TimeSpan.FromSeconds(70));
+
+                        List<CloudJob> jobs = boundJobSchedule.ListJobs().ToList();
+                        Assert.Equal(i, jobs.Count);
+
+                        jobs = batchCli.JobScheduleOperations.ListJobs(jobScheduleId).ToList();
+                        Assert.Equal(i, jobs.Count);
+
+                        //Terminate the current job to force a new job to be created
+                        batchCli.JobOperations.TerminateJob(expectedJobId);
                     }
+                }
+                finally
+                {
+                    // clean up
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                 }
             };
 
@@ -512,75 +502,73 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestEnableDisableDeleteJobSchedule";
+
+                try
                 {
-                    string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestEnableDisableDeleteJobSchedule";
-
-                    try
+                    Schedule schedule = new Schedule()
                     {
-                        Schedule schedule = new Schedule()
-                        {
-                            DoNotRunAfter = DateTime.UtcNow.Add(TimeSpan.FromDays(1))
-                        };
+                        DoNotRunAfter = DateTime.UtcNow.Add(TimeSpan.FromDays(1))
+                    };
 
-                        JobSpecification jobSpecification = new JobSpecification(new PoolInformation()
-                            {
-                                PoolId = "DummyPool"
-                            });
-
-                        CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, schedule, jobSpecification);
-                        unboundJobSchedule.Commit();
-
-                        CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
-
-                        //Disable the job schedule via instance
-                        boundJobSchedule.Disable();
-                        boundJobSchedule.Refresh();
-                        
-                        Assert.NotNull(boundJobSchedule.State);
-                        Assert.Equal(JobScheduleState.Disabled, boundJobSchedule.State);
-
-                        //Enable the job schedule via instance
-                        boundJobSchedule.Enable();
-                        boundJobSchedule.Refresh();
-
-                        Assert.NotNull(boundJobSchedule.State);
-                        Assert.Equal(JobScheduleState.Active, boundJobSchedule.State);
-
-                        //Disable the job schedule via operations
-                        batchCli.JobScheduleOperations.DisableJobSchedule(jobScheduleId);
-                        boundJobSchedule.Refresh();
-
-                        Assert.NotNull(boundJobSchedule.State);
-                        Assert.Equal(JobScheduleState.Disabled, boundJobSchedule.State);
-
-                        //Enable the job schedule via instance
-                        batchCli.JobScheduleOperations.EnableJobSchedule(jobScheduleId);
-                        boundJobSchedule.Refresh();
-
-                        Assert.NotNull(boundJobSchedule.State);
-                        Assert.Equal(JobScheduleState.Active, boundJobSchedule.State);
-
-                        //Terminate the job schedule
-                        batchCli.JobScheduleOperations.TerminateJobSchedule(jobScheduleId);
-
-                        boundJobSchedule.Refresh();
-                        Assert.True(boundJobSchedule.State == JobScheduleState.Completed || boundJobSchedule.State == JobScheduleState.Terminating);
-
-                        //Delete the job schedule
-                        boundJobSchedule.Delete();
-                        
-                        //Wait for deletion to take
-                        BatchException be = TestUtilities.AssertThrowsEventuallyAsync<BatchException>(() => boundJobSchedule.RefreshAsync(), TimeSpan.FromSeconds(30)).Result;
-                        Assert.NotNull(be.RequestInformation);
-                        Assert.NotNull(be.RequestInformation.BatchError);
-                        Assert.Equal("JobScheduleNotFound", be.RequestInformation.BatchError.Code);
-                    }
-                    finally
+                    JobSpecification jobSpecification = new JobSpecification(new PoolInformation()
                     {
-                        // clean up
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
-                    }
+                        PoolId = "DummyPool"
+                    });
+
+                    CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, schedule, jobSpecification);
+                    unboundJobSchedule.Commit();
+
+                    CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
+
+                    //Disable the job schedule via instance
+                    boundJobSchedule.Disable();
+                    boundJobSchedule.Refresh();
+
+                    Assert.NotNull(boundJobSchedule.State);
+                    Assert.Equal(JobScheduleState.Disabled, boundJobSchedule.State);
+
+                    //Enable the job schedule via instance
+                    boundJobSchedule.Enable();
+                    boundJobSchedule.Refresh();
+
+                    Assert.NotNull(boundJobSchedule.State);
+                    Assert.Equal(JobScheduleState.Active, boundJobSchedule.State);
+
+                    //Disable the job schedule via operations
+                    batchCli.JobScheduleOperations.DisableJobSchedule(jobScheduleId);
+                    boundJobSchedule.Refresh();
+
+                    Assert.NotNull(boundJobSchedule.State);
+                    Assert.Equal(JobScheduleState.Disabled, boundJobSchedule.State);
+
+                    //Enable the job schedule via instance
+                    batchCli.JobScheduleOperations.EnableJobSchedule(jobScheduleId);
+                    boundJobSchedule.Refresh();
+
+                    Assert.NotNull(boundJobSchedule.State);
+                    Assert.Equal(JobScheduleState.Active, boundJobSchedule.State);
+
+                    //Terminate the job schedule
+                    batchCli.JobScheduleOperations.TerminateJobSchedule(jobScheduleId);
+
+                    boundJobSchedule.Refresh();
+                    Assert.True(boundJobSchedule.State == JobScheduleState.Completed || boundJobSchedule.State == JobScheduleState.Terminating);
+
+                    //Delete the job schedule
+                    boundJobSchedule.Delete();
+
+                    //Wait for deletion to take
+                    BatchException be = TestUtilities.AssertThrowsEventuallyAsync<BatchException>(() => boundJobSchedule.RefreshAsync(), TimeSpan.FromSeconds(30)).Result;
+                    Assert.NotNull(be.RequestInformation);
+                    Assert.NotNull(be.RequestInformation.BatchError);
+                    Assert.Equal("JobScheduleNotFound", be.RequestInformation.BatchError.Code);
+                }
+                finally
+                {
+                    // clean up
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
@@ -45,42 +45,40 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string poolId = "TestPatchPool-" + TestUtilities.GetMyName();
+                const string metadataKey = "Foo";
+                const string metadataValue = "Bar";
+                const string startTaskCommandLine = "cmd /c dir";
+
+                try
                 {
-                    string poolId = "TestPatchPool-" + TestUtilities.GetMyName();
-                    const string metadataKey = "Foo";
-                    const string metadataValue = "Bar";
-                    const string startTaskCommandLine = "cmd /c dir";
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new CloudServiceConfiguration(PoolFixture.OSFamily),
+                        targetDedicatedComputeNodes: 0);
 
-                    try
-                    {
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new CloudServiceConfiguration(PoolFixture.OSFamily),
-                            targetDedicatedComputeNodes: 0);
+                    await pool.CommitAsync().ConfigureAwait(false);
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        await pool.CommitAsync().ConfigureAwait(false);
-                        await pool.RefreshAsync().ConfigureAwait(false);
-
-                        pool.StartTask = new StartTask(startTaskCommandLine);
-                        pool.Metadata = new List<MetadataItem>()
+                    pool.StartTask = new StartTask(startTaskCommandLine);
+                    pool.Metadata = new List<MetadataItem>()
                             {
                                 new MetadataItem(metadataKey, metadataValue)
                             };
 
-                        await pool.CommitChangesAsync().ConfigureAwait(false);
+                    await pool.CommitChangesAsync().ConfigureAwait(false);
 
-                        await pool.RefreshAsync().ConfigureAwait(false);
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        Assert.Equal(startTaskCommandLine, pool.StartTask.CommandLine);
-                        Assert.Equal(metadataKey, pool.Metadata.Single().Name);
-                        Assert.Equal(metadataValue, pool.Metadata.Single().Value);
-                    }
-                    finally
-                    {
-                        await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
-                    }
+                    Assert.Equal(startTaskCommandLine, pool.StartTask.CommandLine);
+                    Assert.Equal(metadataKey, pool.Metadata.Single().Name);
+                    Assert.Equal(metadataValue, pool.Metadata.Single().Value);
+                }
+                finally
+                {
+                    await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
             };
 
@@ -94,86 +92,84 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                // create a pool with the two new props
+                string poolId = "Bug1505248SupportMultipleTasksPerComputeNode-pool-" + TestUtilities.GetMyName();
+                try
                 {
-                    // create a pool with the two new props
-                    string poolId = "Bug1505248SupportMultipleTasksPerComputeNode-pool-" + TestUtilities.GetMyName();
-                    try
+                    CloudPool newPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
+
+                    newPool.TaskSlotsPerNode = 3;
+
+                    newPool.TaskSchedulingPolicy =
+                        new TaskSchedulingPolicy(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Pack);
+
+                    newPool.Commit();
+
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+
+                    Assert.Equal(3, boundPool.TaskSlotsPerNode);
+                    Assert.Equal(ComputeNodeFillType.Pack, boundPool.TaskSchedulingPolicy.ComputeNodeFillType);
+                }
+                finally
+                {
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
+                }
+
+                string jobId = "Bug1505248SupportMultipleTasksPerComputeNode-Job-" + TestUtilities.GetMyName();
+                try
+                {
+                    // create a job with new props set on pooluserspec
                     {
-                        CloudPool newPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                        AutoPoolSpecification unboundAPS = new AutoPoolSpecification();
+                        PoolSpecification unboundPS = new PoolSpecification();
+                        unboundJob.PoolInformation.AutoPoolSpecification = unboundAPS;
+                        unboundAPS.PoolSpecification = unboundPS;
 
-                        newPool.TaskSlotsPerNode = 3;
+                        unboundPS.TaskSlotsPerNode = 3;
+                        unboundAPS.PoolSpecification.TargetDedicatedComputeNodes = 0; // don't use up compute nodes for this test
+                        unboundPS.TaskSchedulingPolicy = new TaskSchedulingPolicy(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Pack);
 
-                        newPool.TaskSchedulingPolicy =
-                            new TaskSchedulingPolicy(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Pack);
+                        // required but unrelated to test
+                        unboundPS.VirtualMachineSize = PoolFixture.VMSize;
 
-                        newPool.Commit();
+                        unboundPS.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
 
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+                        unboundAPS.PoolLifetimeOption = Microsoft.Azure.Batch.Common.PoolLifetimeOption.Job;
 
-                        Assert.Equal(3, boundPool.TaskSlotsPerNode);
-                        Assert.Equal(ComputeNodeFillType.Pack, boundPool.TaskSchedulingPolicy.ComputeNodeFillType);
+                        unboundJob.Commit();
                     }
-                    finally
-                    {
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
 
-                    string jobId = "Bug1505248SupportMultipleTasksPerComputeNode-Job-" + TestUtilities.GetMyName();
-                    try
-                    {
-                        // create a job with new props set on pooluserspec
-                        {
-                            CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                            AutoPoolSpecification unboundAPS = new AutoPoolSpecification();
-                            PoolSpecification unboundPS = new PoolSpecification();
-                            unboundJob.PoolInformation.AutoPoolSpecification = unboundAPS;
-                            unboundAPS.PoolSpecification = unboundPS;
+                    // confirm props were set
 
-                            unboundPS.TaskSlotsPerNode = 3;
-                            unboundAPS.PoolSpecification.TargetDedicatedComputeNodes = 0; // don't use up compute nodes for this test
-                            unboundPS.TaskSchedulingPolicy = new TaskSchedulingPolicy(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Pack);
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    PoolInformation poolInformation = boundJob.PoolInformation;
+                    AutoPoolSpecification boundAPS = poolInformation.AutoPoolSpecification;
+                    PoolSpecification boundPUS = boundAPS.PoolSpecification;
 
-                            // required but unrelated to test
-                            unboundPS.VirtualMachineSize = PoolFixture.VMSize;
+                    Assert.Equal(3, boundPUS.TaskSlotsPerNode);
+                    Assert.Equal(ComputeNodeFillType.Pack, boundPUS.TaskSchedulingPolicy.ComputeNodeFillType);
 
-                            unboundPS.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
+                    // change the props
 
-                            unboundAPS.PoolLifetimeOption = Microsoft.Azure.Batch.Common.PoolLifetimeOption.Job;
+                    //TODO: Possible change this test to use a JobSchedule here?
+                    //boundPUS.MaxTasksPerComputeNode = 2;
+                    //boundPUS.TaskSchedulingPolicy = new TaskSchedulingPolicy(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Spread);
 
-                            unboundJob.Commit();
-                        }
+                    //boundJob.Commit();
+                    //boundJob.Refresh();
 
-                        // confirm props were set
+                    //boundAPS = boundJob.PoolInformation.AutoPoolSpecification;
+                    //boundPUS = boundAPS.PoolSpecification;
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        PoolInformation poolInformation = boundJob.PoolInformation;
-                        AutoPoolSpecification boundAPS = poolInformation.AutoPoolSpecification;
-                        PoolSpecification boundPUS = boundAPS.PoolSpecification;
+                    //Debug.Assert(2 == boundPUS.MaxTasksPerComputeNode);
+                    //Debug.Assert(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Spread == boundPUS.TaskSchedulingPolicy.ComputeNodeFillType);
 
-                        Assert.Equal(3, boundPUS.TaskSlotsPerNode);
-                        Assert.Equal(ComputeNodeFillType.Pack, boundPUS.TaskSchedulingPolicy.ComputeNodeFillType);
-
-                        // change the props
-
-                        //TODO: Possible change this test to use a JobSchedule here?
-                        //boundPUS.MaxTasksPerComputeNode = 2;
-                        //boundPUS.TaskSchedulingPolicy = new TaskSchedulingPolicy(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Spread);
-
-                        //boundJob.Commit();
-                        //boundJob.Refresh();
-
-                        //boundAPS = boundJob.PoolInformation.AutoPoolSpecification;
-                        //boundPUS = boundAPS.PoolSpecification;
-
-                        //Debug.Assert(2 == boundPUS.MaxTasksPerComputeNode);
-                        //Debug.Assert(Microsoft.Azure.Batch.Common.ComputeNodeFillType.Spread == boundPUS.TaskSchedulingPolicy.ComputeNodeFillType);
-
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -187,121 +183,119 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "Bug1587303Pool-" + TestUtilities.GetMyName();
+
+                const string resourceFileSas = "http://azure.com";
+                const string resourceFileValue = "count0ResFiles.exe";
+
+                const string envSettingName = "envName";
+                const string envSettingValue = "envValue";
+
+                try
                 {
-                    string poolId = "Bug1587303Pool-" + TestUtilities.GetMyName();
-
-                    const string resourceFileSas = "http://azure.com";
-                    const string resourceFileValue = "count0ResFiles.exe";
-
-                    const string envSettingName = "envName";
-                    const string envSettingValue = "envValue";
-
-                    try
+                    // create a pool with env-settings and ResFiles
                     {
-                        // create a pool with env-settings and ResFiles
-                        {
-                            CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
+                        CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
 
-                            StartTask st = new StartTask("dir");
+                        StartTask st = new StartTask("dir");
 
-                            MakeResourceFiles(st, resourceFileSas, resourceFileValue);
-                            AddEnviornmentSettingsToStartTask(st, envSettingName, envSettingValue);
+                        MakeResourceFiles(st, resourceFileSas, resourceFileValue);
+                        AddEnviornmentSettingsToStartTask(st, envSettingName, envSettingValue);
 
-                            // set the pool's start task so the collections get pushed
-                            myPool.StartTask = st;
+                        // set the pool's start task so the collections get pushed
+                        myPool.StartTask = st;
 
-                            myPool.Commit();
-                        }
-
-                        // confirm pool has correct values
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
-
-                        CheckResourceFiles(boundPool.StartTask, resourceFileSas, resourceFileValue);
-                        CheckEnvironmentSettingsOnStartTask(boundPool.StartTask, envSettingName, envSettingValue);
-
-                        // clear the collections
-                        boundPool.StartTask.EnvironmentSettings = null;
-                        boundPool.StartTask.ResourceFiles = null;
-
-                        boundPool.Commit();
-                        boundPool.Refresh();
-
-                        StartTask boundST = boundPool.StartTask;
-
-                        // confirm the collections are cleared/null
-                        Assert.Null(boundST.ResourceFiles);
-                        Assert.Null(boundST.EnvironmentSettings);
-
-                        // set the collections again
-                        MakeResourceFiles(boundST, resourceFileSas, resourceFileValue);
-                        AddEnviornmentSettingsToStartTask(boundST, envSettingName, envSettingValue);
-
-                        boundPool.Commit();
-                        boundPool.Refresh();
-
-                        // confirm the collectsion are correctly re-established
-                        CheckResourceFiles(boundPool.StartTask, resourceFileSas, resourceFileValue);
-                        CheckEnvironmentSettingsOnStartTask(boundPool.StartTask, envSettingName, envSettingValue);
-
-                        //set collections to empty-but-non-null collections
-                        IList<ResourceFile> emptyResfiles = new List<ResourceFile>();
-                        IList<EnvironmentSetting> emptyEnvSettings = new List<EnvironmentSetting>();
-
-                        boundPool.StartTask.EnvironmentSettings = emptyEnvSettings;
-                        boundPool.StartTask.ResourceFiles = emptyResfiles;
-
-                        boundPool.Commit();
-                        boundPool.Refresh();
-
-                        boundST = boundPool.StartTask;
-
-                        var count0ResFiles = boundPool.StartTask.ResourceFiles;
-                        var count0EnvSettings = boundPool.StartTask.EnvironmentSettings;
-
-                        // confirm that the collections are non-null and have count-0
-                        Assert.NotNull(count0ResFiles);
-                        Assert.NotNull(count0EnvSettings);
-                        Assert.Empty(count0ResFiles);
-                        Assert.Empty(count0EnvSettings);
-
-                        //clean up
-                        boundPool.Delete();
-
-                        System.Threading.Thread.Sleep(5000); // wait for pool to be deleted
-
-                        // check pool create with empty-but-non-null collections
-                        {
-                            CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
-
-                            StartTask st = new StartTask("dir");
-                            // use the empty collections from above
-                            st.ResourceFiles = emptyResfiles;
-                            st.EnvironmentSettings = emptyEnvSettings;
-
-                            // set the pool's start task so the collections get pushed
-                            myPool.StartTask = st;
-
-                            myPool.Commit();
-                        }
-
-                        boundPool = batchCli.PoolOperations.GetPool(poolId);
-                        boundST = boundPool.StartTask;
-
-                        count0ResFiles = boundPool.StartTask.ResourceFiles;
-                        count0EnvSettings = boundPool.StartTask.EnvironmentSettings;
-
-                        // confirm that the collections are non-null and have count-0
-                        Assert.NotNull(count0ResFiles);
-                        Assert.NotNull(count0EnvSettings);
-                        Assert.Empty(count0ResFiles);
-                        Assert.Empty(count0EnvSettings);
+                        myPool.Commit();
                     }
-                    finally
+
+                    // confirm pool has correct values
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+
+                    CheckResourceFiles(boundPool.StartTask, resourceFileSas, resourceFileValue);
+                    CheckEnvironmentSettingsOnStartTask(boundPool.StartTask, envSettingName, envSettingValue);
+
+                    // clear the collections
+                    boundPool.StartTask.EnvironmentSettings = null;
+                    boundPool.StartTask.ResourceFiles = null;
+
+                    boundPool.Commit();
+                    boundPool.Refresh();
+
+                    StartTask boundST = boundPool.StartTask;
+
+                    // confirm the collections are cleared/null
+                    Assert.Null(boundST.ResourceFiles);
+                    Assert.Null(boundST.EnvironmentSettings);
+
+                    // set the collections again
+                    MakeResourceFiles(boundST, resourceFileSas, resourceFileValue);
+                    AddEnviornmentSettingsToStartTask(boundST, envSettingName, envSettingValue);
+
+                    boundPool.Commit();
+                    boundPool.Refresh();
+
+                    // confirm the collectsion are correctly re-established
+                    CheckResourceFiles(boundPool.StartTask, resourceFileSas, resourceFileValue);
+                    CheckEnvironmentSettingsOnStartTask(boundPool.StartTask, envSettingName, envSettingValue);
+
+                    //set collections to empty-but-non-null collections
+                    IList<ResourceFile> emptyResfiles = new List<ResourceFile>();
+                    IList<EnvironmentSetting> emptyEnvSettings = new List<EnvironmentSetting>();
+
+                    boundPool.StartTask.EnvironmentSettings = emptyEnvSettings;
+                    boundPool.StartTask.ResourceFiles = emptyResfiles;
+
+                    boundPool.Commit();
+                    boundPool.Refresh();
+
+                    boundST = boundPool.StartTask;
+
+                    var count0ResFiles = boundPool.StartTask.ResourceFiles;
+                    var count0EnvSettings = boundPool.StartTask.EnvironmentSettings;
+
+                    // confirm that the collections are non-null and have count-0
+                    Assert.NotNull(count0ResFiles);
+                    Assert.NotNull(count0EnvSettings);
+                    Assert.Empty(count0ResFiles);
+                    Assert.Empty(count0EnvSettings);
+
+                    //clean up
+                    boundPool.Delete();
+
+                    System.Threading.Thread.Sleep(5000); // wait for pool to be deleted
+
+                    // check pool create with empty-but-non-null collections
                     {
-                        // cleanup
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
+                        CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
+
+                        StartTask st = new StartTask("dir");
+                        // use the empty collections from above
+                        st.ResourceFiles = emptyResfiles;
+                        st.EnvironmentSettings = emptyEnvSettings;
+
+                        // set the pool's start task so the collections get pushed
+                        myPool.StartTask = st;
+
+                        myPool.Commit();
                     }
+
+                    boundPool = batchCli.PoolOperations.GetPool(poolId);
+                    boundST = boundPool.StartTask;
+
+                    count0ResFiles = boundPool.StartTask.ResourceFiles;
+                    count0EnvSettings = boundPool.StartTask.EnvironmentSettings;
+
+                    // confirm that the collections are non-null and have count-0
+                    Assert.NotNull(count0ResFiles);
+                    Assert.NotNull(count0EnvSettings);
+                    Assert.Empty(count0ResFiles);
+                    Assert.Empty(count0EnvSettings);
+                }
+                finally
+                {
+                    // cleanup
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -315,39 +309,37 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "Bug1433123PoolMissingResizeTimeout-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string poolId = "Bug1433123PoolMissingResizeTimeout-" + TestUtilities.GetMyName();
+                    TimeSpan referenceRST = TimeSpan.FromMinutes(5);
 
-                    try
+                    // create a pool with env-settings and ResFiles
                     {
-                        TimeSpan referenceRST = TimeSpan.FromMinutes(5);
+                        CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
 
-                        // create a pool with env-settings and ResFiles
-                        {
-                            CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
+                        // set the reference value
+                        myPool.ResizeTimeout = referenceRST;
 
-                            // set the reference value
-                            myPool.ResizeTimeout = referenceRST;
-
-                            myPool.Commit();
-                        }
-
-                        // confirm pool has correct values
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
-
-                        // confirm value is correct
-                        Assert.Equal(referenceRST, boundPool.ResizeTimeout);
-
-                        // confirm constraint does not allow changes to bound object
-
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundPool.ResizeTimeout = TimeSpan.FromMinutes(1));
+                        myPool.Commit();
                     }
-                    finally
-                    {
-                        // cleanup
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+
+                    // confirm pool has correct values
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+
+                    // confirm value is correct
+                    Assert.Equal(referenceRST, boundPool.ResizeTimeout);
+
+                    // confirm constraint does not allow changes to bound object
+
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => boundPool.ResizeTimeout = TimeSpan.FromMinutes(1));
+                }
+                finally
+                {
+                    // cleanup
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -361,64 +353,62 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jsId = "Bug1656475PoolLifetimeOption-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jsId = "Bug1656475PoolLifetimeOption-" + TestUtilities.GetMyName();
-
-                    try
                     {
-                        {
-                            CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule();
-                            unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(10) };
-                            unboundJobSchedule.Id = jsId;
+                        CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule();
+                        unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(10) };
+                        unboundJobSchedule.Id = jsId;
 
-                            AutoPoolSpecification iaps = new AutoPoolSpecification();
+                        AutoPoolSpecification iaps = new AutoPoolSpecification();
 
-                            // test that it can be read from unbound/unset object
-                            PoolLifetimeOption defaultVal = iaps.PoolLifetimeOption;
+                        // test that it can be read from unbound/unset object
+                        PoolLifetimeOption defaultVal = iaps.PoolLifetimeOption;
 
-                            // test it can be set on unbound and read back
-                            iaps.PoolLifetimeOption = PoolLifetimeOption.JobSchedule;
+                        // test it can be set on unbound and read back
+                        iaps.PoolLifetimeOption = PoolLifetimeOption.JobSchedule;
 
-                            // read it back and confirm value
-                            Assert.Equal(PoolLifetimeOption.JobSchedule, iaps.PoolLifetimeOption);
+                        // read it back and confirm value
+                        Assert.Equal(PoolLifetimeOption.JobSchedule, iaps.PoolLifetimeOption);
 
-                            unboundJobSchedule.JobSpecification = new JobSpecification(new PoolInformation() { AutoPoolSpecification = iaps });
+                        unboundJobSchedule.JobSpecification = new JobSpecification(new PoolInformation() { AutoPoolSpecification = iaps });
 
-                            // make ias viable for adding the wi
-                            iaps.AutoPoolIdPrefix = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName();
+                        // make ias viable for adding the wi
+                        iaps.AutoPoolIdPrefix = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName();
 
-                            PoolSpecification ips = new PoolSpecification();
+                        PoolSpecification ips = new PoolSpecification();
 
-                            iaps.PoolSpecification = ips;
+                        iaps.PoolSpecification = ips;
 
-                            ips.TargetDedicatedComputeNodes = 0;
-                            ips.VirtualMachineSize = PoolFixture.VMSize;
+                        ips.TargetDedicatedComputeNodes = 0;
+                        ips.VirtualMachineSize = PoolFixture.VMSize;
 
-                            ips.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
+                        ips.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily);
 
-                            unboundJobSchedule.Commit();
-                        }
-
-                        CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
-
-                        // confirm the PLO is set correctly on bound WI
-                        Assert.NotNull(boundJobSchedule);
-                        Assert.NotNull(boundJobSchedule.JobSpecification);
-                        Assert.NotNull(boundJobSchedule.JobSpecification.PoolInformation);
-                        Assert.NotNull(boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification);
-
-                        AutoPoolSpecification boundIAPS = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification;
-
-                        Assert.Equal(PoolLifetimeOption.JobSchedule, boundIAPS.PoolLifetimeOption);
-
-                        // in phase 1 PLO is read-only on bound WI/APS so no tests to change it here
+                        unboundJobSchedule.Commit();
                     }
-                    finally
-                    {
-                        // cleanup
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
-                    }
+
+                    CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jsId);
+
+                    // confirm the PLO is set correctly on bound WI
+                    Assert.NotNull(boundJobSchedule);
+                    Assert.NotNull(boundJobSchedule.JobSpecification);
+                    Assert.NotNull(boundJobSchedule.JobSpecification.PoolInformation);
+                    Assert.NotNull(boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification);
+
+                    AutoPoolSpecification boundIAPS = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification;
+
+                    Assert.Equal(PoolLifetimeOption.JobSchedule, boundIAPS.PoolLifetimeOption);
+
+                    // in phase 1 PLO is read-only on bound WI/APS so no tests to change it here
+                }
+                finally
+                {
+                    // cleanup
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
                 }
             };
 
@@ -432,65 +422,63 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "Bug1432812-" + TestUtilities.GetMyName();
+                const string poolASFormulaOrig = "$TargetDedicatedNodes=0;";
+                const string poolASFormula2 = "$TargetDedicatedNodes=1;";
+                // craft exactly how it would be returned by Evaluate so indexof can work
+
+                try
                 {
-                    string poolId = "Bug1432812-" + TestUtilities.GetMyName();
-                    const string poolASFormulaOrig = "$TargetDedicatedNodes=0;";
-                    const string poolASFormula2 = "$TargetDedicatedNodes=1;";
-                    // craft exactly how it would be returned by Evaluate so indexof can work
-
-                    try
+                    // create a pool.. empty for now
                     {
-                        // create a pool.. empty for now
-                        {
-                            CloudPool unboundPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
+                        CloudPool unboundPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily));
 
-                            unboundPool.AutoScaleEnabled = true;
-                            unboundPool.AutoScaleFormula = poolASFormulaOrig;
+                        unboundPool.AutoScaleEnabled = true;
+                        unboundPool.AutoScaleFormula = poolASFormulaOrig;
 
-                            unboundPool.Commit();
+                        unboundPool.Commit();
 
-                            TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
-                        }
-
-                        // EvaluteAutoScale
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
-
-                        Assert.True(boundPool.AutoScaleEnabled.HasValue);
-                        Assert.True(boundPool.AutoScaleEnabled.Value);
-                        Assert.Equal(poolASFormulaOrig, boundPool.AutoScaleFormula);
-
-                        AutoScaleRun eval = boundPool.EvaluateAutoScale(poolASFormula2);
-
-                        Assert.Contains(poolASFormula2, eval.Results);
-
-                        // DisableAutoScale
-                        boundPool.DisableAutoScale();
-
-                        boundPool.Refresh();
-
-                        // autoscale should be disabled now
-                        Assert.True(boundPool.AutoScaleEnabled.HasValue);
-                        Assert.False(boundPool.AutoScaleEnabled.Value);
-
-                        // EnableAutoScale
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(5)).Wait();
-
-                        boundPool.EnableAutoScale(poolASFormula2);
-
-                        boundPool.Refresh();
-
-                        // confirm is enabled and formula has correct value
-
-                        Assert.True(boundPool.AutoScaleEnabled.HasValue);
-                        Assert.True(boundPool.AutoScaleEnabled.Value);
-                        Assert.Equal(poolASFormula2, boundPool.AutoScaleFormula);
-
+                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
                     }
-                    finally
-                    {
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+
+                    // EvaluteAutoScale
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+
+                    Assert.True(boundPool.AutoScaleEnabled.HasValue);
+                    Assert.True(boundPool.AutoScaleEnabled.Value);
+                    Assert.Equal(poolASFormulaOrig, boundPool.AutoScaleFormula);
+
+                    AutoScaleRun eval = boundPool.EvaluateAutoScale(poolASFormula2);
+
+                    Assert.Contains(poolASFormula2, eval.Results);
+
+                    // DisableAutoScale
+                    boundPool.DisableAutoScale();
+
+                    boundPool.Refresh();
+
+                    // autoscale should be disabled now
+                    Assert.True(boundPool.AutoScaleEnabled.HasValue);
+                    Assert.False(boundPool.AutoScaleEnabled.Value);
+
+                    // EnableAutoScale
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(5)).Wait();
+
+                    boundPool.EnableAutoScale(poolASFormula2);
+
+                    boundPool.Refresh();
+
+                    // confirm is enabled and formula has correct value
+
+                    Assert.True(boundPool.AutoScaleEnabled.HasValue);
+                    Assert.True(boundPool.AutoScaleEnabled.Value);
+                    Assert.Equal(poolASFormula2, boundPool.AutoScaleFormula);
+
+                }
+                finally
+                {
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -504,35 +492,33 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "Bug1432819-" + TestUtilities.GetMyName();
+                try
                 {
-                    string poolId = "Bug1432819-" + TestUtilities.GetMyName();
-                    try
+                    CloudPool unboundPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
+                    unboundPool.Commit();
+
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+                    IList<MetadataItem> changedMDI = new List<MetadataItem> { new MetadataItem("name", "value") };
+                    boundPool.Metadata = changedMDI;
+                    boundPool.Commit();
+
+                    CloudPool boundPool2 = batchCli.PoolOperations.GetPool(poolId);
+
+                    Assert.NotNull(boundPool2.Metadata);
+
+                    // confirm the pool was updated
+                    foreach (MetadataItem curMDI in boundPool2.Metadata)
                     {
-                        CloudPool unboundPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
-                        unboundPool.Commit();
-
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
-                        IList<MetadataItem> changedMDI = new List<MetadataItem> { new MetadataItem("name", "value") };
-                        boundPool.Metadata = changedMDI;
-                        boundPool.Commit();
-
-                        CloudPool boundPool2 = batchCli.PoolOperations.GetPool(poolId);
-
-                        Assert.NotNull(boundPool2.Metadata);
-
-                        // confirm the pool was updated
-                        foreach (MetadataItem curMDI in boundPool2.Metadata)
-                        {
-                            Assert.Equal("name", curMDI.Name);
-                            Assert.Equal("value", curMDI.Value);
-                        }
+                        Assert.Equal("name", curMDI.Name);
+                        Assert.Equal("value", curMDI.Value);
                     }
-                    finally
-                    {
-                        // cleanup
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                }
+                finally
+                {
+                    // cleanup
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -546,52 +532,50 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                // test via faking data
+                DateTime endTime = DateTime.UtcNow.AddYears(-1);
+                DateTime startTime = DateTime.UtcNow;
+                const int totalCoreHours = 1;
+                const string virtualMachineSize = "really really big";
+
+                List<Protocol.Models.PoolUsageMetrics> pums = new List<Protocol.Models.PoolUsageMetrics>();
+
+                // create some data to return
+                for (int i = 0; i < 4; i++)
                 {
-                    // test via faking data
-                    DateTime endTime = DateTime.UtcNow.AddYears(-1);
-                    DateTime startTime = DateTime.UtcNow;
-                    const int totalCoreHours = 1;
-                    const string virtualMachineSize = "really really big";
-
-                    List<Protocol.Models.PoolUsageMetrics> pums = new List<Protocol.Models.PoolUsageMetrics>();
-
-                    // create some data to return
-                    for (int i = 0; i < 4; i++)
+                    string id = "my fancy pool id " + i.ToString();
+                    Protocol.Models.PoolUsageMetrics newPum = new Protocol.Models.PoolUsageMetrics()
                     {
-                        string id = "my fancy pool id " + i.ToString();
-                        Protocol.Models.PoolUsageMetrics newPum = new Protocol.Models.PoolUsageMetrics()
-                        {
-                            PoolId = id,
-                            EndTime = endTime,
-                            StartTime = startTime,
-                            TotalCoreHours = totalCoreHours,
-                            VmSize = virtualMachineSize
-                        };
+                        PoolId = id,
+                        EndTime = endTime,
+                        StartTime = startTime,
+                        TotalCoreHours = totalCoreHours,
+                        VmSize = virtualMachineSize
+                    };
 
-                        pums.Add(newPum);
-                    }
-
-                    // our injector of fake data
-                    TestListPoolUsageMetricsFakesYieldInjector injectsTheFakeData = new TestListPoolUsageMetricsFakesYieldInjector(pums);
-
-                    // trigger the call and get our own data back to be tested
-                    List<PoolUsageMetrics> clList = batchCli.PoolOperations.ListPoolUsageMetrics(additionalBehaviors: new[] { injectsTheFakeData }).ToList();
-
-                    // test that our data are honored
-
-                    for (int j = 0; j < 4; j++)
-                    {
-                        string id = "my fancy pool id " + j.ToString();
-                        Assert.Equal(id, clList[j].PoolId);
-                        Assert.Equal(endTime, clList[j].EndTime);
-                        Assert.Equal(startTime, clList[j].StartTime);
-                        Assert.Equal(totalCoreHours, clList[j].TotalCoreHours);
-                        Assert.Equal(virtualMachineSize, clList[j].VirtualMachineSize);
-                    }
-
-                    List<PoolUsageMetrics> list = batchCli.PoolOperations.ListPoolUsageMetrics(DateTime.Now - TimeSpan.FromDays(1)).ToList();
+                    pums.Add(newPum);
                 }
+
+                // our injector of fake data
+                TestListPoolUsageMetricsFakesYieldInjector injectsTheFakeData = new TestListPoolUsageMetricsFakesYieldInjector(pums);
+
+                // trigger the call and get our own data back to be tested
+                List<PoolUsageMetrics> clList = batchCli.PoolOperations.ListPoolUsageMetrics(additionalBehaviors: new[] { injectsTheFakeData }).ToList();
+
+                // test that our data are honored
+
+                for (int j = 0; j < 4; j++)
+                {
+                    string id = "my fancy pool id " + j.ToString();
+                    Assert.Equal(id, clList[j].PoolId);
+                    Assert.Equal(endTime, clList[j].EndTime);
+                    Assert.Equal(startTime, clList[j].StartTime);
+                    Assert.Equal(totalCoreHours, clList[j].TotalCoreHours);
+                    Assert.Equal(virtualMachineSize, clList[j].VirtualMachineSize);
+                }
+
+                List<PoolUsageMetrics> list = batchCli.PoolOperations.ListPoolUsageMetrics(DateTime.Now - TimeSpan.FromDays(1)).ToList();
             };
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -604,41 +588,39 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "TestPoolObjectResizeStopResize" + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                const int newTargetDedicated = 1;
+                try
                 {
-                    string poolId = "TestPoolObjectResizeStopResize" + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    const int newTargetDedicated = 1;
-                    try
-                    {
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
-                        pool.Commit();
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
+                    pool.Commit();
 
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
 
-                        testOutputHelper.WriteLine($"Created pool {poolId}");
+                    testOutputHelper.WriteLine($"Created pool {poolId}");
 
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
 
-                        //Resize the pool
-                        boundPool.Resize(newTargetDedicated, 0);
+                    //Resize the pool
+                    boundPool.Resize(newTargetDedicated, 0);
 
-                        boundPool.Refresh();
-                        Assert.Equal(AllocationState.Resizing, boundPool.AllocationState);
+                    boundPool.Refresh();
+                    Assert.Equal(AllocationState.Resizing, boundPool.AllocationState);
 
-                        boundPool.StopResize();
-                        boundPool.Refresh();
+                    boundPool.StopResize();
+                    boundPool.Refresh();
 
-                        //The pool could be in stopping or steady state
-                        testOutputHelper.WriteLine($"Pool allocation state: {boundPool.AllocationState}");
-                        Assert.True(boundPool.AllocationState == AllocationState.Steady || boundPool.AllocationState == AllocationState.Stopping);
-                    }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                    //The pool could be in stopping or steady state
+                    testOutputHelper.WriteLine($"Pool allocation state: {boundPool.AllocationState}");
+                    Assert.True(boundPool.AllocationState == AllocationState.Steady || boundPool.AllocationState == AllocationState.Stopping);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -652,91 +634,89 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = TestUtilities.GenerateResourceId();
+                const int targetDedicated = 0;
+                const string autoscaleFormula1 = "$TargetDedicatedNodes=0;$TargetLowPriorityNodes=0;$NodeDeallocationOption=requeue";
+                const string autoscaleFormula2 = "$TargetDedicatedNodes=0;$TargetLowPriorityNodes=0;$NodeDeallocationOption=terminate";
+
+                const string evaluateAutoscaleFormula = "myActiveSamples=$ActiveTasks.GetSample(5);";
+                TimeSpan enableAutoScaleMinimumDelay = TimeSpan.FromSeconds(30);  // compiler says can't be const
+
+                try
                 {
-                    string poolId = TestUtilities.GenerateResourceId();
-                    const int targetDedicated = 0;
-                    const string autoscaleFormula1 = "$TargetDedicatedNodes=0;$TargetLowPriorityNodes=0;$NodeDeallocationOption=requeue";
-                    const string autoscaleFormula2 = "$TargetDedicatedNodes=0;$TargetLowPriorityNodes=0;$NodeDeallocationOption=terminate";
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicated);
+                    pool.Commit();
 
-                    const string evaluateAutoscaleFormula = "myActiveSamples=$ActiveTasks.GetSample(5);";
-                    TimeSpan enableAutoScaleMinimumDelay = TimeSpan.FromSeconds(30);  // compiler says can't be const
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
 
-                    try
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+
+                    //Enable autoscale (via instance)
+                    boundPool.EnableAutoScale(autoscaleFormula1);
+                    DateTime utcEarliestCanCallEnableASAgain = DateTime.UtcNow + enableAutoScaleMinimumDelay;
+
+                    boundPool.Refresh();
+                    Assert.True(boundPool.AutoScaleEnabled);
+                    Assert.Equal(autoscaleFormula1, boundPool.AutoScaleFormula);
+                    testOutputHelper.WriteLine($"Got the pool");
+
+                    Assert.NotNull(boundPool.AutoScaleRun);
+                    Assert.NotNull(boundPool.AutoScaleRun.Results);
+                    Assert.Contains(autoscaleFormula1, boundPool.AutoScaleRun.Results);
+
+                    //Evaluate a different formula
+                    AutoScaleRun evaluation = boundPool.EvaluateAutoScale(evaluateAutoscaleFormula);
+
+                    testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
+
+                    Assert.NotNull(evaluation.Results);
+                    Assert.Contains("myActiveSamples", evaluation.Results);
+
+                    //Disable autoscale (via instance)
+                    boundPool.DisableAutoScale();
+                    boundPool.Refresh();
+
+                    Assert.False(boundPool.AutoScaleEnabled);
+
+                    //Wait for the pool to go to steady state
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(2)).Wait();
+
+                    // about to call EnableAutoScale again, must delay to avoid throttle exception
+                    if (DateTime.UtcNow < utcEarliestCanCallEnableASAgain)
                     {
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicated);
-                        pool.Commit();
+                        TimeSpan delayBeforeNextEnableASCall = utcEarliestCanCallEnableASAgain - DateTime.UtcNow;
 
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
-
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
-
-                        //Enable autoscale (via instance)
-                        boundPool.EnableAutoScale(autoscaleFormula1);
-                        DateTime utcEarliestCanCallEnableASAgain = DateTime.UtcNow + enableAutoScaleMinimumDelay;
-
-                        boundPool.Refresh();
-                        Assert.True(boundPool.AutoScaleEnabled);
-                        Assert.Equal(autoscaleFormula1, boundPool.AutoScaleFormula);
-                        testOutputHelper.WriteLine($"Got the pool");
-
-                        Assert.NotNull(boundPool.AutoScaleRun);
-                        Assert.NotNull(boundPool.AutoScaleRun.Results);
-                        Assert.Contains(autoscaleFormula1, boundPool.AutoScaleRun.Results);
-
-                        //Evaluate a different formula
-                        AutoScaleRun evaluation = boundPool.EvaluateAutoScale(evaluateAutoscaleFormula);
-
-                        testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
-
-                        Assert.NotNull(evaluation.Results);
-                        Assert.Contains("myActiveSamples", evaluation.Results);
-
-                        //Disable autoscale (via instance)
-                        boundPool.DisableAutoScale();
-                        boundPool.Refresh();
-
-                        Assert.False(boundPool.AutoScaleEnabled);
-
-                        //Wait for the pool to go to steady state
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(2)).Wait();
-
-                        // about to call EnableAutoScale again, must delay to avoid throttle exception
-                        if (DateTime.UtcNow < utcEarliestCanCallEnableASAgain)
-                        {
-                            TimeSpan delayBeforeNextEnableASCall = utcEarliestCanCallEnableASAgain - DateTime.UtcNow;
-
-                            Thread.Sleep(delayBeforeNextEnableASCall);
-                        }
-
-                        //Enable autoscale (via operations)
-                        batchCli.PoolOperations.EnableAutoScale(poolId, autoscaleFormula2);
-                        boundPool.Refresh();
-
-                        Assert.True(boundPool.AutoScaleEnabled);
-                        Assert.Equal(autoscaleFormula2, boundPool.AutoScaleFormula);
-                        Assert.NotNull(boundPool.AutoScaleRun);
-                        Assert.NotNull(boundPool.AutoScaleRun.Results);
-                        Assert.Contains(autoscaleFormula2, boundPool.AutoScaleRun.Results);
-
-                        evaluation = batchCli.PoolOperations.EvaluateAutoScale(poolId, evaluateAutoscaleFormula);
-
-                        testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
-
-                        Assert.NotNull(evaluation);
-                        Assert.Contains("myActiveSamples", evaluation.Results);
-
-                        batchCli.PoolOperations.DisableAutoScale(poolId);
-                        boundPool.Refresh();
-
-                        Assert.False(boundPool.AutoScaleEnabled);
+                        Thread.Sleep(delayBeforeNextEnableASCall);
                     }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+
+                    //Enable autoscale (via operations)
+                    batchCli.PoolOperations.EnableAutoScale(poolId, autoscaleFormula2);
+                    boundPool.Refresh();
+
+                    Assert.True(boundPool.AutoScaleEnabled);
+                    Assert.Equal(autoscaleFormula2, boundPool.AutoScaleFormula);
+                    Assert.NotNull(boundPool.AutoScaleRun);
+                    Assert.NotNull(boundPool.AutoScaleRun.Results);
+                    Assert.Contains(autoscaleFormula2, boundPool.AutoScaleRun.Results);
+
+                    evaluation = batchCli.PoolOperations.EvaluateAutoScale(poolId, evaluateAutoscaleFormula);
+
+                    testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
+
+                    Assert.NotNull(evaluation);
+                    Assert.Contains("myActiveSamples", evaluation.Results);
+
+                    batchCli.PoolOperations.DisableAutoScale(poolId);
+                    boundPool.Refresh();
+
+                    Assert.False(boundPool.AutoScaleEnabled);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -750,35 +730,33 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "TestPoolVNet" + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                string dummySubnetId = string.Format("/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ClassicNetwork/virtualNetworks/vnet1/subnets/subnet1",
+                    TestCommon.Configuration.BatchSubscription,
+                    TestCommon.Configuration.BatchAccountResourceGroup);
+                try
                 {
-                    string poolId = "TestPoolVNet" + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    string dummySubnetId = string.Format("/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.ClassicNetwork/virtualNetworks/vnet1/subnets/subnet1",
-                        TestCommon.Configuration.BatchSubscription,
-                        TestCommon.Configuration.BatchAccountResourceGroup);
-                    try
-                    {
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new CloudServiceConfiguration(PoolFixture.OSFamily),
-                            targetDedicated);
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new CloudServiceConfiguration(PoolFixture.OSFamily),
+                        targetDedicated);
 
-                        pool.NetworkConfiguration = new NetworkConfiguration()
-                        {
-                            SubnetId = dummySubnetId
-                        };
-
-                        BatchException exception = await TestUtilities.AssertThrowsAsync<BatchException>(async () => await pool.CommitAsync().ConfigureAwait(false)).ConfigureAwait(false);
-                        Assert.Equal(BatchErrorCodeStrings.InvalidPropertyValue, exception.RequestInformation.BatchError.Code);
-                        Assert.Equal("Either the specified VNet does not exist, or the Batch service does not have access to it", exception.RequestInformation.BatchError.Values.Single(value => value.Key == "Reason").Value);
-                    }
-                    finally
+                    pool.NetworkConfiguration = new NetworkConfiguration()
                     {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                        SubnetId = dummySubnetId
+                    };
+
+                    BatchException exception = await TestUtilities.AssertThrowsAsync<BatchException>(async () => await pool.CommitAsync().ConfigureAwait(false)).ConfigureAwait(false);
+                    Assert.Equal(BatchErrorCodeStrings.InvalidPropertyValue, exception.RequestInformation.BatchError.Code);
+                    Assert.Equal("Either the specified VNet does not exist, or the Batch service does not have access to it", exception.RequestInformation.BatchError.Values.Single(value => value.Key == "Reason").Value);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -792,41 +770,39 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string poolId = "TestPoolCreatedWithUserAccounts" + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                try
                 {
-                    string poolId = "TestPoolCreatedWithUserAccounts" + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    try
-                    {
-                        var nodeUserPassword = TestUtilities.GenerateRandomPassword();
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicated);
-                        pool.UserAccounts = new List<UserAccount>()
+                    var nodeUserPassword = TestUtilities.GenerateRandomPassword();
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicated);
+                    pool.UserAccounts = new List<UserAccount>()
                         {
                             new UserAccount("test1", nodeUserPassword),
                             new UserAccount("test2", nodeUserPassword, ElevationLevel.NonAdmin),
                             new UserAccount("test3", nodeUserPassword, ElevationLevel.Admin),
                             new UserAccount("test4", nodeUserPassword, linuxUserConfiguration: new LinuxUserConfiguration(sshPrivateKey: "AAAA==")),
                         };
-                        pool.Commit();
+                    pool.Commit();
 
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
 
-                        Assert.Equal(pool.UserAccounts.Count, boundPool.UserAccounts.Count);
-                        var results = pool.UserAccounts.Zip(boundPool.UserAccounts, (expected, actual) => new { Submitted = expected, Returned = actual });
-                        foreach (var result in results)
-                        {
-                            Assert.Equal(result.Submitted.Name, result.Returned.Name);
-                            Assert.Null(result.Returned.Password);
-                            Assert.Equal(result.Submitted.ElevationLevel ?? ElevationLevel.NonAdmin, result.Returned.ElevationLevel);
-                            Assert.Null(result.Returned.LinuxUserConfiguration?.SshPrivateKey);
-                        }
-                    }
-                    finally
+                    Assert.Equal(pool.UserAccounts.Count, boundPool.UserAccounts.Count);
+                    var results = pool.UserAccounts.Zip(boundPool.UserAccounts, (expected, actual) => new { Submitted = expected, Returned = actual });
+                    foreach (var result in results)
                     {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
+                        Assert.Equal(result.Submitted.Name, result.Returned.Name);
+                        Assert.Null(result.Returned.Password);
+                        Assert.Equal(result.Submitted.ElevationLevel ?? ElevationLevel.NonAdmin, result.Returned.ElevationLevel);
+                        Assert.Null(result.Returned.LinuxUserConfiguration?.SshPrivateKey);
                     }
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -840,36 +816,34 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string poolId = nameof(TestPoolCreatedOSDiskSucceeds) + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                try
                 {
-                    string poolId = nameof(TestPoolCreatedOSDiskSucceeds) + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    try
-                    {
-                        var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
+                    var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
 
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new VirtualMachineConfiguration(
-                                imageDetails.ImageReference,
-                                imageDetails.NodeAgentSkuId)
-                            {
-                                LicenseType = "Windows_Server"
-                            },
-                            targetDedicated);
-                        pool.Commit();
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new VirtualMachineConfiguration(
+                            imageDetails.ImageReference,
+                            imageDetails.NodeAgentSkuId)
+                        {
+                            LicenseType = "Windows_Server"
+                        },
+                        targetDedicated);
+                    pool.Commit();
 
-                        pool.Refresh();
+                    pool.Refresh();
 
-                        Assert.Equal("Windows_Server", pool.VirtualMachineConfiguration.LicenseType);
-                    }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                    Assert.Equal("Windows_Server", pool.VirtualMachineConfiguration.LicenseType);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -883,41 +857,39 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string poolId = nameof(TestPoolCreatedDataDiskSucceeds) + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                try
                 {
-                    string poolId = nameof(TestPoolCreatedDataDiskSucceeds) + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    try
-                    {
-                        var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
-                        const int lun = 50;
-                        const int diskSizeGB = 50;
+                    var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
+                    const int lun = 50;
+                    const int diskSizeGB = 50;
 
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new VirtualMachineConfiguration(
-                                imageDetails.ImageReference,
-                                imageDetails.NodeAgentSkuId)
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new VirtualMachineConfiguration(
+                            imageDetails.ImageReference,
+                            imageDetails.NodeAgentSkuId)
+                        {
+                            DataDisks = new List<DataDisk>
                             {
-                                DataDisks =  new List<DataDisk>
-                                {
                                     new DataDisk(lun, diskSizeGB)
-                                }
-                            },
-                            targetDedicated);
-                        pool.Commit();
-                        pool.Refresh();
+                            }
+                        },
+                        targetDedicated);
+                    pool.Commit();
+                    pool.Refresh();
 
-                        Assert.Equal(lun, pool.VirtualMachineConfiguration.DataDisks.Single().Lun);
-                        Assert.Equal(diskSizeGB, pool.VirtualMachineConfiguration.DataDisks.Single().DiskSizeGB);
-                    }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                    Assert.Equal(lun, pool.VirtualMachineConfiguration.DataDisks.Single().Lun);
+                    Assert.Equal(diskSizeGB, pool.VirtualMachineConfiguration.DataDisks.Single().DiskSizeGB);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -933,35 +905,33 @@ namespace BatchClientIntegrationTests
             {
                 Func<Task<string>> tokenProvider = () => IntegrationTestCommon.GetAuthenticationTokenAsync("https://batch.core.windows.net/");
 
-                using (var client = BatchClient.Open(new BatchTokenCredentials(TestCommon.Configuration.BatchAccountUrl, tokenProvider)))
+                using var client = BatchClient.Open(new BatchTokenCredentials(TestCommon.Configuration.BatchAccountUrl, tokenProvider));
+                string poolId = "TestPoolCreatedWithCustomImage" + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                try
                 {
-                    string poolId = "TestPoolCreatedWithCustomImage" + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    try
-                    {
-                        var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(client);
+                    var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(client);
 
-                        //Create a pool
-                        CloudPool pool = client.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new VirtualMachineConfiguration(
-                                new ImageReference(
-                                    $"/subscriptions/{TestCommon.Configuration.BatchSubscription}/resourceGroups/{TestCommon.Configuration.BatchAccountResourceGroup}/providers/Microsoft.Compute/galleries/FakeGallery/images/FakeImage/versions/FakeImageVersion"),
-                                imageDetails.NodeAgentSkuId),
-                            targetDedicated);
-                        var exception = Assert.Throws<BatchException>(() => pool.Commit());
+                    //Create a pool
+                    CloudPool pool = client.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new VirtualMachineConfiguration(
+                            new ImageReference(
+                                $"/subscriptions/{TestCommon.Configuration.BatchSubscription}/resourceGroups/{TestCommon.Configuration.BatchAccountResourceGroup}/providers/Microsoft.Compute/galleries/FakeGallery/images/FakeImage/versions/FakeImageVersion"),
+                            imageDetails.NodeAgentSkuId),
+                        targetDedicated);
+                    var exception = Assert.Throws<BatchException>(() => pool.Commit());
 
-                        Assert.Equal("InsufficientPermissions", exception.RequestInformation.BatchError.Code);
-                        Assert.Contains(
-                            "The user identity used for this operation does not have the required privelege Microsoft.Compute/galleries/images/versions/read on the specified resource",
-                            exception.RequestInformation.BatchError.Values.Single().Value);
-                    }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
-                    }
+                    Assert.Equal("InsufficientPermissions", exception.RequestInformation.BatchError.Code);
+                    Assert.Contains(
+                        "The user identity used for this operation does not have the required privelege Microsoft.Compute/galleries/images/versions/read on the specified resource",
+                        exception.RequestInformation.BatchError.Values.Single().Value);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
                 }
             };
 
@@ -979,36 +949,34 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string poolId = TestUtilities.GenerateResourceId();
+
+                try
                 {
-                    string poolId = TestUtilities.GenerateResourceId();
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new CloudServiceConfiguration(PoolFixture.OSFamily));
 
-                    try
-                    {
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new CloudServiceConfiguration(PoolFixture.OSFamily));
+                    await pool.CommitAsync().ConfigureAwait(false);
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        await pool.CommitAsync().ConfigureAwait(false);
-                        await pool.RefreshAsync().ConfigureAwait(false);
+                    await TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(1));
 
-                        await TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(1));
+                    await pool.ResizeAsync(
+                        targetDedicatedComputeNodes: targetDedicated,
+                        targetLowPriorityComputeNodes: targetLowPriority,
+                        resizeTimeout: TimeSpan.FromMinutes(10)).ConfigureAwait(false);
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        await pool.ResizeAsync(
-                            targetDedicatedComputeNodes: targetDedicated,
-                            targetLowPriorityComputeNodes: targetLowPriority,
-                            resizeTimeout: TimeSpan.FromMinutes(10)).ConfigureAwait(false);
-                        await pool.RefreshAsync().ConfigureAwait(false);
-
-                        Assert.Equal(targetDedicated ?? 0, pool.TargetDedicatedComputeNodes);
-                        Assert.Equal(targetLowPriority ?? 0, pool.TargetLowPriorityComputeNodes);
-                        Assert.Equal(AllocationState.Resizing, pool.AllocationState);
-                    }
-                    finally
-                    {
-                        await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
-                    }
+                    Assert.Equal(targetDedicated ?? 0, pool.TargetDedicatedComputeNodes);
+                    Assert.Equal(targetLowPriority ?? 0, pool.TargetLowPriorityComputeNodes);
+                    Assert.Equal(AllocationState.Resizing, pool.AllocationState);
+                }
+                finally
+                {
+                    await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
             };
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
@@ -1021,27 +989,25 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                var nodeCounts = batchCli.PoolOperations.ListPoolNodeCounts();
+
+                Assert.NotEmpty(nodeCounts);
+                var poolId = nodeCounts.First().PoolId;
+
+                foreach (var poolNodeCount in nodeCounts)
                 {
-                    var nodeCounts = batchCli.PoolOperations.ListPoolNodeCounts();
+                    Assert.NotEmpty(poolNodeCount.PoolId);
+                    Assert.NotNull(poolNodeCount.Dedicated);
+                    Assert.NotNull(poolNodeCount.LowPriority);
 
-                    Assert.NotEmpty(nodeCounts);
-                    var poolId = nodeCounts.First().PoolId;
-
-                    foreach (var poolNodeCount in nodeCounts)
-                    {
-                        Assert.NotEmpty(poolNodeCount.PoolId);
-                        Assert.NotNull(poolNodeCount.Dedicated);
-                        Assert.NotNull(poolNodeCount.LowPriority);
-
-                        // Check a few properties at random
-                        Assert.Equal(0, poolNodeCount.LowPriority.Unusable);
-                        Assert.Equal(0, poolNodeCount.LowPriority.Offline);
-                    }
-
-                    var filteredNodeCounts = batchCli.PoolOperations.ListPoolNodeCounts(new ODATADetailLevel(filterClause: $"poolId eq '{poolId}'")).ToList();
-                    Assert.Single(filteredNodeCounts);
+                    // Check a few properties at random
+                    Assert.Equal(0, poolNodeCount.LowPriority.Unusable);
+                    Assert.Equal(0, poolNodeCount.LowPriority.Offline);
                 }
+
+                var filteredNodeCounts = batchCli.PoolOperations.ListPoolNodeCounts(new ODATADetailLevel(filterClause: $"poolId eq '{poolId}'")).ToList();
+                Assert.Single(filteredNodeCounts);
             };
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
@@ -1054,22 +1020,20 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                var supportedImages = batchCli.PoolOperations.ListSupportedImages().ToList();
+
+                Assert.True(supportedImages.Count > 0);
+
+                foreach (ImageInformation imageInfo in supportedImages)
                 {
-                    var supportedImages = batchCli.PoolOperations.ListSupportedImages().ToList();
-
-                    Assert.True(supportedImages.Count > 0);
-
-                    foreach (ImageInformation imageInfo in supportedImages)
-                    {
-                        testOutputHelper.WriteLine("ImageInformation:");
-                        testOutputHelper.WriteLine("   skuid: " + imageInfo.NodeAgentSkuId);
-                        testOutputHelper.WriteLine("   OSType: " + imageInfo.OSType);
-                        testOutputHelper.WriteLine("   publisher: " + imageInfo.ImageReference.Publisher);
-                        testOutputHelper.WriteLine("   offer: " + imageInfo.ImageReference.Offer);
-                        testOutputHelper.WriteLine("   sku: " + imageInfo.ImageReference.Sku);
-                        testOutputHelper.WriteLine("   version: " + imageInfo.ImageReference.Version);
-                    }
+                    testOutputHelper.WriteLine("ImageInformation:");
+                    testOutputHelper.WriteLine("   skuid: " + imageInfo.NodeAgentSkuId);
+                    testOutputHelper.WriteLine("   OSType: " + imageInfo.OSType);
+                    testOutputHelper.WriteLine("   publisher: " + imageInfo.ImageReference.Publisher);
+                    testOutputHelper.WriteLine("   offer: " + imageInfo.ImageReference.Offer);
+                    testOutputHelper.WriteLine("   sku: " + imageInfo.ImageReference.Sku);
+                    testOutputHelper.WriteLine("   version: " + imageInfo.ImageReference.Version);
                 }
             };
 
@@ -1083,28 +1047,27 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false))
+                using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
+                string poolId = TestUtilities.GenerateResourceId();
+
+                const string containerName = "blobfusecontainer";
+
+                StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
+                BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, storageAccount);
+                containerClient.CreateIfNotExists();
+
+                try
                 {
-                    string poolId = TestUtilities.GenerateResourceId();
+                    var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
 
-                    const string containerName = "blobfusecontainer";
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new VirtualMachineConfiguration(
+                            imageDetails.ImageReference,
+                            imageDetails.NodeAgentSkuId));
 
-                    StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
-                    BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, storageAccount);
-                    containerClient.CreateIfNotExists();
-
-                    try
-                    {
-                        var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
-
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new VirtualMachineConfiguration(
-                                imageDetails.ImageReference,
-                                imageDetails.NodeAgentSkuId));
-
-                        pool.MountConfiguration = new List<MountConfiguration>
+                    pool.MountConfiguration = new List<MountConfiguration>
                         {
                             new MountConfiguration(
                                 new AzureBlobFileSystemConfiguration(
@@ -1114,18 +1077,17 @@ namespace BatchClientIntegrationTests
                                     AzureStorageAuthenticationKey.FromAccountKey(storageAccount.StorageAccountKey)))
                         };
 
-                        await pool.CommitAsync().ConfigureAwait(false);
-                        await pool.RefreshAsync().ConfigureAwait(false);
+                    await pool.CommitAsync().ConfigureAwait(false);
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        Assert.NotNull(pool.MountConfiguration);
-                        Assert.NotEmpty(pool.MountConfiguration);
-                        Assert.Equal(storageAccount.StorageAccount, pool.MountConfiguration.Single().AzureBlobFileSystemConfiguration.AccountName);
-                        Assert.Equal(containerName, pool.MountConfiguration.Single().AzureBlobFileSystemConfiguration.ContainerName);
-                    }
-                    finally
-                    {
-                        await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
-                    }
+                    Assert.NotNull(pool.MountConfiguration);
+                    Assert.NotEmpty(pool.MountConfiguration);
+                    Assert.Equal(storageAccount.StorageAccount, pool.MountConfiguration.Single().AzureBlobFileSystemConfiguration.AccountName);
+                    Assert.Equal(containerName, pool.MountConfiguration.Single().AzureBlobFileSystemConfiguration.ContainerName);
+                }
+                finally
+                {
+                    await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
             };
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
@@ -1138,35 +1100,33 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string poolId = nameof(TestCreatePoolEncryptionEnabled) + TestUtilities.GetMyName();
+                const int targetDedicated = 0;
+                try
                 {
-                    string poolId = nameof(TestCreatePoolEncryptionEnabled) + TestUtilities.GetMyName();
-                    const int targetDedicated = 0;
-                    try
-                    {
-                        var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
+                    var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
 
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new VirtualMachineConfiguration(
-                                imageDetails.ImageReference,
-                                imageDetails.NodeAgentSkuId)
-                            {
-                                DiskEncryptionConfiguration = new DiskEncryptionConfiguration(new List<DiskEncryptionTarget> { DiskEncryptionTarget.TemporaryDisk })
-                            },
-                            targetDedicated);
-                        pool.Commit();
-                        pool.Refresh();
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new VirtualMachineConfiguration(
+                            imageDetails.ImageReference,
+                            imageDetails.NodeAgentSkuId)
+                        {
+                            DiskEncryptionConfiguration = new DiskEncryptionConfiguration(new List<DiskEncryptionTarget> { DiskEncryptionTarget.TemporaryDisk })
+                        },
+                        targetDedicated);
+                    pool.Commit();
+                    pool.Refresh();
 
-                        Assert.Single(pool.VirtualMachineConfiguration.DiskEncryptionConfiguration.Targets, DiskEncryptionTarget.TemporaryDisk);
-                    }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                    Assert.Single(pool.VirtualMachineConfiguration.DiskEncryptionConfiguration.Targets, DiskEncryptionTarget.TemporaryDisk);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 
@@ -1297,82 +1257,80 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "Bug2251050_TestRemoveComputeNodesResizeTimeout_LR" + TestUtilities.GetMyName();
+                string jobId = "Bug2251050Job-" + TestUtilities.GetMyName();
+                const int targetDedicated = 2;
+                try
                 {
-                    string poolId = "Bug2251050_TestRemoveComputeNodesResizeTimeout_LR" + TestUtilities.GetMyName();
-                    string jobId = "Bug2251050Job-" + TestUtilities.GetMyName();
-                    const int targetDedicated = 2;
-                    try
+                    //Create a pool with 2 compute nodes
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
+                    pool.Commit();
+
+                    testOutputHelper.WriteLine("Created pool {0}", poolId);
+
+                    CloudPool refreshablePool = batchCli.PoolOperations.GetPool(poolId);
+                    //Wait for compute node allocation
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(5)).Wait();
+                    refreshablePool.Refresh();
+                    Assert.Equal(targetDedicated, refreshablePool.CurrentDedicatedComputeNodes);
+
+                    IEnumerable<ComputeNode> computeNodes = refreshablePool.ListComputeNodes();
+
+                    Assert.Equal(targetDedicated, computeNodes.Count());
+
+                    //
+                    //Create a job on this pool with targetDedicated tasks which run for 10m each
+                    //
+                    CloudJob workflowJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
+                    workflowJob.Commit();
+
+                    const int taskDurationSeconds = 600;
+                    string taskCmdLine = string.Format("ping 127.0.0.1 -n {0}", taskDurationSeconds);
+
+                    for (int i = 0; i < targetDedicated; i++)
                     {
-                        //Create a pool with 2 compute nodes
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
-                        pool.Commit();
-
-                        testOutputHelper.WriteLine("Created pool {0}", poolId);
-
-                        CloudPool refreshablePool = batchCli.PoolOperations.GetPool(poolId);
-                        //Wait for compute node allocation
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(5)).Wait();
-                        refreshablePool.Refresh();
-                        Assert.Equal(targetDedicated, refreshablePool.CurrentDedicatedComputeNodes);
-
-                        IEnumerable<ComputeNode> computeNodes = refreshablePool.ListComputeNodes();
-
-                        Assert.Equal(targetDedicated, computeNodes.Count());
-
-                        //
-                        //Create a job on this pool with targetDedicated tasks which run for 10m each
-                        //
-                        CloudJob workflowJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
-                        workflowJob.Commit();
-
-                        const int taskDurationSeconds = 600;
-                        string taskCmdLine = string.Format("ping 127.0.0.1 -n {0}", taskDurationSeconds);
-
-                        for (int i = 0; i < targetDedicated; i++)
-                        {
-                            string taskId = string.Format("T_{0}", i);
-                            batchCli.JobOperations.AddTask(jobId, new CloudTask(taskId, taskCmdLine));
-                        }
-
-                        //
-                        // Wait for tasks to both go to running
-                        //
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-                        taskStateMonitor.WaitAll(
-                            batchCli.JobOperations.ListTasks(jobId),
-                            Microsoft.Azure.Batch.Common.TaskState.Running,
-                            TimeSpan.FromMinutes(20));
-
-                        //
-                        // Remove pool compute nodes
-                        //
-                        TimeSpan resizeTimeout = TimeSpan.FromMinutes(5);
-                        batchCli.PoolOperations.RemoveFromPool(poolId, computeNodes, ComputeNodeDeallocationOption.TaskCompletion, resizeTimeout);
-
-                        //
-                        // Wait for the resize to timeout
-                        //
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(6)).Wait();
-                        refreshablePool.Refresh();
-
-                        Assert.NotNull(refreshablePool.ResizeErrors);
-                        Assert.Equal(1, refreshablePool.ResizeErrors.Count);
-
-                        var resizeError = refreshablePool.ResizeErrors.Single();
-                        Assert.Equal(PoolResizeErrorCodes.AllocationTimedOut, resizeError.Code);
-
-                        testOutputHelper.WriteLine("Resize error: {0}", resizeError.Message);
+                        string taskId = string.Format("T_{0}", i);
+                        batchCli.JobOperations.AddTask(jobId, new CloudTask(taskId, taskCmdLine));
                     }
-                    finally
-                    {
-                        //Delete the pool
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
 
-                        //Delete the job schedule
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    //
+                    // Wait for tasks to both go to running
+                    //
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+                    taskStateMonitor.WaitAll(
+                        batchCli.JobOperations.ListTasks(jobId),
+                        Microsoft.Azure.Batch.Common.TaskState.Running,
+                        TimeSpan.FromMinutes(20));
+
+                    //
+                    // Remove pool compute nodes
+                    //
+                    TimeSpan resizeTimeout = TimeSpan.FromMinutes(5);
+                    batchCli.PoolOperations.RemoveFromPool(poolId, computeNodes, ComputeNodeDeallocationOption.TaskCompletion, resizeTimeout);
+
+                    //
+                    // Wait for the resize to timeout
+                    //
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(6)).Wait();
+                    refreshablePool.Refresh();
+
+                    Assert.NotNull(refreshablePool.ResizeErrors);
+                    Assert.Equal(1, refreshablePool.ResizeErrors.Count);
+
+                    var resizeError = refreshablePool.ResizeErrors.Single();
+                    Assert.Equal(PoolResizeErrorCodes.AllocationTimedOut, resizeError.Code);
+
+                    testOutputHelper.WriteLine("Resize error: {0}", resizeError.Message);
+                }
+                finally
+                {
+                    //Delete the pool
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
+
+                    //Delete the job schedule
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -1402,105 +1360,103 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "TestRemovePoolComputeNodes_LongRunning" + TestUtilities.GetMyName();
+                const int targetDedicated = 3;
+                try
                 {
-                    string poolId = "TestRemovePoolComputeNodes_LongRunning" + TestUtilities.GetMyName();
-                    const int targetDedicated = 3;
-                    try
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
+
+                    pool.Commit();
+
+                    testOutputHelper.WriteLine("Created pool {0}", poolId);
+
+                    CloudPool refreshablePool = batchCli.PoolOperations.GetPool(poolId);
+                    //Wait for compute node allocation
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
+                    refreshablePool.Refresh();
+                    Assert.Equal(targetDedicated, refreshablePool.CurrentDedicatedComputeNodes);
+
+                    IEnumerable<ComputeNode> computeNodes = refreshablePool.ListComputeNodes();
+
+                    Assert.Equal(targetDedicated, computeNodes.Count());
+
+                    //
+                    //Remove first compute node from the pool
+                    //
+                    ComputeNode computeNodeToRemove = computeNodes.First();
+
+                    //For Bug234298 ensure start task property doesn't throw
+                    Assert.Null(computeNodeToRemove.StartTask);
+
+                    testOutputHelper.WriteLine("Will remove compute node: {0}", computeNodeToRemove.Id);
+
+                    //Remove the compute node from the pool by instance
+                    refreshablePool.RemoveFromPool(computeNodeToRemove);
+
+                    //Wait for pool to got to steady state again
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
+
+                    refreshablePool.Refresh();
+                    //Ensure that the other ComputeNodes were not impacted and we now have 1 less ComputeNode
+                    List<ComputeNode> computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
+
+                    Assert.Equal(targetDedicated - 1, computeNodesAfterRemove.Count);
+
+                    List<string> remainingComputeNodeIds = computeNodesAfterRemove.Select(computeNode => computeNode.Id).ToList();
+                    foreach (ComputeNode originalComputeNode in computeNodes)
                     {
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
-
-                        pool.Commit();
-
-                        testOutputHelper.WriteLine("Created pool {0}", poolId);
-
-                        CloudPool refreshablePool = batchCli.PoolOperations.GetPool(poolId);
-                        //Wait for compute node allocation
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
-                        refreshablePool.Refresh();
-                        Assert.Equal(targetDedicated, refreshablePool.CurrentDedicatedComputeNodes);
-
-                        IEnumerable<ComputeNode> computeNodes = refreshablePool.ListComputeNodes();
-
-                        Assert.Equal(targetDedicated, computeNodes.Count());
-
-                        //
-                        //Remove first compute node from the pool
-                        //
-                        ComputeNode computeNodeToRemove = computeNodes.First();
-
-                        //For Bug234298 ensure start task property doesn't throw
-                        Assert.Null(computeNodeToRemove.StartTask);
-
-                        testOutputHelper.WriteLine("Will remove compute node: {0}", computeNodeToRemove.Id);
-
-                        //Remove the compute node from the pool by instance
-                        refreshablePool.RemoveFromPool(computeNodeToRemove);
-
-                        //Wait for pool to got to steady state again
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
-
-                        refreshablePool.Refresh();
-                        //Ensure that the other ComputeNodes were not impacted and we now have 1 less ComputeNode
-                        List<ComputeNode> computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
-
-                        Assert.Equal(targetDedicated - 1, computeNodesAfterRemove.Count);
-
-                        List<string> remainingComputeNodeIds = computeNodesAfterRemove.Select(computeNode => computeNode.Id).ToList();
-                        foreach (ComputeNode originalComputeNode in computeNodes)
-                        {
-                            Assert.Contains(originalComputeNode.Id, remainingComputeNodeIds);
-                        }
-
-                        testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
-
-                        //
-                        //Remove a second compute node from the pool
-                        //
-
-                        ComputeNode secondComputeNodeToRemove = computeNodesAfterRemove.First();
-                        string secondComputeNodeToRemoveId = secondComputeNodeToRemove.Id;
-
-                        //Remove the IComputeNode from the pool by id
-                        refreshablePool.RemoveFromPool(secondComputeNodeToRemoveId);
-
-                        //Wait for pool to got to steady state again
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
-                        refreshablePool.Refresh();
-
-                        //Ensure that the other ComputeNodes were not impacted and we now have 1 less ComputeNode
-                        computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
-
-                        Assert.Single(computeNodesAfterRemove);
-
-                        testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
-
-                        //
-                        //Remove a 3rd compute node from pool
-                        //
-
-                        ComputeNode thirdComputeNodeToRemove = computeNodesAfterRemove.First();
-                        string thirdComputeNodeToRemoveId = thirdComputeNodeToRemove.Id;
-                        testOutputHelper.WriteLine("Will remove compute node: {0}", thirdComputeNodeToRemoveId);
-
-                        //Remove the IComputeNode from the pool using the ComputeNode object
-                        thirdComputeNodeToRemove.RemoveFromPool();
-
-                        //Wait for pool to got to steady state again
-                        TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
-
-                        //Ensure that the other ComputeNodes were not impacted and we now have 1 less ComputeNode
-                        computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
-                        Assert.Empty(computeNodesAfterRemove);
-
-                        testOutputHelper.WriteLine("Verified that the ComputeNode was removed correctly");
+                        Assert.Contains(originalComputeNode.Id, remainingComputeNodeIds);
                     }
-                    finally
-                    {
-                        //Delete the pool
-                        batchCli.PoolOperations.DeletePool(poolId);
-                    }
+
+                    testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
+
+                    //
+                    //Remove a second compute node from the pool
+                    //
+
+                    ComputeNode secondComputeNodeToRemove = computeNodesAfterRemove.First();
+                    string secondComputeNodeToRemoveId = secondComputeNodeToRemove.Id;
+
+                    //Remove the IComputeNode from the pool by id
+                    refreshablePool.RemoveFromPool(secondComputeNodeToRemoveId);
+
+                    //Wait for pool to got to steady state again
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
+                    refreshablePool.Refresh();
+
+                    //Ensure that the other ComputeNodes were not impacted and we now have 1 less ComputeNode
+                    computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
+
+                    Assert.Single(computeNodesAfterRemove);
+
+                    testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
+
+                    //
+                    //Remove a 3rd compute node from pool
+                    //
+
+                    ComputeNode thirdComputeNodeToRemove = computeNodesAfterRemove.First();
+                    string thirdComputeNodeToRemoveId = thirdComputeNodeToRemove.Id;
+                    testOutputHelper.WriteLine("Will remove compute node: {0}", thirdComputeNodeToRemoveId);
+
+                    //Remove the IComputeNode from the pool using the ComputeNode object
+                    thirdComputeNodeToRemove.RemoveFromPool();
+
+                    //Wait for pool to got to steady state again
+                    TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).Wait();
+
+                    //Ensure that the other ComputeNodes were not impacted and we now have 1 less ComputeNode
+                    computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
+                    Assert.Empty(computeNodesAfterRemove);
+
+                    testOutputHelper.WriteLine("Verified that the ComputeNode was removed correctly");
+                }
+                finally
+                {
+                    //Delete the pool
+                    batchCli.PoolOperations.DeletePool(poolId);
                 }
             };
 
@@ -1530,43 +1486,41 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "TestLowPri_LongRunning" + TestUtilities.GetMyName();
+                const int targetLowPriority = 1;
+                try
                 {
-                    string poolId = "TestLowPri_LongRunning" + TestUtilities.GetMyName();
-                    const int targetLowPriority = 1;
-                    try
-                    {
-                        //Create a pool
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new CloudServiceConfiguration(PoolFixture.OSFamily),
-                            targetLowPriorityComputeNodes: targetLowPriority);
+                    //Create a pool
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new CloudServiceConfiguration(PoolFixture.OSFamily),
+                        targetLowPriorityComputeNodes: targetLowPriority);
 
-                        await pool.CommitAsync().ConfigureAwait(false);
+                    await pool.CommitAsync().ConfigureAwait(false);
 
-                        testOutputHelper.WriteLine("Created pool {0}", poolId);
-                        await pool.RefreshAsync().ConfigureAwait(false);
+                    testOutputHelper.WriteLine("Created pool {0}", poolId);
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        //Wait for compute node allocation
-                        await TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).ConfigureAwait(false);
+                    //Wait for compute node allocation
+                    await TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromMinutes(10)).ConfigureAwait(false);
 
-                        //Refresh pool to get latest from server
-                        await pool.RefreshAsync().ConfigureAwait(false);
+                    //Refresh pool to get latest from server
+                    await pool.RefreshAsync().ConfigureAwait(false);
 
-                        Assert.Equal(targetLowPriority, pool.CurrentLowPriorityComputeNodes);
+                    Assert.Equal(targetLowPriority, pool.CurrentLowPriorityComputeNodes);
 
-                        IEnumerable<ComputeNode> computeNodes = pool.ListComputeNodes();
-                        Assert.Single(computeNodes);
+                    IEnumerable<ComputeNode> computeNodes = pool.ListComputeNodes();
+                    Assert.Single(computeNodes);
 
-                        ComputeNode node = computeNodes.Single();
-                        Assert.False(node.IsDedicated);
-                    }
-                    finally
-                    {
-                        //Delete the pool
-                        await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
-                    }
+                    ComputeNode node = computeNodes.Single();
+                    Assert.False(node.IsDedicated);
+                }
+                finally
+                {
+                    //Delete the pool
+                    await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
             };
 
@@ -1592,118 +1546,116 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "LongRunning_Bug1771277_1771278_RebootReimageComputeNode" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "LongRunning_Bug1771277_1771278_RebootReimageComputeNode" + TestUtilities.GetMyName();
+                    //
+                    // Get the pool and check its targets
+                    //
+                    CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                    try
+                    //
+                    //Create a job on this pool with targetDedicated tasks which run for 2m each
+                    //
+                    const int taskDurationSeconds = 600;
+
+                    CloudJob workflowJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    workflowJob.Commit();
+
+                    CloudJob boundWorkflowJob = batchCli.JobOperations.GetJob(jobId);
+
+                    string taskCmdLine = string.Format("ping 127.0.0.1 -n {0}", taskDurationSeconds);
+
+                    for (int i = 0; i < pool.CurrentDedicatedComputeNodes; i++)
                     {
-                        //
-                        // Get the pool and check its targets
-                        //
-                        CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
-
-                        //
-                        //Create a job on this pool with targetDedicated tasks which run for 2m each
-                        //
-                        const int taskDurationSeconds = 600;
-
-                        CloudJob workflowJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        workflowJob.Commit();
-
-                        CloudJob boundWorkflowJob = batchCli.JobOperations.GetJob(jobId);
-
-                        string taskCmdLine = string.Format("ping 127.0.0.1 -n {0}", taskDurationSeconds);
-
-                        for (int i = 0; i < pool.CurrentDedicatedComputeNodes; i++)
-                        {
-                            string taskId = string.Format("T_{0}", i);
-                            boundWorkflowJob.AddTask(new CloudTask(taskId, taskCmdLine));
-                        }
-
-                        //
-                        // Wait for tasks to go to running
-                        //
-                        TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-                        taskStateMonitor.WaitAll(
-                            batchCli.JobOperations.ListTasks(jobId),
-                            Microsoft.Azure.Batch.Common.TaskState.Running,
-                            TimeSpan.FromMinutes(2));
-
-                        //
-                        // Reboot the compute nodes from the pool with requeue option and ensure tasks goes to Active again and compute node state goes to rebooting
-                        //
-
-                        IEnumerable<ComputeNode> computeNodes = pool.ListComputeNodes();
-
-                        foreach (ComputeNode computeNode in computeNodes)
-                        {
-                            computeNode.Reboot(ComputeNodeRebootOption.Requeue);
-                        }
-
-                        //Ensure task goes to active state
-                        taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-                        taskStateMonitor.WaitAll(
-                            batchCli.JobOperations.ListTasks(jobId),
-                            Microsoft.Azure.Batch.Common.TaskState.Active,
-                            TimeSpan.FromMinutes(1));
-
-                        //Ensure each compute node goes to rebooting state
-                        IEnumerable<ComputeNode> rebootingComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
-                        foreach (ComputeNode computeNode in rebootingComputeNodes)
-                        {
-                            Assert.Equal(ComputeNodeState.Rebooting, computeNode.State);
-                        }
-
-                        //Wait for tasks to start to run again
-                        taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-                        taskStateMonitor.WaitAll(
-                            batchCli.JobOperations.ListTasks(jobId),
-                            Microsoft.Azure.Batch.Common.TaskState.Running,
-                            TimeSpan.FromMinutes(10));
-                        //
-                        // Reimage a compute node from the pool with terminate option and ensure task goes to completed and compute node state goes to reimaging
-                        //
-                        computeNodes = pool.ListComputeNodes();
-
-                        foreach (ComputeNode computeNode in computeNodes)
-                        {
-                            computeNode.Reimage(ComputeNodeReimageOption.Terminate);
-                        }
-
-                        //Ensure task goes to completed state
-                        taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-                        taskStateMonitor.WaitAll(
-                            batchCli.JobOperations.ListTasks(jobId),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(1));
-
-                        //Ensure each compute node goes to reimaging state
-                        IEnumerable<ComputeNode> reimagingComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
-                        foreach (ComputeNode computeNode in reimagingComputeNodes)
-                        {
-                            Assert.Equal(ComputeNodeState.Reimaging, computeNode.State);
-                        }
+                        string taskId = string.Format("T_{0}", i);
+                        boundWorkflowJob.AddTask(new CloudTask(taskId, taskCmdLine));
                     }
-                    finally
+
+                    //
+                    // Wait for tasks to go to running
+                    //
+                    TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    taskStateMonitor.WaitAll(
+                        batchCli.JobOperations.ListTasks(jobId),
+                        Microsoft.Azure.Batch.Common.TaskState.Running,
+                        TimeSpan.FromMinutes(2));
+
+                    //
+                    // Reboot the compute nodes from the pool with requeue option and ensure tasks goes to Active again and compute node state goes to rebooting
+                    //
+
+                    IEnumerable<ComputeNode> computeNodes = pool.ListComputeNodes();
+
+                    foreach (ComputeNode computeNode in computeNodes)
                     {
-                        //Delete the job
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        computeNode.Reboot(ComputeNodeRebootOption.Requeue);
+                    }
 
-                        //Wait until the compute nodes are idle again
-                        //TODO: Use a Utilities waiter
-                        TimeSpan computeNodeSteadyTimeout = TimeSpan.FromMinutes(15);
-                        DateTime allocationWaitStartTime = DateTime.UtcNow;
-                        DateTime timeoutAfterThisTimeUtc = allocationWaitStartTime.Add(computeNodeSteadyTimeout);
+                    //Ensure task goes to active state
+                    taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    taskStateMonitor.WaitAll(
+                        batchCli.JobOperations.ListTasks(jobId),
+                        Microsoft.Azure.Batch.Common.TaskState.Active,
+                        TimeSpan.FromMinutes(1));
 
-                        IEnumerable<ComputeNode> computeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
+                    //Ensure each compute node goes to rebooting state
+                    IEnumerable<ComputeNode> rebootingComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
+                    foreach (ComputeNode computeNode in rebootingComputeNodes)
+                    {
+                        Assert.Equal(ComputeNodeState.Rebooting, computeNode.State);
+                    }
 
-                        while (computeNodes.Any(computeNode => computeNode.State != ComputeNodeState.Idle))
-                        {
-                            Thread.Sleep(TimeSpan.FromSeconds(10));
-                            computeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
-                            Assert.False(DateTime.UtcNow > timeoutAfterThisTimeUtc, "Timed out waiting for compute nodes in pool to reach idle state");
-                        }
+                    //Wait for tasks to start to run again
+                    taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    taskStateMonitor.WaitAll(
+                        batchCli.JobOperations.ListTasks(jobId),
+                        Microsoft.Azure.Batch.Common.TaskState.Running,
+                        TimeSpan.FromMinutes(10));
+                    //
+                    // Reimage a compute node from the pool with terminate option and ensure task goes to completed and compute node state goes to reimaging
+                    //
+                    computeNodes = pool.ListComputeNodes();
+
+                    foreach (ComputeNode computeNode in computeNodes)
+                    {
+                        computeNode.Reimage(ComputeNodeReimageOption.Terminate);
+                    }
+
+                    //Ensure task goes to completed state
+                    taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    taskStateMonitor.WaitAll(
+                        batchCli.JobOperations.ListTasks(jobId),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(1));
+
+                    //Ensure each compute node goes to reimaging state
+                    IEnumerable<ComputeNode> reimagingComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
+                    foreach (ComputeNode computeNode in reimagingComputeNodes)
+                    {
+                        Assert.Equal(ComputeNodeState.Reimaging, computeNode.State);
+                    }
+                }
+                finally
+                {
+                    //Delete the job
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+
+                    //Wait until the compute nodes are idle again
+                    //TODO: Use a Utilities waiter
+                    TimeSpan computeNodeSteadyTimeout = TimeSpan.FromMinutes(15);
+                    DateTime allocationWaitStartTime = DateTime.UtcNow;
+                    DateTime timeoutAfterThisTimeUtc = allocationWaitStartTime.Add(computeNodeSteadyTimeout);
+
+                    IEnumerable<ComputeNode> computeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
+
+                    while (computeNodes.Any(computeNode => computeNode.State != ComputeNodeState.Idle))
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(10));
+                        computeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
+                        Assert.False(DateTime.UtcNow > timeoutAfterThisTimeUtc, "Timed out waiting for compute nodes in pool to reach idle state");
                     }
                 }
             };

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
@@ -1091,7 +1091,7 @@ namespace BatchClientIntegrationTests
 
                     StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
                     BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, storageAccount);
-                    await containerClient.CreateIfNotExistsAsync();
+                    containerClient.CreateIfNotExists();
 
                     try
                     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
@@ -617,7 +617,7 @@ namespace BatchClientIntegrationTests
 
                         TestUtilities.WaitForPoolToReachStateAsync(batchCli, poolId, AllocationState.Steady, TimeSpan.FromSeconds(20)).Wait();
 
-                        this.testOutputHelper.WriteLine($"Created pool {poolId}");
+                        testOutputHelper.WriteLine($"Created pool {poolId}");
 
                         CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
 
@@ -631,7 +631,7 @@ namespace BatchClientIntegrationTests
                         boundPool.Refresh();
 
                         //The pool could be in stopping or steady state
-                        this.testOutputHelper.WriteLine($"Pool allocation state: {boundPool.AllocationState}");
+                        testOutputHelper.WriteLine($"Pool allocation state: {boundPool.AllocationState}");
                         Assert.True(boundPool.AllocationState == AllocationState.Steady || boundPool.AllocationState == AllocationState.Stopping);
                     }
                     finally
@@ -679,7 +679,7 @@ namespace BatchClientIntegrationTests
                         boundPool.Refresh();
                         Assert.True(boundPool.AutoScaleEnabled);
                         Assert.Equal(autoscaleFormula1, boundPool.AutoScaleFormula);
-                        this.testOutputHelper.WriteLine($"Got the pool");
+                        testOutputHelper.WriteLine($"Got the pool");
 
                         Assert.NotNull(boundPool.AutoScaleRun);
                         Assert.NotNull(boundPool.AutoScaleRun.Results);
@@ -688,7 +688,7 @@ namespace BatchClientIntegrationTests
                         //Evaluate a different formula
                         AutoScaleRun evaluation = boundPool.EvaluateAutoScale(evaluateAutoscaleFormula);
 
-                        this.testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
+                        testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
 
                         Assert.NotNull(evaluation.Results);
                         Assert.Contains("myActiveSamples", evaluation.Results);
@@ -722,7 +722,7 @@ namespace BatchClientIntegrationTests
 
                         evaluation = batchCli.PoolOperations.EvaluateAutoScale(poolId, evaluateAutoscaleFormula);
 
-                        this.testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
+                        testOutputHelper.WriteLine("Autoscale evaluate results: {0}", evaluation.Results);
 
                         Assert.NotNull(evaluation);
                         Assert.Contains("myActiveSamples", evaluation.Results);
@@ -1062,13 +1062,13 @@ namespace BatchClientIntegrationTests
 
                     foreach (ImageInformation imageInfo in supportedImages)
                     {
-                        this.testOutputHelper.WriteLine("ImageInformation:");
-                        this.testOutputHelper.WriteLine("   skuid: " + imageInfo.NodeAgentSkuId);
-                        this.testOutputHelper.WriteLine("   OSType: " + imageInfo.OSType);
-                        this.testOutputHelper.WriteLine("   publisher: " + imageInfo.ImageReference.Publisher);
-                        this.testOutputHelper.WriteLine("   offer: " + imageInfo.ImageReference.Offer);
-                        this.testOutputHelper.WriteLine("   sku: " + imageInfo.ImageReference.Sku);
-                        this.testOutputHelper.WriteLine("   version: " + imageInfo.ImageReference.Version);
+                        testOutputHelper.WriteLine("ImageInformation:");
+                        testOutputHelper.WriteLine("   skuid: " + imageInfo.NodeAgentSkuId);
+                        testOutputHelper.WriteLine("   OSType: " + imageInfo.OSType);
+                        testOutputHelper.WriteLine("   publisher: " + imageInfo.ImageReference.Publisher);
+                        testOutputHelper.WriteLine("   offer: " + imageInfo.ImageReference.Offer);
+                        testOutputHelper.WriteLine("   sku: " + imageInfo.ImageReference.Sku);
+                        testOutputHelper.WriteLine("   version: " + imageInfo.ImageReference.Version);
                     }
                 }
             };
@@ -1209,10 +1209,10 @@ namespace BatchClientIntegrationTests
             internal TestListPoolUsageMetricsFakesYieldInjector(IList<Protocol.Models.PoolUsageMetrics> poolUsageMetricsList)
             {
                 // here is our interceptor
-                base.ModificationInterceptHandler = this.RequestInterceptor;
+                base.ModificationInterceptHandler = RequestInterceptor;
 
                 // remember our fake data
-                this._poolUsageMetricsList = poolUsageMetricsList;
+                _poolUsageMetricsList = poolUsageMetricsList;
             }
         }
 
@@ -1308,7 +1308,7 @@ namespace BatchClientIntegrationTests
                         CloudPool pool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: targetDedicated);
                         pool.Commit();
 
-                        this.testOutputHelper.WriteLine("Created pool {0}", poolId);
+                        testOutputHelper.WriteLine("Created pool {0}", poolId);
 
                         CloudPool refreshablePool = batchCli.PoolOperations.GetPool(poolId);
                         //Wait for compute node allocation
@@ -1363,7 +1363,7 @@ namespace BatchClientIntegrationTests
                         var resizeError = refreshablePool.ResizeErrors.Single();
                         Assert.Equal(PoolResizeErrorCodes.AllocationTimedOut, resizeError.Code);
 
-                        this.testOutputHelper.WriteLine("Resize error: {0}", resizeError.Message);
+                        testOutputHelper.WriteLine("Resize error: {0}", resizeError.Message);
                     }
                     finally
                     {
@@ -1413,7 +1413,7 @@ namespace BatchClientIntegrationTests
 
                         pool.Commit();
 
-                        this.testOutputHelper.WriteLine("Created pool {0}", poolId);
+                        testOutputHelper.WriteLine("Created pool {0}", poolId);
 
                         CloudPool refreshablePool = batchCli.PoolOperations.GetPool(poolId);
                         //Wait for compute node allocation
@@ -1433,7 +1433,7 @@ namespace BatchClientIntegrationTests
                         //For Bug234298 ensure start task property doesn't throw
                         Assert.Null(computeNodeToRemove.StartTask);
 
-                        this.testOutputHelper.WriteLine("Will remove compute node: {0}", computeNodeToRemove.Id);
+                        testOutputHelper.WriteLine("Will remove compute node: {0}", computeNodeToRemove.Id);
 
                         //Remove the compute node from the pool by instance
                         refreshablePool.RemoveFromPool(computeNodeToRemove);
@@ -1453,7 +1453,7 @@ namespace BatchClientIntegrationTests
                             Assert.Contains(originalComputeNode.Id, remainingComputeNodeIds);
                         }
 
-                        this.testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
+                        testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
 
                         //
                         //Remove a second compute node from the pool
@@ -1474,7 +1474,7 @@ namespace BatchClientIntegrationTests
 
                         Assert.Single(computeNodesAfterRemove);
 
-                        this.testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
+                        testOutputHelper.WriteLine("Verified that the compute node was removed correctly");
 
                         //
                         //Remove a 3rd compute node from pool
@@ -1482,7 +1482,7 @@ namespace BatchClientIntegrationTests
 
                         ComputeNode thirdComputeNodeToRemove = computeNodesAfterRemove.First();
                         string thirdComputeNodeToRemoveId = thirdComputeNodeToRemove.Id;
-                        this.testOutputHelper.WriteLine("Will remove compute node: {0}", thirdComputeNodeToRemoveId);
+                        testOutputHelper.WriteLine("Will remove compute node: {0}", thirdComputeNodeToRemoveId);
 
                         //Remove the IComputeNode from the pool using the ComputeNode object
                         thirdComputeNodeToRemove.RemoveFromPool();
@@ -1494,7 +1494,7 @@ namespace BatchClientIntegrationTests
                         computeNodesAfterRemove = refreshablePool.ListComputeNodes().ToList();
                         Assert.Empty(computeNodesAfterRemove);
 
-                        this.testOutputHelper.WriteLine("Verified that the ComputeNode was removed correctly");
+                        testOutputHelper.WriteLine("Verified that the ComputeNode was removed correctly");
                     }
                     finally
                     {
@@ -1545,7 +1545,7 @@ namespace BatchClientIntegrationTests
 
                         await pool.CommitAsync().ConfigureAwait(false);
 
-                        this.testOutputHelper.WriteLine("Created pool {0}", poolId);
+                        testOutputHelper.WriteLine("Created pool {0}", poolId);
                         await pool.RefreshAsync().ConfigureAwait(false);
 
                         //Wait for compute node allocation
@@ -1577,13 +1577,11 @@ namespace BatchClientIntegrationTests
     [Collection("SharedPoolCollection")]
     public class IntegrationCloudPoolTestsWithSharedPool
     {
-        private readonly ITestOutputHelper testOutputHelper;
         private readonly PoolFixture poolFixture;
         private static readonly TimeSpan LongTestTimeout = TimeSpan.FromMinutes(20);
 
-        public IntegrationCloudPoolTestsWithSharedPool(ITestOutputHelper testOutputHelper, PaasWindowsPoolFixture poolFixture)
+        public IntegrationCloudPoolTestsWithSharedPool(PaasWindowsPoolFixture poolFixture)
         {
-            this.testOutputHelper = testOutputHelper;
             this.poolFixture = poolFixture;
         }
 
@@ -1603,14 +1601,14 @@ namespace BatchClientIntegrationTests
                         //
                         // Get the pool and check its targets
                         //
-                        CloudPool pool = batchCli.PoolOperations.GetPool(this.poolFixture.PoolId);
+                        CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
                         //
                         //Create a job on this pool with targetDedicated tasks which run for 2m each
                         //
                         const int taskDurationSeconds = 600;
 
-                        CloudJob workflowJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob workflowJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         workflowJob.Commit();
 
                         CloudJob boundWorkflowJob = batchCli.JobOperations.GetJob(jobId);
@@ -1651,7 +1649,7 @@ namespace BatchClientIntegrationTests
                             TimeSpan.FromMinutes(1));
 
                         //Ensure each compute node goes to rebooting state
-                        IEnumerable<ComputeNode> rebootingComputeNodes = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId);
+                        IEnumerable<ComputeNode> rebootingComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
                         foreach (ComputeNode computeNode in rebootingComputeNodes)
                         {
                             Assert.Equal(ComputeNodeState.Rebooting, computeNode.State);
@@ -1681,7 +1679,7 @@ namespace BatchClientIntegrationTests
                             TimeSpan.FromMinutes(1));
 
                         //Ensure each compute node goes to reimaging state
-                        IEnumerable<ComputeNode> reimagingComputeNodes = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId);
+                        IEnumerable<ComputeNode> reimagingComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
                         foreach (ComputeNode computeNode in reimagingComputeNodes)
                         {
                             Assert.Equal(ComputeNodeState.Reimaging, computeNode.State);
@@ -1698,12 +1696,12 @@ namespace BatchClientIntegrationTests
                         DateTime allocationWaitStartTime = DateTime.UtcNow;
                         DateTime timeoutAfterThisTimeUtc = allocationWaitStartTime.Add(computeNodeSteadyTimeout);
 
-                        IEnumerable<ComputeNode> computeNodes = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId);
+                        IEnumerable<ComputeNode> computeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
 
                         while (computeNodes.Any(computeNode => computeNode.State != ComputeNodeState.Idle))
                         {
                             Thread.Sleep(TimeSpan.FromSeconds(10));
-                            computeNodes = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                            computeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
                             Assert.False(DateTime.UtcNow > timeoutAfterThisTimeUtc, "Timed out waiting for compute nodes in pool to reach idle state");
                         }
                     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
@@ -576,7 +576,7 @@ namespace BatchClientIntegrationTests
                     TestListPoolUsageMetricsFakesYieldInjector injectsTheFakeData = new TestListPoolUsageMetricsFakesYieldInjector(pums);
 
                     // trigger the call and get our own data back to be tested
-                    List<Microsoft.Azure.Batch.PoolUsageMetrics> clList = batchCli.PoolOperations.ListPoolUsageMetrics(additionalBehaviors: new[] { injectsTheFakeData }).ToList();
+                    List<PoolUsageMetrics> clList = batchCli.PoolOperations.ListPoolUsageMetrics(additionalBehaviors: new[] { injectsTheFakeData }).ToList();
 
                     // test that our data are honored
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
@@ -93,7 +93,7 @@
         public IntegrationMultiInstanceCloudTaskTests(ITestOutputHelper testOutputHelper)
         {
             this.testOutputHelper = testOutputHelper;
-            this.poolId = TestUtilities.GetMyName() + "-poolmulti";
+            poolId = TestUtilities.GetMyName() + "-poolmulti";
             using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
             {
                 CreatePool(batchCli, poolId); //TODO: If this is failed to construct then the dispose is not called
@@ -126,7 +126,7 @@
                     {
                         // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
                         // get an empty unbound Job
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolId });
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
                         unboundJob.Commit();
 
                         // Open the new Job as bound.
@@ -160,14 +160,14 @@
                             string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
                             string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                            this.testOutputHelper.WriteLine("StdOut: ");
-                            this.testOutputHelper.WriteLine("");
-                            this.testOutputHelper.WriteLine(stdOut);
-                            this.testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("StdOut: ");
+                            testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine(stdOut);
+                            testOutputHelper.WriteLine("");
 
-                            this.testOutputHelper.WriteLine("StdErr: ");
-                            this.testOutputHelper.WriteLine(stdErr);
-                            this.testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("StdErr: ");
+                            testOutputHelper.WriteLine(stdErr);
+                            testOutputHelper.WriteLine("");
 
 
                             List<SubtaskInformation> subtasks;
@@ -194,7 +194,7 @@
                             // Shouldnot assume the subtasks have order.
                             Assert.True((subtasks[0].Id == 1 && subtasks[1].Id == 2) || (subtasks[0].Id == 2 && subtasks[1].Id == 1));
 
-                            this.testOutputHelper.WriteLine("Multi-instance test complete");
+                            testOutputHelper.WriteLine("Multi-instance test complete");
                         }
                     }
                     finally
@@ -224,7 +224,7 @@
                     {
                         // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
                         // get an empty unbound Job
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolId });
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
                         unboundJob.Commit();
 
                         // Open the new Job as bound.
@@ -233,8 +233,10 @@
                         // get an empty unbound Task
                         CloudTask hwTask = new CloudTask(id: "mpi", commandline: @"cmd /c ""%MSMPI_BIN%\mpiexec.exe"" -p 6050 -wdir %AZ_BATCH_TASK_SHARED_DIR%\ Sieve.exe 1000");
                         hwTask.MultiInstanceSettings = new MultiInstanceSettings(@"cmd /c start cmd /c ""%MSMPI_BIN%\smpd.exe"" -d 3 -p 6050", 3);
-                        hwTask.MultiInstanceSettings.CommonResourceFiles = new List<ResourceFile>();
-                        hwTask.MultiInstanceSettings.CommonResourceFiles.Add(ResourceFile.FromUrl("https://manoj123.blob.core.windows.net/mpi/Sieve.exe", "Sieve.exe"));
+                        hwTask.MultiInstanceSettings.CommonResourceFiles = new List<ResourceFile>
+                        {
+                            ResourceFile.FromUrl("https://manoj123.blob.core.windows.net/mpi/Sieve.exe", "Sieve.exe")
+                        };
 
                         // add Task to Job
                         boundJob.AddTask(hwTask);
@@ -254,14 +256,14 @@
                             string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
                             string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                            this.testOutputHelper.WriteLine("StdOut: ");
-                            this.testOutputHelper.WriteLine("");
-                            this.testOutputHelper.WriteLine(stdOut);
-                            this.testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("StdOut: ");
+                            testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine(stdOut);
+                            testOutputHelper.WriteLine("");
 
-                            this.testOutputHelper.WriteLine("StdErr: ");
-                            this.testOutputHelper.WriteLine(stdErr);
-                            this.testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("StdErr: ");
+                            testOutputHelper.WriteLine(stdErr);
+                            testOutputHelper.WriteLine("");
 
                             Assert.Contains("There are 168 primes less than or equal to 1000", stdOut);
 
@@ -282,7 +284,7 @@
 
                             Assert.True(sw.Elapsed <= checkSubtasksStateTimeout, string.Format("The subtasks state is not set to Complete after {0} seconds", checkSubtasksStateTimeout.TotalSeconds));
 
-                            this.testOutputHelper.WriteLine("MPI test complete");
+                            testOutputHelper.WriteLine("MPI test complete");
                         }
                     }
                     finally
@@ -327,7 +329,7 @@
 
                         // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
                         // get an empty unbound Job
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         unboundJob.Commit();
 
                         // Open the new Job as bound.
@@ -372,14 +374,14 @@
                             string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
                             string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                            this.testOutputHelper.WriteLine("StdOut: ");
-                            this.testOutputHelper.WriteLine("");
-                            this.testOutputHelper.WriteLine(stdOut);
-                            this.testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("StdOut: ");
+                            testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine(stdOut);
+                            testOutputHelper.WriteLine("");
 
-                            this.testOutputHelper.WriteLine("StdErr: ");
-                            this.testOutputHelper.WriteLine(stdErr);
-                            this.testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("StdErr: ");
+                            testOutputHelper.WriteLine(stdErr);
+                            testOutputHelper.WriteLine("");
 
                             // get env settings
                             IEnumerable<EnvironmentSetting> boundSettings = myCompletedTask.EnvironmentSettings;
@@ -392,14 +394,14 @@
                             // confirm #
                             Assert.Equal(numEnvSettings, compEnvSettings.Count);
 
-                            this.testOutputHelper.WriteLine("Environement Settings: ");
+                            testOutputHelper.WriteLine("Environement Settings: ");
 
                             foreach (EnvironmentSetting curEnvSetting in boundSettings)
                             {
-                                this.testOutputHelper.WriteLine("    Name: " + curEnvSetting.Name + ", Value: " + curEnvSetting.Value);
+                                testOutputHelper.WriteLine("    Name: " + curEnvSetting.Name + ", Value: " + curEnvSetting.Value);
                             }
 
-                            this.testOutputHelper.WriteLine("Env Setting test complete");
+                            testOutputHelper.WriteLine("Env Setting test complete");
                         }
                     }
                     finally
@@ -425,7 +427,7 @@
 
                     try
                     {
-                        CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         createJob.CommitAsync().Wait();
 
                         const string unboundTaskId = "bug1432973AffinityInfo";
@@ -467,7 +469,7 @@
 
                     try
                     {
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         unboundJob.Commit();
 
                         // Open the new Job as bound.
@@ -496,16 +498,16 @@
                         string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
                         string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                        this.testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
-                        this.testOutputHelper.WriteLine("StdOut: ");
-                        this.testOutputHelper.WriteLine(stdOut);
-                        this.testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
+                        testOutputHelper.WriteLine("StdOut: ");
+                        testOutputHelper.WriteLine(stdOut);
+                        testOutputHelper.WriteLine("");
 
-                        this.testOutputHelper.WriteLine("StdErr: ");
-                        this.testOutputHelper.WriteLine(stdErr);
-                        this.testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine("StdErr: ");
+                        testOutputHelper.WriteLine(stdErr);
+                        testOutputHelper.WriteLine("");
 
-                        this.testOutputHelper.WriteLine("TaskConstraints:");
+                        testOutputHelper.WriteLine("TaskConstraints:");
 
                         TaskConstraints compTC = myCompletedTask.Constraints;
 
@@ -513,20 +515,20 @@
 
                         if (null == compTC)
                         {
-                            this.testOutputHelper.WriteLine("<null>");
+                            testOutputHelper.WriteLine("<null>");
                         }
                         else
                         {
-                            this.testOutputHelper.WriteLine("");
-                            this.testOutputHelper.WriteLine("    maxWallClockTime: " + (compTC.MaxWallClockTime.HasValue ? compTC.MaxWallClockTime.ToString() : "<null>"));
-                            this.testOutputHelper.WriteLine("    retentionTime: " + (compTC.RetentionTime.HasValue ? compTC.RetentionTime.Value.ToString() : "<null>"));
-                            this.testOutputHelper.WriteLine("    maxTaskRetryCount: " + (compTC.MaxTaskRetryCount.HasValue ? compTC.MaxTaskRetryCount.Value.ToString() : "<null>"));
+                            testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("    maxWallClockTime: " + (compTC.MaxWallClockTime.HasValue ? compTC.MaxWallClockTime.ToString() : "<null>"));
+                            testOutputHelper.WriteLine("    retentionTime: " + (compTC.RetentionTime.HasValue ? compTC.RetentionTime.Value.ToString() : "<null>"));
+                            testOutputHelper.WriteLine("    maxTaskRetryCount: " + (compTC.MaxTaskRetryCount.HasValue ? compTC.MaxTaskRetryCount.Value.ToString() : "<null>"));
 
                             Assert.True(compTC.MaxTaskRetryCount.HasValue);
                             Assert.Equal(99, compTC.MaxTaskRetryCount.Value);
                         }
 
-                        this.testOutputHelper.WriteLine("TaskExecutionInfo: ");
+                        testOutputHelper.WriteLine("TaskExecutionInfo: ");
 
                         TaskExecutionInformation tei = myCompletedTask.ExecutionInformation;
 
@@ -534,27 +536,27 @@
 
                         if (null == tei)
                         {
-                            this.testOutputHelper.WriteLine("<null>");
+                            testOutputHelper.WriteLine("<null>");
                         }
                         else
                         {
-                            this.testOutputHelper.WriteLine("");
-                            this.testOutputHelper.WriteLine("    StartTime: " + (tei.StartTime.HasValue ? tei.StartTime.Value.ToString() : "<null>"));
-                            this.testOutputHelper.WriteLine("    LastUpdateTime:   " + (tei.EndTime.HasValue ? tei.EndTime.Value.ToString() : "<null>"));
-                            this.testOutputHelper.WriteLine("    ExitCode:  " + (tei.ExitCode.HasValue ? tei.ExitCode.Value.ToString() : "<null>"));
+                            testOutputHelper.WriteLine("");
+                            testOutputHelper.WriteLine("    StartTime: " + (tei.StartTime.HasValue ? tei.StartTime.Value.ToString() : "<null>"));
+                            testOutputHelper.WriteLine("    LastUpdateTime:   " + (tei.EndTime.HasValue ? tei.EndTime.Value.ToString() : "<null>"));
+                            testOutputHelper.WriteLine("    ExitCode:  " + (tei.ExitCode.HasValue ? tei.ExitCode.Value.ToString() : "<null>"));
                         }
 
-                        this.testOutputHelper.WriteLine("Stats: ");
+                        testOutputHelper.WriteLine("Stats: ");
 
                         TaskStatistics compTS = myCompletedTask.Statistics;
 
                         if (null == compTS)
                         {
-                            this.testOutputHelper.WriteLine("<null>");
+                            testOutputHelper.WriteLine("<null>");
                         }
                         else
                         {
-                            this.testOutputHelper.WriteLine("Url: " + compTS.Url);
+                            testOutputHelper.WriteLine("Url: " + compTS.Url);
                         }
                     }
                     finally
@@ -582,7 +584,7 @@
 
                     try
                     {
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         unboundJob.Commit();
 
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
@@ -596,9 +598,7 @@
                         // add some files to confirm file staging is working
                         FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, stagingStorageAccount);
 
-                        newTaskToAdd.FilesToStage = new List<IFileStagingProvider>();
-
-                        newTaskToAdd.FilesToStage.Add(wordsDotText);
+                        newTaskToAdd.FilesToStage = new List<IFileStagingProvider> { wordsDotText };
 
                         batchCli.JobOperations.AddTask(jobId, newTaskToAdd);
 
@@ -614,11 +614,11 @@
 
                         foreach (CloudTask curTask in boundJob.ListTasks())
                         {
-                            this.testOutputHelper.WriteLine("TaskId: " + curTask.Id);
+                            testOutputHelper.WriteLine("TaskId: " + curTask.Id);
 
                             foreach (NodeFile curFile in curTask.ListNodeFiles(recursive: true))
                             {
-                                this.testOutputHelper.WriteLine("    filename: " + curFile.Path);
+                                testOutputHelper.WriteLine("    filename: " + curFile.Path);
 
                                 if (curFile.Path.IndexOf("localWords.txt", StringComparison.InvariantCultureIgnoreCase) >= 0)
                                 {
@@ -653,7 +653,7 @@
                     string jobId = "Bug1611592Job-" + TestUtilities.GetMyName();
                     try
                     {
-                        CloudJob unJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob unJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         unJob.Commit();
 
                         CloudTask unTask = new CloudTask("Bug1611592", "hostname");
@@ -677,11 +677,11 @@
 
                             Assert.NotNull(computeNodeInfo);
 
-                            this.testOutputHelper.WriteLine("Task: " + curTask.Id);
-                            this.testOutputHelper.WriteLine("ComputeNodeInfo:");
+                            testOutputHelper.WriteLine("Task: " + curTask.Id);
+                            testOutputHelper.WriteLine("ComputeNodeInfo:");
 
-                            this.testOutputHelper.WriteLine("    PoolId: " + computeNodeInfo.PoolId);
-                            this.testOutputHelper.WriteLine("    ComputeNodeId: " + computeNodeInfo.ComputeNodeId);
+                            testOutputHelper.WriteLine("    PoolId: " + computeNodeInfo.PoolId);
+                            testOutputHelper.WriteLine("    ComputeNodeId: " + computeNodeInfo.ComputeNodeId);
                         }
                     }
                     finally
@@ -711,9 +711,9 @@
                         CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
                         cloudJob.PoolInformation = new PoolInformation()
                         {
-                            PoolId = this.poolFixture.PoolId
+                            PoolId = poolFixture.PoolId
                         };
-                        this.testOutputHelper.WriteLine("Creating job: {0}", jobId);
+                        testOutputHelper.WriteLine("Creating job: {0}", jobId);
                         cloudJob.Commit();
 
                         {
@@ -722,7 +722,7 @@
                             CloudTask taskToAdd = new CloudTask(taskId, "ping 127.0.0.1 -n 60"); //Task which runs for 60s
 
                             //Add the task
-                            this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                            testOutputHelper.WriteLine("Adding task: {0}", taskId);
                             batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
                             //Wait for the task to go to running state
@@ -741,7 +741,7 @@
                                 new ODATAMonitorControl {DelayBetweenDataFetch = TimeSpan.FromSeconds(5)});
 
                             //Terminate the running task
-                            this.testOutputHelper.WriteLine("Terminating task {0}", taskId);
+                            testOutputHelper.WriteLine("Terminating task {0}", taskId);
                             CloudTask runningTask = batchCli.JobOperations.GetTask(jobId, taskId);
                             runningTask.Terminate();
 
@@ -753,7 +753,7 @@
                             runningTask.Refresh();
 
                             //Delete the task
-                            this.testOutputHelper.WriteLine("Deleting task {0}", taskId);
+                            testOutputHelper.WriteLine("Deleting task {0}", taskId);
                             runningTask.Delete();
 
                             List<CloudTask> taskListAfterDelete = batchCli.JobOperations.ListTasks(jobId).ToList();
@@ -767,7 +767,7 @@
                             CloudTask taskToAdd = new CloudTask(taskId, "ping 127.0.0.1 -n 60"); //Task which runs for 60s
 
                             //Add the task
-                            this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                            testOutputHelper.WriteLine("Adding task: {0}", taskId);
                             batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
                             //Wait for the task to go to running state
@@ -787,7 +787,7 @@
                                 new ODATAMonitorControl { DelayBetweenDataFetch = TimeSpan.FromSeconds(5) });
                             
                             //Terminate the running task
-                            this.testOutputHelper.WriteLine("Terminating task {0}", taskId);
+                            testOutputHelper.WriteLine("Terminating task {0}", taskId);
                             CloudTask runningTask = batchCli.JobOperations.GetTask(jobId, taskId);
                             batchCli.JobOperations.TerminateTask(jobId, taskId);
 
@@ -799,7 +799,7 @@
                             runningTask.Refresh();
 
                             //Delete the task
-                            this.testOutputHelper.WriteLine("Deleting task {0}", taskId);
+                            testOutputHelper.WriteLine("Deleting task {0}", taskId);
                             runningTask.Delete();
 
                             List<CloudTask> taskListAfterDelete = batchCli.JobOperations.ListTasks(jobId).ToList();
@@ -832,8 +832,8 @@
                     {
                         //Create the job
                         CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation() { PoolId = this.poolFixture.PoolId };
-                        this.testOutputHelper.WriteLine("Creating job: {0}", jobId);
+                        cloudJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
+                        testOutputHelper.WriteLine("Creating job: {0}", jobId);
                         cloudJob.Commit();
                         
                         //Create a task
@@ -841,7 +841,7 @@
                         CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"ping 127.0.0.1 -n 20 > nul && exit /b 3\"");
 
                         //Add the task
-                        this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
                         batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
                         CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
@@ -886,7 +886,7 @@
                     try
                     {
                         //Create the job
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         cloudJob.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction;
 
                         cloudJob.UsesTaskDependencies = true;
@@ -897,7 +897,7 @@
                         CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"ping 127.0.0.1 \"");
                         
                         //Add the task
-                        this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
                         taskToAdd.ExitConditions = new ExitConditions { Default = new ExitOptions {JobAction = JobAction.Terminate, DependencyAction = DependencyAction.Satisfy} };
                         batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
@@ -933,8 +933,8 @@
                     {
                         //Create the job
                         CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation { PoolId = this.poolFixture.PoolId };
-                        this.testOutputHelper.WriteLine("Creating job: {0}", jobId);
+                        cloudJob.PoolInformation = new PoolInformation { PoolId = poolFixture.PoolId };
+                        testOutputHelper.WriteLine("Creating job: {0}", jobId);
                         cloudJob.Commit();
 
                         //Create a task
@@ -975,7 +975,7 @@
 
                     try
                     {
-                        TestUtilities.HelloWorld(batchCli, this.testOutputHelper, this.poolFixture.Pool, out jobId, out string taskId, false);
+                        TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out jobId, out string taskId, false);
 
                         CloudJob job = batchCli.JobOperations.GetJob(jobId);
 
@@ -1008,7 +1008,7 @@
                     const string nonAdminTaskId = "nonAdminTask";
                     try
                     {
-                        CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() {PoolId = this.poolFixture.PoolId });
+                        CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() {PoolId = poolFixture.PoolId });
                         job.Commit();
 
                         Func<string, string, CloudTask> createTask = (taskId, userName) =>
@@ -1081,7 +1081,7 @@
                             PoolId = "PoolWhoDoesntExist"
                         };
 
-                        this.testOutputHelper.WriteLine("Initial job schedule commit()");
+                        testOutputHelper.WriteLine("Initial job schedule commit()");
                         jobSchedule.Commit();
 
                         //Get the job
@@ -1089,7 +1089,7 @@
                         CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
 
                         //Add the task
-                        this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
                         boundJob.AddTask(myTask);
 
                         //Get the task and check the constraints
@@ -1104,7 +1104,7 @@
                         const int maxRetryCount = 1;
                         boundTask.Constraints = new TaskConstraints(maxWallClockTime, dataRetentionTime, maxRetryCount);
 
-                        this.testOutputHelper.WriteLine("Updating task constraints");
+                        testOutputHelper.WriteLine("Updating task constraints");
 
                         boundTask.Commit();
 
@@ -1197,7 +1197,7 @@
 
                         //Terminate bound task with if-match header, it should fail
                         Exception e = TestUtilities.AssertThrows<BatchException>(() => boundTask.Terminate(additionalBehaviors: new[] { interceptor }));
-                        TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, this.testOutputHelper);
+                        TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, testOutputHelper);
                     }
                     finally
                     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
@@ -151,7 +151,7 @@
 
                             CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks())[0];
 
-                            Assert.Equal<TaskState?>(TaskState.Completed, myCompletedTask.State);
+                            Assert.Equal(TaskState.Completed, myCompletedTask.State);
 
                             Assert.NotNull(myCompletedTask.MultiInstanceSettings);
                             Assert.Equal(3, myCompletedTask.MultiInstanceSettings.NumberOfInstances);
@@ -1175,8 +1175,7 @@
                         BatchClientBehavior interceptor = new Protocol.RequestInterceptor(
                             (req) =>
                             {
-                                var typedParams = req.Options as Protocol.Models.TaskUpdateOptions;
-                                if (typedParams != null)
+                                if (req.Options is Protocol.Models.TaskUpdateOptions typedParams)
                                 {
                                     typedParams.IfMatch = capturedEtag1;
                                 }
@@ -1190,8 +1189,7 @@
                         interceptor = new Protocol.RequestInterceptor(
                             (req) =>
                             {
-                                var typedParams = req.Options as Protocol.Models.TaskTerminateOptions;
-                                if (typedParams != null)
+                                if (req.Options is Protocol.Models.TaskTerminateOptions typedParams)
                                 {
                                     typedParams.IfMatch = capturedEtag1;
                                 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
@@ -94,19 +94,15 @@
         {
             this.testOutputHelper = testOutputHelper;
             poolId = TestUtilities.GetMyName() + "-poolmulti";
-            using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
-            {
-                CreatePool(batchCli, poolId); //TODO: If this is failed to construct then the dispose is not called
-            }
+            using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+            CreatePool(batchCli, poolId); //TODO: If this is failed to construct then the dispose is not called
         }
 
         public void Dispose()
         {
-            using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
-            {
-                // the original shared pool is not deleted and we leave this one too to speed debugging and re-run
-                //TestUtilities.DeletePoolIfExistsAsync(batchCli, this.poolId).Wait();
-            }
+            using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+            // the original shared pool is not deleted and we leave this one too to speed debugging and re-run
+            //TestUtilities.DeletePoolIfExistsAsync(batchCli, this.poolId).Wait();
         }
 
         [Fact]
@@ -118,89 +114,87 @@
 
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string jobId = "MultiInstance-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "MultiInstance-" + TestUtilities.GetMyName();
+                    // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
+                    // get an empty unbound Job
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
+                    unboundJob.Commit();
 
-                    try
+                    // Open the new Job as bound.
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                    // get an empty unbound Task
+                    CloudTask hwTask = new CloudTask(id: "multi1", commandline: "hostname");
+                    hwTask.MultiInstanceSettings = new MultiInstanceSettings("cmd /c set", numberOfInstances: 3);
+
+                    // add Task to Job
+                    boundJob.AddTask(hwTask);
+
                     {
-                        // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
-                        // get an empty unbound Job
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
-                        unboundJob.Commit();
+                        // wait for the task to complete
+                        Utilities utilities = batchCli.Utilities;
+                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
 
-                        // Open the new Job as bound.
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                        taskStateMonitor.WaitAll(
+                            boundJob.ListTasks(),
+                            Microsoft.Azure.Batch.Common.TaskState.Completed,
+                            TimeSpan.FromMinutes(3));
 
-                        // get an empty unbound Task
-                        CloudTask hwTask = new CloudTask(id: "multi1", commandline: "hostname");
-                        hwTask.MultiInstanceSettings = new MultiInstanceSettings("cmd /c set", numberOfInstances: 3);
+                        CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks())[0];
 
-                        // add Task to Job
-                        boundJob.AddTask(hwTask);
+                        Assert.Equal(TaskState.Completed, myCompletedTask.State);
 
+                        Assert.NotNull(myCompletedTask.MultiInstanceSettings);
+                        Assert.Equal(3, myCompletedTask.MultiInstanceSettings.NumberOfInstances);
+                        Assert.Equal("cmd /c set", myCompletedTask.MultiInstanceSettings.CoordinationCommandLine);
+
+                        string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                        string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
+
+                        testOutputHelper.WriteLine("StdOut: ");
+                        testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine(stdOut);
+                        testOutputHelper.WriteLine("");
+
+                        testOutputHelper.WriteLine("StdErr: ");
+                        testOutputHelper.WriteLine(stdErr);
+                        testOutputHelper.WriteLine("");
+
+
+                        List<SubtaskInformation> subtasks;
+                        Stopwatch sw = new Stopwatch();
+                        sw.Start();
+                        do
                         {
-                            // wait for the task to complete
-                            Utilities utilities = batchCli.Utilities;
-                            TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+                            IPagedEnumerable<SubtaskInformation> results = myCompletedTask.ListSubtasks();
 
-                            taskStateMonitor.WaitAll(
-                                boundJob.ListTasks(),
-                                Microsoft.Azure.Batch.Common.TaskState.Completed,
-                                TimeSpan.FromMinutes(3));
-
-                            CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks())[0];
-
-                            Assert.Equal(TaskState.Completed, myCompletedTask.State);
-
-                            Assert.NotNull(myCompletedTask.MultiInstanceSettings);
-                            Assert.Equal(3, myCompletedTask.MultiInstanceSettings.NumberOfInstances);
-                            Assert.Equal("cmd /c set", myCompletedTask.MultiInstanceSettings.CoordinationCommandLine);
-
-                            string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
-                            string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
-
-                            testOutputHelper.WriteLine("StdOut: ");
-                            testOutputHelper.WriteLine("");
-                            testOutputHelper.WriteLine(stdOut);
-                            testOutputHelper.WriteLine("");
-
-                            testOutputHelper.WriteLine("StdErr: ");
-                            testOutputHelper.WriteLine(stdErr);
-                            testOutputHelper.WriteLine("");
-
-
-                            List<SubtaskInformation> subtasks;
-                            Stopwatch sw = new Stopwatch();
-                            sw.Start();
-                            do
+                            subtasks = results.ToList();
+                            if (subtasks.All(t => t.State == SubtaskState.Completed))
                             {
-                                IPagedEnumerable<SubtaskInformation> results = myCompletedTask.ListSubtasks();
+                                break;
+                            }
+                            Thread.Sleep(500);
+                        } while (sw.Elapsed <= checkSubtasksStateTimeout);
 
-                                subtasks = results.ToList();
-                                if (subtasks.All(t => t.State == SubtaskState.Completed))
-                                {
-                                    break;
-                                }
-                                Thread.Sleep(500);
-                            } while (sw.Elapsed <= checkSubtasksStateTimeout);
+                        Assert.True(sw.Elapsed <= checkSubtasksStateTimeout, string.Format("The subtasks state is not set to Complete after {0} seconds", checkSubtasksStateTimeout.TotalSeconds));
+                        Assert.Equal(2, subtasks.Count);
+                        Assert.Equal(0, subtasks[0].ExitCode);
+                        Assert.Null(subtasks[0].FailureInformation);
+                        Assert.Equal(0, subtasks[1].ExitCode);
+                        Assert.Null(subtasks[1].FailureInformation);
+                        // Shouldnot assume the subtasks have order.
+                        Assert.True((subtasks[0].Id == 1 && subtasks[1].Id == 2) || (subtasks[0].Id == 2 && subtasks[1].Id == 1));
 
-                            Assert.True(sw.Elapsed <= checkSubtasksStateTimeout, string.Format("The subtasks state is not set to Complete after {0} seconds", checkSubtasksStateTimeout.TotalSeconds));
-                            Assert.Equal(2, subtasks.Count);
-                            Assert.Equal(0, subtasks[0].ExitCode);
-                            Assert.Null(subtasks[0].FailureInformation);
-                            Assert.Equal(0, subtasks[1].ExitCode);
-                            Assert.Null(subtasks[1].FailureInformation);
-                            // Shouldnot assume the subtasks have order.
-                            Assert.True((subtasks[0].Id == 1 && subtasks[1].Id == 2) || (subtasks[0].Id == 2 && subtasks[1].Id == 1));
-
-                            testOutputHelper.WriteLine("Multi-instance test complete");
-                        }
+                        testOutputHelper.WriteLine("Multi-instance test complete");
                     }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -216,81 +210,79 @@
 
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string jobId = "MPI-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "MPI-" + TestUtilities.GetMyName();
+                    // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
+                    // get an empty unbound Job
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
+                    unboundJob.Commit();
 
-                    try
-                    {
-                        // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
-                        // get an empty unbound Job
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
-                        unboundJob.Commit();
+                    // Open the new Job as bound.
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                        // Open the new Job as bound.
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                        // get an empty unbound Task
-                        CloudTask hwTask = new CloudTask(id: "mpi", commandline: @"cmd /c ""%MSMPI_BIN%\mpiexec.exe"" -p 6050 -wdir %AZ_BATCH_TASK_SHARED_DIR%\ Sieve.exe 1000");
-                        hwTask.MultiInstanceSettings = new MultiInstanceSettings(@"cmd /c start cmd /c ""%MSMPI_BIN%\smpd.exe"" -d 3 -p 6050", 3);
-                        hwTask.MultiInstanceSettings.CommonResourceFiles = new List<ResourceFile>
+                    // get an empty unbound Task
+                    CloudTask hwTask = new CloudTask(id: "mpi", commandline: @"cmd /c ""%MSMPI_BIN%\mpiexec.exe"" -p 6050 -wdir %AZ_BATCH_TASK_SHARED_DIR%\ Sieve.exe 1000");
+                    hwTask.MultiInstanceSettings = new MultiInstanceSettings(@"cmd /c start cmd /c ""%MSMPI_BIN%\smpd.exe"" -d 3 -p 6050", 3);
+                    hwTask.MultiInstanceSettings.CommonResourceFiles = new List<ResourceFile>
                         {
                             ResourceFile.FromUrl("https://manoj123.blob.core.windows.net/mpi/Sieve.exe", "Sieve.exe")
                         };
 
-                        // add Task to Job
-                        boundJob.AddTask(hwTask);
+                    // add Task to Job
+                    boundJob.AddTask(hwTask);
 
-                        {
-                            // wait for the task to complete
-                            Utilities utilities = batchCli.Utilities;
-                            TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                            taskStateMonitor.WaitAll(
-                                boundJob.ListTasks(),
-                                Microsoft.Azure.Batch.Common.TaskState.Completed,
-                                TimeSpan.FromMinutes(3));
-
-                            CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks()).Single();
-
-                            string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
-                            string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
-
-                            testOutputHelper.WriteLine("StdOut: ");
-                            testOutputHelper.WriteLine("");
-                            testOutputHelper.WriteLine(stdOut);
-                            testOutputHelper.WriteLine("");
-
-                            testOutputHelper.WriteLine("StdErr: ");
-                            testOutputHelper.WriteLine(stdErr);
-                            testOutputHelper.WriteLine("");
-
-                            Assert.Contains("There are 168 primes less than or equal to 1000", stdOut);
-
-                            List<SubtaskInformation> subtasks;
-                            Stopwatch sw = new Stopwatch();
-                            sw.Start();
-                            do
-                            {
-                                IPagedEnumerable<SubtaskInformation> results = batchCli.JobOperations.ListSubtasks(jobId, myCompletedTask.Id);
-
-                                subtasks = results.ToList();
-                                if (subtasks.All(t => t.State == SubtaskState.Completed))
-                                {
-                                    break;
-                                }
-                                Thread.Sleep(500);
-                            } while (sw.Elapsed <= checkSubtasksStateTimeout);
-
-                            Assert.True(sw.Elapsed <= checkSubtasksStateTimeout, string.Format("The subtasks state is not set to Complete after {0} seconds", checkSubtasksStateTimeout.TotalSeconds));
-
-                            testOutputHelper.WriteLine("MPI test complete");
-                        }
-                    }
-                    finally
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        // wait for the task to complete
+                        Utilities utilities = batchCli.Utilities;
+                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                        taskStateMonitor.WaitAll(
+                            boundJob.ListTasks(),
+                            Microsoft.Azure.Batch.Common.TaskState.Completed,
+                            TimeSpan.FromMinutes(3));
+
+                        CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks()).Single();
+
+                        string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                        string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
+
+                        testOutputHelper.WriteLine("StdOut: ");
+                        testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine(stdOut);
+                        testOutputHelper.WriteLine("");
+
+                        testOutputHelper.WriteLine("StdErr: ");
+                        testOutputHelper.WriteLine(stdErr);
+                        testOutputHelper.WriteLine("");
+
+                        Assert.Contains("There are 168 primes less than or equal to 1000", stdOut);
+
+                        List<SubtaskInformation> subtasks;
+                        Stopwatch sw = new Stopwatch();
+                        sw.Start();
+                        do
+                        {
+                            IPagedEnumerable<SubtaskInformation> results = batchCli.JobOperations.ListSubtasks(jobId, myCompletedTask.Id);
+
+                            subtasks = results.ToList();
+                            if (subtasks.All(t => t.State == SubtaskState.Completed))
+                            {
+                                break;
+                            }
+                            Thread.Sleep(500);
+                        } while (sw.Elapsed <= checkSubtasksStateTimeout);
+
+                        Assert.True(sw.Elapsed <= checkSubtasksStateTimeout, string.Format("The subtasks state is not set to Complete after {0} seconds", checkSubtasksStateTimeout.TotalSeconds));
+
+                        testOutputHelper.WriteLine("MPI test complete");
                     }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -318,96 +310,94 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1432830Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1432830Job-" + TestUtilities.GetMyName();
+                    // remember how many env settings we create
+                    int numEnvSettings = 0;
 
-                    try
+                    // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
+                    // get an empty unbound Job
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    unboundJob.Commit();
+
+                    // Open the new Job as bound.
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                    // get an empty unbound Task
+                    CloudTask hwTask = new CloudTask(id: "dwsHelloWorldTask", commandline: "cmd /c echo Hello World");
+
+                    // get settings off of unbound task to confirm null
+                    IEnumerable<EnvironmentSetting> envSettings = hwTask.EnvironmentSettings;
+
+                    // unbound task should have null for env settings
+                    Assert.Null(envSettings);
+
+                    // construct sample settings to test feature
+                    List<EnvironmentSetting> newEnvSettings = new List<EnvironmentSetting>();
+                    EnvironmentSetting myES = new EnvironmentSetting("bug1432830EnvName", "bug1432830EnvValue");
+
+                    newEnvSettings.Add(myES);
+
+                    // remember how many we create
+                    numEnvSettings = newEnvSettings.Count;
+
+                    // set the env settings
+                    hwTask.EnvironmentSettings = newEnvSettings;
+
+                    // add Task to Job
+                    boundJob.AddTask(hwTask);
+
                     {
-                        // remember how many env settings we create
-                        int numEnvSettings = 0;
+                        // wait for the task to complete
+                        Utilities utilities = batchCli.Utilities;
+                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
 
-                        // here we show how to use an unbound Job + Commit() to run a simple "Hello World" task
-                        // get an empty unbound Job
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        unboundJob.Commit();
+                        taskStateMonitor.WaitAll(
+                            boundJob.ListTasks(),
+                            Microsoft.Azure.Batch.Common.TaskState.Completed,
+                            TimeSpan.FromMinutes(3));
 
-                        // Open the new Job as bound.
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                        CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks())[0];
 
-                        // get an empty unbound Task
-                        CloudTask hwTask = new CloudTask(id: "dwsHelloWorldTask", commandline: "cmd /c echo Hello World");
+                        string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                        string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                        // get settings off of unbound task to confirm null
-                        IEnumerable<EnvironmentSetting> envSettings = hwTask.EnvironmentSettings;
+                        testOutputHelper.WriteLine("StdOut: ");
+                        testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine(stdOut);
+                        testOutputHelper.WriteLine("");
 
-                        // unbound task should have null for env settings
-                        Assert.Null(envSettings);
+                        testOutputHelper.WriteLine("StdErr: ");
+                        testOutputHelper.WriteLine(stdErr);
+                        testOutputHelper.WriteLine("");
 
-                        // construct sample settings to test feature
-                        List<EnvironmentSetting> newEnvSettings = new List<EnvironmentSetting>();
-                        EnvironmentSetting myES = new EnvironmentSetting("bug1432830EnvName", "bug1432830EnvValue");
+                        // get env settings
+                        IEnumerable<EnvironmentSetting> boundSettings = myCompletedTask.EnvironmentSettings;
 
-                        newEnvSettings.Add(myES);
+                        // we set above so there should be a collection
+                        Assert.NotNull(boundSettings);
 
-                        // remember how many we create
-                        numEnvSettings = newEnvSettings.Count;
+                        List<EnvironmentSetting> compEnvSettings = new List<EnvironmentSetting>(boundSettings);
 
-                        // set the env settings
-                        hwTask.EnvironmentSettings = newEnvSettings;
+                        // confirm #
+                        Assert.Equal(numEnvSettings, compEnvSettings.Count);
 
-                        // add Task to Job
-                        boundJob.AddTask(hwTask);
+                        testOutputHelper.WriteLine("Environement Settings: ");
 
+                        foreach (EnvironmentSetting curEnvSetting in boundSettings)
                         {
-                            // wait for the task to complete
-                            Utilities utilities = batchCli.Utilities;
-                            TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                            taskStateMonitor.WaitAll(
-                                boundJob.ListTasks(),
-                                Microsoft.Azure.Batch.Common.TaskState.Completed,
-                                TimeSpan.FromMinutes(3));
-
-                            CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks())[0];
-
-                            string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
-                            string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
-
-                            testOutputHelper.WriteLine("StdOut: ");
-                            testOutputHelper.WriteLine("");
-                            testOutputHelper.WriteLine(stdOut);
-                            testOutputHelper.WriteLine("");
-
-                            testOutputHelper.WriteLine("StdErr: ");
-                            testOutputHelper.WriteLine(stdErr);
-                            testOutputHelper.WriteLine("");
-
-                            // get env settings
-                            IEnumerable<EnvironmentSetting> boundSettings = myCompletedTask.EnvironmentSettings;
-
-                            // we set above so there should be a collection
-                            Assert.NotNull(boundSettings);
-
-                            List<EnvironmentSetting> compEnvSettings = new List<EnvironmentSetting>(boundSettings);
-
-                            // confirm #
-                            Assert.Equal(numEnvSettings, compEnvSettings.Count);
-
-                            testOutputHelper.WriteLine("Environement Settings: ");
-
-                            foreach (EnvironmentSetting curEnvSetting in boundSettings)
-                            {
-                                testOutputHelper.WriteLine("    Name: " + curEnvSetting.Name + ", Value: " + curEnvSetting.Value);
-                            }
-
-                            testOutputHelper.WriteLine("Env Setting test complete");
+                            testOutputHelper.WriteLine("    Name: " + curEnvSetting.Name + ", Value: " + curEnvSetting.Value);
                         }
+
+                        testOutputHelper.WriteLine("Env Setting test complete");
                     }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -421,35 +411,33 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1432973Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1432973Job-" + TestUtilities.GetMyName();
+                    CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    createJob.CommitAsync().Wait();
 
-                    try
-                    {
-                        CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        createJob.CommitAsync().Wait();
+                    const string unboundTaskId = "bug1432973AffinityInfo";
+                    CloudTask unboundTask = new CloudTask(unboundTaskId, "hostname");
 
-                        const string unboundTaskId = "bug1432973AffinityInfo";
-                        CloudTask unboundTask = new CloudTask(unboundTaskId, "hostname");
+                    const string referenceAffinityId = "bug1432973AffinityInfoHintHint";
+                    AffinityInformation aff = new AffinityInformation(referenceAffinityId);
 
-                        const string referenceAffinityId = "bug1432973AffinityInfoHintHint";
-                        AffinityInformation aff = new AffinityInformation(referenceAffinityId);
+                    // confirm aff is settable on unbound
+                    unboundTask.AffinityInformation = aff;
 
-                        // confirm aff is settable on unbound
-                        unboundTask.AffinityInformation = aff;
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    boundJob.AddTask(unboundTask);
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        boundJob.AddTask(unboundTask);
+                    CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, unboundTaskId);
 
-                        CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, unboundTaskId);
-
-                        Assert.Equal(referenceAffinityId, boundTask.AffinityInformation.AffinityId);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.Equal(referenceAffinityId, boundTask.AffinityInformation.AffinityId);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -463,106 +451,104 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1447214Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1447214Job-" + TestUtilities.GetMyName();
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    unboundJob.Commit();
 
-                    try
+                    // Open the new Job as bound.
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                    CloudTask myTask = new CloudTask(id: "Bug1447214Task", commandline: @"hostname");
+
+                    TaskConstraints ts = new TaskConstraints(maxWallClockTime: TimeSpan.FromHours(1), retentionTime: TimeSpan.FromHours(1), maxTaskRetryCount: 99);
+
+                    myTask.Constraints = ts;
+
+                    // add the task to the job
+                    boundJob.AddTask(myTask);
+
+                    // wait for the task to complete
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(3));
+
+                    CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks(null))[0];
+
+                    string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                    string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
+
+                    testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
+                    testOutputHelper.WriteLine("StdOut: ");
+                    testOutputHelper.WriteLine(stdOut);
+                    testOutputHelper.WriteLine("");
+
+                    testOutputHelper.WriteLine("StdErr: ");
+                    testOutputHelper.WriteLine(stdErr);
+                    testOutputHelper.WriteLine("");
+
+                    testOutputHelper.WriteLine("TaskConstraints:");
+
+                    TaskConstraints compTC = myCompletedTask.Constraints;
+
+                    Assert.NotNull(compTC);
+
+                    if (null == compTC)
                     {
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        unboundJob.Commit();
-
-                        // Open the new Job as bound.
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                        CloudTask myTask = new CloudTask(id: "Bug1447214Task", commandline: @"hostname");
-
-                        TaskConstraints ts = new TaskConstraints(maxWallClockTime: TimeSpan.FromHours(1), retentionTime: TimeSpan.FromHours(1), maxTaskRetryCount: 99);
-
-                        myTask.Constraints = ts;
-
-                        // add the task to the job
-                        boundJob.AddTask(myTask);
-
-                        // wait for the task to complete
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(3));
-                        
-                        CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks(null))[0];
-
-                        string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
-                        string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
-
-                        testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
-                        testOutputHelper.WriteLine("StdOut: ");
-                        testOutputHelper.WriteLine(stdOut);
-                        testOutputHelper.WriteLine("");
-
-                        testOutputHelper.WriteLine("StdErr: ");
-                        testOutputHelper.WriteLine(stdErr);
-                        testOutputHelper.WriteLine("");
-
-                        testOutputHelper.WriteLine("TaskConstraints:");
-
-                        TaskConstraints compTC = myCompletedTask.Constraints;
-
-                        Assert.NotNull(compTC);
-
-                        if (null == compTC)
-                        {
-                            testOutputHelper.WriteLine("<null>");
-                        }
-                        else
-                        {
-                            testOutputHelper.WriteLine("");
-                            testOutputHelper.WriteLine("    maxWallClockTime: " + (compTC.MaxWallClockTime.HasValue ? compTC.MaxWallClockTime.ToString() : "<null>"));
-                            testOutputHelper.WriteLine("    retentionTime: " + (compTC.RetentionTime.HasValue ? compTC.RetentionTime.Value.ToString() : "<null>"));
-                            testOutputHelper.WriteLine("    maxTaskRetryCount: " + (compTC.MaxTaskRetryCount.HasValue ? compTC.MaxTaskRetryCount.Value.ToString() : "<null>"));
-
-                            Assert.True(compTC.MaxTaskRetryCount.HasValue);
-                            Assert.Equal(99, compTC.MaxTaskRetryCount.Value);
-                        }
-
-                        testOutputHelper.WriteLine("TaskExecutionInfo: ");
-
-                        TaskExecutionInformation tei = myCompletedTask.ExecutionInformation;
-
-                        Assert.NotNull(tei);
-
-                        if (null == tei)
-                        {
-                            testOutputHelper.WriteLine("<null>");
-                        }
-                        else
-                        {
-                            testOutputHelper.WriteLine("");
-                            testOutputHelper.WriteLine("    StartTime: " + (tei.StartTime.HasValue ? tei.StartTime.Value.ToString() : "<null>"));
-                            testOutputHelper.WriteLine("    LastUpdateTime:   " + (tei.EndTime.HasValue ? tei.EndTime.Value.ToString() : "<null>"));
-                            testOutputHelper.WriteLine("    ExitCode:  " + (tei.ExitCode.HasValue ? tei.ExitCode.Value.ToString() : "<null>"));
-                        }
-
-                        testOutputHelper.WriteLine("Stats: ");
-
-                        TaskStatistics compTS = myCompletedTask.Statistics;
-
-                        if (null == compTS)
-                        {
-                            testOutputHelper.WriteLine("<null>");
-                        }
-                        else
-                        {
-                            testOutputHelper.WriteLine("Url: " + compTS.Url);
-                        }
+                        testOutputHelper.WriteLine("<null>");
                     }
-                    finally
+                    else
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine("    maxWallClockTime: " + (compTC.MaxWallClockTime.HasValue ? compTC.MaxWallClockTime.ToString() : "<null>"));
+                        testOutputHelper.WriteLine("    retentionTime: " + (compTC.RetentionTime.HasValue ? compTC.RetentionTime.Value.ToString() : "<null>"));
+                        testOutputHelper.WriteLine("    maxTaskRetryCount: " + (compTC.MaxTaskRetryCount.HasValue ? compTC.MaxTaskRetryCount.Value.ToString() : "<null>"));
+
+                        Assert.True(compTC.MaxTaskRetryCount.HasValue);
+                        Assert.Equal(99, compTC.MaxTaskRetryCount.Value);
                     }
+
+                    testOutputHelper.WriteLine("TaskExecutionInfo: ");
+
+                    TaskExecutionInformation tei = myCompletedTask.ExecutionInformation;
+
+                    Assert.NotNull(tei);
+
+                    if (null == tei)
+                    {
+                        testOutputHelper.WriteLine("<null>");
+                    }
+                    else
+                    {
+                        testOutputHelper.WriteLine("");
+                        testOutputHelper.WriteLine("    StartTime: " + (tei.StartTime.HasValue ? tei.StartTime.Value.ToString() : "<null>"));
+                        testOutputHelper.WriteLine("    LastUpdateTime:   " + (tei.EndTime.HasValue ? tei.EndTime.Value.ToString() : "<null>"));
+                        testOutputHelper.WriteLine("    ExitCode:  " + (tei.ExitCode.HasValue ? tei.ExitCode.Value.ToString() : "<null>"));
+                    }
+
+                    testOutputHelper.WriteLine("Stats: ");
+
+                    TaskStatistics compTS = myCompletedTask.Statistics;
+
+                    if (null == compTS)
+                    {
+                        testOutputHelper.WriteLine("<null>");
+                    }
+                    else
+                    {
+                        testOutputHelper.WriteLine("Url: " + compTS.Url);
+                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -576,65 +562,63 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                StagingStorageAccount stagingStorageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
+
+                string jobId = "Bug1535329Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    StagingStorageAccount stagingStorageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    unboundJob.Commit();
 
-                    string jobId = "Bug1535329Job-" + TestUtilities.GetMyName();
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                    try
+                    CloudTask unboundTask = new CloudTask(id: "bug1535329Task0", commandline: "hostname");
+
+                    boundJob.AddTask(unboundTask);
+
+                    CloudTask newTaskToAdd = new CloudTask(id: "bug1535329NewTask", commandline: "hostname");
+
+                    // add some files to confirm file staging is working
+                    FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, stagingStorageAccount);
+
+                    newTaskToAdd.FilesToStage = new List<IFileStagingProvider> { wordsDotText };
+
+                    batchCli.JobOperations.AddTask(jobId, newTaskToAdd);
+
+                    bool foundLocalWords = false;
+
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(5));
+
+                    foreach (CloudTask curTask in boundJob.ListTasks())
                     {
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        unboundJob.Commit();
+                        testOutputHelper.WriteLine("TaskId: " + curTask.Id);
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                        CloudTask unboundTask = new CloudTask(id: "bug1535329Task0", commandline: "hostname");
-
-                        boundJob.AddTask(unboundTask);
-
-                        CloudTask newTaskToAdd = new CloudTask(id: "bug1535329NewTask", commandline: "hostname");
-
-                        // add some files to confirm file staging is working
-                        FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, stagingStorageAccount);
-
-                        newTaskToAdd.FilesToStage = new List<IFileStagingProvider> { wordsDotText };
-
-                        batchCli.JobOperations.AddTask(jobId, newTaskToAdd);
-
-                        bool foundLocalWords = false;
-
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(5));
-
-                        foreach (CloudTask curTask in boundJob.ListTasks())
+                        foreach (NodeFile curFile in curTask.ListNodeFiles(recursive: true))
                         {
-                            testOutputHelper.WriteLine("TaskId: " + curTask.Id);
+                            testOutputHelper.WriteLine("    filename: " + curFile.Path);
 
-                            foreach (NodeFile curFile in curTask.ListNodeFiles(recursive: true))
+                            if (curFile.Path.IndexOf("localWords.txt", StringComparison.InvariantCultureIgnoreCase) >= 0)
                             {
-                                testOutputHelper.WriteLine("    filename: " + curFile.Path);
-
-                                if (curFile.Path.IndexOf("localWords.txt", StringComparison.InvariantCultureIgnoreCase) >= 0)
-                                {
-                                    Assert.False(foundLocalWords);
-                                    foundLocalWords = true;
-                                }
+                                Assert.False(foundLocalWords);
+                                foundLocalWords = true;
                             }
                         }
+                    }
 
-                        Assert.True(foundLocalWords);
-                    }
-                    finally
-                    {
-                        // clean up
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.True(foundLocalWords);
+                }
+                finally
+                {
+                    // clean up
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -648,46 +632,44 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1611592Job-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "Bug1611592Job-" + TestUtilities.GetMyName();
-                    try
+                    CloudJob unJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    unJob.Commit();
+
+                    CloudTask unTask = new CloudTask("Bug1611592", "hostname");
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { var f = unTask.ComputeNodeInformation; });
+
+                    CloudJob bndJob = batchCli.JobOperations.GetJob(jobId);
+
+                    bndJob.AddTask(unTask);
+
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        bndJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(5));
+
+                    foreach (CloudTask curTask in bndJob.ListTasks())
                     {
-                        CloudJob unJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        unJob.Commit();
+                        ComputeNodeInformation computeNodeInfo = curTask.ComputeNodeInformation;
 
-                        CloudTask unTask = new CloudTask("Bug1611592", "hostname");
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { var f = unTask.ComputeNodeInformation; });
+                        Assert.NotNull(computeNodeInfo);
 
-                        CloudJob bndJob = batchCli.JobOperations.GetJob(jobId);
+                        testOutputHelper.WriteLine("Task: " + curTask.Id);
+                        testOutputHelper.WriteLine("ComputeNodeInfo:");
 
-                        bndJob.AddTask(unTask);
-
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            bndJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(5));
-
-                        foreach (CloudTask curTask in bndJob.ListTasks())
-                        {
-                            ComputeNodeInformation computeNodeInfo = curTask.ComputeNodeInformation;
-
-                            Assert.NotNull(computeNodeInfo);
-
-                            testOutputHelper.WriteLine("Task: " + curTask.Id);
-                            testOutputHelper.WriteLine("ComputeNodeInfo:");
-
-                            testOutputHelper.WriteLine("    PoolId: " + computeNodeInfo.PoolId);
-                            testOutputHelper.WriteLine("    ComputeNodeId: " + computeNodeInfo.ComputeNodeId);
-                        }
+                        testOutputHelper.WriteLine("    PoolId: " + computeNodeInfo.PoolId);
+                        testOutputHelper.WriteLine("    ComputeNodeId: " + computeNodeInfo.ComputeNodeId);
                     }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -701,116 +683,114 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundTaskTerminateAndDelete";
+
+                try
                 {
-                    string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundTaskTerminateAndDelete";
-
-                    try
+                    //Create the job
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    cloudJob.PoolInformation = new PoolInformation()
                     {
-                        //Create the job
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation()
-                        {
-                            PoolId = poolFixture.PoolId
-                        };
-                        testOutputHelper.WriteLine("Creating job: {0}", jobId);
-                        cloudJob.Commit();
+                        PoolId = poolFixture.PoolId
+                    };
+                    testOutputHelper.WriteLine("Creating job: {0}", jobId);
+                    cloudJob.Commit();
 
-                        {
-                            //Create a task
-                            const string taskId = "T1";
-                            CloudTask taskToAdd = new CloudTask(taskId, "ping 127.0.0.1 -n 60"); //Task which runs for 60s
-
-                            //Add the task
-                            testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                            batchCli.JobOperations.AddTask(jobId, taskToAdd);
-
-                            //Wait for the task to go to running state
-                            List<CloudTask> tasks = batchCli.JobOperations.ListTasks(jobId).ToList();
-
-                            Assert.Single(tasks);
-
-                            //Check that the task is running
-                            TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-
-                            //Wait for the task state to be running
-                            taskStateMonitor.WaitAll(
-                                tasks,
-                                TaskState.Running,
-                                TimeSpan.FromSeconds(30),
-                                new ODATAMonitorControl {DelayBetweenDataFetch = TimeSpan.FromSeconds(5)});
-
-                            //Terminate the running task
-                            testOutputHelper.WriteLine("Terminating task {0}", taskId);
-                            CloudTask runningTask = batchCli.JobOperations.GetTask(jobId, taskId);
-                            runningTask.Terminate();
-
-                            //Check task state
-                            runningTask.Refresh();
-
-                            Assert.Equal(TaskState.Completed, runningTask.State);
-
-                            runningTask.Refresh();
-
-                            //Delete the task
-                            testOutputHelper.WriteLine("Deleting task {0}", taskId);
-                            runningTask.Delete();
-
-                            List<CloudTask> taskListAfterDelete = batchCli.JobOperations.ListTasks(jobId).ToList();
-
-                            Assert.Empty(taskListAfterDelete);
-                        }
-
-                        {
-                            //Create a task
-                            const string taskId = "T2";
-                            CloudTask taskToAdd = new CloudTask(taskId, "ping 127.0.0.1 -n 60"); //Task which runs for 60s
-
-                            //Add the task
-                            testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                            batchCli.JobOperations.AddTask(jobId, taskToAdd);
-
-                            //Wait for the task to go to running state
-                            List<CloudTask> tasks = batchCli.JobOperations.ListTasks(jobId).ToList();
-
-                            Assert.Single(tasks);
-
-                            //Check that the task is running
-                            TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-
-                            //Wait for the task state to be running
-
-                            taskStateMonitor.WaitAll(
-                                tasks,
-                                TaskState.Running,
-                                TimeSpan.FromSeconds(30),
-                                new ODATAMonitorControl { DelayBetweenDataFetch = TimeSpan.FromSeconds(5) });
-                            
-                            //Terminate the running task
-                            testOutputHelper.WriteLine("Terminating task {0}", taskId);
-                            CloudTask runningTask = batchCli.JobOperations.GetTask(jobId, taskId);
-                            batchCli.JobOperations.TerminateTask(jobId, taskId);
-
-                            //Check task state
-                            runningTask.Refresh();
-
-                            Assert.Equal(TaskState.Completed, runningTask.State);
-
-                            runningTask.Refresh();
-
-                            //Delete the task
-                            testOutputHelper.WriteLine("Deleting task {0}", taskId);
-                            runningTask.Delete();
-
-                            List<CloudTask> taskListAfterDelete = batchCli.JobOperations.ListTasks(jobId).ToList();
-
-                            Assert.Empty(taskListAfterDelete);
-                        }
-                    }
-                    finally
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        //Create a task
+                        const string taskId = "T1";
+                        CloudTask taskToAdd = new CloudTask(taskId, "ping 127.0.0.1 -n 60"); //Task which runs for 60s
+
+                        //Add the task
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        batchCli.JobOperations.AddTask(jobId, taskToAdd);
+
+                        //Wait for the task to go to running state
+                        List<CloudTask> tasks = batchCli.JobOperations.ListTasks(jobId).ToList();
+
+                        Assert.Single(tasks);
+
+                        //Check that the task is running
+                        TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+
+                        //Wait for the task state to be running
+                        taskStateMonitor.WaitAll(
+                            tasks,
+                            TaskState.Running,
+                            TimeSpan.FromSeconds(30),
+                            new ODATAMonitorControl { DelayBetweenDataFetch = TimeSpan.FromSeconds(5) });
+
+                        //Terminate the running task
+                        testOutputHelper.WriteLine("Terminating task {0}", taskId);
+                        CloudTask runningTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                        runningTask.Terminate();
+
+                        //Check task state
+                        runningTask.Refresh();
+
+                        Assert.Equal(TaskState.Completed, runningTask.State);
+
+                        runningTask.Refresh();
+
+                        //Delete the task
+                        testOutputHelper.WriteLine("Deleting task {0}", taskId);
+                        runningTask.Delete();
+
+                        List<CloudTask> taskListAfterDelete = batchCli.JobOperations.ListTasks(jobId).ToList();
+
+                        Assert.Empty(taskListAfterDelete);
                     }
+
+                    {
+                        //Create a task
+                        const string taskId = "T2";
+                        CloudTask taskToAdd = new CloudTask(taskId, "ping 127.0.0.1 -n 60"); //Task which runs for 60s
+
+                        //Add the task
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        batchCli.JobOperations.AddTask(jobId, taskToAdd);
+
+                        //Wait for the task to go to running state
+                        List<CloudTask> tasks = batchCli.JobOperations.ListTasks(jobId).ToList();
+
+                        Assert.Single(tasks);
+
+                        //Check that the task is running
+                        TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+
+                        //Wait for the task state to be running
+
+                        taskStateMonitor.WaitAll(
+                            tasks,
+                            TaskState.Running,
+                            TimeSpan.FromSeconds(30),
+                            new ODATAMonitorControl { DelayBetweenDataFetch = TimeSpan.FromSeconds(5) });
+
+                        //Terminate the running task
+                        testOutputHelper.WriteLine("Terminating task {0}", taskId);
+                        CloudTask runningTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                        batchCli.JobOperations.TerminateTask(jobId, taskId);
+
+                        //Check task state
+                        runningTask.Refresh();
+
+                        Assert.Equal(TaskState.Completed, runningTask.State);
+
+                        runningTask.Refresh();
+
+                        //Delete the task
+                        testOutputHelper.WriteLine("Deleting task {0}", taskId);
+                        runningTask.Delete();
+
+                        List<CloudTask> taskListAfterDelete = batchCli.JobOperations.ListTasks(jobId).ToList();
+
+                        Assert.Empty(taskListAfterDelete);
+                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -824,48 +804,46 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
+
+                try
                 {
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
+                    //Create the job
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    cloudJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
+                    testOutputHelper.WriteLine("Creating job: {0}", jobId);
+                    cloudJob.Commit();
 
-                    try
-                    {
-                        //Create the job
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
-                        testOutputHelper.WriteLine("Creating job: {0}", jobId);
-                        cloudJob.Commit();
-                        
-                        //Create a task
-                        const string taskId = "T1";
-                        CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"ping 127.0.0.1 -n 20 > nul && exit /b 3\"");
+                    //Create a task
+                    const string taskId = "T1";
+                    CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"ping 127.0.0.1 -n 20 > nul && exit /b 3\"");
 
-                        //Add the task
-                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                        batchCli.JobOperations.AddTask(jobId, taskToAdd);
+                    //Add the task
+                    testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                    batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
-                        CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
-                        TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
+                    TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
 
-                        //Wait for the task state to complete 
-                        taskStateMonitor.WaitAll(new[] { task }, TaskState.Completed, TimeSpan.FromMinutes(2));
+                    //Wait for the task state to complete 
+                    taskStateMonitor.WaitAll(new[] { task }, TaskState.Completed, TimeSpan.FromMinutes(2));
 
-                        task.Refresh();
-                        Assert.Equal(3, task.ExecutionInformation.ExitCode);
+                    task.Refresh();
+                    Assert.Equal(3, task.ExecutionInformation.ExitCode);
 
-                        // If you disable the job the tasks stay in the active state.
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        boundJob.Disable(DisableJobOption.Requeue);
+                    // If you disable the job the tasks stay in the active state.
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    boundJob.Disable(DisableJobOption.Requeue);
 
-                        //Reactivate failed task
-                        task.Reactivate();
-                        task.Refresh();
-                        Assert.Equal(TaskState.Active, task.State);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    //Reactivate failed task
+                    task.Reactivate();
+                    task.Refresh();
+                    Assert.Equal(TaskState.Active, task.State);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -879,41 +857,39 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
+
+                try
                 {
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
+                    //Create the job
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    cloudJob.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction;
 
-                    try
-                    {
-                        //Create the job
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        cloudJob.OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction;
+                    cloudJob.UsesTaskDependencies = true;
+                    cloudJob.Commit();
 
-                        cloudJob.UsesTaskDependencies = true;
-                        cloudJob.Commit();
+                    //Create a task
+                    const string taskId = "T1";
+                    CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"ping 127.0.0.1 \"");
 
-                        //Create a task
-                        const string taskId = "T1";
-                        CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"ping 127.0.0.1 \"");
-                        
-                        //Add the task
-                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                        taskToAdd.ExitConditions = new ExitConditions { Default = new ExitOptions {JobAction = JobAction.Terminate, DependencyAction = DependencyAction.Satisfy} };
-                        batchCli.JobOperations.AddTask(jobId, taskToAdd);
+                    //Add the task
+                    testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                    taskToAdd.ExitConditions = new ExitConditions { Default = new ExitOptions { JobAction = JobAction.Terminate, DependencyAction = DependencyAction.Satisfy } };
+                    batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
-                        CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
-                        TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
+                    TaskStateMonitor taskStateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
 
-                        //Wait for the task state to complete 
-                        taskStateMonitor.WaitAll(new[] { task }, TaskState.Completed, TimeSpan.FromMinutes(2));
+                    //Wait for the task state to complete 
+                    taskStateMonitor.WaitAll(new[] { task }, TaskState.Completed, TimeSpan.FromMinutes(2));
 
-                        task.Refresh();
-                        Assert.Equal(DependencyAction.Satisfy, task.ExitConditions.Default.DependencyAction);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    task.Refresh();
+                    Assert.Equal(DependencyAction.Satisfy, task.ExitConditions.Default.DependencyAction);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -926,36 +902,34 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
+                try
                 {
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
-                    try
+                    //Create the job
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    cloudJob.PoolInformation = new PoolInformation { PoolId = poolFixture.PoolId };
+                    testOutputHelper.WriteLine("Creating job: {0}", jobId);
+                    cloudJob.Commit();
+
+                    //Create a task
+                    const string taskId = "T1";
+
+                    CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"set\"")
                     {
-                        //Create the job
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation { PoolId = poolFixture.PoolId };
-                        testOutputHelper.WriteLine("Creating job: {0}", jobId);
-                        cloudJob.Commit();
+                        DisplayName = "name",
+                        AuthenticationTokenSettings = new AuthenticationTokenSettings { Access = AccessScope.Job }
+                    };
 
-                        //Create a task
-                        const string taskId = "T1";
+                    batchCli.JobOperations.AddTask(jobId, taskToAdd);
 
-                        CloudTask taskToAdd = new CloudTask(taskId, "cmd /c \"set\"")
-                        {
-                            DisplayName = "name",
-                            AuthenticationTokenSettings = new AuthenticationTokenSettings { Access = AccessScope.Job }
-                        };
+                    CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
 
-                        batchCli.JobOperations.AddTask(jobId, taskToAdd);
-
-                        CloudTask task = batchCli.JobOperations.GetTask(jobId, taskId);
-
-                        Assert.Equal(AccessScope.Job, task.AuthenticationTokenSettings.Access);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.Equal(AccessScope.Job, task.AuthenticationTokenSettings.Access);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -969,25 +943,23 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = null;
+
+                try
                 {
-                    string jobId = null;
+                    TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out jobId, out string taskId, false);
 
-                    try
-                    {
-                        TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out jobId, out string taskId, false);
+                    CloudJob job = batchCli.JobOperations.GetJob(jobId);
 
-                        CloudJob job = batchCli.JobOperations.GetJob(jobId);
+                    CloudTask viajobScheduleOperations = batchCli.JobOperations.GetTask(jobId, taskId);
+                    CloudTask viaJob = job.GetTask(taskId);
 
-                        CloudTask viajobScheduleOperations = batchCli.JobOperations.GetTask(jobId, taskId);
-                        CloudTask viaJob = job.GetTask(taskId);
-
-                        Assert.Equal(viajobScheduleOperations.Id, viaJob.Id);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.Equal(viajobScheduleOperations.Id, viaJob.Id);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -1001,45 +973,43 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
+                const string adminTaskId = "adminTask";
+                const string nonAdminTaskId = "nonAdminTask";
+                try
                 {
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
-                    const string adminTaskId = "adminTask";
-                    const string nonAdminTaskId = "nonAdminTask";
-                    try
-                    {
-                        CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() {PoolId = poolFixture.PoolId });
-                        job.Commit();
+                    CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    job.Commit();
 
-                        Func<string, string, CloudTask> createTask = (taskId, userName) =>
-                        {
+                    Func<string, string, CloudTask> createTask = (taskId, userName) =>
+                    {
                             //The magic command below will succeed on an admin account but fail for a non-admin account
                             CloudTask task = new CloudTask(taskId, "cmd /c net session >nul 2>&1")
-                            {
-                                UserIdentity = new UserIdentity(userName)
-                            };
-                            return task;
+                        {
+                            UserIdentity = new UserIdentity(userName)
                         };
+                        return task;
+                    };
 
-                        var adminTask = createTask(adminTaskId, PoolFixture.AdminUserAccountName);
-                        var nonAdminTask = createTask(nonAdminTaskId, PoolFixture.NonAdminUserAccountName);
-                        batchCli.JobOperations.AddTask(jobId, new List<CloudTask> { adminTask, nonAdminTask });
+                    var adminTask = createTask(adminTaskId, PoolFixture.AdminUserAccountName);
+                    var nonAdminTask = createTask(nonAdminTaskId, PoolFixture.NonAdminUserAccountName);
+                    batchCli.JobOperations.AddTask(jobId, new List<CloudTask> { adminTask, nonAdminTask });
 
-                        var tasks = batchCli.JobOperations.ListTasks(jobId);
+                    var tasks = batchCli.JobOperations.ListTasks(jobId);
 
-                        batchCli.Utilities.CreateTaskStateMonitor().WaitAll(tasks, TaskState.Completed, TimeSpan.FromMinutes(1));
+                    batchCli.Utilities.CreateTaskStateMonitor().WaitAll(tasks, TaskState.Completed, TimeSpan.FromMinutes(1));
 
-                        var boundAdminTask = batchCli.JobOperations.GetTask(jobId, adminTaskId);
-                        var boundNonAdminTask = batchCli.JobOperations.GetTask(jobId, nonAdminTaskId);
+                    var boundAdminTask = batchCli.JobOperations.GetTask(jobId, adminTaskId);
+                    var boundNonAdminTask = batchCli.JobOperations.GetTask(jobId, nonAdminTaskId);
 
-                        Assert.Equal(0, boundAdminTask.ExecutionInformation.ExitCode);
-                        Assert.NotEqual(0, boundNonAdminTask.ExecutionInformation.ExitCode);
+                    Assert.Equal(0, boundAdminTask.ExecutionInformation.ExitCode);
+                    Assert.NotEqual(0, boundNonAdminTask.ExecutionInformation.ExitCode);
 
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -1064,78 +1034,76 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string taskId = "task1";
+
+                string jobId = TestUtilities.GenerateResourceId();
+                TaskConstraints defaultConstraints = new TaskConstraints(TimeSpan.MaxValue, TimeSpan.FromDays(7), 0);
+                try
                 {
-                    const string taskId = "task1";
-
-                    string jobId = TestUtilities.GenerateResourceId();
-                    TaskConstraints defaultConstraints = new TaskConstraints(TimeSpan.MaxValue, TimeSpan.FromDays(7), 0);
-                    try
+                    //
+                    // Create the job
+                    //
+                    CloudJob jobSchedule = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    jobSchedule.PoolInformation = new PoolInformation()
                     {
-                        //
-                        // Create the job
-                        //
-                        CloudJob jobSchedule = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        jobSchedule.PoolInformation = new PoolInformation()
-                        {
-                            PoolId = "PoolWhoDoesntExist"
-                        };
+                        PoolId = "PoolWhoDoesntExist"
+                    };
 
-                        testOutputHelper.WriteLine("Initial job schedule commit()");
-                        jobSchedule.Commit();
+                    testOutputHelper.WriteLine("Initial job schedule commit()");
+                    jobSchedule.Commit();
 
-                        //Get the job
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+                    //Get the job
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
 
-                        //Add the task
-                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                        boundJob.AddTask(myTask);
+                    //Add the task
+                    testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                    boundJob.AddTask(myTask);
 
-                        //Get the task and check the constraints
-                        CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                    //Get the task and check the constraints
+                    CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
 
-                        Assert.Equal(defaultConstraints.MaxTaskRetryCount, boundTask.Constraints.MaxTaskRetryCount);
-                        Assert.Equal(defaultConstraints.MaxWallClockTime, boundTask.Constraints.MaxWallClockTime);
-                        Assert.Equal(defaultConstraints.RetentionTime, boundTask.Constraints.RetentionTime);
+                    Assert.Equal(defaultConstraints.MaxTaskRetryCount, boundTask.Constraints.MaxTaskRetryCount);
+                    Assert.Equal(defaultConstraints.MaxWallClockTime, boundTask.Constraints.MaxWallClockTime);
+                    Assert.Equal(defaultConstraints.RetentionTime, boundTask.Constraints.RetentionTime);
 
-                        TimeSpan maxWallClockTime = TimeSpan.FromHours(1);
-                        TimeSpan dataRetentionTime = TimeSpan.FromHours(2);
-                        const int maxRetryCount = 1;
-                        boundTask.Constraints = new TaskConstraints(maxWallClockTime, dataRetentionTime, maxRetryCount);
+                    TimeSpan maxWallClockTime = TimeSpan.FromHours(1);
+                    TimeSpan dataRetentionTime = TimeSpan.FromHours(2);
+                    const int maxRetryCount = 1;
+                    boundTask.Constraints = new TaskConstraints(maxWallClockTime, dataRetentionTime, maxRetryCount);
 
-                        testOutputHelper.WriteLine("Updating task constraints");
+                    testOutputHelper.WriteLine("Updating task constraints");
 
-                        boundTask.Commit();
+                    boundTask.Commit();
 
-                        //Ensure the commit worked
-                        boundTask.Refresh();
+                    //Ensure the commit worked
+                    boundTask.Refresh();
 
-                        Assert.Equal(maxRetryCount, boundTask.Constraints.MaxTaskRetryCount);
-                        Assert.Equal(maxWallClockTime, boundTask.Constraints.MaxWallClockTime);
-                        Assert.Equal(dataRetentionTime, boundTask.Constraints.RetentionTime);
+                    Assert.Equal(maxRetryCount, boundTask.Constraints.MaxTaskRetryCount);
+                    Assert.Equal(maxWallClockTime, boundTask.Constraints.MaxWallClockTime);
+                    Assert.Equal(dataRetentionTime, boundTask.Constraints.RetentionTime);
 
-                        CloudTask freshTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                    CloudTask freshTask = batchCli.JobOperations.GetTask(jobId, taskId);
 
-                        Assert.Equal(maxRetryCount, freshTask.Constraints.MaxTaskRetryCount);
-                        Assert.Equal(maxWallClockTime, freshTask.Constraints.MaxWallClockTime);
-                        Assert.Equal(dataRetentionTime, freshTask.Constraints.RetentionTime);
+                    Assert.Equal(maxRetryCount, freshTask.Constraints.MaxTaskRetryCount);
+                    Assert.Equal(maxWallClockTime, freshTask.Constraints.MaxWallClockTime);
+                    Assert.Equal(dataRetentionTime, freshTask.Constraints.RetentionTime);
 
-                        //Update the task constraints to be null again
-                        freshTask.Constraints = null;
-                        freshTask.Commit();
+                    //Update the task constraints to be null again
+                    freshTask.Constraints = null;
+                    freshTask.Commit();
 
-                        freshTask.Refresh();
+                    freshTask.Refresh();
 
-                        //Ensure the commit worked
-                        Assert.Equal(defaultConstraints.MaxTaskRetryCount, freshTask.Constraints.MaxTaskRetryCount);
-                        Assert.Equal(defaultConstraints.MaxWallClockTime, freshTask.Constraints.MaxWallClockTime);
-                        Assert.Equal(defaultConstraints.RetentionTime, freshTask.Constraints.RetentionTime);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    //Ensure the commit worked
+                    Assert.Equal(defaultConstraints.MaxTaskRetryCount, freshTask.Constraints.MaxTaskRetryCount);
+                    Assert.Equal(defaultConstraints.MaxWallClockTime, freshTask.Constraints.MaxWallClockTime);
+                    Assert.Equal(defaultConstraints.RetentionTime, freshTask.Constraints.RetentionTime);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -1149,60 +1117,58 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string jobId = "TaskConditionalHeaders-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "TaskConditionalHeaders-" + TestUtilities.GetMyName();
-                    try
+                    PoolInformation poolInfo = new PoolInformation()
                     {
-                        PoolInformation poolInfo = new PoolInformation()
+                        PoolId = "Fake"
+                    };
+
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
+                    unboundJob.Commit();
+
+                    const string taskId = "T1";
+
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    boundJob.AddTask(new CloudTask(taskId, "cmd /c dir"));
+
+                    CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                    string capturedEtag1 = boundTask.ETag;
+
+                    boundTask.Constraints = new TaskConstraints(null, null, 5);
+
+                    BatchClientBehavior interceptor = new Protocol.RequestInterceptor(
+                        (req) =>
                         {
-                            PoolId = "Fake"
-                        };
-
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, poolInfo);
-                        unboundJob.Commit();
-
-                        const string taskId = "T1";
-
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        boundJob.AddTask(new CloudTask(taskId, "cmd /c dir"));
-
-                        CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
-                        string capturedEtag1 = boundTask.ETag;
-
-                        boundTask.Constraints = new TaskConstraints(null, null, 5);
-
-                        BatchClientBehavior interceptor = new Protocol.RequestInterceptor(
-                            (req) =>
+                            if (req.Options is Protocol.Models.TaskUpdateOptions typedParams)
                             {
-                                if (req.Options is Protocol.Models.TaskUpdateOptions typedParams)
-                                {
-                                    typedParams.IfMatch = capturedEtag1;
-                                }
-                            });
+                                typedParams.IfMatch = capturedEtag1;
+                            }
+                        });
 
-                        //Update bound task with if-match header, it should succeed
-                        boundTask.Commit(additionalBehaviors: new[] { interceptor });
+                    //Update bound task with if-match header, it should succeed
+                    boundTask.Commit(additionalBehaviors: new[] { interceptor });
 
-                        boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                    boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
 
-                        interceptor = new Protocol.RequestInterceptor(
-                            (req) =>
+                    interceptor = new Protocol.RequestInterceptor(
+                        (req) =>
+                        {
+                            if (req.Options is Protocol.Models.TaskTerminateOptions typedParams)
                             {
-                                if (req.Options is Protocol.Models.TaskTerminateOptions typedParams)
-                                {
-                                    typedParams.IfMatch = capturedEtag1;
-                                }
-                            });
+                                typedParams.IfMatch = capturedEtag1;
+                            }
+                        });
 
-                        //Terminate bound task with if-match header, it should fail
-                        Exception e = TestUtilities.AssertThrows<BatchException>(() => boundTask.Terminate(additionalBehaviors: new[] { interceptor }));
-                        TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, testOutputHelper);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    //Terminate bound task with if-match header, it should fail
+                    Exception e = TestUtilities.AssertThrows<BatchException>(() => boundTask.Terminate(additionalBehaviors: new[] { interceptor }));
+                    TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(e, BatchErrorCodeStrings.ConditionNotMet, testOutputHelper);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -1215,42 +1181,40 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string taskId = "t1";
+                const string poolId = nameof(AddTaskOnContainerPool_TaskIsExecuted);
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + nameof(AddTaskOnContainerPool_TaskIsExecuted);
+                try
                 {
-                    const string taskId = "t1";
-                    const string poolId = nameof(AddTaskOnContainerPool_TaskIsExecuted);
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + nameof(AddTaskOnContainerPool_TaskIsExecuted);
-                    try
-                    {
-                        var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
+                    var imageDetails = IaasLinuxPoolFixture.GetUbuntuImageDetails(batchCli);
 
-                        CloudPool pool = batchCli.PoolOperations.CreatePool(
-                            poolId,
-                            PoolFixture.VMSize,
-                            new VirtualMachineConfiguration(
-                                imageDetails.ImageReference,
-                                imageDetails.NodeAgentSkuId)
+                    CloudPool pool = batchCli.PoolOperations.CreatePool(
+                        poolId,
+                        PoolFixture.VMSize,
+                        new VirtualMachineConfiguration(
+                            imageDetails.ImageReference,
+                            imageDetails.NodeAgentSkuId)
+                        {
+                            ContainerConfiguration = new ContainerConfiguration()
                             {
-                                ContainerConfiguration = new ContainerConfiguration()
-                                {
-                                    ContainerImageNames = new List<string> {"busybox"}
-                                }
-                            });
-                        pool.Commit();
+                                ContainerImageNames = new List<string> { "busybox" }
+                            }
+                        });
+                    pool.Commit();
 
-                        pool = PoolFixture.WaitForPoolAllocation(batchCli, poolId);
+                    pool = PoolFixture.WaitForPoolAllocation(batchCli, poolId);
 
-                        CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() {PoolId = poolId});
-                        job.Commit();
+                    CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolId });
+                    job.Commit();
 
-                        var task = new CloudTask(taskId, "echo hello");
-                        batchCli.JobOperations.AddTask(jobId, task);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    var task = new CloudTask(taskId, "echo hello");
+                    batchCli.JobOperations.AddTask(jobId, task);
+                }
+                finally
+                {
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
@@ -87,7 +87,7 @@ namespace BatchClientIntegrationTests
                     finally
                     {
                         await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
-                        await containerClient.DeleteIfExistsAsync();
+                        containerClient.DeleteIfExists();
                     }
                 }
             };

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
@@ -22,13 +22,11 @@ namespace BatchClientIntegrationTests
     [Collection("SharedLinuxPoolCollection")]
     public class CloudTaskLinuxIntegrationTests
     {
-        private readonly ITestOutputHelper testOutputHelper;
         private readonly PoolFixture poolFixture;
         private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(3);
 
-        public CloudTaskLinuxIntegrationTests(ITestOutputHelper testOutputHelper, IaasLinuxPoolFixture poolFixture)
+        public CloudTaskLinuxIntegrationTests(IaasLinuxPoolFixture poolFixture)
         {
-            this.testOutputHelper = testOutputHelper;
             this.poolFixture = poolFixture;
         }
 
@@ -53,7 +51,7 @@ namespace BatchClientIntegrationTests
                         containerClient.CreateIfNotExists();
                         string sasUri = BlobUtilities.GetWriteableSasUri(containerClient, storageAccount);
 
-                        CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         createJob.Commit();
 
                         const string blobPrefix = "foo/bar";
@@ -110,7 +108,7 @@ namespace BatchClientIntegrationTests
                     {
                         var job = client.JobOperations.CreateJob(jobId, new PoolInformation()
                         {
-                            PoolId = this.poolFixture.PoolId
+                            PoolId = poolFixture.PoolId
                         });
                         job.Commit();
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
@@ -37,56 +37,54 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "RunTaskAndUploadFiles-" + TestUtilities.GetMyName();
+                string containerName = "runtaskanduploadfiles";
+                StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
+                BlobServiceClient blobClient = BlobUtilities.GetBlobServiceClient(storageAccount);
+                BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, blobClient, storageAccount);
+
+                try
                 {
-                    string jobId = "RunTaskAndUploadFiles-" + TestUtilities.GetMyName();
-                    string containerName = "runtaskanduploadfiles";
-                    StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
-                    BlobServiceClient blobClient = BlobUtilities.GetBlobServiceClient(storageAccount);
-                    BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, blobClient, storageAccount);
+                    // Create container and writeable SAS
+                    containerClient.CreateIfNotExists();
+                    string sasUri = BlobUtilities.GetWriteableSasUri(containerClient, storageAccount);
 
-                    try
+                    CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    createJob.Commit();
+
+                    const string blobPrefix = "foo/bar";
+                    const string taskId = "simpletask";
+
+                    OutputFileDestination destination = new OutputFileDestination(new OutputFileBlobContainerDestination(sasUri, blobPrefix));
+                    OutputFileUploadOptions uploadOptions = new OutputFileUploadOptions(uploadCondition: OutputFileUploadCondition.TaskCompletion);
+                    CloudTask unboundTask = new CloudTask(taskId, "echo test")
                     {
-                        // Create container and writeable SAS
-                        containerClient.CreateIfNotExists();
-                        string sasUri = BlobUtilities.GetWriteableSasUri(containerClient, storageAccount);
-
-                        CloudJob createJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        createJob.Commit();
-
-                        const string blobPrefix = "foo/bar";
-                        const string taskId = "simpletask";
-
-                        OutputFileDestination destination = new OutputFileDestination(new OutputFileBlobContainerDestination(sasUri, blobPrefix));
-                        OutputFileUploadOptions uploadOptions = new OutputFileUploadOptions(uploadCondition: OutputFileUploadCondition.TaskCompletion);
-                        CloudTask unboundTask = new CloudTask(taskId, "echo test")
-                        {
-                            OutputFiles = new List<OutputFile>
+                        OutputFiles = new List<OutputFile>
                             {
                                 new OutputFile(@"../*.txt", destination, uploadOptions)
                             }
-                        };
+                    };
 
-                        batchCli.JobOperations.AddTask(jobId, unboundTask);
+                    batchCli.JobOperations.AddTask(jobId, unboundTask);
 
-                        var tasks = batchCli.JobOperations.ListTasks(jobId);
+                    var tasks = batchCli.JobOperations.ListTasks(jobId);
 
-                        var monitor = batchCli.Utilities.CreateTaskStateMonitor();
-                        monitor.WaitAll(tasks, TaskState.Completed, TimeSpan.FromMinutes(1));
+                    var monitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    monitor.WaitAll(tasks, TaskState.Completed, TimeSpan.FromMinutes(1));
 
-                        // Ensure that the correct files got uploaded
-                        var blobs = containerClient.GetAllBlobs();
-                        Assert.Equal(4, blobs.Count()); //There are 4 .txt files created, stdout, stderr, fileuploadout, and fileuploaderr
-                        foreach (var blob in blobs)
-                        {
-                            Assert.StartsWith(blobPrefix, blob.Name);
-                        }
-                    }
-                    finally
+                    // Ensure that the correct files got uploaded
+                    var blobs = containerClient.GetAllBlobs();
+                    Assert.Equal(4, blobs.Count()); //There are 4 .txt files created, stdout, stderr, fileuploadout, and fileuploaderr
+                    foreach (var blob in blobs)
                     {
-                        await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
-                        containerClient.DeleteIfExists();
+                        Assert.StartsWith(blobPrefix, blob.Name);
                     }
+                }
+                finally
+                {
+                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
+                    containerClient.DeleteIfExists();
                 }
             };
 
@@ -100,38 +98,36 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "ContainerJob" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "ContainerJob" + TestUtilities.GetMyName();
-
-                    try
+                    var job = client.JobOperations.CreateJob(jobId, new PoolInformation()
                     {
-                        var job = client.JobOperations.CreateJob(jobId, new PoolInformation()
-                        {
-                            PoolId = poolFixture.PoolId
-                        });
-                        job.Commit();
+                        PoolId = poolFixture.PoolId
+                    });
+                    job.Commit();
 
-                        var newTask = new CloudTask("a", "cat /etc/centos-release")
-                        {
-                            ContainerSettings = new TaskContainerSettings("centos")
-                        };
-                        client.JobOperations.AddTask(jobId, newTask);
-
-                        var tasks = client.JobOperations.ListTasks(jobId);
-
-                        var monitor = client.Utilities.CreateTaskStateMonitor();
-                        monitor.WaitAll(tasks, TaskState.Completed, TimeSpan.FromMinutes(7));
-
-                        var task = tasks.Single();
-                        task.Refresh();
-
-                        Assert.Equal("ContainerPoolNotSupported", task.ExecutionInformation.FailureInformation.Code);
-                    }
-                    finally
+                    var newTask = new CloudTask("a", "cat /etc/centos-release")
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
-                    }
+                        ContainerSettings = new TaskContainerSettings("centos")
+                    };
+                    client.JobOperations.AddTask(jobId, newTask);
+
+                    var tasks = client.JobOperations.ListTasks(jobId);
+
+                    var monitor = client.Utilities.CreateTaskStateMonitor();
+                    monitor.WaitAll(tasks, TaskState.Completed, TimeSpan.FromMinutes(7));
+
+                    var task = tasks.Single();
+                    task.Refresh();
+
+                    Assert.Equal("ContainerPoolNotSupported", task.ExecutionInformation.FailureInformation.Code);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
@@ -83,8 +83,15 @@ namespace BatchClientIntegrationTests
                 }
                 finally
                 {
-                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
-                    containerClient.DeleteIfExists();
+                    try
+                    {
+                        await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).ConfigureAwait(false);
+                        containerClient.DeleteIfExists();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw;
+                    }
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
@@ -839,7 +839,7 @@ namespace BatchClientIntegrationTests
                     }
                     finally
                     {
-                        await containerClient.DeleteIfExistsAsync();
+                        containerClient.DeleteIfExists();
                     }
                 }
             };

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
@@ -48,7 +48,7 @@ namespace BatchClientIntegrationTests
             {
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
-                    CloudPool pool = batchCli.PoolOperations.GetPool(this.poolFixture.PoolId);
+                    CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
                     // confirm start task info exists and has rational values
 
@@ -77,7 +77,7 @@ namespace BatchClientIntegrationTests
                 {
                     PoolOperations poolOperations = batchCli.PoolOperations;
 
-                    List<ComputeNode> computeNodeList = poolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                    List<ComputeNode> computeNodeList = poolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
                     ComputeNode computeNodeToGet = computeNodeList.First();
                     string computeNodeId = computeNodeToGet.Id;
@@ -85,13 +85,13 @@ namespace BatchClientIntegrationTests
                     // Get compute node via the manager
                     //
 
-                    ComputeNode computeNodeFromManager = poolOperations.GetComputeNode(this.poolFixture.PoolId, computeNodeId);
+                    ComputeNode computeNodeFromManager = poolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
                     CompareComputeNodeObjects(computeNodeToGet, computeNodeFromManager);
 
                     //
                     // Get compute node via the pool
                     //
-                    CloudPool pool = poolOperations.GetPool(this.poolFixture.PoolId);
+                    CloudPool pool = poolOperations.GetPool(poolFixture.PoolId);
 
                     ComputeNode computeNodeFromPool = pool.GetComputeNode(computeNodeId);
                     CompareComputeNodeObjects(computeNodeToGet, computeNodeFromPool);
@@ -130,7 +130,7 @@ namespace BatchClientIntegrationTests
                     Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor();
                     batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
 
-                    List<ComputeNode> computeNodeList = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                    List<ComputeNode> computeNodeList = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
                     ComputeNode computeNode = computeNodeList.First();
 
@@ -162,7 +162,7 @@ namespace BatchClientIntegrationTests
                         // Create the job
                         //
                         CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
 
                         unboundJob.Commit();
 
@@ -171,7 +171,7 @@ namespace BatchClientIntegrationTests
 
                         boundJob.AddTask(myTask);
 
-                        this.testOutputHelper.WriteLine("Initial job commit()");
+                        testOutputHelper.WriteLine("Initial job commit()");
 
                         //
                         // Wait for task to go to completion
@@ -192,13 +192,13 @@ namespace BatchClientIntegrationTests
                         //
                         // Check recent tasks
                         //
-                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(this.poolFixture.PoolId, computeNodeId);
+                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
 
-                        this.testOutputHelper.WriteLine("Recent tasks:");
+                        testOutputHelper.WriteLine("Recent tasks:");
 
                         foreach (TaskInformation recentTask in computeNode.RecentTasks)
                         {
-                            this.testOutputHelper.WriteLine("Compute node has recent task Job: {0}, Task: {1}, State: {2}, Subtask: {3}",
+                            testOutputHelper.WriteLine("Compute node has recent task Job: {0}, Task: {1}, State: {2}, Subtask: {3}",
                                 recentTask.JobId,
                                 recentTask.TaskId,
                                 recentTask.TaskState,
@@ -235,9 +235,10 @@ namespace BatchClientIntegrationTests
                                         new List<Protocol.Models.ComputeNodeError>();
 
                                     //Generate first Compute Node Error
-                                    List<Protocol.Models.NameValuePair> nvps =
-                                        new List<Protocol.Models.NameValuePair>();
-                                    nvps.Add(new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue });
+                                    List<Protocol.Models.NameValuePair> nvps = new List<Protocol.Models.NameValuePair>
+                                    {
+                                        new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
+                                    };
 
                                     Protocol.Models.ComputeNodeError error1 = new Protocol.Models.ComputeNodeError();
                                     error1.Code = expectedErrorCode;
@@ -247,8 +248,10 @@ namespace BatchClientIntegrationTests
                                     errors.Add(error1);
 
                                     //Generate second Compute Node Error
-                                    nvps = new List<Protocol.Models.NameValuePair>();
-                                    nvps.Add(new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue });
+                                    nvps = new List<Protocol.Models.NameValuePair>
+                                    {
+                                        new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
+                                    };
 
                                     Protocol.Models.ComputeNodeError error2 = new Protocol.Models.ComputeNodeError();
                                     error2.Code = expectedErrorCode;
@@ -271,7 +274,7 @@ namespace BatchClientIntegrationTests
 
                         batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
 
-                        computeNode = batchCli.PoolOperations.GetComputeNode(this.poolFixture.PoolId, computeNodeId);
+                        computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
 
                         Assert.Equal(computeNodeId, computeNode.Id);
                         Assert.NotNull(computeNode.Errors);
@@ -309,7 +312,7 @@ namespace BatchClientIntegrationTests
                     List<string> names = new List<string>() { TestUtilities.GetMyName(), TestUtilities.GetMyName() + "1", TestUtilities.GetMyName() + "2", TestUtilities.GetMyName() + "3", TestUtilities.GetMyName() + "4" };
 
                     // pick a compute node to victimize with user accounts
-                    IEnumerable<ComputeNode> ienmComputeNodes = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId);
+                    IEnumerable<ComputeNode> ienmComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
                     List<ComputeNode> computeNodeList = new List<ComputeNode>(ienmComputeNodes);
                     ComputeNode computeNode = computeNodeList[0];
 
@@ -319,7 +322,7 @@ namespace BatchClientIntegrationTests
 
                         // test user public constructor and IPoolMgr verbs
                         {
-                            ComputeNodeUser newUser = batchCli.PoolOperations.CreateComputeNodeUser(this.poolFixture.PoolId, computeNode.Id);
+                            ComputeNodeUser newUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
 
                             newUser.Name = names[0];
                             newUser.IsAdmin = true;
@@ -342,7 +345,7 @@ namespace BatchClientIntegrationTests
                             }
 
                             // pull the rdp file
-                            batchCli.PoolOperations.GetRDPFile(this.poolFixture.PoolId, computeNode.Id, rdpFileName);
+                            batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpFileName);
 
                             // simple validation tests on the rdp file
                             TestFileExistsAndHasLength(rdpFileName);
@@ -352,12 +355,12 @@ namespace BatchClientIntegrationTests
 
                             // "test" delete user from IPoolMgr
                             // TODO: when GET/LIST User is available we should close the loop and confirm the user is gone.
-                            batchCli.PoolOperations.DeleteComputeNodeUser(this.poolFixture.PoolId, computeNode.Id, newUser.Name);
+                            batchCli.PoolOperations.DeleteComputeNodeUser(poolFixture.PoolId, computeNode.Id, newUser.Name);
                         }
 
                         // test IPoolMgr CreateUser
                         {
-                            ComputeNodeUser pmcUser = batchCli.PoolOperations.CreateComputeNodeUser(this.poolFixture.PoolId, computeNode.Id);
+                            ComputeNodeUser pmcUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
 
                             pmcUser.Name = names[1];
                             pmcUser.IsAdmin = true;
@@ -368,7 +371,7 @@ namespace BatchClientIntegrationTests
                             pmcUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
 
                             // pull rdp file
-                            batchCli.PoolOperations.GetRDPFile(this.poolFixture.PoolId, computeNode.Id, rdpFileName);
+                            batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpFileName);
 
                             // simple validation on rdp file
                             TestFileExistsAndHasLength(rdpFileName);
@@ -377,12 +380,12 @@ namespace BatchClientIntegrationTests
                             File.Delete(rdpFileName);
 
                             // delete user
-                            batchCli.PoolOperations.DeleteComputeNodeUser(this.poolFixture.PoolId, computeNode.Id, pmcUser.Name);
+                            batchCli.PoolOperations.DeleteComputeNodeUser(poolFixture.PoolId, computeNode.Id, pmcUser.Name);
                         }
 
                         // test IComputeNode verbs
                         {
-                            ComputeNodeUser poolMgrUser = batchCli.PoolOperations.CreateComputeNodeUser(this.poolFixture.PoolId, computeNode.Id);
+                            ComputeNodeUser poolMgrUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
 
                             poolMgrUser.Name = names[2];
                             poolMgrUser.IsAdmin = true;
@@ -406,7 +409,7 @@ namespace BatchClientIntegrationTests
 
                         // test ComputeNodeUser.Delete
                         {
-                            ComputeNodeUser usrDelete = batchCli.PoolOperations.CreateComputeNodeUser(this.poolFixture.PoolId, computeNode.Id);
+                            ComputeNodeUser usrDelete = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
 
                             usrDelete.Name = names[3];
                             usrDelete.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
@@ -420,7 +423,7 @@ namespace BatchClientIntegrationTests
                         // test rdp-by-stream IPoolMgr and IComputeNode
                         // the by-stream paths do not converge with the by-filename paths until IProtocol so we test them seperately
                         {
-                            ComputeNodeUser byStreamUser = batchCli.PoolOperations.CreateComputeNodeUser(this.poolFixture.PoolId, computeNode.Id);
+                            ComputeNodeUser byStreamUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
 
                             byStreamUser.Name = names[4];
                             byStreamUser.IsAdmin = true;
@@ -432,7 +435,7 @@ namespace BatchClientIntegrationTests
                             // IPoolMgr
                             using (Stream rdpStreamPoolMgr = File.Create(rdpFileName))
                             {
-                                batchCli.PoolOperations.GetRDPFile(this.poolFixture.PoolId, computeNode.Id, rdpStreamPoolMgr);
+                                batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpStreamPoolMgr);
 
                                 rdpStreamPoolMgr.Flush();
                                 rdpStreamPoolMgr.Close();
@@ -468,7 +471,7 @@ namespace BatchClientIntegrationTests
 
                             try
                             {
-                                ComputeNodeUser deleteThis = batchCli.PoolOperations.CreateComputeNodeUser(this.poolFixture.PoolId, computeNode.Id);
+                                ComputeNodeUser deleteThis = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
                                 deleteThis.Name = curName;
                                 deleteThis.Delete();
                             }
@@ -497,9 +500,9 @@ namespace BatchClientIntegrationTests
             {
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
-                    CloudPool pool = batchCli.PoolOperations.GetPool(this.poolFixture.PoolId);
+                    CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                    this.testOutputHelper.WriteLine("Getting pool");
+                    testOutputHelper.WriteLine("Getting pool");
                     StartTask poolStartTask = pool.StartTask;
 
                     Assert.NotNull(poolStartTask);
@@ -509,10 +512,10 @@ namespace BatchClientIntegrationTests
 
                     Assert.True(computeNodes.Any());
 
-                    this.testOutputHelper.WriteLine("Checking every compute nodes start task in the pool matches the pools start task");
+                    testOutputHelper.WriteLine("Checking every compute nodes start task in the pool matches the pools start task");
                     foreach (ComputeNode computeNode in computeNodes)
                     {
-                        this.testOutputHelper.WriteLine("Checking start task of compute node: {0}", computeNode.Id);
+                        testOutputHelper.WriteLine("Checking start task of compute node: {0}", computeNode.Id);
 
                         //Check that the property is correctly set on each compute node
                         Assert.NotNull(computeNode.StartTask);
@@ -584,7 +587,7 @@ namespace BatchClientIntegrationTests
                     using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
                     {
                         TimeSpan refreshPollingTimeout = TimeSpan.FromMinutes(3);
-                        CloudPool pool = this.poolFixture.Pool;
+                        CloudPool pool = poolFixture.Pool;
 
                         List<ComputeNode> nodes = pool.ListComputeNodes().ToList();
 
@@ -656,7 +659,7 @@ namespace BatchClientIntegrationTests
                                 }
                                 catch (Exception ex)
                                 {
-                                    TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.NodeAlreadyInTargetSchedulingState, this.testOutputHelper);
+                                    TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.NodeAlreadyInTargetSchedulingState, testOutputHelper);
 
                                     gotCorrectException = true;
                                 }
@@ -679,7 +682,7 @@ namespace BatchClientIntegrationTests
                             }
                             catch (Exception ex)
                             {
-                                this.testOutputHelper.WriteLine(string.Format("OnlineOfflineTest: exception during exit trying to restore scheduling state: {0}", ex.ToString()));
+                                testOutputHelper.WriteLine(string.Format("OnlineOfflineTest: exception during exit trying to restore scheduling state: {0}", ex.ToString()));
                             }
                         }
                     }
@@ -734,7 +737,7 @@ namespace BatchClientIntegrationTests
             {
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
-                    CloudPool sharedPool = this.poolFixture.Pool;
+                    CloudPool sharedPool = poolFixture.Pool;
                     List<string> cnuNamesToDelete = new List<string>();
 
                     // pick a compute node to victimize with user accounts
@@ -770,13 +773,13 @@ namespace BatchClientIntegrationTests
                         {
                             foreach (string curCNUName in cnuNamesToDelete)
                             {
-                                this.testOutputHelper.WriteLine("TestComputeNodeUserIAAS attempting to delete the following <nodeid,user>: <{0},{1}>", cn.Id, curCNUName);
+                                testOutputHelper.WriteLine("TestComputeNodeUserIAAS attempting to delete the following <nodeid,user>: <{0},{1}>", cn.Id, curCNUName);
                                 cn.DeleteComputeNodeUser(curCNUName);
                             }
                         }
                         catch (Exception ex)
                         {
-                            this.testOutputHelper.WriteLine("TestComputeNodeUserIAAS: exception deleting user account.  ex: " + ex.ToString());
+                            testOutputHelper.WriteLine("TestComputeNodeUserIAAS: exception deleting user account.  ex: " + ex.ToString());
                         }
                     }
                 }
@@ -814,9 +817,9 @@ namespace BatchClientIntegrationTests
 
                         var startTime = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(5));
 
-                        var node = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).First();
+                        var node = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).First();
                         var result = batchCli.PoolOperations.UploadComputeNodeBatchServiceLogs(
-                            this.poolFixture.PoolId,
+                            poolFixture.PoolId,
                             node.Id,
                             sasUri,
                             startTime);
@@ -856,7 +859,7 @@ namespace BatchClientIntegrationTests
             {
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
-                    CloudPool sharedPool = this.poolFixture.Pool;
+                    CloudPool sharedPool = poolFixture.Pool;
 
                     try
                     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
@@ -46,20 +46,18 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
+
+                // confirm start task info exists and has rational values
+
+                foreach (ComputeNode curComputeNode in pool.ListComputeNodes())
                 {
-                    CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
+                    StartTaskInformation sti = curComputeNode.StartTaskInformation;
 
-                    // confirm start task info exists and has rational values
-
-                    foreach (ComputeNode curComputeNode in pool.ListComputeNodes())
-                    {
-                        StartTaskInformation sti = curComputeNode.StartTaskInformation;
-
-                        // set when pool was created
-                        Assert.NotNull(sti);
-                        Assert.True(StartTaskState.Running == sti.State || StartTaskState.Completed == sti.State);
-                    }
+                    // set when pool was created
+                    Assert.NotNull(sti);
+                    Assert.True(StartTaskState.Running == sti.State || StartTaskState.Completed == sti.State);
                 }
             };
 
@@ -73,46 +71,44 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                {
-                    PoolOperations poolOperations = batchCli.PoolOperations;
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                PoolOperations poolOperations = batchCli.PoolOperations;
 
-                    List<ComputeNode> computeNodeList = poolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
+                List<ComputeNode> computeNodeList = poolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
-                    ComputeNode computeNodeToGet = computeNodeList.First();
-                    string computeNodeId = computeNodeToGet.Id;
-                    //
-                    // Get compute node via the manager
-                    //
+                ComputeNode computeNodeToGet = computeNodeList.First();
+                string computeNodeId = computeNodeToGet.Id;
+                //
+                // Get compute node via the manager
+                //
 
-                    ComputeNode computeNodeFromManager = poolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
-                    CompareComputeNodeObjects(computeNodeToGet, computeNodeFromManager);
+                ComputeNode computeNodeFromManager = poolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
+                CompareComputeNodeObjects(computeNodeToGet, computeNodeFromManager);
 
-                    //
-                    // Get compute node via the pool
-                    //
-                    CloudPool pool = poolOperations.GetPool(poolFixture.PoolId);
+                //
+                // Get compute node via the pool
+                //
+                CloudPool pool = poolOperations.GetPool(poolFixture.PoolId);
 
-                    ComputeNode computeNodeFromPool = pool.GetComputeNode(computeNodeId);
-                    CompareComputeNodeObjects(computeNodeToGet, computeNodeFromPool);
-                    //
-                    // Refresh compute node
-                    //
+                ComputeNode computeNodeFromPool = pool.GetComputeNode(computeNodeId);
+                CompareComputeNodeObjects(computeNodeToGet, computeNodeFromPool);
+                //
+                // Refresh compute node
+                //
 
-                    //Refresh with a detail level
-                    computeNodeToGet.Refresh(new ODATADetailLevel() { SelectClause = "affinityId,id" });
+                //Refresh with a detail level
+                computeNodeToGet.Refresh(new ODATADetailLevel() { SelectClause = "affinityId,id" });
 
-                    //Confirm we have the reduced detail level
-                    Assert.Equal(computeNodeToGet.AffinityId, computeNodeFromManager.AffinityId);
-                    Assert.Null(computeNodeToGet.IPAddress);
-                    Assert.Null(computeNodeToGet.LastBootTime);
-                    Assert.Null(computeNodeToGet.State);
-                    Assert.Null(computeNodeToGet.StartTaskInformation);
+                //Confirm we have the reduced detail level
+                Assert.Equal(computeNodeToGet.AffinityId, computeNodeFromManager.AffinityId);
+                Assert.Null(computeNodeToGet.IPAddress);
+                Assert.Null(computeNodeToGet.LastBootTime);
+                Assert.Null(computeNodeToGet.State);
+                Assert.Null(computeNodeToGet.StartTaskInformation);
 
-                    //Refresh again with increased detail level
-                    computeNodeToGet.Refresh();
-                    CompareComputeNodeObjects(computeNodeToGet, computeNodeFromManager);
-                }
+                //Refresh again with increased detail level
+                computeNodeToGet.Refresh();
+                CompareComputeNodeObjects(computeNodeToGet, computeNodeFromManager);
             };
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -125,18 +121,16 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false))
-                {
-                    Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor();
-                    batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
+                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor();
+                batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
 
-                    List<ComputeNode> computeNodeList = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
+                List<ComputeNode> computeNodeList = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
-                    ComputeNode computeNode = computeNodeList.First();
+                ComputeNode computeNode = computeNodeList.First();
 
-                    Assert.Equal(2, computeNode.CustomBehaviors.Count);
-                    Assert.Contains(interceptor, computeNode.CustomBehaviors);
-                }
+                Assert.Equal(2, computeNode.CustomBehaviors.Count);
+                Assert.Contains(interceptor, computeNode.CustomBehaviors);
             };
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -149,150 +143,148 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug2329884Job-" + TestUtilities.GetMyName();
+                Protocol.RequestInterceptor interceptor = null;
+
+                try
                 {
-                    string jobId = "Bug2329884Job-" + TestUtilities.GetMyName();
-                    Protocol.RequestInterceptor interceptor = null;
+                    const string taskId = "hiWorld";
 
-                    try
+                    //
+                    // Create the job
+                    //
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+
+                    unboundJob.Commit();
+
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+
+                    boundJob.AddTask(myTask);
+
+                    testOutputHelper.WriteLine("Initial job commit()");
+
+                    //
+                    // Wait for task to go to completion
+                    //
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        new TimeSpan(0, 3 /*min*/, 0));
+
+                    CloudTask boundTask = boundJob.GetTask(taskId);
+
+                    //Since the compute node name comes back as "Node:<computeNodeId>" we need to split on : to get the actual compute node name
+                    string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
+
+                    //
+                    // Check recent tasks
+                    //
+                    ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
+
+                    testOutputHelper.WriteLine("Recent tasks:");
+
+                    foreach (TaskInformation recentTask in computeNode.RecentTasks)
                     {
-                        const string taskId = "hiWorld";
+                        testOutputHelper.WriteLine("Compute node has recent task Job: {0}, Task: {1}, State: {2}, Subtask: {3}",
+                            recentTask.JobId,
+                            recentTask.TaskId,
+                            recentTask.TaskState,
+                            recentTask.SubtaskId);
+                    }
 
-                        //
-                        // Create the job
-                        //
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+                    TaskInformation myTaskInfo = computeNode.RecentTasks.First(taskInfo => taskInfo.JobId.Equals(
+                        jobId, StringComparison.InvariantCultureIgnoreCase) &&
+                        taskInfo.TaskId.Equals(taskId, StringComparison.InvariantCultureIgnoreCase));
 
-                        unboundJob.Commit();
+                    Assert.Equal(TaskState.Completed, myTaskInfo.TaskState);
+                    Assert.NotNull(myTaskInfo.ExecutionInformation);
+                    Assert.Equal(0, myTaskInfo.ExecutionInformation.ExitCode);
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+                    //
+                    // Check compute node Error
+                    //
+                    const string expectedErrorCode = "TestErrorCode";
+                    const string expectedErrorMessage = "Test error message";
+                    const string nvpValue = "Test";
 
-                        boundJob.AddTask(myTask);
-
-                        testOutputHelper.WriteLine("Initial job commit()");
-
-                        //
-                        // Wait for task to go to completion
-                        //
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            new TimeSpan(0, 3 /*min*/, 0));
-
-                        CloudTask boundTask = boundJob.GetTask(taskId);
-
-                        //Since the compute node name comes back as "Node:<computeNodeId>" we need to split on : to get the actual compute node name
-                        string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
-
-                        //
-                        // Check recent tasks
-                        //
-                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
-
-                        testOutputHelper.WriteLine("Recent tasks:");
-
-                        foreach (TaskInformation recentTask in computeNode.RecentTasks)
+                    //We use mocking to return a fake compute node object here to test Compute Node Error because we cannot force one easily
+                    interceptor = new Protocol.RequestInterceptor((req =>
+                    {
+                        if (req is ComputeNodeGetBatchRequest)
                         {
-                            testOutputHelper.WriteLine("Compute node has recent task Job: {0}, Task: {1}, State: {2}, Subtask: {3}",
-                                recentTask.JobId,
-                                recentTask.TaskId,
-                                recentTask.TaskState,
-                                recentTask.SubtaskId);
-                        }
+                            var typedRequest = req as ComputeNodeGetBatchRequest;
 
-                        TaskInformation myTaskInfo = computeNode.RecentTasks.First(taskInfo => taskInfo.JobId.Equals(
-                            jobId, StringComparison.InvariantCultureIgnoreCase) &&
-                            taskInfo.TaskId.Equals(taskId, StringComparison.InvariantCultureIgnoreCase));
-
-                        Assert.Equal(TaskState.Completed, myTaskInfo.TaskState);
-                        Assert.NotNull(myTaskInfo.ExecutionInformation);
-                        Assert.Equal(0, myTaskInfo.ExecutionInformation.ExitCode);
-
-                        //
-                        // Check compute node Error
-                        //
-                        const string expectedErrorCode = "TestErrorCode";
-                        const string expectedErrorMessage = "Test error message";
-                        const string nvpValue = "Test";
-
-                        //We use mocking to return a fake compute node object here to test Compute Node Error because we cannot force one easily
-                        interceptor = new Protocol.RequestInterceptor((req =>
-                        {
-                            if (req is ComputeNodeGetBatchRequest)
+                            typedRequest.ServiceRequestFunc = (token) =>
                             {
-                                var typedRequest = req as ComputeNodeGetBatchRequest;
+                                var response = new AzureOperationResponse<Protocol.Models.ComputeNode, Protocol.Models.ComputeNodeGetHeaders>();
 
-                                typedRequest.ServiceRequestFunc = (token) =>
-                                {
-                                    var response = new AzureOperationResponse<Protocol.Models.ComputeNode, Protocol.Models.ComputeNodeGetHeaders>();
-
-                                    List<Protocol.Models.ComputeNodeError> errors =
-                                        new List<Protocol.Models.ComputeNodeError>();
+                                List<Protocol.Models.ComputeNodeError> errors =
+                                    new List<Protocol.Models.ComputeNodeError>();
 
                                     //Generate first Compute Node Error
                                     List<Protocol.Models.NameValuePair> nvps = new List<Protocol.Models.NameValuePair>
-                                    {
+                                {
                                         new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
-                                    };
+                                };
 
-                                    Protocol.Models.ComputeNodeError error1 = new Protocol.Models.ComputeNodeError();
-                                    error1.Code = expectedErrorCode;
-                                    error1.Message = expectedErrorMessage;
-                                    error1.ErrorDetails = nvps;
+                                Protocol.Models.ComputeNodeError error1 = new Protocol.Models.ComputeNodeError();
+                                error1.Code = expectedErrorCode;
+                                error1.Message = expectedErrorMessage;
+                                error1.ErrorDetails = nvps;
 
-                                    errors.Add(error1);
+                                errors.Add(error1);
 
                                     //Generate second Compute Node Error
                                     nvps = new List<Protocol.Models.NameValuePair>
-                                    {
+                                {
                                         new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
-                                    };
-
-                                    Protocol.Models.ComputeNodeError error2 = new Protocol.Models.ComputeNodeError();
-                                    error2.Code = expectedErrorCode;
-                                    error2.Message = expectedErrorMessage;
-                                    error2.ErrorDetails = nvps;
-
-                                    errors.Add(error2);
-
-                                    Protocol.Models.ComputeNode protoComputeNode = new Protocol.Models.ComputeNode();
-                                    protoComputeNode.Id = computeNodeId;
-                                    protoComputeNode.State = Protocol.Models.ComputeNodeState.Idle;
-                                    protoComputeNode.Errors = errors;
-
-                                    response.Body = protoComputeNode;
-
-                                    return Task.FromResult(response);
                                 };
-                            }
-                        }));
 
-                        batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
+                                Protocol.Models.ComputeNodeError error2 = new Protocol.Models.ComputeNodeError();
+                                error2.Code = expectedErrorCode;
+                                error2.Message = expectedErrorMessage;
+                                error2.ErrorDetails = nvps;
 
-                        computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
+                                errors.Add(error2);
 
-                        Assert.Equal(computeNodeId, computeNode.Id);
-                        Assert.NotNull(computeNode.Errors);
-                        Assert.Equal(2, computeNode.Errors.Count());
+                                Protocol.Models.ComputeNode protoComputeNode = new Protocol.Models.ComputeNode();
+                                protoComputeNode.Id = computeNodeId;
+                                protoComputeNode.State = Protocol.Models.ComputeNodeState.Idle;
+                                protoComputeNode.Errors = errors;
 
-                        foreach (ComputeNodeError computeNodeError in computeNode.Errors)
-                        {
-                            Assert.Equal(expectedErrorCode, computeNodeError.Code);
-                            Assert.Equal(expectedErrorMessage, computeNodeError.Message);
-                            Assert.NotNull(computeNodeError.ErrorDetails);
-                            Assert.Single(computeNodeError.ErrorDetails);
-                            Assert.Contains(nvpValue, computeNodeError.ErrorDetails.First().Name);
+                                response.Body = protoComputeNode;
+
+                                return Task.FromResult(response);
+                            };
                         }
-                    }
-                    finally
+                    }));
+
+                    batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
+
+                    computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
+
+                    Assert.Equal(computeNodeId, computeNode.Id);
+                    Assert.NotNull(computeNode.Errors);
+                    Assert.Equal(2, computeNode.Errors.Count());
+
+                    foreach (ComputeNodeError computeNodeError in computeNode.Errors)
                     {
-                        batchCli.JobOperations.DeleteJob(jobId);
+                        Assert.Equal(expectedErrorCode, computeNodeError.Code);
+                        Assert.Equal(expectedErrorMessage, computeNodeError.Message);
+                        Assert.NotNull(computeNodeError.ErrorDetails);
+                        Assert.Single(computeNodeError.ErrorDetails);
+                        Assert.Contains(nvpValue, computeNodeError.ErrorDetails.First().Name);
                     }
+                }
+                finally
+                {
+                    batchCli.JobOperations.DeleteJob(jobId);
                 }
             };
 
@@ -306,184 +298,182 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                // names to create/delete
+                List<string> names = new List<string>() { TestUtilities.GetMyName(), TestUtilities.GetMyName() + "1", TestUtilities.GetMyName() + "2", TestUtilities.GetMyName() + "3", TestUtilities.GetMyName() + "4" };
+
+                // pick a compute node to victimize with user accounts
+                IEnumerable<ComputeNode> ienmComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
+                List<ComputeNode> computeNodeList = new List<ComputeNode>(ienmComputeNodes);
+                ComputeNode computeNode = computeNodeList[0];
+
+                try
                 {
-                    // names to create/delete
-                    List<string> names = new List<string>() { TestUtilities.GetMyName(), TestUtilities.GetMyName() + "1", TestUtilities.GetMyName() + "2", TestUtilities.GetMyName() + "3", TestUtilities.GetMyName() + "4" };
+                    string rdpFileName = "Bug1770933.rdp";
 
-                    // pick a compute node to victimize with user accounts
-                    IEnumerable<ComputeNode> ienmComputeNodes = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId);
-                    List<ComputeNode> computeNodeList = new List<ComputeNode>(ienmComputeNodes);
-                    ComputeNode computeNode = computeNodeList[0];
-
-                    try
+                    // test user public constructor and IPoolMgr verbs
                     {
-                        string rdpFileName = "Bug1770933.rdp";
+                        ComputeNodeUser newUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
 
-                        // test user public constructor and IPoolMgr verbs
+                        newUser.Name = names[0];
+                        newUser.IsAdmin = true;
+                        newUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
+                        newUser.Password = @"!!Admin!!";
+
+                        // commit that creates/adds the user
+                        newUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
+
+                        // now update the user's password
+                        newUser.Password = @"!!!Admin!!!";
+
+                        // commit that updates
+                        newUser.Commit(ComputeNodeUserCommitSemantics.UpdateUser);
+
+                        // clean up from prev run
+                        if (File.Exists(rdpFileName))
                         {
-                            ComputeNodeUser newUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
-
-                            newUser.Name = names[0];
-                            newUser.IsAdmin = true;
-                            newUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
-                            newUser.Password = @"!!Admin!!";
-
-                            // commit that creates/adds the user
-                            newUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
-
-                            // now update the user's password
-                            newUser.Password = @"!!!Admin!!!";
-
-                            // commit that updates
-                            newUser.Commit(ComputeNodeUserCommitSemantics.UpdateUser);
-
-                            // clean up from prev run
-                            if (File.Exists(rdpFileName))
-                            {
-                                File.Delete(rdpFileName);
-                            }
-
-                            // pull the rdp file
-                            batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpFileName);
-
-                            // simple validation tests on the rdp file
-                            TestFileExistsAndHasLength(rdpFileName);
-
-                            // cleanup the rdp file
                             File.Delete(rdpFileName);
-
-                            // "test" delete user from IPoolMgr
-                            // TODO: when GET/LIST User is available we should close the loop and confirm the user is gone.
-                            batchCli.PoolOperations.DeleteComputeNodeUser(poolFixture.PoolId, computeNode.Id, newUser.Name);
                         }
 
-                        // test IPoolMgr CreateUser
-                        {
-                            ComputeNodeUser pmcUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
+                        // pull the rdp file
+                        batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpFileName);
 
-                            pmcUser.Name = names[1];
-                            pmcUser.IsAdmin = true;
-                            pmcUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
-                            pmcUser.Password = @"!!!Admin!!!";
+                        // simple validation tests on the rdp file
+                        TestFileExistsAndHasLength(rdpFileName);
 
-                            // add the user
-                            pmcUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
+                        // cleanup the rdp file
+                        File.Delete(rdpFileName);
 
-                            // pull rdp file
-                            batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpFileName);
-
-                            // simple validation on rdp file
-                            TestFileExistsAndHasLength(rdpFileName);
-
-                            // cleanup
-                            File.Delete(rdpFileName);
-
-                            // delete user
-                            batchCli.PoolOperations.DeleteComputeNodeUser(poolFixture.PoolId, computeNode.Id, pmcUser.Name);
-                        }
-
-                        // test IComputeNode verbs
-                        {
-                            ComputeNodeUser poolMgrUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
-
-                            poolMgrUser.Name = names[2];
-                            poolMgrUser.IsAdmin = true;
-                            poolMgrUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
-                            poolMgrUser.Password = @"!!!Admin!!!";
-
-                            poolMgrUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
-
-                            // pull rdp file
-                            computeNode.GetRDPFile(rdpFileName);
-
-                            // simple validation on rdp file
-                            TestFileExistsAndHasLength(rdpFileName);
-
-                            // cleanup
-                            File.Delete(rdpFileName);
-
-                            // delete user
-                            computeNode.DeleteComputeNodeUser(poolMgrUser.Name);
-                        }
-
-                        // test ComputeNodeUser.Delete
-                        {
-                            ComputeNodeUser usrDelete = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
-
-                            usrDelete.Name = names[3];
-                            usrDelete.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
-                            usrDelete.Password = @"!!!Admin!!!";
-
-                            usrDelete.Commit(ComputeNodeUserCommitSemantics.AddUser);
-
-                            usrDelete.Delete();
-                        }
-
-                        // test rdp-by-stream IPoolMgr and IComputeNode
-                        // the by-stream paths do not converge with the by-filename paths until IProtocol so we test them seperately
-                        {
-                            ComputeNodeUser byStreamUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
-
-                            byStreamUser.Name = names[4];
-                            byStreamUser.IsAdmin = true;
-                            byStreamUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
-                            byStreamUser.Password = @"!!!Admin!!!";
-
-                            byStreamUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
-
-                            // IPoolMgr
-                            using (Stream rdpStreamPoolMgr = File.Create(rdpFileName))
-                            {
-                                batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpStreamPoolMgr);
-
-                                rdpStreamPoolMgr.Flush();
-                                rdpStreamPoolMgr.Close();
-
-                                TestFileExistsAndHasLength(rdpFileName);
-
-                                File.Delete(rdpFileName);
-                            }
-
-                            // IComputeNode
-                            using (Stream rdpViaIComputeNode = File.Create(rdpFileName))
-                            {
-                                computeNode.GetRDPFile(rdpViaIComputeNode);
-
-                                rdpViaIComputeNode.Flush();
-                                rdpViaIComputeNode.Close();
-
-                                TestFileExistsAndHasLength(rdpFileName);
-
-                                File.Delete(rdpFileName);
-                            }
-
-                            // delete the user account
-                            byStreamUser.Delete();
-                        }
+                        // "test" delete user from IPoolMgr
+                        // TODO: when GET/LIST User is available we should close the loop and confirm the user is gone.
+                        batchCli.PoolOperations.DeleteComputeNodeUser(poolFixture.PoolId, computeNode.Id, newUser.Name);
                     }
-                    finally
+
+                    // test IPoolMgr CreateUser
                     {
-                        // clear any old accounts
-                        foreach (string curName in names)
+                        ComputeNodeUser pmcUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
+
+                        pmcUser.Name = names[1];
+                        pmcUser.IsAdmin = true;
+                        pmcUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
+                        pmcUser.Password = @"!!!Admin!!!";
+
+                        // add the user
+                        pmcUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
+
+                        // pull rdp file
+                        batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpFileName);
+
+                        // simple validation on rdp file
+                        TestFileExistsAndHasLength(rdpFileName);
+
+                        // cleanup
+                        File.Delete(rdpFileName);
+
+                        // delete user
+                        batchCli.PoolOperations.DeleteComputeNodeUser(poolFixture.PoolId, computeNode.Id, pmcUser.Name);
+                    }
+
+                    // test IComputeNode verbs
+                    {
+                        ComputeNodeUser poolMgrUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
+
+                        poolMgrUser.Name = names[2];
+                        poolMgrUser.IsAdmin = true;
+                        poolMgrUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
+                        poolMgrUser.Password = @"!!!Admin!!!";
+
+                        poolMgrUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
+
+                        // pull rdp file
+                        computeNode.GetRDPFile(rdpFileName);
+
+                        // simple validation on rdp file
+                        TestFileExistsAndHasLength(rdpFileName);
+
+                        // cleanup
+                        File.Delete(rdpFileName);
+
+                        // delete user
+                        computeNode.DeleteComputeNodeUser(poolMgrUser.Name);
+                    }
+
+                    // test ComputeNodeUser.Delete
+                    {
+                        ComputeNodeUser usrDelete = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
+
+                        usrDelete.Name = names[3];
+                        usrDelete.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
+                        usrDelete.Password = @"!!!Admin!!!";
+
+                        usrDelete.Commit(ComputeNodeUserCommitSemantics.AddUser);
+
+                        usrDelete.Delete();
+                    }
+
+                    // test rdp-by-stream IPoolMgr and IComputeNode
+                    // the by-stream paths do not converge with the by-filename paths until IProtocol so we test them seperately
+                    {
+                        ComputeNodeUser byStreamUser = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
+
+                        byStreamUser.Name = names[4];
+                        byStreamUser.IsAdmin = true;
+                        byStreamUser.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(1.0);
+                        byStreamUser.Password = @"!!!Admin!!!";
+
+                        byStreamUser.Commit(ComputeNodeUserCommitSemantics.AddUser);
+
+                        // IPoolMgr
+                        using (Stream rdpStreamPoolMgr = File.Create(rdpFileName))
                         {
-                            bool hitException = false;
+                            batchCli.PoolOperations.GetRDPFile(poolFixture.PoolId, computeNode.Id, rdpStreamPoolMgr);
 
-                            try
-                            {
-                                ComputeNodeUser deleteThis = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
-                                deleteThis.Name = curName;
-                                deleteThis.Delete();
-                            }
-                            catch (BatchException ex)
-                            {
-                                Assert.Equal(BatchErrorCodeStrings.NodeUserNotFound, ex.RequestInformation.BatchError.Code);
-                                hitException = true;
-                             
-                            }
+                            rdpStreamPoolMgr.Flush();
+                            rdpStreamPoolMgr.Close();
 
-                            Assert.True(hitException, "Should have hit exception on user: " + curName + ", compute node: " + computeNode.Id + ".");
+                            TestFileExistsAndHasLength(rdpFileName);
+
+                            File.Delete(rdpFileName);
                         }
+
+                        // IComputeNode
+                        using (Stream rdpViaIComputeNode = File.Create(rdpFileName))
+                        {
+                            computeNode.GetRDPFile(rdpViaIComputeNode);
+
+                            rdpViaIComputeNode.Flush();
+                            rdpViaIComputeNode.Close();
+
+                            TestFileExistsAndHasLength(rdpFileName);
+
+                            File.Delete(rdpFileName);
+                        }
+
+                        // delete the user account
+                        byStreamUser.Delete();
+                    }
+                }
+                finally
+                {
+                    // clear any old accounts
+                    foreach (string curName in names)
+                    {
+                        bool hitException = false;
+
+                        try
+                        {
+                            ComputeNodeUser deleteThis = batchCli.PoolOperations.CreateComputeNodeUser(poolFixture.PoolId, computeNode.Id);
+                            deleteThis.Name = curName;
+                            deleteThis.Delete();
+                        }
+                        catch (BatchException ex)
+                        {
+                            Assert.Equal(BatchErrorCodeStrings.NodeUserNotFound, ex.RequestInformation.BatchError.Code);
+                            hitException = true;
+
+                        }
+
+                        Assert.True(hitException, "Should have hit exception on user: " + curName + ", compute node: " + computeNode.Id + ".");
                     }
                 }
             };
@@ -498,78 +488,76 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
+
+                testOutputHelper.WriteLine("Getting pool");
+                StartTask poolStartTask = pool.StartTask;
+
+                Assert.NotNull(poolStartTask);
+                Assert.NotNull(poolStartTask.EnvironmentSettings);
+
+                IEnumerable<ComputeNode> computeNodes = pool.ListComputeNodes();
+
+                Assert.True(computeNodes.Any());
+
+                testOutputHelper.WriteLine("Checking every compute nodes start task in the pool matches the pools start task");
+                foreach (ComputeNode computeNode in computeNodes)
                 {
-                    CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
+                    testOutputHelper.WriteLine("Checking start task of compute node: {0}", computeNode.Id);
 
-                    testOutputHelper.WriteLine("Getting pool");
-                    StartTask poolStartTask = pool.StartTask;
+                    //Check that the property is correctly set on each compute node
+                    Assert.NotNull(computeNode.StartTask);
 
-                    Assert.NotNull(poolStartTask);
-                    Assert.NotNull(poolStartTask.EnvironmentSettings);
+                    Assert.Equal(poolStartTask.CommandLine, computeNode.StartTask.CommandLine);
+                    Assert.Equal(poolStartTask.MaxTaskRetryCount, computeNode.StartTask.MaxTaskRetryCount);
+                    Assert.Equal(AutoUserScope.Pool, poolStartTask.UserIdentity.AutoUser.Scope);
+                    Assert.Equal(AutoUserScope.Pool, computeNode.StartTask.UserIdentity.AutoUser.Scope);
+                    Assert.Equal(poolStartTask.WaitForSuccess, computeNode.StartTask.WaitForSuccess);
 
-                    IEnumerable<ComputeNode> computeNodes = pool.ListComputeNodes();
-
-                    Assert.True(computeNodes.Any());
-
-                    testOutputHelper.WriteLine("Checking every compute nodes start task in the pool matches the pools start task");
-                    foreach (ComputeNode computeNode in computeNodes)
+                    if (poolStartTask.EnvironmentSettings != null)
                     {
-                        testOutputHelper.WriteLine("Checking start task of compute node: {0}", computeNode.Id);
-
-                        //Check that the property is correctly set on each compute node
-                        Assert.NotNull(computeNode.StartTask);
-
-                        Assert.Equal(poolStartTask.CommandLine, computeNode.StartTask.CommandLine);
-                        Assert.Equal(poolStartTask.MaxTaskRetryCount, computeNode.StartTask.MaxTaskRetryCount);
-                        Assert.Equal(AutoUserScope.Pool, poolStartTask.UserIdentity.AutoUser.Scope);
-                        Assert.Equal(AutoUserScope.Pool, computeNode.StartTask.UserIdentity.AutoUser.Scope);
-                        Assert.Equal(poolStartTask.WaitForSuccess, computeNode.StartTask.WaitForSuccess);
-
-                        if (poolStartTask.EnvironmentSettings != null)
+                        Assert.Equal(poolStartTask.EnvironmentSettings.Count, computeNode.StartTask.EnvironmentSettings.Count);
+                        foreach (EnvironmentSetting environmentSetting in poolStartTask.EnvironmentSettings)
                         {
-                            Assert.Equal(poolStartTask.EnvironmentSettings.Count, computeNode.StartTask.EnvironmentSettings.Count);
-                            foreach (EnvironmentSetting environmentSetting in poolStartTask.EnvironmentSettings)
-                            {
-                                EnvironmentSetting matchingEnvSetting = computeNode.StartTask.EnvironmentSettings.FirstOrDefault(envSetting => envSetting.Name == environmentSetting.Name);
+                            EnvironmentSetting matchingEnvSetting = computeNode.StartTask.EnvironmentSettings.FirstOrDefault(envSetting => envSetting.Name == environmentSetting.Name);
 
-                                Assert.NotNull(matchingEnvSetting);
-                                Assert.Equal(environmentSetting.Name, matchingEnvSetting.Name);
-                                Assert.Equal(environmentSetting.Value, matchingEnvSetting.Value);
-                            }
+                            Assert.NotNull(matchingEnvSetting);
+                            Assert.Equal(environmentSetting.Name, matchingEnvSetting.Name);
+                            Assert.Equal(environmentSetting.Value, matchingEnvSetting.Value);
                         }
+                    }
 
-                        if (poolStartTask.ResourceFiles != null)
+                    if (poolStartTask.ResourceFiles != null)
+                    {
+                        Assert.Equal(poolStartTask.ResourceFiles.Count, computeNode.StartTask.ResourceFiles.Count);
+
+                        foreach (ResourceFile resourceFile in poolStartTask.ResourceFiles)
                         {
-                            Assert.Equal(poolStartTask.ResourceFiles.Count, computeNode.StartTask.ResourceFiles.Count);
+                            ResourceFile matchingResourceFile = computeNode.StartTask.ResourceFiles.FirstOrDefault(item => item.HttpUrl == resourceFile.HttpUrl);
 
-                            foreach (ResourceFile resourceFile in poolStartTask.ResourceFiles)
-                            {
-                                ResourceFile matchingResourceFile = computeNode.StartTask.ResourceFiles.FirstOrDefault(item => item.HttpUrl == resourceFile.HttpUrl);
-
-                                Assert.NotNull(matchingResourceFile);
-                                Assert.Equal(resourceFile.HttpUrl, matchingResourceFile.HttpUrl);
-                                Assert.Equal(resourceFile.FilePath, matchingResourceFile.FilePath);
-                            }
+                            Assert.NotNull(matchingResourceFile);
+                            Assert.Equal(resourceFile.HttpUrl, matchingResourceFile.HttpUrl);
+                            Assert.Equal(resourceFile.FilePath, matchingResourceFile.FilePath);
                         }
+                    }
 
-                        //Try to set some properties of the compute node's start task and ensure it fails
+                    //Try to set some properties of the compute node's start task and ensure it fails
 
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.CommandLine = "Test"; });
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.MaxTaskRetryCount = 5; });
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.UserIdentity = new UserIdentity("foo"); });
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.WaitForSuccess = true; });
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.EnvironmentSettings = new List<EnvironmentSetting>(); });
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.CommandLine = "Test"; });
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.MaxTaskRetryCount = 5; });
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.UserIdentity = new UserIdentity("foo"); });
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.WaitForSuccess = true; });
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.EnvironmentSettings = new List<EnvironmentSetting>(); });
 
-                        if (computeNode.StartTask.EnvironmentSettings != null)
-                        {
-                            TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.EnvironmentSettings.Add(new EnvironmentSetting("test", "test")); });
-                        }
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.ResourceFiles = new List<ResourceFile>(); });
-                        if (computeNode.StartTask.ResourceFiles != null)
-                        {
-                            TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.ResourceFiles.Add(ResourceFile.FromUrl("test", "test")); });
-                        }
+                    if (computeNode.StartTask.EnvironmentSettings != null)
+                    {
+                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.EnvironmentSettings.Add(new EnvironmentSetting("test", "test")); });
+                    }
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.ResourceFiles = new List<ResourceFile>(); });
+                    if (computeNode.StartTask.ResourceFiles != null)
+                    {
+                        TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.ResourceFiles.Add(ResourceFile.FromUrl("test", "test")); });
                     }
                 }
             };
@@ -584,106 +572,104 @@ namespace BatchClientIntegrationTests
         {
             await SynchronizationContextHelper.RunTestAsync(async () =>
                 {
-                    using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                    using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                    TimeSpan refreshPollingTimeout = TimeSpan.FromMinutes(3);
+                    CloudPool pool = poolFixture.Pool;
+
+                    List<ComputeNode> nodes = pool.ListComputeNodes().ToList();
+
+                    Assert.True(nodes.Count > 0);
+
+                    // pick a victim compute node.  cleanup code needs this set
+                    ComputeNode victim = nodes[0];
+
+                    try
                     {
-                        TimeSpan refreshPollingTimeout = TimeSpan.FromMinutes(3);
-                        CloudPool pool = poolFixture.Pool;
+                        Assert.True(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState));
+                        Assert.True(victim.State.HasValue && (ComputeNodeState.Idle == victim.State));
 
-                        List<ComputeNode> nodes = pool.ListComputeNodes().ToList();
-
-                        Assert.True(nodes.Count > 0);
-
-                        // pick a victim compute node.  cleanup code needs this set
-                        ComputeNode victim = nodes[0];
-
-                        try
+                        // PoolOperations methods
                         {
-                            Assert.True(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState));
-                            Assert.True(victim.State.HasValue && (ComputeNodeState.Idle == victim.State));
+                            // disable task scheduling
+                            batchCli.PoolOperations.DisableComputeNodeScheduling(pool.Id, victim.Id, DisableComputeNodeSchedulingOption.Terminate);
 
-                            // PoolOperations methods
-                            {
-                                // disable task scheduling
-                                batchCli.PoolOperations.DisableComputeNodeScheduling(pool.Id, victim.Id, DisableComputeNodeSchedulingOption.Terminate);
+                            // Li says state change is not atomic so we will sleep
+                            // asserted above this node is idle so no need to wait for task fussery
+                            await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
+                                    refreshing: victim,
+                                    condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Disabled == victim.SchedulingState)),
+                                    timeout: refreshPollingTimeout).ConfigureAwait(false);
 
-                                // Li says state change is not atomic so we will sleep
-                                // asserted above this node is idle so no need to wait for task fussery
-                                await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
-                                        refreshing: victim,
-                                        condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Disabled == victim.SchedulingState)),
-                                        timeout: refreshPollingTimeout).ConfigureAwait(false);
+                            Assert.Equal(SchedulingState.Disabled, victim.SchedulingState);
 
-                                Assert.Equal(SchedulingState.Disabled, victim.SchedulingState);
+                            // enable task scheduling
+                            batchCli.PoolOperations.EnableComputeNodeScheduling(pool.Id, victim.Id);
 
-                                // enable task scheduling
-                                batchCli.PoolOperations.EnableComputeNodeScheduling(pool.Id, victim.Id);
+                            await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
+                                    refreshing: victim,
+                                    condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState)),
+                                    timeout: refreshPollingTimeout);
 
-                                await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
-                                        refreshing: victim,
-                                        condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState)),
-                                        timeout: refreshPollingTimeout);
-
-                                Assert.Equal(SchedulingState.Enabled, victim.SchedulingState);
-                            }
-
-                            // ComputeNode methods
-                            {
-                                // disable task scheduling
-
-                                victim.DisableScheduling(DisableComputeNodeSchedulingOption.TaskCompletion);
-
-                                await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
-                                        refreshing: victim,
-                                        condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Disabled == victim.SchedulingState)),
-                                        timeout: refreshPollingTimeout).ConfigureAwait(false);
-
-                                Assert.Equal(SchedulingState.Disabled, victim.SchedulingState);
-
-                                // enable task scheduling
-
-                                victim.EnableScheduling();
-
-                                await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
-                                        refreshing: victim,
-                                        condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState)),
-                                        timeout: refreshPollingTimeout).ConfigureAwait(false);
-
-                                Assert.Equal(SchedulingState.Enabled, victim.SchedulingState);
-
-                                // now test azureerror code for: NodeAlreadyInTargetSchedulingState
-                                bool gotCorrectException = false;
-
-                                try
-                                {
-                                    victim.EnableScheduling();  // it is already enabled so this should trigger exception
-                                }
-                                catch (Exception ex)
-                                {
-                                    TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.NodeAlreadyInTargetSchedulingState, testOutputHelper);
-
-                                    gotCorrectException = true;
-                                }
-
-                                if (!gotCorrectException)
-                                {
-                                    throw new Exception("OnlineOfflineTest: failed to see an exception for NodeAlreadyInTargetSchedulingState test");
-                                }
-                            }
+                            Assert.Equal(SchedulingState.Enabled, victim.SchedulingState);
                         }
-                        finally // restore state of victim compute node
+
+                        // ComputeNode methods
                         {
+                            // disable task scheduling
+
+                            victim.DisableScheduling(DisableComputeNodeSchedulingOption.TaskCompletion);
+
+                            await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
+                                    refreshing: victim,
+                                    condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Disabled == victim.SchedulingState)),
+                                    timeout: refreshPollingTimeout).ConfigureAwait(false);
+
+                            Assert.Equal(SchedulingState.Disabled, victim.SchedulingState);
+
+                            // enable task scheduling
+
+                            victim.EnableScheduling();
+
+                            await TestUtilities.RefreshBasedPollingWithTimeoutAsync(
+                                    refreshing: victim,
+                                    condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState)),
+                                    timeout: refreshPollingTimeout).ConfigureAwait(false);
+
+                            Assert.Equal(SchedulingState.Enabled, victim.SchedulingState);
+
+                            // now test azureerror code for: NodeAlreadyInTargetSchedulingState
+                            bool gotCorrectException = false;
+
                             try
                             {
-                                // do not pollute the shared pool with disabled scheduling
-                                if (null != victim)
-                                {
-                                    victim.EnableScheduling();
-                                }
+                                victim.EnableScheduling();  // it is already enabled so this should trigger exception
                             }
                             catch (Exception ex)
                             {
-                                testOutputHelper.WriteLine(string.Format("OnlineOfflineTest: exception during exit trying to restore scheduling state: {0}", ex.ToString()));
+                                TestUtilities.AssertIsBatchExceptionAndHasCorrectAzureErrorCode(ex, Microsoft.Azure.Batch.Common.BatchErrorCodeStrings.NodeAlreadyInTargetSchedulingState, testOutputHelper);
+
+                                gotCorrectException = true;
                             }
+
+                            if (!gotCorrectException)
+                            {
+                                throw new Exception("OnlineOfflineTest: failed to see an exception for NodeAlreadyInTargetSchedulingState test");
+                            }
+                        }
+                    }
+                    finally // restore state of victim compute node
+                    {
+                        try
+                        {
+                            // do not pollute the shared pool with disabled scheduling
+                            if (null != victim)
+                            {
+                                victim.EnableScheduling();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            testOutputHelper.WriteLine(string.Format("OnlineOfflineTest: exception during exit trying to restore scheduling state: {0}", ex.ToString()));
                         }
                     }
                 },
@@ -735,52 +721,50 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                CloudPool sharedPool = poolFixture.Pool;
+                List<string> cnuNamesToDelete = new List<string>();
+
+                // pick a compute node to victimize with user accounts
+                var nodes = sharedPool.ListComputeNodes().ToList();
+
+                ComputeNode cn = nodes[0];
+
+                try
                 {
-                    CloudPool sharedPool = poolFixture.Pool;
-                    List<string> cnuNamesToDelete = new List<string>();
+                    ComputeNodeUser bob = batchCli.PoolOperations.CreateComputeNodeUser(sharedPool.Id, cn.Id);
 
-                    // pick a compute node to victimize with user accounts
-                    var nodes = sharedPool.ListComputeNodes().ToList();
+                    bob.Name = "bob";
+                    bob.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(25);
+                    bob.Password = "password";
+                    bob.SshPublicKey = "base64==";
 
-                    ComputeNode cn = nodes[0];
+                    cnuNamesToDelete.Add(bob.Name); // remember to clean this up
 
+                    bob.Commit(ComputeNodeUserCommitSemantics.AddUser);
+
+                    bob.SshPublicKey = "base65==";
+
+                    bob.Commit(ComputeNodeUserCommitSemantics.UpdateUser);
+
+                    // TODO:  need to close the loop on this somehow... move to unit/interceptor-based?
+                    //        currently the server is timing out.
+
+                }
+                finally
+                {
+                    // clear any old accounts
                     try
                     {
-                        ComputeNodeUser bob = batchCli.PoolOperations.CreateComputeNodeUser(sharedPool.Id, cn.Id);
-
-                        bob.Name = "bob";
-                        bob.ExpiryTime = DateTime.UtcNow + TimeSpan.FromHours(25);
-                        bob.Password = "password";
-                        bob.SshPublicKey = "base64==";
-
-                        cnuNamesToDelete.Add(bob.Name); // remember to clean this up
-
-                        bob.Commit(ComputeNodeUserCommitSemantics.AddUser);
-
-                        bob.SshPublicKey = "base65==";
-
-                        bob.Commit(ComputeNodeUserCommitSemantics.UpdateUser);
-
-                        // TODO:  need to close the loop on this somehow... move to unit/interceptor-based?
-                        //        currently the server is timing out.
-
+                        foreach (string curCNUName in cnuNamesToDelete)
+                        {
+                            testOutputHelper.WriteLine("TestComputeNodeUserIAAS attempting to delete the following <nodeid,user>: <{0},{1}>", cn.Id, curCNUName);
+                            cn.DeleteComputeNodeUser(curCNUName);
+                        }
                     }
-                    finally
+                    catch (Exception ex)
                     {
-                        // clear any old accounts
-                        try
-                        {
-                            foreach (string curCNUName in cnuNamesToDelete)
-                            {
-                                testOutputHelper.WriteLine("TestComputeNodeUserIAAS attempting to delete the following <nodeid,user>: <{0},{1}>", cn.Id, curCNUName);
-                                cn.DeleteComputeNodeUser(curCNUName);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            testOutputHelper.WriteLine("TestComputeNodeUserIAAS: exception deleting user account.  ex: " + ex.ToString());
-                        }
+                        testOutputHelper.WriteLine("TestComputeNodeUserIAAS: exception deleting user account.  ex: " + ex.ToString());
                     }
                 }
             };
@@ -795,55 +779,52 @@ namespace BatchClientIntegrationTests
         {
             Func<Task> test = async () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                const string containerName = "computenodelogscontainer";
+
+                // Generate a storage container URL
+                StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
+                BlobServiceClient blobClient = BlobUtilities.GetBlobServiceClient(storageAccount);
+                BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, blobClient, storageAccount);
+
+                try
                 {
+                    containerClient.CreateIfNotExists();
+                    string sasUri = BlobUtilities.GetWriteableSasUri(containerClient, storageAccount);
 
-                    const string containerName = "computenodelogscontainer";
+                    var blobs = containerClient.GetAllBlobs();
 
-                    // Generate a storage container URL
-                    StagingStorageAccount storageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
-                    BlobServiceClient blobClient = BlobUtilities.GetBlobServiceClient(storageAccount);
-                    BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, blobClient, storageAccount);
+                    // Ensure that there are no items in the container to begin with
+                    Assert.Empty(blobs);
 
-                    try
+                    var startTime = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(5));
+
+                    var node = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).First();
+                    var result = batchCli.PoolOperations.UploadComputeNodeBatchServiceLogs(
+                        poolFixture.PoolId,
+                        node.Id,
+                        sasUri,
+                        startTime);
+
+                    Assert.NotEqual(0, result.NumberOfFilesUploaded);
+                    Assert.NotEmpty(result.VirtualDirectoryName);
+
+                    // Allow up to 2m for files to get uploaded
+                    DateTime timeoutAt = DateTime.UtcNow.AddMinutes(2);
+                    while (DateTime.UtcNow < timeoutAt)
                     {
-                        containerClient.CreateIfNotExists();
-                        string sasUri = BlobUtilities.GetWriteableSasUri(containerClient, storageAccount);
-
-                        var blobs = containerClient.GetAllBlobs();
-
-                        // Ensure that there are no items in the container to begin with
-                        Assert.Empty(blobs);
-
-                        var startTime = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(5));
-
-                        var node = batchCli.PoolOperations.ListComputeNodes(poolFixture.PoolId).First();
-                        var result = batchCli.PoolOperations.UploadComputeNodeBatchServiceLogs(
-                            poolFixture.PoolId,
-                            node.Id,
-                            sasUri,
-                            startTime);
-
-                        Assert.NotEqual(0, result.NumberOfFilesUploaded);
-                        Assert.NotEmpty(result.VirtualDirectoryName);
-
-                        // Allow up to 2m for files to get uploaded
-                        DateTime timeoutAt = DateTime.UtcNow.AddMinutes(2);
-                        while (DateTime.UtcNow < timeoutAt)
+                        blobs = containerClient.GetAllBlobs();
+                        if (blobs.Any())
                         {
-                            blobs = containerClient.GetAllBlobs();
-                            if (blobs.Any())
-                            {
-                                break;
-                            }
+                            break;
                         }
+                    }
 
-                        Assert.NotEmpty(blobs);
-                    }
-                    finally
-                    {
-                        containerClient.DeleteIfExists();
-                    }
+                    Assert.NotEmpty(blobs);
+                }
+                finally
+                {
+                    containerClient.DeleteIfExists();
                 }
             };
 
@@ -857,41 +838,39 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                CloudPool sharedPool = poolFixture.Pool;
+
+                try
                 {
-                    CloudPool sharedPool = poolFixture.Pool;
+                    // get a compute node.
+                    // get its RLS via PoolOps and via CN
+                    // Assert there are values and that the values are equal
 
-                    try
-                    {
-                        // get a compute node.
-                        // get its RLS via PoolOps and via CN
-                        // Assert there are values and that the values are equal
+                    var nodes = sharedPool.ListComputeNodes().ToList();
 
-                        var nodes = sharedPool.ListComputeNodes().ToList();
+                    Assert.Single(nodes);
 
-                        Assert.Single(nodes);
+                    ComputeNode cn = nodes[0];
 
-                        ComputeNode cn = nodes[0];
+                    // get the RLS via each object
+                    RemoteLoginSettings rlsViaPoolOps = batchCli.PoolOperations.GetRemoteLoginSettings(sharedPool.Id, cn.Id);
+                    RemoteLoginSettings rlsViaNode = cn.GetRemoteLoginSettings();
 
-                        // get the RLS via each object
-                        RemoteLoginSettings rlsViaPoolOps = batchCli.PoolOperations.GetRemoteLoginSettings(sharedPool.Id, cn.Id);
-                        RemoteLoginSettings rlsViaNode = cn.GetRemoteLoginSettings();
+                    // they must have RLS
+                    Assert.NotNull(rlsViaNode);
+                    Assert.NotNull(rlsViaPoolOps);
 
-                        // they must have RLS
-                        Assert.NotNull(rlsViaNode);
-                        Assert.NotNull(rlsViaPoolOps);
+                    // there must be an IP in each RLS
+                    Assert.False(string.IsNullOrWhiteSpace(rlsViaPoolOps.IPAddress));
+                    Assert.False(string.IsNullOrWhiteSpace(rlsViaNode.IPAddress));
 
-                        // there must be an IP in each RLS
-                        Assert.False(string.IsNullOrWhiteSpace(rlsViaPoolOps.IPAddress));
-                        Assert.False(string.IsNullOrWhiteSpace(rlsViaNode.IPAddress));
-                        
-                        // the ports must match
-                        Assert.Equal(expected: rlsViaNode.Port, actual: rlsViaPoolOps.Port);
-                    }
-                    finally
-                    {
-                        // cleanup goes here
-                    }
+                    // the ports must match
+                    Assert.Equal(expected: rlsViaNode.Port, actual: rlsViaPoolOps.Port);
+                }
+                finally
+                {
+                    // cleanup goes here
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
@@ -127,7 +127,7 @@ namespace BatchClientIntegrationTests
             {
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false))
                 {
-                    Microsoft.Azure.Batch.Protocol.RequestInterceptor interceptor = new Microsoft.Azure.Batch.Protocol.RequestInterceptor();
+                    Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor();
                     batchCli.PoolOperations.CustomBehaviors.Add(interceptor);
 
                     List<ComputeNode> computeNodeList = batchCli.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
@@ -610,7 +610,7 @@ namespace BatchClientIntegrationTests
                                         condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Disabled == victim.SchedulingState)),
                                         timeout: refreshPollingTimeout).ConfigureAwait(false);
 
-                                Assert.Equal<SchedulingState?>(SchedulingState.Disabled, victim.SchedulingState);
+                                Assert.Equal(SchedulingState.Disabled, victim.SchedulingState);
 
                                 // enable task scheduling
                                 batchCli.PoolOperations.EnableComputeNodeScheduling(pool.Id, victim.Id);
@@ -620,7 +620,7 @@ namespace BatchClientIntegrationTests
                                         condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState)),
                                         timeout: refreshPollingTimeout);
 
-                                Assert.Equal<SchedulingState?>(SchedulingState.Enabled, victim.SchedulingState);
+                                Assert.Equal(SchedulingState.Enabled, victim.SchedulingState);
                             }
 
                             // ComputeNode methods
@@ -634,7 +634,7 @@ namespace BatchClientIntegrationTests
                                         condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Disabled == victim.SchedulingState)),
                                         timeout: refreshPollingTimeout).ConfigureAwait(false);
 
-                                Assert.Equal<SchedulingState?>(SchedulingState.Disabled, victim.SchedulingState);
+                                Assert.Equal(SchedulingState.Disabled, victim.SchedulingState);
 
                                 // enable task scheduling
 
@@ -645,7 +645,7 @@ namespace BatchClientIntegrationTests
                                         condition: () => Task.FromResult(victim.SchedulingState.HasValue && (SchedulingState.Enabled == victim.SchedulingState)),
                                         timeout: refreshPollingTimeout).ConfigureAwait(false);
 
-                                Assert.Equal<SchedulingState?>(SchedulingState.Enabled, victim.SchedulingState);
+                                Assert.Equal(SchedulingState.Enabled, victim.SchedulingState);
 
                                 // now test azureerror code for: NodeAlreadyInTargetSchedulingState
                                 bool gotCorrectException = false;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
@@ -777,7 +777,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task ComputeNodeUploadLogs()
         {
-            Func<Task> test = async () =>
+            Action test = () =>
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 const string containerName = "computenodelogscontainer";
@@ -828,7 +828,7 @@ namespace BatchClientIntegrationTests
                 }
             };
 
-            await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
+            SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
 
         [Fact]

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
@@ -57,7 +57,7 @@
                     {
                         CloudJob quickJob = batchCli.JobOperations.CreateJob();
                         quickJob.Id = jobId;
-                        quickJob.PoolInformation = new PoolInformation() { PoolId = this.poolFixture.PoolId };
+                        quickJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
                         quickJob.Commit();
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
@@ -66,9 +66,7 @@
                         // first we have local files that we want pushed to the compute node before the commandline is invoked
                         FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, storageCreds);                // use "default" mapping to base name of local file
 
-                        myTask.FilesToStage = new List<IFileStagingProvider>();
-
-                        myTask.FilesToStage.Add(wordsDotText);
+                        myTask.FilesToStage = new List<IFileStagingProvider> { wordsDotText };
 
                         // add the task to the job
                         var artifacts = boundJob.AddTask(myTask);
@@ -81,7 +79,7 @@
 
                         // test to ensure the task is read only
                         TestUtilities.AssertThrows<InvalidOperationException>(() => myTask.FilesToStage = new List<IFileStagingProvider>());
-                        
+
                         // Open the new Job as bound.
                         CloudPool boundPool = batchCli.PoolOperations.GetPool(boundJob.ExecutionInformation.PoolId);
 
@@ -100,19 +98,19 @@
                             // spam/logging interceptor
                             new RequestInterceptor((x) =>
                             {
-                                this.testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
+                                testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
 
                                 try
                                 {
                                     // print out the compute node states... we are actually waiting on the compute nodes
                                     List<ComputeNode> allComputeNodes = boundPool.ListComputeNodes().ToList();
 
-                                    this.testOutputHelper.WriteLine("    #compute nodes: " + allComputeNodes.Count);
+                                    testOutputHelper.WriteLine("    #compute nodes: " + allComputeNodes.Count);
 
                                     allComputeNodes.ForEach(
                                         (icn) =>
                                         {
-                                            this.testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State);
+                                            testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State);
                                         });
                                 }
                                 catch (Exception ex)
@@ -122,33 +120,33 @@
                                 }
                             })
                         });
-                        
+
                         List<CloudTask> tasks = boundJob.ListTasks(null).ToList();
                         CloudTask myCompletedTask = tasks[0];
 
                         foreach (CloudTask curTask in tasks)
                         {
-                            this.testOutputHelper.WriteLine("Task Id: " + curTask.Id + ", state: " + curTask.State);
+                            testOutputHelper.WriteLine("Task Id: " + curTask.Id + ", state: " + curTask.State);
                         }
 
                         boundPool.Refresh();
 
-                        this.testOutputHelper.WriteLine("Pool Id: " + boundPool.Id + ", state: " + boundPool.State);
+                        testOutputHelper.WriteLine("Pool Id: " + boundPool.Id + ", state: " + boundPool.State);
 
                         string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
                         string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                        this.testOutputHelper.WriteLine("StdOut: ");
-                        this.testOutputHelper.WriteLine(stdOut);
+                        testOutputHelper.WriteLine("StdOut: ");
+                        testOutputHelper.WriteLine(stdOut);
 
-                        this.testOutputHelper.WriteLine("StdErr: ");
-                        this.testOutputHelper.WriteLine(stdErr);
+                        testOutputHelper.WriteLine("StdErr: ");
+                        testOutputHelper.WriteLine(stdErr);
 
-                        this.testOutputHelper.WriteLine("Task Files:");
+                        testOutputHelper.WriteLine("Task Files:");
 
                         foreach (NodeFile curFile in myCompletedTask.ListNodeFiles(recursive: true))
                         {
-                            this.testOutputHelper.WriteLine("    FilePath: " + curFile.Path);
+                            testOutputHelper.WriteLine("    FilePath: " + curFile.Path);
                         }
 
                         // confirm the files are there
@@ -184,7 +182,7 @@
             {
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
-                    TestUtilities.HelloWorld(batchCli, this.testOutputHelper, this.poolFixture.Pool, out string job, out string task);
+                    TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out string job, out string task);
                 }
             };
 
@@ -233,7 +231,7 @@
                     PoolOperations poolOperations = batchCli.PoolOperations;
                     try
                     {
-                        this.testOutputHelper.WriteLine("Listing OS Versions:");
+                        testOutputHelper.WriteLine("Listing OS Versions:");
 
                         // create pool tests
 
@@ -295,15 +293,15 @@
                     //Since we cannot really validate that the stats returned by the service are correct, the best we can do is make sure we get some
 
                     //Dump a few properties from each stats bag to make sure they are populated
-                    this.testOutputHelper.WriteLine("JobScheduleStatistics.StartTime: {0}", jobStatistics.StartTime);
-                    this.testOutputHelper.WriteLine("JobScheduleStatistics.LastUpdateTime: {0}", jobStatistics.LastUpdateTime);
-                    this.testOutputHelper.WriteLine("JobScheduleStatistics.NumSucceededTasks: {0}", jobStatistics.SucceededTaskCount);
-                    this.testOutputHelper.WriteLine("JobScheduleStatistics.UserCpuTime: {0}", jobStatistics.UserCpuTime);
+                    testOutputHelper.WriteLine("JobScheduleStatistics.StartTime: {0}", jobStatistics.StartTime);
+                    testOutputHelper.WriteLine("JobScheduleStatistics.LastUpdateTime: {0}", jobStatistics.LastUpdateTime);
+                    testOutputHelper.WriteLine("JobScheduleStatistics.NumSucceededTasks: {0}", jobStatistics.SucceededTaskCount);
+                    testOutputHelper.WriteLine("JobScheduleStatistics.UserCpuTime: {0}", jobStatistics.UserCpuTime);
 
-                    this.testOutputHelper.WriteLine("PoolStatistics.StartTime: {0}", poolStatistics.StartTime);
-                    this.testOutputHelper.WriteLine("PoolStatistics.LastUpdateTime: {0}", poolStatistics.LastUpdateTime);
-                    this.testOutputHelper.WriteLine("PoolStatistics.ResourceStatistics.AvgMemory: {0}", poolStatistics.ResourceStatistics.AverageMemoryGiB);
-                    this.testOutputHelper.WriteLine("PoolStatistics.UsageStatistics.DedicatedCoreTime: {0}", poolStatistics.UsageStatistics.DedicatedCoreTime);
+                    testOutputHelper.WriteLine("PoolStatistics.StartTime: {0}", poolStatistics.StartTime);
+                    testOutputHelper.WriteLine("PoolStatistics.LastUpdateTime: {0}", poolStatistics.LastUpdateTime);
+                    testOutputHelper.WriteLine("PoolStatistics.ResourceStatistics.AvgMemory: {0}", poolStatistics.ResourceStatistics.AverageMemoryGiB);
+                    testOutputHelper.WriteLine("PoolStatistics.UsageStatistics.DedicatedCoreTime: {0}", poolStatistics.UsageStatistics.DedicatedCoreTime);
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
@@ -48,53 +48,52 @@
             {
                 StagingStorageAccount storageCreds = TestUtilities.GetStorageCredentialsFromEnvironment();
 
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "SampleWithFilesJob-" + TestUtilities.GetMyName();
+
+
+                try
                 {
-                    string jobId = "SampleWithFilesJob-" + TestUtilities.GetMyName();
+                    CloudJob quickJob = batchCli.JobOperations.CreateJob();
+                    quickJob.Id = jobId;
+                    quickJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
+                    quickJob.Commit();
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
+                    CloudTask myTask = new CloudTask(id: "CountWordsTask", commandline: @"cmd /c dir /s .. & dir & wc localwords.txt");
 
-                    try
+                    // first we have local files that we want pushed to the compute node before the commandline is invoked
+                    FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, storageCreds);                // use "default" mapping to base name of local file
+
+                    myTask.FilesToStage = new List<IFileStagingProvider> { wordsDotText };
+
+                    // add the task to the job
+                    var artifacts = boundJob.AddTask(myTask);
+                    var specificArtifact = artifacts[typeof(FileToStage)];
+                    SequentialFileStagingArtifact sfsa = specificArtifact as SequentialFileStagingArtifact;
+
+                    Assert.NotNull(sfsa);
+
+                    // add a million more tasks...
+
+                    // test to ensure the task is read only
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => myTask.FilesToStage = new List<IFileStagingProvider>());
+
+                    // Open the new Job as bound.
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(boundJob.ExecutionInformation.PoolId);
+
+                    // wait for the task to complete
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(10),
+                        controlParams: null,
+                        additionalBehaviors:
+                            new[]
                     {
-                        CloudJob quickJob = batchCli.JobOperations.CreateJob();
-                        quickJob.Id = jobId;
-                        quickJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
-                        quickJob.Commit();
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                        CloudTask myTask = new CloudTask(id: "CountWordsTask", commandline: @"cmd /c dir /s .. & dir & wc localwords.txt");
-
-                        // first we have local files that we want pushed to the compute node before the commandline is invoked
-                        FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, storageCreds);                // use "default" mapping to base name of local file
-
-                        myTask.FilesToStage = new List<IFileStagingProvider> { wordsDotText };
-
-                        // add the task to the job
-                        var artifacts = boundJob.AddTask(myTask);
-                        var specificArtifact = artifacts[typeof(FileToStage)];
-                        SequentialFileStagingArtifact sfsa = specificArtifact as SequentialFileStagingArtifact;
-
-                        Assert.NotNull(sfsa);
-
-                        // add a million more tasks...
-
-                        // test to ensure the task is read only
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => myTask.FilesToStage = new List<IFileStagingProvider>());
-
-                        // Open the new Job as bound.
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(boundJob.ExecutionInformation.PoolId);
-
-                        // wait for the task to complete
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(10),
-                            controlParams: null,
-                            additionalBehaviors:
-                                new[]
-                        {
                             // spam/logging interceptor
                             new RequestInterceptor((x) =>
                             {
@@ -119,54 +118,53 @@
                                     Assert.True(false, "SampleWithFilesAndPool probably can ignore this if its pool not found: " + ex.ToString());
                                 }
                             })
-                        });
+                    });
 
-                        List<CloudTask> tasks = boundJob.ListTasks(null).ToList();
-                        CloudTask myCompletedTask = tasks[0];
+                    List<CloudTask> tasks = boundJob.ListTasks(null).ToList();
+                    CloudTask myCompletedTask = tasks[0];
 
-                        foreach (CloudTask curTask in tasks)
-                        {
-                            testOutputHelper.WriteLine("Task Id: " + curTask.Id + ", state: " + curTask.State);
-                        }
-
-                        boundPool.Refresh();
-
-                        testOutputHelper.WriteLine("Pool Id: " + boundPool.Id + ", state: " + boundPool.State);
-
-                        string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
-                        string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
-
-                        testOutputHelper.WriteLine("StdOut: ");
-                        testOutputHelper.WriteLine(stdOut);
-
-                        testOutputHelper.WriteLine("StdErr: ");
-                        testOutputHelper.WriteLine(stdErr);
-
-                        testOutputHelper.WriteLine("Task Files:");
-
-                        foreach (NodeFile curFile in myCompletedTask.ListNodeFiles(recursive: true))
-                        {
-                            testOutputHelper.WriteLine("    FilePath: " + curFile.Path);
-                        }
-
-                        // confirm the files are there
-                        Assert.True(FoundFile("localwords.txt", myCompletedTask.ListNodeFiles(recursive: true)), "mising file: localwords.txt");
-
-                        // test validation of StagingStorageAccount
-
-                        TestUtilities.AssertThrows<ArgumentOutOfRangeException>(() => { new StagingStorageAccount(storageAccount: " ", storageAccountKey: "key", blobEndpoint: "blob"); });
-                        TestUtilities.AssertThrows<ArgumentOutOfRangeException>(() => { new StagingStorageAccount(storageAccount: "account", storageAccountKey: " ", blobEndpoint: "blob"); });
-                        TestUtilities.AssertThrows<ArgumentOutOfRangeException>(() => { new StagingStorageAccount(storageAccount: "account", storageAccountKey: "key", blobEndpoint: ""); });
-
-                        if (null != sfsa)
-                        {
-                            // TODO: delete the container!
-                        }
-                    }
-                    finally
+                    foreach (CloudTask curTask in tasks)
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        testOutputHelper.WriteLine("Task Id: " + curTask.Id + ", state: " + curTask.State);
                     }
+
+                    boundPool.Refresh();
+
+                    testOutputHelper.WriteLine("Pool Id: " + boundPool.Id + ", state: " + boundPool.State);
+
+                    string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                    string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
+
+                    testOutputHelper.WriteLine("StdOut: ");
+                    testOutputHelper.WriteLine(stdOut);
+
+                    testOutputHelper.WriteLine("StdErr: ");
+                    testOutputHelper.WriteLine(stdErr);
+
+                    testOutputHelper.WriteLine("Task Files:");
+
+                    foreach (NodeFile curFile in myCompletedTask.ListNodeFiles(recursive: true))
+                    {
+                        testOutputHelper.WriteLine("    FilePath: " + curFile.Path);
+                    }
+
+                    // confirm the files are there
+                    Assert.True(FoundFile("localwords.txt", myCompletedTask.ListNodeFiles(recursive: true)), "mising file: localwords.txt");
+
+                    // test validation of StagingStorageAccount
+
+                    TestUtilities.AssertThrows<ArgumentOutOfRangeException>(() => { new StagingStorageAccount(storageAccount: " ", storageAccountKey: "key", blobEndpoint: "blob"); });
+                    TestUtilities.AssertThrows<ArgumentOutOfRangeException>(() => { new StagingStorageAccount(storageAccount: "account", storageAccountKey: " ", blobEndpoint: "blob"); });
+                    TestUtilities.AssertThrows<ArgumentOutOfRangeException>(() => { new StagingStorageAccount(storageAccount: "account", storageAccountKey: "key", blobEndpoint: ""); });
+
+                    if (null != sfsa)
+                    {
+                        // TODO: delete the container!
+                    }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -180,10 +178,8 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                {
-                    TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out string job, out string task);
-                }
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out string job, out string task);
             };
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -226,49 +222,47 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                PoolOperations poolOperations = batchCli.PoolOperations;
+                try
                 {
-                    PoolOperations poolOperations = batchCli.PoolOperations;
-                    try
+                    testOutputHelper.WriteLine("Listing OS Versions:");
+
+                    // create pool tests
+
+                    // forget to set CloudServiceConfiguration on Create, get error
                     {
-                        testOutputHelper.WriteLine("Listing OS Versions:");
+                        CloudPool noArgs = poolOperations.CreatePool("Bug1965363ButNoOSFamily-" + TestUtilities.GetMyName(), PoolFixture.VMSize, default(CloudServiceConfiguration), targetDedicatedComputeNodes: 0);
 
-                        // create pool tests
+                        BatchException ex = TestUtilities.AssertThrows<BatchException>(() => noArgs.Commit());
+                        string exStr = ex.ToString();
 
-                        // forget to set CloudServiceConfiguration on Create, get error
+                        // we are expecting an exception, assert if the exception is not the correct one.
+                        Assert.Contains("cloudServiceConfiguration", exStr);
+                    }
+
+                    // create a pool WITH an osFamily
+                    {
+                        string poolIdHOSF = "Bug1965363HasOSF-" + TestUtilities.GetMyName();
+                        try
                         {
-                            CloudPool noArgs = poolOperations.CreatePool("Bug1965363ButNoOSFamily-" + TestUtilities.GetMyName(), PoolFixture.VMSize, default(CloudServiceConfiguration), targetDedicatedComputeNodes: 0);
+                            CloudPool hasOSF = poolOperations.CreatePool(poolIdHOSF, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
 
-                            BatchException ex = TestUtilities.AssertThrows<BatchException>(() => noArgs.Commit());
-                            string exStr = ex.ToString();
-
-                            // we are expecting an exception, assert if the exception is not the correct one.
-                            Assert.Contains("cloudServiceConfiguration", exStr);
+                            hasOSF.Commit();
                         }
-
-                        // create a pool WITH an osFamily
+                        finally
                         {
-                            string poolIdHOSF = "Bug1965363HasOSF-" + TestUtilities.GetMyName();
-                            try
-                            {
-                                CloudPool hasOSF = poolOperations.CreatePool(poolIdHOSF, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
-
-                                hasOSF.Commit();
-                            }
-                            finally
-                            {
-                                poolOperations.DeletePool(poolIdHOSF);
-                            }
+                            poolOperations.DeletePool(poolIdHOSF);
                         }
                     }
-                    catch (Exception ex)
-                    {
-                        // special case os version beacuse it is a common failure and requires human intervention/editing
-                        // test for expired os version
-                        Assert.DoesNotContain("The specified OS Version does not exists", ex.ToString());
+                }
+                catch (Exception ex)
+                {
+                    // special case os version beacuse it is a common failure and requires human intervention/editing
+                    // test for expired os version
+                    Assert.DoesNotContain("The specified OS Version does not exists", ex.ToString());
 
-                        throw;
-                    }
+                    throw;
                 }
             };
 
@@ -282,27 +276,25 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                {
-                    JobStatistics jobStatistics = batchCli.JobOperations.GetAllLifetimeStatistics();
-                    PoolStatistics poolStatistics = batchCli.PoolOperations.GetAllLifetimeStatistics();
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                JobStatistics jobStatistics = batchCli.JobOperations.GetAllLifetimeStatistics();
+                PoolStatistics poolStatistics = batchCli.PoolOperations.GetAllLifetimeStatistics();
 
-                    Assert.NotNull(jobStatistics);
-                    Assert.NotNull(poolStatistics);
+                Assert.NotNull(jobStatistics);
+                Assert.NotNull(poolStatistics);
 
-                    //Since we cannot really validate that the stats returned by the service are correct, the best we can do is make sure we get some
+                //Since we cannot really validate that the stats returned by the service are correct, the best we can do is make sure we get some
 
-                    //Dump a few properties from each stats bag to make sure they are populated
-                    testOutputHelper.WriteLine("JobScheduleStatistics.StartTime: {0}", jobStatistics.StartTime);
-                    testOutputHelper.WriteLine("JobScheduleStatistics.LastUpdateTime: {0}", jobStatistics.LastUpdateTime);
-                    testOutputHelper.WriteLine("JobScheduleStatistics.NumSucceededTasks: {0}", jobStatistics.SucceededTaskCount);
-                    testOutputHelper.WriteLine("JobScheduleStatistics.UserCpuTime: {0}", jobStatistics.UserCpuTime);
+                //Dump a few properties from each stats bag to make sure they are populated
+                testOutputHelper.WriteLine("JobScheduleStatistics.StartTime: {0}", jobStatistics.StartTime);
+                testOutputHelper.WriteLine("JobScheduleStatistics.LastUpdateTime: {0}", jobStatistics.LastUpdateTime);
+                testOutputHelper.WriteLine("JobScheduleStatistics.NumSucceededTasks: {0}", jobStatistics.SucceededTaskCount);
+                testOutputHelper.WriteLine("JobScheduleStatistics.UserCpuTime: {0}", jobStatistics.UserCpuTime);
 
-                    testOutputHelper.WriteLine("PoolStatistics.StartTime: {0}", poolStatistics.StartTime);
-                    testOutputHelper.WriteLine("PoolStatistics.LastUpdateTime: {0}", poolStatistics.LastUpdateTime);
-                    testOutputHelper.WriteLine("PoolStatistics.ResourceStatistics.AvgMemory: {0}", poolStatistics.ResourceStatistics.AverageMemoryGiB);
-                    testOutputHelper.WriteLine("PoolStatistics.UsageStatistics.DedicatedCoreTime: {0}", poolStatistics.UsageStatistics.DedicatedCoreTime);
-                }
+                testOutputHelper.WriteLine("PoolStatistics.StartTime: {0}", poolStatistics.StartTime);
+                testOutputHelper.WriteLine("PoolStatistics.LastUpdateTime: {0}", poolStatistics.LastUpdateTime);
+                testOutputHelper.WriteLine("PoolStatistics.ResourceStatistics.AvgMemory: {0}", poolStatistics.ResourceStatistics.AverageMemoryGiB);
+                testOutputHelper.WriteLine("PoolStatistics.UsageStatistics.DedicatedCoreTime: {0}", poolStatistics.UsageStatistics.DedicatedCoreTime);
             };
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -315,21 +307,19 @@
         {
             Action test = () =>
                 {
-                    using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                    {
-                        string requestId = null;
-                        //Set up an interceptor to read RequestId from all responses
-                        ResponseInterceptor responseInterceptor = new ResponseInterceptor(
-                            (response, request) =>
-                                {
-                                    requestId = response.RequestId;
-                                    return Task.FromResult(response);
-                                });
+                    using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                    string requestId = null;
+                    //Set up an interceptor to read RequestId from all responses
+                    ResponseInterceptor responseInterceptor = new ResponseInterceptor(
+                        (response, request) =>
+                            {
+                                requestId = response.RequestId;
+                                return Task.FromResult(response);
+                            });
 
-                        batchCli.PoolOperations.ListPools(additionalBehaviors: new[] { responseInterceptor} ).ToList(); //Force an enumeration to go to the server
+                    batchCli.PoolOperations.ListPools(additionalBehaviors: new[] { responseInterceptor }).ToList(); //Force an enumeration to go to the server
 
-                        Assert.NotNull(requestId);
-                    }
+                    Assert.NotNull(requestId);
                 };
 
 
@@ -343,33 +333,31 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
-                {
-                    Guid myClientRequestid = Guid.NewGuid();
-                    RequestInterceptor clientRequestIdGenerator = new ClientRequestIdProvider(
-                        request => myClientRequestid);
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                Guid myClientRequestid = Guid.NewGuid();
+                RequestInterceptor clientRequestIdGenerator = new ClientRequestIdProvider(
+                    request => myClientRequestid);
 
-                    RequestInterceptor setReturnClientRequestId = new RequestInterceptor(
-                        request =>
-                            {
-                                request.Options.ReturnClientRequestId = true;
-                            });
+                RequestInterceptor setReturnClientRequestId = new RequestInterceptor(
+                    request =>
+                        {
+                            request.Options.ReturnClientRequestId = true;
+                        });
 
-                    BatchException batchException = TestUtilities.AssertThrowsAsync<BatchException>(async () =>
-                        await batchCli.JobOperations.GetJobAsync("this-job-doesnt-exist", additionalBehaviors: new [] { clientRequestIdGenerator, setReturnClientRequestId })).Result;
+                BatchException batchException = TestUtilities.AssertThrowsAsync<BatchException>(async () =>
+                    await batchCli.JobOperations.GetJobAsync("this-job-doesnt-exist", additionalBehaviors: new[] { clientRequestIdGenerator, setReturnClientRequestId })).Result;
 
-                    Assert.NotNull(batchException.RequestInformation);
-                    Assert.NotNull(batchException.RequestInformation.BatchError);
-                    Assert.NotNull(batchException.RequestInformation.BatchError.Message);
+                Assert.NotNull(batchException.RequestInformation);
+                Assert.NotNull(batchException.RequestInformation.BatchError);
+                Assert.NotNull(batchException.RequestInformation.BatchError.Message);
 
-                    Assert.Equal(BatchErrorCodeStrings.JobNotFound, batchException.RequestInformation.BatchError.Code);
-                    Assert.Equal(HttpStatusCode.NotFound, batchException.RequestInformation.HttpStatusCode);
-                    Assert.Contains("The specified job does not exist", batchException.RequestInformation.BatchError.Message.Value);
+                Assert.Equal(BatchErrorCodeStrings.JobNotFound, batchException.RequestInformation.BatchError.Code);
+                Assert.Equal(HttpStatusCode.NotFound, batchException.RequestInformation.HttpStatusCode);
+                Assert.Contains("The specified job does not exist", batchException.RequestInformation.BatchError.Message.Value);
 
-                    Assert.Equal(myClientRequestid, batchException.RequestInformation.ClientRequestId);
-                    Assert.NotNull(batchException.RequestInformation.ServiceRequestId);
-                    Assert.Equal("The specified job does not exist.", batchException.RequestInformation.HttpStatusMessage);
-                }
+                Assert.Equal(myClientRequestid, batchException.RequestInformation.ClientRequestId);
+                Assert.NotNull(batchException.RequestInformation.ServiceRequestId);
+                Assert.Equal("The specified job does not exist.", batchException.RequestInformation.HttpStatusMessage);
             };
 
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
@@ -98,7 +98,7 @@
                                 new[]
                         {
                             // spam/logging interceptor
-                            new Microsoft.Azure.Batch.Protocol.RequestInterceptor((x) =>
+                            new RequestInterceptor((x) =>
                             {
                                 this.testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
 
@@ -321,7 +321,7 @@
                     {
                         string requestId = null;
                         //Set up an interceptor to read RequestId from all responses
-                        Microsoft.Azure.Batch.Protocol.ResponseInterceptor responseInterceptor = new ResponseInterceptor(
+                        ResponseInterceptor responseInterceptor = new ResponseInterceptor(
                             (response, request) =>
                                 {
                                     requestId = response.RequestId;
@@ -348,10 +348,10 @@
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
                     Guid myClientRequestid = Guid.NewGuid();
-                    Microsoft.Azure.Batch.Protocol.RequestInterceptor clientRequestIdGenerator = new ClientRequestIdProvider(
+                    RequestInterceptor clientRequestIdGenerator = new ClientRequestIdProvider(
                         request => myClientRequestid);
 
-                    Microsoft.Azure.Batch.Protocol.RequestInterceptor setReturnClientRequestId = new RequestInterceptor(
+                    RequestInterceptor setReturnClientRequestId = new RequestInterceptor(
                         request =>
                             {
                                 request.Options.ReturnClientRequestId = true;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/IaasLinuxPoolFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/IaasLinuxPoolFixture.cs
@@ -14,7 +14,7 @@
     {
         public IaasLinuxPoolFixture() : base(TestUtilities.GetMyName() + "-pooltest-linux")
         {
-            this.Pool = this.CreatePool();
+            Pool = CreatePool();
         }
 
         public static ImageInformation GetUbuntuImageDetails(BatchClient client)
@@ -33,19 +33,19 @@
 
         protected CloudPool CreatePool()
         {
-            CloudPool currentPool = this.FindPoolIfExists();
+            CloudPool currentPool = FindPoolIfExists();
 
             // gotta create a new pool
             if (currentPool == null)
             {
-                var ubuntuImageDetails = GetUbuntuImageDetails(this.client);
+                var ubuntuImageDetails = GetUbuntuImageDetails(client);
 
                 VirtualMachineConfiguration virtualMachineConfiguration = new VirtualMachineConfiguration(
                     ubuntuImageDetails.ImageReference,
                     nodeAgentSkuId: ubuntuImageDetails.NodeAgentSkuId);
 
-                currentPool = this.client.PoolOperations.CreatePool(
-                    poolId: this.PoolId,
+                currentPool = client.PoolOperations.CreatePool(
+                    poolId: PoolId,
                     virtualMachineSize: VMSize,
                     virtualMachineConfiguration: virtualMachineConfiguration,
                     targetDedicatedComputeNodes: 1);
@@ -53,7 +53,7 @@
                 currentPool.Commit();
             }
 
-            return WaitForPoolAllocation(this.client, this.PoolId);
+            return WaitForPoolAllocation(client, PoolId);
         }
     }
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PaasWindowsPoolFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PaasWindowsPoolFixture.cs
@@ -15,20 +15,20 @@
         public PaasWindowsPoolFixture()
             : base(TestUtilities.GetMyName() + "-pooltest")
         {
-            this.Pool = this.CreatePool();
+            Pool = CreatePool();
         }
 
         protected CloudPool CreatePool()
         {
-            CloudPool currentPool = this.FindPoolIfExists();
+            CloudPool currentPool = FindPoolIfExists();
 
             if (currentPool == null)
             {
                 // gotta create a new pool
                 CloudServiceConfiguration passConfiguration = new CloudServiceConfiguration(OSFamily);
 
-                currentPool = this.client.PoolOperations.CreatePool(
-                    this.PoolId,
+                currentPool = client.PoolOperations.CreatePool(
+                    PoolId,
                     VMSize,
                     passConfiguration,
                     targetDedicatedComputeNodes: 1);
@@ -55,7 +55,7 @@
                 currentPool.Commit();
             }
 
-            return WaitForPoolAllocation(this.client, this.PoolId);
+            return WaitForPoolAllocation(client, PoolId);
         }
     }
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PoolFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PoolFixture.cs
@@ -28,8 +28,8 @@
 
         protected PoolFixture(string poolId)
         {
-            this.PoolId = poolId;
-            this.client = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+            PoolId = poolId;
+            client = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
         }
 
         public void Dispose()
@@ -44,17 +44,17 @@
             {
 
             }
-            this.client.Dispose();
+            client.Dispose();
         }
 
         protected CloudPool FindPoolIfExists()
         {
             // reuse existing pool if it exists
-            List<CloudPool> pools = new List<CloudPool>(this.client.PoolOperations.ListPools());
+            List<CloudPool> pools = new List<CloudPool>(client.PoolOperations.ListPools());
 
             foreach (CloudPool curPool in pools)
             {
-                if (curPool.Id.Equals(this.PoolId))
+                if (curPool.Id.Equals(PoolId))
                 {
                     return curPool;
                 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/InboundEndpointIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/InboundEndpointIntegrationTests.cs
@@ -32,34 +32,32 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string poolId = "InboundEndpoints-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string poolId = "InboundEndpoints-" + TestUtilities.GetMyName();
+                    var pool = CreatePool(batchCli, poolId);
+                    pool.NetworkConfiguration = GetNetworkConfiguration();
+                    pool.Commit();
 
-                    try
+                    var actualPool = batchCli.PoolOperations.GetPool(poolId);
+
+                    var expectedInboundNatPools = pool.NetworkConfiguration.EndpointConfiguration.InboundNatPools.OrderBy(inp => inp.Name).ToList();
+                    var actualInboundNatPools = actualPool.NetworkConfiguration.EndpointConfiguration.InboundNatPools.OrderBy(inp => inp.Name).ToList();
+
+                    Assert.Equal(expectedInboundNatPools.Count, actualInboundNatPools.Count);
+
+                    for (var i = 0; i < expectedInboundNatPools.Count; i++)
                     {
-                        var pool = CreatePool(batchCli, poolId);
-                        pool.NetworkConfiguration = GetNetworkConfiguration();
-                        pool.Commit();
+                        ValidateEquality(expectedInboundNatPools[i], actualInboundNatPools[i]);
 
-                        var actualPool = batchCli.PoolOperations.GetPool(poolId);
-
-                        var expectedInboundNatPools = pool.NetworkConfiguration.EndpointConfiguration.InboundNatPools.OrderBy(inp => inp.Name).ToList();
-                        var actualInboundNatPools = actualPool.NetworkConfiguration.EndpointConfiguration.InboundNatPools.OrderBy(inp => inp.Name).ToList();
-
-                        Assert.Equal(expectedInboundNatPools.Count, actualInboundNatPools.Count);
-
-                        for (var i = 0; i < expectedInboundNatPools.Count; i++)
-                        {
-                            ValidateEquality(expectedInboundNatPools[i], actualInboundNatPools[i]);
-
-                            ValidateNatPool(expectedInboundNatPools[i], actualInboundNatPools[i]);
-                        }
+                        ValidateNatPool(expectedInboundNatPools[i], actualInboundNatPools[i]);
                     }
-                    finally
-                    {
-                        TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
-                    }
+                }
+                finally
+                {
+                    TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
@@ -263,7 +263,7 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
             StorageSharedKeyCredential shardKeyCredentials = new StorageSharedKeyCredential(account, key);
             BlobContainerClient containerClient = BlobUtilities.GetBlobContainerClient(containerName, stagingCredentials);
             // 2. create container if it doesn't exist
-            await containerClient.CreateIfNotExistsAsync();
+            containerClient.CreateIfNotExists();
 
             // 3. validate policy, create/overwrite if doesn't match
             BlobSignedIdentifier identifier = new BlobSignedIdentifier
@@ -283,7 +283,7 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
 
             if (policyFound == false)
             {
-                await containerClient.SetAccessPolicyAsync(PublicAccessType.Blob, permissions: new List<BlobSignedIdentifier> { identifier });
+                await containerClient.SetAccessPolicyAsync(PublicAccessType.BlobContainer, permissions: new List<BlobSignedIdentifier> { identifier });
             }
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
@@ -75,15 +75,15 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
         /// <param name="blobEndpoint">A string specifying the primary Blob service endpoint.</param>
         public StagingStorageAccount(string storageAccount, string storageAccountKey, string blobEndpoint)
         {
-            this.StorageAccount = storageAccount;
-            this.StorageAccountKey = storageAccountKey;
+            StorageAccount = storageAccount;
+            StorageAccountKey = storageAccountKey;
 
-            if (string.IsNullOrWhiteSpace(this.StorageAccount))
+            if (string.IsNullOrWhiteSpace(StorageAccount))
             {
                 throw new ArgumentOutOfRangeException("storageAccount");
             }
 
-            if (string.IsNullOrWhiteSpace(this.StorageAccountKey))
+            if (string.IsNullOrWhiteSpace(StorageAccountKey))
             {
                 throw new ArgumentOutOfRangeException("storageAccountKey");
             }
@@ -94,7 +94,7 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
             }
 
             // Constructed here to give immediate validation/failure experience.
-            this.BlobUri = new Uri(blobEndpoint);
+            BlobUri = new Uri(blobEndpoint);
         }
     }
 
@@ -157,10 +157,10 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
         /// the name on the compute node will be set to the value of localFileToStage stripped of all path information.</param>
         public FileToStage(string localFileToStage, StagingStorageAccount storageCredentials, string nodeFileName = null)
         {
-            this.LocalFileToStage = localFileToStage;
-            this.StagingStorageAccount = storageCredentials;
+            LocalFileToStage = localFileToStage;
+            StagingStorageAccount = storageCredentials;
 
-            if (string.IsNullOrWhiteSpace(this.LocalFileToStage))
+            if (string.IsNullOrWhiteSpace(LocalFileToStage))
             {
                 throw new ArgumentOutOfRangeException("localFileToStage");
             }
@@ -168,11 +168,11 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
             // map null to base name of local file
             if (string.IsNullOrWhiteSpace(nodeFileName))
             {
-                this.NodeFileName = Path.GetFileName(this.LocalFileToStage);
+                NodeFileName = Path.GetFileName(LocalFileToStage);
             }
             else
             {
-                this.NodeFileName = nodeFileName;
+                NodeFileName = nodeFileName;
             }
         }
 
@@ -209,9 +209,9 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
         /// </summary>
         public void Validate()
         {
-            if (!File.Exists(this.LocalFileToStage))
+            if (!File.Exists(LocalFileToStage))
             {
-                throw new FileNotFoundException($"The following local file cannot be staged because it cannot be found: {this.LocalFileToStage}");
+                throw new FileNotFoundException($"The following local file cannot be staged because it cannot be found: {LocalFileToStage}");
             }
         }
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
@@ -428,16 +428,16 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
             string blobName = Path.GetFileName(stageThisFile.LocalFileToStage);
 
             BlobContainerClient blobContainerClient = BlobUtilities.GetBlobContainerClient(containerName, storecreds);
-            BlockBlobClient blobClient = blobContainerClient.GetBlockBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
 
-            bool doesBlobExist = await blobClient.ExistsAsync(); 
+            bool doesBlobExist = await blobClient.ExistsAsync().ConfigureAwait(false);
             bool mustUploadBlob = true;  // we do not re-upload blobs if they have already been uploaded
 
             if (doesBlobExist) // if the blob exists, compare
             {
                 FileInfo fi = new FileInfo(stageThisFile.LocalFileToStage);
 
-                var properties = await blobClient.GetPropertiesAsync();
+                var properties = await blobClient.GetPropertiesAsync().ConfigureAwait(false);
                 var length = properties.Value.ContentLength;
                 // since we don't have a hash of the contents... we check length
                 if (length == fi.Length)
@@ -448,12 +448,7 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
 
             if (mustUploadBlob)
             {
-                using FileStream stream = new FileStream(stageThisFile.LocalFileToStage, FileMode.Open);
-                
-                // upload the file
-                Task uploadTask = blobClient.UploadAsync(stream);
-
-                await uploadTask.ConfigureAwait(continueOnCapturedContext: false);
+                await blobClient.UploadAsync(stageThisFile.LocalFileToStage).ConfigureAwait(false);
             }
 
             // get the SAS for the blob

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/SynchronizationContextHelper.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/SynchronizationContextHelper.cs
@@ -40,32 +40,30 @@
             SetSynchronizationContext();
 
             TaskCompletionSource<bool> timeoutTaskSource = new TaskCompletionSource<bool>();
-            using (CancellationTokenSource tokenSource = new CancellationTokenSource(timeout))
+            using CancellationTokenSource tokenSource = new CancellationTokenSource(timeout);
+            //In the case the a debugger is attached, we do not want to enforce timeout because a breakpoint may
+            //cause a test which is supposed to run for 1 second to in fact run for 1 minute, and we want to
+            //allow that.
+            if (!Debugger.IsAttached)
             {
-                //In the case the a debugger is attached, we do not want to enforce timeout because a breakpoint may
-                //cause a test which is supposed to run for 1 second to in fact run for 1 minute, and we want to
-                //allow that.
-                if (!Debugger.IsAttached)
-                {
-                    tokenSource.Token.Register(() =>
-                        {
-                            timeoutTaskSource.SetResult(false);
-                        });
-                }
+                tokenSource.Token.Register(() =>
+                    {
+                        timeoutTaskSource.SetResult(false);
+                    });
+            }
 
-                Task testTask = test(); //Start running the actual test
+            Task testTask = test(); //Start running the actual test
 
-                await Task.WhenAny(testTask, timeoutTaskSource.Task).ConfigureAwait(false);
+            await Task.WhenAny(testTask, timeoutTaskSource.Task).ConfigureAwait(false);
 
-                if (testTask.IsCompleted)
-                {
-                    await testTask.ConfigureAwait(false); //Propagate exceptions
-                }
-                else
-                {
-                    //Force an assertion failure to fail the test with a timeout
-                    Assert.False(true, string.Format("SynchronizationContextHelper has terminated this test due to extreme tardiness. Test timed out after {0}", timeout));
-                }
+            if (testTask.IsCompleted)
+            {
+                await testTask.ConfigureAwait(false); //Propagate exceptions
+            }
+            else
+            {
+                //Force an assertion failure to fail the test with a timeout
+                Assert.False(true, string.Format("SynchronizationContextHelper has terminated this test due to extreme tardiness. Test timed out after {0}", timeout));
             }
         }
     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/TestUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/TestUtilities.cs
@@ -85,14 +85,12 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
 
         public static T AssertThrows<T>(Action codeUnderTest) where T : Exception
         {
-            using (Task<T> t = AssertThrowsAsync<T>(() =>
+            using Task<T> t = AssertThrowsAsync<T>(() =>
                 {
                     codeUnderTest();
                     return Task.Delay(0);
-                }))
-            {
-                return t.Result;
-            }
+                });
+            return t.Result;
         }
 
         public static async Task<T> AssertThrowsAsync<T>(Func<Task> codeUnderTest) where T : Exception

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/TestUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/TestUtilities.cs
@@ -170,15 +170,15 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
                 theOneInner = ae.InnerExceptions[0];
             }
 
-            if (!(theOneInner is Microsoft.Azure.Batch.Common.BatchException))
+            if (!(theOneInner is BatchException))
             {
                  outputHelper.WriteLine(string.Format("AssertIsBatchExceptionAndHasCorrectAzureErrorCode: incorrect exception: {0}", ex.ToString()));
             }
 
             // it must have the correct type
-            Assert.IsAssignableFrom<Microsoft.Azure.Batch.Common.BatchException>(theOneInner);
+            Assert.IsAssignableFrom<BatchException>(theOneInner);
 
-            Microsoft.Azure.Batch.Common.BatchException be = (Microsoft.Azure.Batch.Common.BatchException)theOneInner;
+            BatchException be = (BatchException)theOneInner;
 
             // whew we got it!  check the message
             Assert.Equal(expected: correctCode, actual: be.RequestInformation.BatchError.Code);

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/JobPrepReleaseIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/JobPrepReleaseIntegrationTests.cs
@@ -77,7 +77,7 @@
                         Protocol.RequestInterceptor increaseTimeoutInterceptor =
                             new Protocol.RequestInterceptor((x) =>
                             {
-                                this.testOutputHelper.WriteLine("TestOMJobSpecAndRelease: setting request timeout.  Request type: " + x.GetType().ToString() + ", ClientRequestID: " + x.Options.ClientRequestId);
+                                testOutputHelper.WriteLine("TestOMJobSpecAndRelease: setting request timeout.  Request type: " + x.GetType().ToString() + ", ClientRequestID: " + x.Options.ClientRequestId);
                                 var timeoutOptions = x.Options as Protocol.Models.ITimeoutOptions;
                                 timeoutOptions.Timeout = 5 * 60;
                             });
@@ -97,7 +97,7 @@
                         {
                             CloudJobSchedule unboundJobSchedule = client.JobScheduleOperations.CreateJobSchedule(jsId, null, null);
                             unboundJobSchedule.JobSpecification = new JobSpecification(new PoolInformation());
-                            unboundJobSchedule.JobSpecification.PoolInformation.PoolId = this.poolFixture.PoolId;
+                            unboundJobSchedule.JobSpecification.PoolInformation.PoolId = poolFixture.PoolId;
                             unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(3) };
 
                             // add the jobPrep task to the job schedule
@@ -228,7 +228,7 @@
                             Assert.Equal(JobPrepWaitForSuccessUpdate, updatedJobSchedule.JobSpecification.JobPreparationTask.WaitForSuccess);
                         }
 
-                        TestGetPrepReleaseStatusCalls(client, updatedJobSchedule, this.poolFixture.PoolId, resFiles);
+                        TestGetPrepReleaseStatusCalls(client, updatedJobSchedule, poolFixture.PoolId, resFiles);
                     }
                     finally
                     {
@@ -261,7 +261,7 @@
                         {
                             CloudJob unboundJob = client.JobOperations.CreateJob(jobId, null);
                             unboundJob.PoolInformation = new PoolInformation();
-                            unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                            unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
 
                             // add the jobPrep task to the job
                             {
@@ -283,7 +283,7 @@
                         }
 
                         // the victim nodes.  pool should have size 1.
-                        List<ComputeNode> computeNodes = client.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                        List<ComputeNode> computeNodes = client.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
                         Assert.Single(computeNodes);
                         // now we have a job with zero tasks... lets call get-status methods
@@ -322,7 +322,7 @@
                     {
                         // create job with prep that triggers prep scheduling error
                         {
-                            CloudJob unboundJob = client.JobOperations.CreateJob(jobId, new PoolInformation() {PoolId = this.poolFixture.PoolId});
+                            CloudJob unboundJob = client.JobOperations.CreateJob(jobId, new PoolInformation() {PoolId = poolFixture.PoolId});
                             // add the jobPrep task to the job
                             {
                                 JobPreparationTask prep = new JobPreparationTask("cmd /c JobPrep Task");
@@ -345,7 +345,7 @@
                         client.JobOperations.AddTask(boundJob.Id, new CloudTask("ForceJobPrep", "cmd /c echo TestOMJobPrepSchedulingError"));
 
                         // the victim compute node.  pool should have size 1.
-                        List<ComputeNode> nodes = client.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                        List<ComputeNode> nodes = client.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
                         Assert.Single(nodes);
 
@@ -374,10 +374,10 @@
                                     Assert.Equal(TaskExecutionResult.Failure, jpStatus.JobPreparationTaskExecutionInformation.Result);
 
                                     // spew the failure
-                                    this.OutputFailureInfo(jpStatus.JobPreparationTaskExecutionInformation.FailureInformation);
+                                    OutputFailureInfo(jpStatus.JobPreparationTaskExecutionInformation.FailureInformation);
                                 }
 
-                                this.testOutputHelper.WriteLine("Job Prep is running (waiting for blob dl to timeout)");
+                                testOutputHelper.WriteLine("Job Prep is running (waiting for blob dl to timeout)");
                             }
                         }
                     }
@@ -406,7 +406,7 @@
                     {
                         // create job schedule with prep that succeeds and release the triggers scheduling error
                         {
-                            PoolInformation poolInfo = new PoolInformation() {PoolId = this.poolFixture.PoolId};
+                            PoolInformation poolInfo = new PoolInformation() {PoolId = poolFixture.PoolId};
                             CloudJob unboundJob = client.JobOperations.CreateJob(jobId, poolInfo);
 
                             // add the jobPrep task to the job
@@ -450,18 +450,18 @@
                                     // spam/logging interceptor
                                     new Protocol.RequestInterceptor((x) =>
                                         {
-                                            this.testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
+                                            testOutputHelper.WriteLine("Issuing request type: " + x.GetType().ToString());
 
                                             // print out the compute node states... we are actually waiting on the compute nodes
-                                            List<ComputeNode> allComputeNodes = client.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                                            List<ComputeNode> allComputeNodes = client.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
-                                            this.testOutputHelper.WriteLine("    #compute nodes: " + allComputeNodes.Count);
+                                            testOutputHelper.WriteLine("    #compute nodes: " + allComputeNodes.Count);
 
                                             allComputeNodes.ForEach((icn) =>
                                                 {
-                                                    this.testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State);
+                                                    testOutputHelper.WriteLine("  computeNode.id: " + icn.Id + ", state: " + icn.State);
                                                 });
-                                            this.testOutputHelper.WriteLine("");
+                                            testOutputHelper.WriteLine("");
                                         })
                                 }
                             );
@@ -470,7 +470,7 @@
                         client.JobOperations.TerminateJob(jobId, "BUG: Server will throw 500 if I don't provide reason");
 
                         // the victim compute node.  pool should have size 1.
-                        List<ComputeNode> computeNodes = client.PoolOperations.ListComputeNodes(this.poolFixture.PoolId).ToList();
+                        List<ComputeNode> computeNodes = client.PoolOperations.ListComputeNodes(poolFixture.PoolId).ToList();
 
                         Assert.Single(computeNodes);
 
@@ -498,11 +498,11 @@
                                     Assert.Equal(TaskExecutionResult.Failure, prepAndReleaseStatus.JobReleaseTaskExecutionInformation.Result);
 
                                     // spew the failure info
-                                    this.OutputFailureInfo(prepAndReleaseStatus.JobReleaseTaskExecutionInformation.FailureInformation);
+                                    OutputFailureInfo(prepAndReleaseStatus.JobReleaseTaskExecutionInformation.FailureInformation);
                                 }
                             }
                             Thread.Sleep(2000);
-                            this.testOutputHelper.WriteLine("Job Release tasks still running (waiting for blob dl to timeout).");
+                            testOutputHelper.WriteLine("Job Release tasks still running (waiting for blob dl to timeout).");
                         }
                     }
                     finally
@@ -550,7 +550,7 @@
 
                 while (keepLooking)
                 {
-                    this.testOutputHelper.WriteLine("Waiting for task to be scheduled.");
+                    testOutputHelper.WriteLine("Waiting for task to be scheduled.");
 
                     foreach (CloudTask curTask in batchCli.JobOperations.GetJob(jobId).ListTasks())
                     {
@@ -581,8 +581,8 @@
                     Assert.True(beforeJobPrepRuns < jptei.JobPreparationTaskExecutionInformation.StartTime + TimeSpan.FromSeconds(10));  // test that the start time is rational -- 10s of wiggle room
                     Assert.Null(jptei.JobPreparationTaskExecutionInformation.FailureInformation);
 
-                    this.testOutputHelper.WriteLine("");
-                    this.testOutputHelper.WriteLine("listing files for compute node: " + victimComputeNodeRunningPrepAndRelease.Id);
+                    testOutputHelper.WriteLine("");
+                    testOutputHelper.WriteLine("listing files for compute node: " + victimComputeNodeRunningPrepAndRelease.Id);
 
                     // fiter the list so reduce noise
                     List<NodeFile> filteredListJobPrep = new List<NodeFile>();
@@ -592,7 +592,7 @@
                         // filter on the jsId since we only run one job per job in this test.
                         if (curTF.Path.IndexOf(boundJobSchedule.Id, StringComparison.InvariantCultureIgnoreCase) >= 0)
                         {
-                            this.testOutputHelper.WriteLine("    name:" + curTF.Path + ", size: " + ((curTF.IsDirectory.HasValue && curTF.IsDirectory.Value) ? "<dir>" : curTF.Properties.ContentLength.ToString()));
+                            testOutputHelper.WriteLine("    name:" + curTF.Path + ", size: " + ((curTF.IsDirectory.HasValue && curTF.IsDirectory.Value) ? "<dir>" : curTF.Properties.ContentLength.ToString()));
 
                             filteredListJobPrep.Add(curTF);
                         }
@@ -614,7 +614,7 @@
                     // poll for completion
                     while (JobPreparationTaskState.Completed != jptei.JobPreparationTaskExecutionInformation.State)
                     {
-                        this.testOutputHelper.WriteLine("waiting for jopPrep to complete");
+                        testOutputHelper.WriteLine("waiting for jopPrep to complete");
                         Thread.Sleep(2000);
 
                         // refresh the state info
@@ -646,8 +646,8 @@
                         //Swallow any exceptions here since stderr may not exist
                     }
 
-                    this.testOutputHelper.WriteLine(stdOut);
-                    this.testOutputHelper.WriteLine(stdErr);
+                    testOutputHelper.WriteLine(stdOut);
+                    testOutputHelper.WriteLine(stdErr);
 
                     Assert.True(!string.IsNullOrWhiteSpace(stdOut));
                     Assert.Contains("jobpreparation", stdOut.ToLower());
@@ -661,16 +661,16 @@
                 Protocol.RequestInterceptor consoleSpammer =
                                                 new Protocol.RequestInterceptor((x) =>
                                                 {
-                                                    this.testOutputHelper.WriteLine("TestGetPrepReleaseStatusCalls: waiting for JobPrep and task to complete");
+                                                    testOutputHelper.WriteLine("TestGetPrepReleaseStatusCalls: waiting for JobPrep and task to complete");
 
                                                     ODATADetailLevel detailLevel = new ODATADetailLevel() { FilterClause = string.Format("nodeId eq '{0}'", victimComputeNodeRunningPrepAndRelease.Id) };
                                                     jobPrepStatusList = batchCli.JobOperations.ListJobPreparationAndReleaseTaskStatus(jobId, detailLevel: detailLevel).ToList();
                                                     JobPreparationAndReleaseTaskExecutionInformation jpteiInterceptor =
                                                         jobPrepStatusList.First();
 
-                                                    this.testOutputHelper.WriteLine("    JobPrep.State: " + jpteiInterceptor.JobPreparationTaskExecutionInformation.State);
+                                                    testOutputHelper.WriteLine("    JobPrep.State: " + jpteiInterceptor.JobPreparationTaskExecutionInformation.State);
 
-                                                    this.testOutputHelper.WriteLine("");
+                                                    testOutputHelper.WriteLine("");
                                                 });
 
                 // waiting for the task to complete means so JobRelease is run.
@@ -699,13 +699,13 @@
                         Assert.NotNull(jrtei);
                         if (jrtei.JobReleaseTaskExecutionInformation.State != JobReleaseTaskState.Completed)
                         {
-                            this.testOutputHelper.WriteLine("JobReleaseTask state is: " + jrtei.JobReleaseTaskExecutionInformation.State);
+                            testOutputHelper.WriteLine("JobReleaseTask state is: " + jrtei.JobReleaseTaskExecutionInformation.State);
 
                             Thread.Sleep(5000);
                         }
                         else
                         {
-                            this.testOutputHelper.WriteLine("JobRelease commpleted!");
+                            testOutputHelper.WriteLine("JobRelease commpleted!");
 
                             // we are done
                             break;
@@ -798,21 +798,21 @@
 
             private void RequestInterceptHandler(Protocol.IBatchRequest request)
             {
-                this.stopwatch.Reset();
-                this.stopwatch.Start();
+                stopwatch.Reset();
+                stopwatch.Start();
             }
 
             private Task<IAzureOperationResponse> ResponseInterceptHandler(IAzureOperationResponse response, Protocol.IBatchRequest request)
             {
-                this.stopwatch.Stop();
+                stopwatch.Stop();
 
                 return Task.FromResult(response);
             }
 
             internal CallTimerViaInterceptors()
             {
-                this.ReqInterceptor = new Protocol.RequestInterceptor(this.RequestInterceptHandler);
-                this.ResInterceptor = new Protocol.ResponseInterceptor(this.ResponseInterceptHandler);
+                ReqInterceptor = new Protocol.RequestInterceptor(RequestInterceptHandler);
+                ResInterceptor = new Protocol.ResponseInterceptor(ResponseInterceptHandler);
             }
         }
 
@@ -837,20 +837,20 @@
 
         private void OutputFailureInfo(TaskFailureInformation failureInfo)
         {
-            this.testOutputHelper.WriteLine("JP Failure Info:");
-            this.testOutputHelper.WriteLine("    category: " + failureInfo.Category);
-            this.testOutputHelper.WriteLine("    code: " + failureInfo.Code);
-            this.testOutputHelper.WriteLine("    details:" + (null == failureInfo.Details ? " <null>" : string.Empty));
+            testOutputHelper.WriteLine("JP Failure Info:");
+            testOutputHelper.WriteLine("    category: " + failureInfo.Category);
+            testOutputHelper.WriteLine("    code: " + failureInfo.Code);
+            testOutputHelper.WriteLine("    details:" + (null == failureInfo.Details ? " <null>" : string.Empty));
 
             if (null != failureInfo.Details)
             {
                 foreach (NameValuePair curDetail in failureInfo.Details)
                 {
-                    this.testOutputHelper.WriteLine("        name: " + curDetail.Name + ", value: " + curDetail.Value);
+                    testOutputHelper.WriteLine("        name: " + curDetail.Name + ", value: " + curDetail.Value);
                 }
             }
 
-            this.testOutputHelper.WriteLine("    message: " + failureInfo.Message);
+            testOutputHelper.WriteLine("    message: " + failureInfo.Message);
         }
 
         #endregion

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/NodeFileIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/NodeFileIntegrationTests.cs
@@ -44,7 +44,7 @@
                     try
                     {
                         // here we show how to use an unbound Job + Commit() to run millions of Tasks
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         unboundJob.Commit();
 
                         // Open the new Job as bound.
@@ -69,21 +69,21 @@
                         string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
                         string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
 
-                        this.testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
-                        this.testOutputHelper.WriteLine("StdOut: ");
-                        this.testOutputHelper.WriteLine(stdOut);
+                        testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
+                        testOutputHelper.WriteLine("StdOut: ");
+                        testOutputHelper.WriteLine(stdOut);
 
-                        this.testOutputHelper.WriteLine("StdErr: ");
-                        this.testOutputHelper.WriteLine(stdErr);
+                        testOutputHelper.WriteLine("StdErr: ");
+                        testOutputHelper.WriteLine(stdErr);
 
-                        this.testOutputHelper.WriteLine("Task Files:");
+                        testOutputHelper.WriteLine("Task Files:");
 
                         bool foundAtLeastOneDir = false;
 
                         foreach (NodeFile curFile in myCompletedTask.ListNodeFiles())
                         {
-                            this.testOutputHelper.WriteLine("    Filepath: " + curFile.Path);
-                            this.testOutputHelper.WriteLine("       IsDirectory: " + curFile.IsDirectory.ToString());
+                            testOutputHelper.WriteLine("    Filepath: " + curFile.Path);
+                            testOutputHelper.WriteLine("       IsDirectory: " + curFile.IsDirectory.ToString());
 
                             // turns out wd is created for each task so use it as sentinal
                             if (curFile.Path.Equals("wd") && curFile.IsDirectory.HasValue && curFile.IsDirectory.Value)
@@ -130,7 +130,7 @@
                         // Create the job
                         //
                         CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
                         unboundJob.Commit();
 
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
@@ -142,7 +142,7 @@
                         boundJob.AddTask(directoryCreationTask1);
                         boundJob.AddTask(directoryCreationTask2);
 
-                        this.testOutputHelper.WriteLine("Initial job commit()");
+                        testOutputHelper.WriteLine("Initial job commit()");
 
                         //
                         // Wait for task to go to completion
@@ -227,7 +227,7 @@
                         // Create the job
                         //
                         CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
                         unboundJob.Commit();
 
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
@@ -239,7 +239,7 @@
                         boundJob.AddTask(directoryCreationTask1);
                         boundJob.AddTask(directoryCreationTask2);
 
-                        this.testOutputHelper.WriteLine("Initial job commit()");
+                        testOutputHelper.WriteLine("Initial job commit()");
 
                         //
                         // Wait for task to go to completion
@@ -256,18 +256,18 @@
                         //Since the compute node name comes back as "Node:<computeNodeId>" we need to split on : to get the actual compute node name
                         string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
 
-                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(this.poolFixture.PoolId, computeNodeId);
+                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
 
-                        this.testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
+                        testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
 
                         //Ensure that ListFiles done without a recursive option, or with recursive false return the same values
                         {
                             List<NodeFile> filesByComputeNodeRecursiveOmitted = batchCli.PoolOperations.ListNodeFiles(
-                                this.poolFixture.PoolId, 
+                                poolFixture.PoolId, 
                                 computeNodeId).ToList();
 
                             List<NodeFile> filesByComputeNodeRecursiveFalse = batchCli.PoolOperations.ListNodeFiles(
-                                this.poolFixture.PoolId, 
+                                poolFixture.PoolId, 
                                 computeNodeId, 
                                 recursive: false).ToList();
 
@@ -291,11 +291,11 @@
                         // List all node files from operations -- recursive true
                         //
                         //TODO: Detail level?
-                        List<NodeFile> fileListFromComputeNodeOperations = batchCli.PoolOperations.ListNodeFiles(this.poolFixture.PoolId, computeNodeId, recursive: true).ToList();
+                        List<NodeFile> fileListFromComputeNodeOperations = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).ToList();
 
                         foreach (NodeFile f in fileListFromComputeNodeOperations)
                         {
-                            this.testOutputHelper.WriteLine("Found file: {0}", f.Path);
+                            testOutputHelper.WriteLine("Found file: {0}", f.Path);
                         }
                         //Check to make sure the expected folder named "Shared" exists
                         Assert.Contains("shared", fileListFromComputeNodeOperations.Select(f => f.Path));
@@ -306,7 +306,7 @@
                         List<NodeFile> fileListFromComputeNode = computeNode.ListNodeFiles(recursive: true).ToList();
                         foreach (NodeFile f in fileListFromComputeNodeOperations)
                         {
-                            this.testOutputHelper.WriteLine("Found file: {0}", f.Path);
+                            testOutputHelper.WriteLine("Found file: {0}", f.Path);
                         }
                         //Check to make sure the expected folder named "Shared" exists
                         Assert.Contains("shared", fileListFromComputeNode.Select(f => f.Path));
@@ -315,46 +315,46 @@
                         // Get file from operations
                         //
                         string filePathToGet = fileListFromComputeNode.First(f => !f.IsDirectory.Value && f.Properties.ContentLength > 0).Path;
-                        this.testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
-                        NodeFile computeNodeFileFromManager = batchCli.PoolOperations.GetNodeFile(this.poolFixture.PoolId, computeNodeId, filePathToGet);
-                        this.testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
-                        this.testOutputHelper.WriteLine("---- File data: ----");
+                        testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
+                        NodeFile computeNodeFileFromManager = batchCli.PoolOperations.GetNodeFile(poolFixture.PoolId, computeNodeId, filePathToGet);
+                        testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
+                        testOutputHelper.WriteLine("---- File data: ----");
                         var computeNodeFileContentFromManager = computeNodeFileFromManager.ReadAsString();
-                        this.testOutputHelper.WriteLine(computeNodeFileContentFromManager);
+                        testOutputHelper.WriteLine(computeNodeFileContentFromManager);
                         Assert.NotEmpty(computeNodeFileContentFromManager);
 
                         //
                         // Get file directly from operations (bypassing the properties call)
                         //
-                        var computeNodeFileContentDirect = batchCli.PoolOperations.CopyNodeFileContentToString(this.poolFixture.PoolId, computeNodeId, filePathToGet);
-                        this.testOutputHelper.WriteLine("---- File data: ----");
-                        this.testOutputHelper.WriteLine(computeNodeFileContentDirect);
+                        var computeNodeFileContentDirect = batchCli.PoolOperations.CopyNodeFileContentToString(poolFixture.PoolId, computeNodeId, filePathToGet);
+                        testOutputHelper.WriteLine("---- File data: ----");
+                        testOutputHelper.WriteLine(computeNodeFileContentDirect);
                         Assert.NotEmpty(computeNodeFileContentDirect);
 
                         //
                         // Get file from compute node
                         //
-                        this.testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
+                        testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
                         NodeFile fileFromComputeNode = computeNode.GetNodeFile(filePathToGet);
-                        this.testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
-                        this.testOutputHelper.WriteLine("---- File data: ----");
+                        testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
+                        testOutputHelper.WriteLine("---- File data: ----");
                         var computeNodeFileContentFromNode = fileFromComputeNode.ReadAsString();
-                        this.testOutputHelper.WriteLine(computeNodeFileContentFromNode);
+                        testOutputHelper.WriteLine(computeNodeFileContentFromNode);
                         Assert.NotEmpty(computeNodeFileContentFromNode);
 
                         //
                         // Get file from compute node (bypassing the properties call)
                         //
                         computeNodeFileContentDirect = computeNode.CopyNodeFileContentToString(filePathToGet);
-                        this.testOutputHelper.WriteLine("---- File data: ----");
-                        this.testOutputHelper.WriteLine(computeNodeFileContentDirect);
+                        testOutputHelper.WriteLine("---- File data: ----");
+                        testOutputHelper.WriteLine(computeNodeFileContentDirect);
                         Assert.NotEmpty(computeNodeFileContentDirect);
 
                         //
                         // NodeFile delete
                         //
                         string filePath = Path.Combine(@"workitems", jobId, "job-1", taskId, Constants.StandardOutFileName);
-                        NodeFile nodeFile = batchCli.PoolOperations.GetNodeFile(this.poolFixture.PoolId, computeNodeId, filePath);
+                        NodeFile nodeFile = batchCli.PoolOperations.GetNodeFile(poolFixture.PoolId, computeNodeId, filePath);
 
                         nodeFile.Delete();
 
@@ -364,12 +364,12 @@
 
                         //Delete directory
 
-                        NodeFile directory = batchCli.PoolOperations.ListNodeFiles(this.poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameOne));
+                        NodeFile directory = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameOne));
                         Assert.True(directory.IsDirectory);
                         TestUtilities.AssertThrows<BatchException>(() => directory.Delete(recursive: false));
                         directory.Delete(recursive: true);
 
-                        Assert.Null(batchCli.PoolOperations.ListNodeFiles(this.poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameOne)));
+                        Assert.Null(batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameOne)));
 
                         //
                         // PoolManager delete node file
@@ -377,18 +377,18 @@
                         filePath = Path.Combine(@"workitems", jobId, "job-1", taskId, Constants.StandardErrorFileName);
 
                         NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName);
-                        batchCli.PoolOperations.DeleteNodeFile(this.poolFixture.PoolId, computeNodeId, filePath);
+                        batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, filePath);
 
                         //Ensure delete succeeded
                         TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName));
 
                         //Delete directory
-                        directory = batchCli.PoolOperations.ListNodeFiles(this.poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameTwo));
+                        directory = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameTwo));
                         Assert.True(directory.IsDirectory);
-                        TestUtilities.AssertThrows<BatchException>(() => batchCli.PoolOperations.DeleteNodeFile(this.poolFixture.PoolId, computeNodeId, directory.Path, recursive: false));
-                        batchCli.PoolOperations.DeleteNodeFile(this.poolFixture.PoolId, computeNodeId, directory.Path, recursive: true);
+                        TestUtilities.AssertThrows<BatchException>(() => batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, directory.Path, recursive: false));
+                        batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, directory.Path, recursive: true);
 
-                        Assert.Null(batchCli.PoolOperations.ListNodeFiles(this.poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameTwo)));
+                        Assert.Null(batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameTwo)));
                     }
                     finally
                     {
@@ -421,7 +421,7 @@
                             //
                             // Create the job
                             //
-                            CloudJob unboundJob = jobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                            CloudJob unboundJob = jobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                             unboundJob.Commit();
 
                             CloudJob boundJob = jobOperations.GetJob(jobId);
@@ -429,7 +429,7 @@
 
                             boundJob.AddTask(myTask);
 
-                            this.testOutputHelper.WriteLine("Initial job commit()");
+                            testOutputHelper.WriteLine("Initial job commit()");
 
                             //
                             // Wait for task to go to completion
@@ -481,7 +481,7 @@
                         // Create the job
                         //
                         CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
                         unboundJob.Commit();
 
                         CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
@@ -489,7 +489,7 @@
 
                         boundJob.AddTask(myTask);
 
-                        this.testOutputHelper.WriteLine("Initial job commit()");
+                        testOutputHelper.WriteLine("Initial job commit()");
 
                         //
                         // Wait for task to go to completion
@@ -509,11 +509,11 @@
                         //
                         NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
 
-                        this.testOutputHelper.WriteLine("File {0} has content length: {1}", Constants.StandardOutFileName, file.Properties.ContentLength);
-                        this.testOutputHelper.WriteLine("File {0} has content type: {1}", Constants.StandardOutFileName, file.Properties.ContentType);
+                        testOutputHelper.WriteLine("File {0} has content length: {1}", Constants.StandardOutFileName, file.Properties.ContentLength);
+                        testOutputHelper.WriteLine("File {0} has content type: {1}", Constants.StandardOutFileName, file.Properties.ContentType);
 
-                        this.testOutputHelper.WriteLine("File {0} has creation time: {1}", Constants.StandardOutFileName, file.Properties.CreationTime);
-                        this.testOutputHelper.WriteLine("File {0} has last modified time: {1}", Constants.StandardOutFileName, file.Properties.LastModified);
+                        testOutputHelper.WriteLine("File {0} has creation time: {1}", Constants.StandardOutFileName, file.Properties.CreationTime);
+                        testOutputHelper.WriteLine("File {0} has last modified time: {1}", Constants.StandardOutFileName, file.Properties.LastModified);
 
                         Assert.Equal(expectedFileSize, file.Properties.ContentLength);
                         Assert.Equal("text/plain", file.Properties.ContentType);
@@ -524,24 +524,24 @@
                         CloudTask boundTask = boundJob.GetTask(taskId);
                         string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
 
-                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(this.poolFixture.PoolId, computeNodeId);
+                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
 
-                        this.testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
+                        testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
 
                         List<NodeFile> files = computeNode.ListNodeFiles(recursive: true).ToList();
                         foreach (NodeFile nodeFile in files)
                         {
-                            this.testOutputHelper.WriteLine("Found file: {0}", nodeFile.Path);
+                            testOutputHelper.WriteLine("Found file: {0}", nodeFile.Path);
                         }
 
                         string filePathToGet = string.Format("workitems/{0}/{1}/{2}/{3}", jobId, "job-1", taskId, Constants.StandardOutFileName);
                         file = computeNode.GetNodeFile(filePathToGet);
 
-                        this.testOutputHelper.WriteLine("File {0} has content length: {1}", filePathToGet, file.Properties.ContentLength);
-                        this.testOutputHelper.WriteLine("File {0} has content type: {1}", filePathToGet, file.Properties.ContentType);
+                        testOutputHelper.WriteLine("File {0} has content length: {1}", filePathToGet, file.Properties.ContentLength);
+                        testOutputHelper.WriteLine("File {0} has content type: {1}", filePathToGet, file.Properties.ContentType);
 
-                        this.testOutputHelper.WriteLine("File {0} has creation time: {1}", filePathToGet, file.Properties.CreationTime);
-                        this.testOutputHelper.WriteLine("File {0} has last modified time: {1}", filePathToGet, file.Properties.LastModified);
+                        testOutputHelper.WriteLine("File {0} has creation time: {1}", filePathToGet, file.Properties.CreationTime);
+                        testOutputHelper.WriteLine("File {0} has last modified time: {1}", filePathToGet, file.Properties.LastModified);
 
                         Assert.Equal(expectedFileSize, file.Properties.ContentLength);
                         Assert.Equal("text/plain", file.Properties.ContentType);
@@ -576,17 +576,17 @@
                         CloudJob job = jobOperations.CreateJob(jobId, new PoolInformation());
                         job.PoolInformation = new PoolInformation()
                         {
-                            PoolId = this.poolFixture.PoolId
+                            PoolId = poolFixture.PoolId
                         };
 
-                        this.testOutputHelper.WriteLine("Initial job schedule commit()");
+                        testOutputHelper.WriteLine("Initial job schedule commit()");
 
                         job.Commit();
 
                         //
                         // Wait for the job
                         //
-                        this.testOutputHelper.WriteLine("Waiting for job");
+                        testOutputHelper.WriteLine("Waiting for job");
                         CloudJob boundJob = jobOperations.GetJob(jobId);
 
                         //
@@ -595,14 +595,14 @@
                         const string taskId = "T1";
                         const string taskMessage = "This is a test";
 
-                        this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
                         CloudTask task = new CloudTask(taskId, string.Format("cmd /c echo {0}", taskMessage));
                         boundJob.AddTask(task);
 
                         //
                         // Wait for the task to complete
                         //
-                        this.testOutputHelper.WriteLine("Waiting for the task to complete");
+                        testOutputHelper.WriteLine("Waiting for the task to complete");
                         Utilities utilities = batchCli.Utilities;
                         TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
 
@@ -613,15 +613,15 @@
                             TimeSpan.FromSeconds(30));
 
                         //Download the data
-                        this.testOutputHelper.WriteLine("Downloading the stdout for the file");
+                        testOutputHelper.WriteLine("Downloading the stdout for the file");
                         NodeFile file = jobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
                         string data = file.ReadAsString();
-                        this.testOutputHelper.WriteLine("Data: {0}", data);
+                        testOutputHelper.WriteLine("Data: {0}", data);
                         Assert.Contains(taskMessage, data);
 
                         // Download the data again using the JobOperations read file content helper
                         data = batchCli.JobOperations.CopyNodeFileContentToString(jobId, taskId, Constants.StandardOutFileName);
-                        this.testOutputHelper.WriteLine("Data: {0}", data);
+                        testOutputHelper.WriteLine("Data: {0}", data);
                         Assert.Contains(taskMessage, data);
                     }
                     finally
@@ -694,14 +694,14 @@
                         // create some files on the node
                         TestUtilities.HelloWorld(
                             batchCli,
-                            this.testOutputHelper,
-                            this.poolFixture.Pool,
+                            testOutputHelper,
+                            poolFixture.Pool,
                             out jobId,
                             out taskId,
                             deleteJob: false,
                             isLinux: true);
 
-                        var nodes = this.poolFixture.Pool.ListComputeNodes().ToList();
+                        var nodes = poolFixture.Pool.ListComputeNodes().ToList();
                         ComputeNode cn = nodes[0]; // get the node that has files on it
 
                         List<NodeFile> files = cn.ListNodeFiles(recursive: true).ToList();

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/NodeFileIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/NodeFileIntegrationTests.cs
@@ -37,67 +37,65 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1480489Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1480489Job-" + TestUtilities.GetMyName();
+                    // here we show how to use an unbound Job + Commit() to run millions of Tasks
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    unboundJob.Commit();
 
-                    try
+                    // Open the new Job as bound.
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                    CloudTask myTask = new CloudTask(id: "Bug1480489Task", commandline: @"md Bug1480489Directory");
+
+                    // add the task to the job
+                    boundJob.AddTask(myTask);
+
+                    // wait for the task to complete
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(3));
+
+                    CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks(null))[0];
+
+                    string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
+                    string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
+
+                    testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
+                    testOutputHelper.WriteLine("StdOut: ");
+                    testOutputHelper.WriteLine(stdOut);
+
+                    testOutputHelper.WriteLine("StdErr: ");
+                    testOutputHelper.WriteLine(stdErr);
+
+                    testOutputHelper.WriteLine("Task Files:");
+
+                    bool foundAtLeastOneDir = false;
+
+                    foreach (NodeFile curFile in myCompletedTask.ListNodeFiles())
                     {
-                        // here we show how to use an unbound Job + Commit() to run millions of Tasks
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        unboundJob.Commit();
+                        testOutputHelper.WriteLine("    Filepath: " + curFile.Path);
+                        testOutputHelper.WriteLine("       IsDirectory: " + curFile.IsDirectory.ToString());
 
-                        // Open the new Job as bound.
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                        CloudTask myTask = new CloudTask(id: "Bug1480489Task", commandline: @"md Bug1480489Directory");
-
-                        // add the task to the job
-                        boundJob.AddTask(myTask);
-
-                        // wait for the task to complete
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(3));
-
-                        CloudTask myCompletedTask = new List<CloudTask>(boundJob.ListTasks(null))[0];
-
-                        string stdOut = myCompletedTask.GetNodeFile(Constants.StandardOutFileName).ReadAsString();
-                        string stdErr = myCompletedTask.GetNodeFile(Constants.StandardErrorFileName).ReadAsString();
-
-                        testOutputHelper.WriteLine("TaskId: " + myCompletedTask.Id);
-                        testOutputHelper.WriteLine("StdOut: ");
-                        testOutputHelper.WriteLine(stdOut);
-
-                        testOutputHelper.WriteLine("StdErr: ");
-                        testOutputHelper.WriteLine(stdErr);
-
-                        testOutputHelper.WriteLine("Task Files:");
-
-                        bool foundAtLeastOneDir = false;
-
-                        foreach (NodeFile curFile in myCompletedTask.ListNodeFiles())
+                        // turns out wd is created for each task so use it as sentinal
+                        if (curFile.Path.Equals("wd") && curFile.IsDirectory.HasValue && curFile.IsDirectory.Value)
                         {
-                            testOutputHelper.WriteLine("    Filepath: " + curFile.Path);
-                            testOutputHelper.WriteLine("       IsDirectory: " + curFile.IsDirectory.ToString());
-
-                            // turns out wd is created for each task so use it as sentinal
-                            if (curFile.Path.Equals("wd") && curFile.IsDirectory.HasValue && curFile.IsDirectory.Value)
-                            {
-                                foundAtLeastOneDir = true;
-                            }
+                            foundAtLeastOneDir = true;
                         }
+                    }
 
-                        Assert.True(foundAtLeastOneDir);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.True(foundAtLeastOneDir);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -111,91 +109,89 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug230285Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug230285Job-" + TestUtilities.GetMyName();
+                    const string taskId = "hiWorld";
+                    const string directoryCreationTaskId1 = "dirTask1";
+                    const string directoryCreationTaskId2 = "dirTask2";
 
-                    try
-                    {
-                        const string taskId = "hiWorld";
-                        const string directoryCreationTaskId1 = "dirTask1";
-                        const string directoryCreationTaskId2 = "dirTask2";
+                    const string directoryNameOne = "Foo";
+                    const string directoryNameTwo = "Bar";
 
-                        const string directoryNameOne = "Foo";
-                        const string directoryNameTwo = "Bar";
-                        
-                        const string directory2PathOnNode = "wd/" + directoryNameTwo;
+                    const string directory2PathOnNode = "wd/" + directoryNameTwo;
 
-                        //
-                        // Create the job
-                        //
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
-                        unboundJob.Commit();
+                    //
+                    // Create the job
+                    //
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+                    unboundJob.Commit();
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
-                        CloudTask directoryCreationTask1 = new CloudTask(directoryCreationTaskId1, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameOne));
-                        CloudTask directoryCreationTask2 = new CloudTask(directoryCreationTaskId2, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameTwo));
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+                    CloudTask directoryCreationTask1 = new CloudTask(directoryCreationTaskId1, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameOne));
+                    CloudTask directoryCreationTask2 = new CloudTask(directoryCreationTaskId2, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameTwo));
 
-                        boundJob.AddTask(myTask);
-                        boundJob.AddTask(directoryCreationTask1);
-                        boundJob.AddTask(directoryCreationTask2);
+                    boundJob.AddTask(myTask);
+                    boundJob.AddTask(directoryCreationTask1);
+                    boundJob.AddTask(directoryCreationTask2);
 
-                        testOutputHelper.WriteLine("Initial job commit()");
+                    testOutputHelper.WriteLine("Initial job commit()");
 
-                        //
-                        // Wait for task to go to completion
-                        //
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+                    //
+                    // Wait for task to go to completion
+                    //
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
 
-                        taskStateMonitor.WaitAll(
-                                boundJob.ListTasks(),
-                                Microsoft.Azure.Batch.Common.TaskState.Completed,
-                                TimeSpan.FromMinutes(3));
-                        
-                        //
-                        // NodeFile delete
-                        //
-                        
-                        //Delete single file
-                        NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
-                        file.Delete();
+                    taskStateMonitor.WaitAll(
+                            boundJob.ListTasks(),
+                            Microsoft.Azure.Batch.Common.TaskState.Completed,
+                            TimeSpan.FromMinutes(3));
 
-                        //Ensure delete succeeded
-                        TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName));
+                    //
+                    // NodeFile delete
+                    //
 
-                        //Delete directory
+                    //Delete single file
+                    NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
+                    file.Delete();
 
-                        NodeFile directory = batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId1, recursive: true).First(item => item.Path.Contains(directoryNameOne));
-                        Assert.True(directory.IsDirectory);
-                        TestUtilities.AssertThrows<BatchException>(() => directory.Delete(recursive: false));
-                        directory.Delete(recursive: true);
+                    //Ensure delete succeeded
+                    TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName));
 
-                        Assert.Null(batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId1, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameOne)));
+                    //Delete directory
 
-                        //
-                        // JobScheduleOperations delete task file
-                        //
-                        batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName);
-                        batchCli.JobOperations.DeleteNodeFile(jobId, taskId, Constants.StandardErrorFileName);
+                    NodeFile directory = batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId1, recursive: true).First(item => item.Path.Contains(directoryNameOne));
+                    Assert.True(directory.IsDirectory);
+                    TestUtilities.AssertThrows<BatchException>(() => directory.Delete(recursive: false));
+                    directory.Delete(recursive: true);
 
-                        //Ensure delete succeeded
-                        TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName));
+                    Assert.Null(batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId1, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameOne)));
 
-                        //Delete directory
-                        directory = batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId2, recursive: true).First(item => item.Path.Contains(directoryNameTwo));
-                        Assert.True(directory.IsDirectory);
-                        TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.DeleteNodeFile(jobId, directoryCreationTaskId2, directory2PathOnNode, recursive: false));
-                        batchCli.JobOperations.DeleteNodeFile(jobId, directoryCreationTaskId2, directory2PathOnNode, recursive: true);
+                    //
+                    // JobScheduleOperations delete task file
+                    //
+                    batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName);
+                    batchCli.JobOperations.DeleteNodeFile(jobId, taskId, Constants.StandardErrorFileName);
 
-                        Assert.Null(batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId2, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameTwo)));
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    //Ensure delete succeeded
+                    TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName));
+
+                    //Delete directory
+                    directory = batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId2, recursive: true).First(item => item.Path.Contains(directoryNameTwo));
+                    Assert.True(directory.IsDirectory);
+                    TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.DeleteNodeFile(jobId, directoryCreationTaskId2, directory2PathOnNode, recursive: false));
+                    batchCli.JobOperations.DeleteNodeFile(jobId, directoryCreationTaskId2, directory2PathOnNode, recursive: true);
+
+                    Assert.Null(batchCli.JobOperations.ListNodeFiles(jobId, directoryCreationTaskId2, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameTwo)));
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -209,192 +205,189 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "TestNodeGetListDeleteFiles-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "TestNodeGetListDeleteFiles-" + TestUtilities.GetMyName();
+                    const string taskId = "hiWorld";
 
-                    try
+                    const string directoryCreationTaskId1 = "dirTask1";
+                    const string directoryCreationTaskId2 = "dirTask2";
+
+                    const string directoryNameOne = "Foo";
+                    const string directoryNameTwo = "Bar";
+
+                    //
+                    // Create the job
+                    //
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+                    unboundJob.Commit();
+
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+                    CloudTask directoryCreationTask1 = new CloudTask(directoryCreationTaskId1, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameOne));
+                    CloudTask directoryCreationTask2 = new CloudTask(directoryCreationTaskId2, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameTwo));
+
+                    boundJob.AddTask(myTask);
+                    boundJob.AddTask(directoryCreationTask1);
+                    boundJob.AddTask(directoryCreationTask2);
+
+                    testOutputHelper.WriteLine("Initial job commit()");
+
+                    //
+                    // Wait for task to go to completion
+                    //
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(3));
+
+                    CloudTask boundTask = boundJob.GetTask(taskId);
+                    //Since the compute node name comes back as "Node:<computeNodeId>" we need to split on : to get the actual compute node name
+                    string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
+
+                    ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
+
+                    testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
+
+                    //Ensure that ListFiles done without a recursive option, or with recursive false return the same values
                     {
-                        const string taskId = "hiWorld";
+                        List<NodeFile> filesByComputeNodeRecursiveOmitted = batchCli.PoolOperations.ListNodeFiles(
+                            poolFixture.PoolId,
+                            computeNodeId).ToList();
 
-                        const string directoryCreationTaskId1 = "dirTask1";
-                        const string directoryCreationTaskId2 = "dirTask2";
+                        List<NodeFile> filesByComputeNodeRecursiveFalse = batchCli.PoolOperations.ListNodeFiles(
+                            poolFixture.PoolId,
+                            computeNodeId,
+                            recursive: false).ToList();
 
-                        const string directoryNameOne = "Foo";
-                        const string directoryNameTwo = "Bar";
-
-                        //
-                        // Create the job
-                        //
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
-                        unboundJob.Commit();
-
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
-                        CloudTask directoryCreationTask1 = new CloudTask(directoryCreationTaskId1, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameOne));
-                        CloudTask directoryCreationTask2 = new CloudTask(directoryCreationTaskId2, string.Format("cmd /c mkdir {0} && echo test > {0}/testfile.txt", directoryNameTwo));
-
-                        boundJob.AddTask(myTask);
-                        boundJob.AddTask(directoryCreationTask1);
-                        boundJob.AddTask(directoryCreationTask2);
-
-                        testOutputHelper.WriteLine("Initial job commit()");
-
-                        //
-                        // Wait for task to go to completion
-                        //
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(3));
-
-                        CloudTask boundTask = boundJob.GetTask(taskId);
-                        //Since the compute node name comes back as "Node:<computeNodeId>" we need to split on : to get the actual compute node name
-                        string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
-
-                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
-
-                        testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
-
-                        //Ensure that ListFiles done without a recursive option, or with recursive false return the same values
-                        {
-                            List<NodeFile> filesByComputeNodeRecursiveOmitted = batchCli.PoolOperations.ListNodeFiles(
-                                poolFixture.PoolId, 
-                                computeNodeId).ToList();
-
-                            List<NodeFile> filesByComputeNodeRecursiveFalse = batchCli.PoolOperations.ListNodeFiles(
-                                poolFixture.PoolId, 
-                                computeNodeId, 
-                                recursive: false).ToList();
-
-                            AssertFileListsMatch(filesByComputeNodeRecursiveOmitted, filesByComputeNodeRecursiveFalse);
-                        }
-
-                        {
-                            List<NodeFile> filesByTaskRecursiveOmitted = batchCli.JobOperations.ListNodeFiles(
-                                jobId,
-                                taskId).ToList();
-
-                            List<NodeFile> filesByTaskRecursiveFalse = batchCli.JobOperations.ListNodeFiles(
-                                jobId,
-                                taskId,
-                                recursive: false).ToList();
-
-                            AssertFileListsMatch(filesByTaskRecursiveOmitted, filesByTaskRecursiveFalse);
-                        }
-
-                        //
-                        // List all node files from operations -- recursive true
-                        //
-                        //TODO: Detail level?
-                        List<NodeFile> fileListFromComputeNodeOperations = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).ToList();
-
-                        foreach (NodeFile f in fileListFromComputeNodeOperations)
-                        {
-                            testOutputHelper.WriteLine("Found file: {0}", f.Path);
-                        }
-                        //Check to make sure the expected folder named "Shared" exists
-                        Assert.Contains("shared", fileListFromComputeNodeOperations.Select(f => f.Path));
-
-                        //
-                        // List all node files from the compute node -- recursive true
-                        //
-                        List<NodeFile> fileListFromComputeNode = computeNode.ListNodeFiles(recursive: true).ToList();
-                        foreach (NodeFile f in fileListFromComputeNodeOperations)
-                        {
-                            testOutputHelper.WriteLine("Found file: {0}", f.Path);
-                        }
-                        //Check to make sure the expected folder named "Shared" exists
-                        Assert.Contains("shared", fileListFromComputeNode.Select(f => f.Path));
-
-                        //
-                        // Get file from operations
-                        //
-                        string filePathToGet = fileListFromComputeNode.First(f => !f.IsDirectory.Value && f.Properties.ContentLength > 0).Path;
-                        testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
-                        NodeFile computeNodeFileFromManager = batchCli.PoolOperations.GetNodeFile(poolFixture.PoolId, computeNodeId, filePathToGet);
-                        testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
-                        testOutputHelper.WriteLine("---- File data: ----");
-                        var computeNodeFileContentFromManager = computeNodeFileFromManager.ReadAsString();
-                        testOutputHelper.WriteLine(computeNodeFileContentFromManager);
-                        Assert.NotEmpty(computeNodeFileContentFromManager);
-
-                        //
-                        // Get file directly from operations (bypassing the properties call)
-                        //
-                        var computeNodeFileContentDirect = batchCli.PoolOperations.CopyNodeFileContentToString(poolFixture.PoolId, computeNodeId, filePathToGet);
-                        testOutputHelper.WriteLine("---- File data: ----");
-                        testOutputHelper.WriteLine(computeNodeFileContentDirect);
-                        Assert.NotEmpty(computeNodeFileContentDirect);
-
-                        //
-                        // Get file from compute node
-                        //
-                        testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
-                        NodeFile fileFromComputeNode = computeNode.GetNodeFile(filePathToGet);
-                        testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
-                        testOutputHelper.WriteLine("---- File data: ----");
-                        var computeNodeFileContentFromNode = fileFromComputeNode.ReadAsString();
-                        testOutputHelper.WriteLine(computeNodeFileContentFromNode);
-                        Assert.NotEmpty(computeNodeFileContentFromNode);
-
-                        //
-                        // Get file from compute node (bypassing the properties call)
-                        //
-                        computeNodeFileContentDirect = computeNode.CopyNodeFileContentToString(filePathToGet);
-                        testOutputHelper.WriteLine("---- File data: ----");
-                        testOutputHelper.WriteLine(computeNodeFileContentDirect);
-                        Assert.NotEmpty(computeNodeFileContentDirect);
-
-                        //
-                        // NodeFile delete
-                        //
-                        string filePath = Path.Combine(@"workitems", jobId, "job-1", taskId, Constants.StandardOutFileName);
-                        NodeFile nodeFile = batchCli.PoolOperations.GetNodeFile(poolFixture.PoolId, computeNodeId, filePath);
-
-                        nodeFile.Delete();
-
-                        //Ensure delete succeeded
-
-                        TestUtilities.AssertThrows<BatchException>(() => nodeFile.Refresh());
-
-                        //Delete directory
-
-                        NodeFile directory = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameOne));
-                        Assert.True(directory.IsDirectory);
-                        TestUtilities.AssertThrows<BatchException>(() => directory.Delete(recursive: false));
-                        directory.Delete(recursive: true);
-
-                        Assert.Null(batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameOne)));
-
-                        //
-                        // PoolManager delete node file
-                        //
-                        filePath = Path.Combine(@"workitems", jobId, "job-1", taskId, Constants.StandardErrorFileName);
-
-                        NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName);
-                        batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, filePath);
-
-                        //Ensure delete succeeded
-                        TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName));
-
-                        //Delete directory
-                        directory = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameTwo));
-                        Assert.True(directory.IsDirectory);
-                        TestUtilities.AssertThrows<BatchException>(() => batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, directory.Path, recursive: false));
-                        batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, directory.Path, recursive: true);
-
-                        Assert.Null(batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameTwo)));
-                    }
-                    finally
-                    {
-                        batchCli.JobOperations.DeleteJob(jobId);
+                        AssertFileListsMatch(filesByComputeNodeRecursiveOmitted, filesByComputeNodeRecursiveFalse);
                     }
 
+                    {
+                        List<NodeFile> filesByTaskRecursiveOmitted = batchCli.JobOperations.ListNodeFiles(
+                            jobId,
+                            taskId).ToList();
+
+                        List<NodeFile> filesByTaskRecursiveFalse = batchCli.JobOperations.ListNodeFiles(
+                            jobId,
+                            taskId,
+                            recursive: false).ToList();
+
+                        AssertFileListsMatch(filesByTaskRecursiveOmitted, filesByTaskRecursiveFalse);
+                    }
+
+                    //
+                    // List all node files from operations -- recursive true
+                    //
+                    //TODO: Detail level?
+                    List<NodeFile> fileListFromComputeNodeOperations = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).ToList();
+
+                    foreach (NodeFile f in fileListFromComputeNodeOperations)
+                    {
+                        testOutputHelper.WriteLine("Found file: {0}", f.Path);
+                    }
+                    //Check to make sure the expected folder named "Shared" exists
+                    Assert.Contains("shared", fileListFromComputeNodeOperations.Select(f => f.Path));
+
+                    //
+                    // List all node files from the compute node -- recursive true
+                    //
+                    List<NodeFile> fileListFromComputeNode = computeNode.ListNodeFiles(recursive: true).ToList();
+                    foreach (NodeFile f in fileListFromComputeNodeOperations)
+                    {
+                        testOutputHelper.WriteLine("Found file: {0}", f.Path);
+                    }
+                    //Check to make sure the expected folder named "Shared" exists
+                    Assert.Contains("shared", fileListFromComputeNode.Select(f => f.Path));
+
+                    //
+                    // Get file from operations
+                    //
+                    string filePathToGet = fileListFromComputeNode.First(f => !f.IsDirectory.Value && f.Properties.ContentLength > 0).Path;
+                    testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
+                    NodeFile computeNodeFileFromManager = batchCli.PoolOperations.GetNodeFile(poolFixture.PoolId, computeNodeId, filePathToGet);
+                    testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
+                    testOutputHelper.WriteLine("---- File data: ----");
+                    var computeNodeFileContentFromManager = computeNodeFileFromManager.ReadAsString();
+                    testOutputHelper.WriteLine(computeNodeFileContentFromManager);
+                    Assert.NotEmpty(computeNodeFileContentFromManager);
+
+                    //
+                    // Get file directly from operations (bypassing the properties call)
+                    //
+                    var computeNodeFileContentDirect = batchCli.PoolOperations.CopyNodeFileContentToString(poolFixture.PoolId, computeNodeId, filePathToGet);
+                    testOutputHelper.WriteLine("---- File data: ----");
+                    testOutputHelper.WriteLine(computeNodeFileContentDirect);
+                    Assert.NotEmpty(computeNodeFileContentDirect);
+
+                    //
+                    // Get file from compute node
+                    //
+                    testOutputHelper.WriteLine("Getting file: {0}", filePathToGet);
+                    NodeFile fileFromComputeNode = computeNode.GetNodeFile(filePathToGet);
+                    testOutputHelper.WriteLine("Successfully retrieved file: {0}", filePathToGet);
+                    testOutputHelper.WriteLine("---- File data: ----");
+                    var computeNodeFileContentFromNode = fileFromComputeNode.ReadAsString();
+                    testOutputHelper.WriteLine(computeNodeFileContentFromNode);
+                    Assert.NotEmpty(computeNodeFileContentFromNode);
+
+                    //
+                    // Get file from compute node (bypassing the properties call)
+                    //
+                    computeNodeFileContentDirect = computeNode.CopyNodeFileContentToString(filePathToGet);
+                    testOutputHelper.WriteLine("---- File data: ----");
+                    testOutputHelper.WriteLine(computeNodeFileContentDirect);
+                    Assert.NotEmpty(computeNodeFileContentDirect);
+
+                    //
+                    // NodeFile delete
+                    //
+                    string filePath = Path.Combine(@"workitems", jobId, "job-1", taskId, Constants.StandardOutFileName);
+                    NodeFile nodeFile = batchCli.PoolOperations.GetNodeFile(poolFixture.PoolId, computeNodeId, filePath);
+
+                    nodeFile.Delete();
+
+                    //Ensure delete succeeded
+
+                    TestUtilities.AssertThrows<BatchException>(() => nodeFile.Refresh());
+
+                    //Delete directory
+
+                    NodeFile directory = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameOne));
+                    Assert.True(directory.IsDirectory);
+                    TestUtilities.AssertThrows<BatchException>(() => directory.Delete(recursive: false));
+                    directory.Delete(recursive: true);
+
+                    Assert.Null(batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameOne)));
+
+                    //
+                    // PoolManager delete node file
+                    //
+                    filePath = Path.Combine(@"workitems", jobId, "job-1", taskId, Constants.StandardErrorFileName);
+
+                    NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName);
+                    batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, filePath);
+
+                    //Ensure delete succeeded
+                    TestUtilities.AssertThrows<BatchException>(() => batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardErrorFileName));
+
+                    //Delete directory
+                    directory = batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).First(item => item.Path.Contains(directoryNameTwo));
+                    Assert.True(directory.IsDirectory);
+                    TestUtilities.AssertThrows<BatchException>(() => batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, directory.Path, recursive: false));
+                    batchCli.PoolOperations.DeleteNodeFile(poolFixture.PoolId, computeNodeId, directory.Path, recursive: true);
+
+                    Assert.Null(batchCli.PoolOperations.ListNodeFiles(poolFixture.PoolId, computeNodeId, recursive: true).FirstOrDefault(item => item.Path.Contains(directoryNameTwo)));
+                }
+                finally
+                {
+                    batchCli.JobOperations.DeleteJob(jobId);
                 }
             };
 
@@ -408,53 +401,51 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                JobOperations jobOperations = batchCli.JobOperations;
                 {
-                    JobOperations jobOperations = batchCli.JobOperations;
+                    string jobId = "Bug2338301Job-" + TestUtilities.GetMyName();
+
+                    try
                     {
-                        string jobId = "Bug2338301Job-" + TestUtilities.GetMyName();
+                        const string taskId = "hiWorld";
 
-                        try
-                        {
-                            const string taskId = "hiWorld";
+                        //
+                        // Create the job
+                        //
+                        CloudJob unboundJob = jobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                        unboundJob.Commit();
 
-                            //
-                            // Create the job
-                            //
-                            CloudJob unboundJob = jobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                            unboundJob.Commit();
+                        CloudJob boundJob = jobOperations.GetJob(jobId);
+                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
 
-                            CloudJob boundJob = jobOperations.GetJob(jobId);
-                            CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+                        boundJob.AddTask(myTask);
 
-                            boundJob.AddTask(myTask);
+                        testOutputHelper.WriteLine("Initial job commit()");
 
-                            testOutputHelper.WriteLine("Initial job commit()");
+                        //
+                        // Wait for task to go to completion
+                        //
+                        Utilities utilities = batchCli.Utilities;
+                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+                        taskStateMonitor.WaitAll(
+                            boundJob.ListTasks(),
+                            Microsoft.Azure.Batch.Common.TaskState.Completed,
+                            TimeSpan.FromMinutes(3));
 
-                            //
-                            // Wait for task to go to completion
-                            //
-                            Utilities utilities = batchCli.Utilities;
-                            TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-                            taskStateMonitor.WaitAll(
-                                boundJob.ListTasks(),
-                                Microsoft.Azure.Batch.Common.TaskState.Completed,
-                                TimeSpan.FromMinutes(3));
+                        CloudTask boundTask = boundJob.GetTask(taskId);
 
-                            CloudTask boundTask = boundJob.GetTask(taskId);
+                        //Get the task file
+                        const string fileToGet = "stdout.txt";
+                        NodeFile file = boundTask.GetNodeFile(fileToGet);
 
-                            //Get the task file
-                            const string fileToGet = "stdout.txt";
-                            NodeFile file = boundTask.GetNodeFile(fileToGet);
-
-                            //Download the file data
-                            string result = file.ReadAsString();
-                            Assert.True(result.Length > 0);
-                        }
-                        finally
-                        {
-                            jobOperations.DeleteJob(jobId);
-                        }
+                        //Download the file data
+                        string result = file.ReadAsString();
+                        Assert.True(result.Length > 0);
+                    }
+                    finally
+                    {
+                        jobOperations.DeleteJob(jobId);
                     }
                 }
             };
@@ -469,87 +460,85 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1480491Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    string jobId = "Bug1480491Job-" + TestUtilities.GetMyName();
+                    const string taskId = "hiWorld";
 
-                    try
+                    //
+                    // Create the job
+                    //
+                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+                    unboundJob.Commit();
+
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                    CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+
+                    boundJob.AddTask(myTask);
+
+                    testOutputHelper.WriteLine("Initial job commit()");
+
+                    //
+                    // Wait for task to go to completion
+                    //
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+
+                    taskStateMonitor.WaitAll(
+                        boundJob.ListTasks(),
+                        Microsoft.Azure.Batch.Common.TaskState.Completed,
+                        TimeSpan.FromMinutes(3));
+
+                    const int expectedFileSize = 13; //Magic number based on output generated by the task
+
+                    //
+                    // NodeFile by task
+                    //
+                    NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
+
+                    testOutputHelper.WriteLine("File {0} has content length: {1}", Constants.StandardOutFileName, file.Properties.ContentLength);
+                    testOutputHelper.WriteLine("File {0} has content type: {1}", Constants.StandardOutFileName, file.Properties.ContentType);
+
+                    testOutputHelper.WriteLine("File {0} has creation time: {1}", Constants.StandardOutFileName, file.Properties.CreationTime);
+                    testOutputHelper.WriteLine("File {0} has last modified time: {1}", Constants.StandardOutFileName, file.Properties.LastModified);
+
+                    Assert.Equal(expectedFileSize, file.Properties.ContentLength);
+                    Assert.Equal("text/plain", file.Properties.ContentType);
+
+                    //
+                    // NodeFile by node
+                    //
+                    CloudTask boundTask = boundJob.GetTask(taskId);
+                    string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
+
+                    ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
+
+                    testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
+
+                    List<NodeFile> files = computeNode.ListNodeFiles(recursive: true).ToList();
+                    foreach (NodeFile nodeFile in files)
                     {
-                        const string taskId = "hiWorld";
-
-                        //
-                        // Create the job
-                        //
-                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
-                        unboundJob.Commit();
-
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
-
-                        boundJob.AddTask(myTask);
-
-                        testOutputHelper.WriteLine("Initial job commit()");
-
-                        //
-                        // Wait for task to go to completion
-                        //
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
-
-                        taskStateMonitor.WaitAll(
-                            boundJob.ListTasks(),
-                            Microsoft.Azure.Batch.Common.TaskState.Completed,
-                            TimeSpan.FromMinutes(3));
-
-                        const int expectedFileSize = 13; //Magic number based on output generated by the task
-
-                        //
-                        // NodeFile by task
-                        //
-                        NodeFile file = batchCli.JobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
-
-                        testOutputHelper.WriteLine("File {0} has content length: {1}", Constants.StandardOutFileName, file.Properties.ContentLength);
-                        testOutputHelper.WriteLine("File {0} has content type: {1}", Constants.StandardOutFileName, file.Properties.ContentType);
-
-                        testOutputHelper.WriteLine("File {0} has creation time: {1}", Constants.StandardOutFileName, file.Properties.CreationTime);
-                        testOutputHelper.WriteLine("File {0} has last modified time: {1}", Constants.StandardOutFileName, file.Properties.LastModified);
-
-                        Assert.Equal(expectedFileSize, file.Properties.ContentLength);
-                        Assert.Equal("text/plain", file.Properties.ContentType);
-
-                        //
-                        // NodeFile by node
-                        //
-                        CloudTask boundTask = boundJob.GetTask(taskId);
-                        string computeNodeId = boundTask.ComputeNodeInformation.AffinityId.Split(':')[1];
-
-                        ComputeNode computeNode = batchCli.PoolOperations.GetComputeNode(poolFixture.PoolId, computeNodeId);
-
-                        testOutputHelper.WriteLine("Task ran on compute node: {0}", computeNodeId);
-
-                        List<NodeFile> files = computeNode.ListNodeFiles(recursive: true).ToList();
-                        foreach (NodeFile nodeFile in files)
-                        {
-                            testOutputHelper.WriteLine("Found file: {0}", nodeFile.Path);
-                        }
-
-                        string filePathToGet = string.Format("workitems/{0}/{1}/{2}/{3}", jobId, "job-1", taskId, Constants.StandardOutFileName);
-                        file = computeNode.GetNodeFile(filePathToGet);
-
-                        testOutputHelper.WriteLine("File {0} has content length: {1}", filePathToGet, file.Properties.ContentLength);
-                        testOutputHelper.WriteLine("File {0} has content type: {1}", filePathToGet, file.Properties.ContentType);
-
-                        testOutputHelper.WriteLine("File {0} has creation time: {1}", filePathToGet, file.Properties.CreationTime);
-                        testOutputHelper.WriteLine("File {0} has last modified time: {1}", filePathToGet, file.Properties.LastModified);
-
-                        Assert.Equal(expectedFileSize, file.Properties.ContentLength);
-                        Assert.Equal("text/plain", file.Properties.ContentType);
+                        testOutputHelper.WriteLine("Found file: {0}", nodeFile.Path);
                     }
-                    finally
-                    {
-                        batchCli.JobOperations.DeleteJob(jobId);
-                    }
+
+                    string filePathToGet = string.Format("workitems/{0}/{1}/{2}/{3}", jobId, "job-1", taskId, Constants.StandardOutFileName);
+                    file = computeNode.GetNodeFile(filePathToGet);
+
+                    testOutputHelper.WriteLine("File {0} has content length: {1}", filePathToGet, file.Properties.ContentLength);
+                    testOutputHelper.WriteLine("File {0} has content type: {1}", filePathToGet, file.Properties.ContentType);
+
+                    testOutputHelper.WriteLine("File {0} has creation time: {1}", filePathToGet, file.Properties.CreationTime);
+                    testOutputHelper.WriteLine("File {0} has last modified time: {1}", filePathToGet, file.Properties.LastModified);
+
+                    Assert.Equal(expectedFileSize, file.Properties.ContentLength);
+                    Assert.Equal("text/plain", file.Properties.ContentType);
+                }
+                finally
+                {
+                    batchCli.JobOperations.DeleteJob(jobId);
                 }
             };
 
@@ -563,71 +552,69 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                JobOperations jobOperations = batchCli.JobOperations;
+
+                string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + nameof(TestGetNodeFileByTask);
+                try
                 {
-                    JobOperations jobOperations = batchCli.JobOperations;
-
-                    string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + nameof(TestGetNodeFileByTask);
-                    try
+                    //
+                    // Create the job
+                    //
+                    CloudJob job = jobOperations.CreateJob(jobId, new PoolInformation());
+                    job.PoolInformation = new PoolInformation()
                     {
-                        //
-                        // Create the job
-                        //
-                        CloudJob job = jobOperations.CreateJob(jobId, new PoolInformation());
-                        job.PoolInformation = new PoolInformation()
-                        {
-                            PoolId = poolFixture.PoolId
-                        };
+                        PoolId = poolFixture.PoolId
+                    };
 
-                        testOutputHelper.WriteLine("Initial job schedule commit()");
+                    testOutputHelper.WriteLine("Initial job schedule commit()");
 
-                        job.Commit();
+                    job.Commit();
 
-                        //
-                        // Wait for the job
-                        //
-                        testOutputHelper.WriteLine("Waiting for job");
-                        CloudJob boundJob = jobOperations.GetJob(jobId);
+                    //
+                    // Wait for the job
+                    //
+                    testOutputHelper.WriteLine("Waiting for job");
+                    CloudJob boundJob = jobOperations.GetJob(jobId);
 
-                        //
-                        // Add task to the job
-                        //
-                        const string taskId = "T1";
-                        const string taskMessage = "This is a test";
+                    //
+                    // Add task to the job
+                    //
+                    const string taskId = "T1";
+                    const string taskMessage = "This is a test";
 
-                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                        CloudTask task = new CloudTask(taskId, string.Format("cmd /c echo {0}", taskMessage));
-                        boundJob.AddTask(task);
+                    testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                    CloudTask task = new CloudTask(taskId, string.Format("cmd /c echo {0}", taskMessage));
+                    boundJob.AddTask(task);
 
-                        //
-                        // Wait for the task to complete
-                        //
-                        testOutputHelper.WriteLine("Waiting for the task to complete");
-                        Utilities utilities = batchCli.Utilities;
-                        TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
+                    //
+                    // Wait for the task to complete
+                    //
+                    testOutputHelper.WriteLine("Waiting for the task to complete");
+                    Utilities utilities = batchCli.Utilities;
+                    TaskStateMonitor taskStateMonitor = utilities.CreateTaskStateMonitor();
 
-                        //Wait for the task state to be running
-                        taskStateMonitor.WaitAll(
-                            jobOperations.ListTasks(jobId),
-                            TaskState.Completed,
-                            TimeSpan.FromSeconds(30));
+                    //Wait for the task state to be running
+                    taskStateMonitor.WaitAll(
+                        jobOperations.ListTasks(jobId),
+                        TaskState.Completed,
+                        TimeSpan.FromSeconds(30));
 
-                        //Download the data
-                        testOutputHelper.WriteLine("Downloading the stdout for the file");
-                        NodeFile file = jobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
-                        string data = file.ReadAsString();
-                        testOutputHelper.WriteLine("Data: {0}", data);
-                        Assert.Contains(taskMessage, data);
+                    //Download the data
+                    testOutputHelper.WriteLine("Downloading the stdout for the file");
+                    NodeFile file = jobOperations.GetNodeFile(jobId, taskId, Constants.StandardOutFileName);
+                    string data = file.ReadAsString();
+                    testOutputHelper.WriteLine("Data: {0}", data);
+                    Assert.Contains(taskMessage, data);
 
-                        // Download the data again using the JobOperations read file content helper
-                        data = batchCli.JobOperations.CopyNodeFileContentToString(jobId, taskId, Constants.StandardOutFileName);
-                        testOutputHelper.WriteLine("Data: {0}", data);
-                        Assert.Contains(taskMessage, data);
-                    }
-                    finally
-                    {
-                        jobOperations.DeleteJob(jobId);
-                    }
+                    // Download the data again using the JobOperations read file content helper
+                    data = batchCli.JobOperations.CopyNodeFileContentToString(jobId, taskId, Constants.StandardOutFileName);
+                    testOutputHelper.WriteLine("Data: {0}", data);
+                    Assert.Contains(taskMessage, data);
+                }
+                finally
+                {
+                    jobOperations.DeleteJob(jobId);
                 }
             };
 
@@ -684,49 +671,46 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = null;
+                try
                 {
-                    string jobId = null;
-                    try
+                    string taskId;
+
+                    // create some files on the node
+                    TestUtilities.HelloWorld(
+                        batchCli,
+                        testOutputHelper,
+                        poolFixture.Pool,
+                        out jobId,
+                        out taskId,
+                        deleteJob: false,
+                        isLinux: true);
+
+                    var nodes = poolFixture.Pool.ListComputeNodes().ToList();
+                    ComputeNode cn = nodes[0]; // get the node that has files on it
+
+                    List<NodeFile> files = cn.ListNodeFiles(recursive: true).ToList();
+
+                    Assert.True(files.Count > 0);
+
+                    bool foundOne = false;
+
+                    // look through all the files for a filemode
+                    foreach (NodeFile curNF in files)
                     {
-                        string taskId;
-
-                        // create some files on the node
-                        TestUtilities.HelloWorld(
-                            batchCli,
-                            testOutputHelper,
-                            poolFixture.Pool,
-                            out jobId,
-                            out taskId,
-                            deleteJob: false,
-                            isLinux: true);
-
-                        var nodes = poolFixture.Pool.ListComputeNodes().ToList();
-                        ComputeNode cn = nodes[0]; // get the node that has files on it
-
-                        List<NodeFile> files = cn.ListNodeFiles(recursive: true).ToList();
-
-                        Assert.True(files.Count > 0);
-
-                        bool foundOne = false;
-
-                        // look through all the files for a filemode
-                        foreach (NodeFile curNF in files)
+                        if ((null != curNF.Properties) && !string.IsNullOrWhiteSpace(curNF.Properties.FileMode))
                         {
-                            if ((null != curNF.Properties) && !string.IsNullOrWhiteSpace(curNF.Properties.FileMode))
-                            {
-                                foundOne = true;
-                                break;
-                            }
+                            foundOne = true;
+                            break;
                         }
+                    }
 
-                        Assert.True(foundOne);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
-                    
+                    Assert.True(foundOne);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
@@ -48,7 +48,7 @@
 
                     try
                     {
-                        CloudJob jobCreate = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob jobCreate = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         jobCreate.Commit();
 
                         CloudJob theJob = batchCli.JobOperations.GetJob(jobId);
@@ -65,14 +65,14 @@
                         int numTasksSeen = 0;
 
                         // test replacement interceptor and forces MaxResults to a low #
-                        Bug957878ReplacementInterceptorBox box0 = new Bug957878ReplacementInterceptorBox(this.testOutputHelper);
+                        Bug957878ReplacementInterceptorBox box0 = new Bug957878ReplacementInterceptorBox(testOutputHelper);
 
                         foreach (CloudTask curTask in theJob.ListTasks(additionalBehaviors: new[] {
                             new Protocol.RequestReplacementInterceptor(box0.Bug957878RequestReplacementInterceptorOpContextFactory)}))
                         {
                             numTasksSeen++;
 
-                            this.testOutputHelper.WriteLine("    Task_Id: " + curTask.Id);
+                            testOutputHelper.WriteLine("    Task_Id: " + curTask.Id);
                         }
 
                         // confirm we'v seen the correct # of tasks during enumeration
@@ -83,8 +83,8 @@
 
                         // >= because the server might hickup too and put in extra empty skiptokens
 
-                        this.testOutputHelper.WriteLine("total tasks created: " + numTasksCreated.ToString());
-                        this.testOutputHelper.WriteLine("total tasks enumerated: " + numTasksSeen.ToString());
+                        testOutputHelper.WriteLine("total tasks created: " + numTasksCreated.ToString());
+                        testOutputHelper.WriteLine("total tasks enumerated: " + numTasksSeen.ToString());
 
                         Assert.Equal(numTasksCreated, numTasksSeen);
 
@@ -114,7 +114,7 @@
                     string jobId = "Bug1568799Job-" + TestUtilities.GetMyName();
                     try
                     {
-                        CloudJob newJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = this.poolFixture.PoolId });
+                        CloudJob newJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                         newJob.Commit();
 
                         // now we have at least one JS (and pool).  double-enumerate them
@@ -152,7 +152,7 @@
                 using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
                 {
                     // pools tested in Bug1770942ExposeBatchRequestProperties
-                    this.testOutputHelper.WriteLine("job schedule tests");
+                    testOutputHelper.WriteLine("job schedule tests");
 
                     // create a bunch of job schedules
                     {
@@ -185,7 +185,7 @@
                                 CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
                                 PoolInformation poolInformation = new PoolInformation();
 
-                                poolInformation.PoolId = this.poolFixture.PoolId;
+                                poolInformation.PoolId = poolFixture.PoolId;
 
                                 unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation);
 
@@ -255,7 +255,7 @@
                         }
                     }
 
-                    this.testOutputHelper.WriteLine("job tests");
+                    testOutputHelper.WriteLine("job tests");
 
                     // jobs
                     string jobId = "Bug1770942Job-" + TestUtilities.GetMyName();
@@ -265,7 +265,7 @@
                         {
                             // create a job
                             CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                            unboundJob.PoolInformation.PoolId = this.poolFixture.PoolId;
+                            unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
                             unboundJob.Commit();
                             CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
@@ -313,7 +313,7 @@
                             Assert.NotEqual(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
                         }
 
-                        this.testOutputHelper.WriteLine("task tests");
+                        testOutputHelper.WriteLine("task tests");
 
                         // tasks
                         {
@@ -394,7 +394,7 @@
                         }
 
                         // task files
-                        this.testOutputHelper.WriteLine("task file tests");
+                        testOutputHelper.WriteLine("task file tests");
 
                         {
                             List<CloudTask> tasks = new List<CloudTask>(batchCli.JobOperations.GetJob(jobId).ListTasks());
@@ -486,11 +486,11 @@
                         CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
                         jobSchedule.JobSpecification = new JobSpecification(new PoolInformation()
                             {
-                                PoolId = this.poolFixture.PoolId
+                                PoolId = poolFixture.PoolId
                             });
                         jobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(1) };
 
-                        this.testOutputHelper.WriteLine("Initial job schedule commit()");
+                        testOutputHelper.WriteLine("Initial job schedule commit()");
                         jobSchedule.Commit();
 
                         //Get the bound job schedule
@@ -503,7 +503,7 @@
                         CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
 
                         //Add the task
-                        this.testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
                         boundJob.AddTask(myTask);
 
                         //Get the task
@@ -515,44 +515,44 @@
                         stateMonitor.WaitAll(new List<CloudTask> { boundTask }, TaskState.Completed, TimeSpan.FromMinutes(2));
                         
                         //Try to refresh the job schedule multiple times
-                        this.testOutputHelper.WriteLine("Refreshing job schedule");
+                        testOutputHelper.WriteLine("Refreshing job schedule");
                         boundJobSchedule.Refresh();
-                        this.testOutputHelper.WriteLine("Refreshing job schedule");
+                        testOutputHelper.WriteLine("Refreshing job schedule");
                         boundJobSchedule.Refresh();
 
                         //Try to refresh the job multiple times
-                        this.testOutputHelper.WriteLine("Refreshing job");
+                        testOutputHelper.WriteLine("Refreshing job");
                         boundJob.Refresh();
-                        this.testOutputHelper.WriteLine("Refreshing job");
+                        testOutputHelper.WriteLine("Refreshing job");
                         boundJob.Refresh();
 
                         //Try to refresh the task multiple times
-                        this.testOutputHelper.WriteLine("Refreshing task");
+                        testOutputHelper.WriteLine("Refreshing task");
                         boundTask.Refresh();
-                        this.testOutputHelper.WriteLine("Refreshing task");
+                        testOutputHelper.WriteLine("Refreshing task");
                         boundTask.Refresh();
 
                         //Try to refresh a file multiple times
                         NodeFile nodeFile = boundTask.GetNodeFile("stdout.txt");
 
-                        this.testOutputHelper.WriteLine("Refreshing task file");
+                        testOutputHelper.WriteLine("Refreshing task file");
                         nodeFile.Refresh();
-                        this.testOutputHelper.WriteLine("Refreshing task file");
+                        testOutputHelper.WriteLine("Refreshing task file");
                         nodeFile.Refresh();
 
                         //Try to refresh the pool multiple times
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(this.poolFixture.PoolId);
+                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                        this.testOutputHelper.WriteLine("Refreshing pool");
+                        testOutputHelper.WriteLine("Refreshing pool");
                         boundPool.Refresh();
-                        this.testOutputHelper.WriteLine("Refreshing pool");
+                        testOutputHelper.WriteLine("Refreshing pool");
                         boundPool.Refresh();
                         //Try to refresh a compute node multiple times
                         ComputeNode computeNode = boundPool.ListComputeNodes().First();
 
-                        this.testOutputHelper.WriteLine("Refreshing compute node");
+                        testOutputHelper.WriteLine("Refreshing compute node");
                         computeNode.Refresh();
-                        this.testOutputHelper.WriteLine("Refreshing compute node");
+                        testOutputHelper.WriteLine("Refreshing compute node");
                         computeNode.Refresh();
 
                         //Try to refresh a node file multiple times
@@ -597,7 +597,7 @@
                     {
                         CloudJobSchedule unboundJobSchedule = jobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
                         PoolInformation poolInformation = new PoolInformation();
-                        poolInformation.PoolId = this.poolFixture.PoolId;
+                        poolInformation.PoolId = poolFixture.PoolId;
                         unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation);
                         unboundJobSchedule.Schedule = new Schedule() { DoNotRunAfter = DateTime.UtcNow.AddDays(1) };
                         unboundJobSchedule.Commit();
@@ -641,7 +641,7 @@
                         // 2015.jul: in GA there is no SetOpCon interceptor and YieldInjector was removed and "the func" exposed
                         //batchClient.CustomBehaviors.Add(new SetOperationContext(Bug1959324SetOperationContext));  // this does not exist in GA
                         //batchClient.CustomBehaviors.Add(new YieldInjectionInterceptor(Bug1959324YieldInjectionInterceptor));  // this is now done by func replacement. see below
-                        batchCli.CustomBehaviors.Add(new Protocol.RequestInterceptor((o) => { interceptorCount++; this.testOutputHelper.WriteLine("Test: random interceptor"); }));
+                        batchCli.CustomBehaviors.Add(new Protocol.RequestInterceptor((o) => { interceptorCount++; testOutputHelper.WriteLine("Test: random interceptor"); }));
 
                         string taskIdHello;
 
@@ -649,16 +649,16 @@
                         {
                             int preSetupCount = interceptorCount;
 
-                            CloudPool sharedPool = batchCli.PoolOperations.GetPool(this.poolFixture.PoolId);
+                            CloudPool sharedPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                            TestUtilities.HelloWorld(batchCli, this.testOutputHelper, sharedPool, out bug1959324JobId, out taskIdHello, deleteJob: false);
+                            TestUtilities.HelloWorld(batchCli, testOutputHelper, sharedPool, out bug1959324JobId, out taskIdHello, deleteJob: false);
 
                             // confirm interceptor was executed
                             Assert.True(interceptorCount > preSetupCount);
                         }
 
                         // test jobOps.ListNodeFiles
-                        this.testOutputHelper.WriteLine("ListNodeFiles");
+                        testOutputHelper.WriteLine("ListNodeFiles");
                         int preListNodeFilesCount = interceptorCount;
                         var files = batchCli.JobOperations.ListNodeFiles(bug1959324JobId, taskIdHello, recursive: true).ToList();
 
@@ -666,7 +666,7 @@
                         Assert.True(interceptorCount > preListNodeFilesCount);
 
                         // test jobOps.ListJobs
-                        this.testOutputHelper.WriteLine("ListJobs");
+                        testOutputHelper.WriteLine("ListJobs");
                         int preListJobsCount = interceptorCount;
                         var jobs = batchCli.JobOperations.ListJobs().ToList();
 
@@ -674,21 +674,21 @@
                         Assert.True(interceptorCount > preListJobsCount);
 
                         // test poolOps.ListPools
-                        this.testOutputHelper.WriteLine("ListPools");
+                        testOutputHelper.WriteLine("ListPools");
                         int preListPoolsCount = interceptorCount;
                         var pools = batchCli.PoolOperations.ListPools().ToList();
 
                         // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
                         Assert.True(interceptorCount > preListPoolsCount);
 
-                        this.testOutputHelper.WriteLine("GetJob Yield Injector test");
+                        testOutputHelper.WriteLine("GetJob Yield Injector test");
 
                         // this yield injector will mung the func to make a get job call
                         // with real arguments.  the call made in the test has arguments that
                         // would fail/throw.
                         Protocol.BatchRequestModificationInterceptHandler yieldInjectionInterceptor = baseRequest =>
                         {
-                            this.testOutputHelper.WriteLine("Yield Injector!");
+                            testOutputHelper.WriteLine("Yield Injector!");
 
                             var request =
                                 (JobGetBatchRequest)baseRequest;
@@ -697,14 +697,14 @@
                             request.ServiceRequestFunc = (token) => { return request.RestClient.Job.GetWithHttpMessagesAsync(bug1959324JobId, request.Options, cancellationToken: token); };
 
                             // the func has been replaced with one that will work.. and the caller will get a real job
-                            this.testOutputHelper.WriteLine("Leaving Yield Injector!");
+                            testOutputHelper.WriteLine("Leaving Yield Injector!");
                         };
 
                         CloudJob boundJob = batchCli.JobOperations.GetJob(
                                             "test value that can't possibly be found as a job id",
                                             additionalBehaviors: new[] { new Protocol.RequestInterceptor(yieldInjectionInterceptor) });
 
-                        this.testOutputHelper.WriteLine("Done. got job.");
+                        testOutputHelper.WriteLine("Done. got job.");
 
                         // confirm the job has a real id from HelloWorld not the bad one passed in
 
@@ -745,22 +745,21 @@
                             //
                             //Test bound pool properties
                             //
-                            CloudPool pool = poolOperations.GetPool(this.poolFixture.PoolId);
-                            pool.Metadata = new List<MetadataItem>();
-                            pool.Metadata.Add(new MetadataItem("test", "test"));
+                            CloudPool pool = poolOperations.GetPool(poolFixture.PoolId);
+                            pool.Metadata = new List<MetadataItem> { new MetadataItem("test", "test") };
 
                             //Note: We rely on the certificate specific tests to validate certificate references work for us
 
                             pool.Commit();
 
-                            pool = poolOperations.GetPool(this.poolFixture.PoolId);
+                            pool = poolOperations.GetPool(poolFixture.PoolId);
 
                             Assert.Equal(1, pool.Metadata.Count);
 
                             //
                             //Unbound job schedule properties
                             //
-                            this.testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
+                            testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
                             CloudJobSchedule unboundJobSchedule = jobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
 
                             Assert.Null(unboundJobSchedule.Metadata);
@@ -818,7 +817,7 @@
 
                             unboundJobSchedule.Commit();
 
-                            this.testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
+                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
                             boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
 
                             Assert.Equal(1, boundJobSchedule.Metadata.Count);
@@ -840,10 +839,10 @@
                             boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Add(new EnvironmentSetting("abc", "abc"));
                             boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Add(ResourceFile.FromUrl("http://abc", "abc"));
 
-                            this.testOutputHelper.WriteLine("Commiting updated Job Schedule with more IList stuff added");
+                            testOutputHelper.WriteLine("Commiting updated Job Schedule with more IList stuff added");
                             boundJobSchedule.Commit();
 
-                            this.testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
+                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
                             boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
 
 
@@ -860,10 +859,10 @@
                             boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles = null;
                             boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings = null;
 
-                            this.testOutputHelper.WriteLine("Commiting updated Job Schedule with some IList stuff removed");
+                            testOutputHelper.WriteLine("Commiting updated Job Schedule with some IList stuff removed");
                             boundJobSchedule.Commit();
 
-                            this.testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
+                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
                             boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
 
                             Assert.Null(boundJobSchedule.Metadata);
@@ -879,7 +878,7 @@
 
                             boundJobSchedule.Commit();
 
-                            this.testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
+                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
                             boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(jobScheduleOperations, jobScheduleId);
 
                             Assert.Null(boundJobSchedule.Metadata);
@@ -918,18 +917,15 @@
                             //
                             // Get the job and add a task
                             //
-                            const string taskId = "test";
+                            CloudTask unboundTask = new CloudTask("test", "cmd /c dir");
+                            unboundTask.EnvironmentSettings = new List<EnvironmentSetting> { new EnvironmentSetting("foo", "baz") };
+
+                            unboundTask.ResourceFiles = new List<ResourceFile> { ResourceFile.FromUrl("http://foo", "baz") };
 
                             CloudJob job = jobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
-
-                            CloudTask unboundTask = new CloudTask("test", "cmd /c dir");
-                            unboundTask.EnvironmentSettings = new List<EnvironmentSetting>();
-                            unboundTask.EnvironmentSettings.Add(new EnvironmentSetting("foo", "baz"));
-
-                            unboundTask.ResourceFiles = new List<ResourceFile>();
-                            unboundTask.ResourceFiles.Add(ResourceFile.FromUrl("http://foo", "baz"));
-
                             job.AddTask(unboundTask);
+
+                            const string taskId = "test";
 
                             //Get the bound task
                             CloudTask boundTask = job.GetTask(taskId);
@@ -1015,7 +1011,7 @@
                     schedule.DoNotRunUntil = DateTime.Now.AddYears(1);
                     unboundJobSchedule.Schedule = schedule;
 
-                    this.testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
+                    testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
                     unboundJobSchedule.Commit();
 
                     try
@@ -1029,7 +1025,7 @@
                         Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName);
 
                         // Verify that job schedule display name cannot be set on bound, but sub property display names can
-                        this.testOutputHelper.WriteLine("Attempting to set display names on job schedule, job specification, pool specification, and job manager task");
+                        testOutputHelper.WriteLine("Attempting to set display names on job schedule, job specification, pool specification, and job manager task");
 
                         TestUtilities.AssertThrows<InvalidOperationException>(() => boundJobSchedule.DisplayName = updatedDisplayName);
 
@@ -1043,7 +1039,7 @@
                     }
                     finally
                     {
-                        this.testOutputHelper.WriteLine("Deleting job schedule {0}", jobScheduleId);
+                        testOutputHelper.WriteLine("Deleting job schedule {0}", jobScheduleId);
                         batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
                     }
 
@@ -1055,9 +1051,9 @@
 
                     Assert.Equal(originalDisplayName, unboundJob.DisplayName);
 
-                    unboundJob.PoolInformation = new PoolInformation() { PoolId = this.poolFixture.PoolId };
+                    unboundJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
 
-                    this.testOutputHelper.WriteLine("Creating job {0}", jobId);
+                    testOutputHelper.WriteLine("Creating job {0}", jobId);
                     unboundJob.Commit();
 
                     try
@@ -1068,7 +1064,7 @@
                         Assert.Equal(originalDisplayName, boundJob.DisplayName);
 
                         // Verify that display name can not be set when bound
-                        this.testOutputHelper.WriteLine("Attempting to set display name on job");
+                        testOutputHelper.WriteLine("Attempting to set display name on job");
                         TestUtilities.AssertThrows<InvalidOperationException>(() => boundJob.DisplayName = updatedDisplayName);
 
                         // Create an unbound task and verify that display name can be set
@@ -1078,7 +1074,7 @@
 
                         Assert.Equal(originalDisplayName, unboundTask.DisplayName);
 
-                        this.testOutputHelper.WriteLine("Adding task {0} to job {1}", taskId, jobId);
+                        testOutputHelper.WriteLine("Adding task {0} to job {1}", taskId, jobId);
                         boundJob.AddTask(unboundTask);
 
                         try
@@ -1089,18 +1085,18 @@
                             Assert.Equal(originalDisplayName, boundTask.DisplayName);
 
                             // Verify that display name can not be set when bound
-                            this.testOutputHelper.WriteLine("Attempting to set display name on task");
+                            testOutputHelper.WriteLine("Attempting to set display name on task");
                             TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.DisplayName = updatedDisplayName);
                         }
                         finally
                         {
-                            this.testOutputHelper.WriteLine("Deleting task {0}", taskId);
+                            testOutputHelper.WriteLine("Deleting task {0}", taskId);
                             batchCli.JobOperations.DeleteTask(jobId, taskId);
                         }
                     }
                     finally
                     {
-                        this.testOutputHelper.WriteLine("Deleting job {0}", jobId);
+                        testOutputHelper.WriteLine("Deleting job {0}", jobId);
                         batchCli.JobOperations.DeleteJob(jobId);
                     }
 
@@ -1111,7 +1107,7 @@
                     unboundPool.DisplayName = originalDisplayName;
 
                     Assert.Equal(originalDisplayName, unboundPool.DisplayName);
-                    this.testOutputHelper.WriteLine("Creating pool {0}", poolId);
+                    testOutputHelper.WriteLine("Creating pool {0}", poolId);
                     unboundPool.Commit();
 
                     try
@@ -1122,13 +1118,13 @@
                         Assert.Equal(originalDisplayName, boundPool.DisplayName);
 
                         // Verify that display name can not be set when bound
-                        this.testOutputHelper.WriteLine("Attempting to set display name on pool");
+                        testOutputHelper.WriteLine("Attempting to set display name on pool");
 
                         TestUtilities.AssertThrows<InvalidOperationException>(() => boundPool.DisplayName = updatedDisplayName);
                     }
                     finally
                     {
-                        this.testOutputHelper.WriteLine("Deleting pool {0}", poolId);
+                        testOutputHelper.WriteLine("Deleting pool {0}", poolId);
                         batchCli.PoolOperations.DeletePool(poolId);
                     }
                 }
@@ -1170,9 +1166,9 @@
             internal void Bug957878RequestReplacementInterceptorOpContextFactory(ref Protocol.IBatchRequest batchRequest)
             {
                 // been called again
-                this.NumTimesCalled++;
+                NumTimesCalled++;
 
-                this.testOutputHelper.WriteLine("     _movenextAsync_call_to_server_");
+                testOutputHelper.WriteLine("     _movenextAsync_call_to_server_");
 
                 if (batchRequest is TaskListBatchRequest)
                 {
@@ -1240,7 +1236,7 @@
                                 PoolFixture.VMSize,
                                 new CloudServiceConfiguration(PoolFixture.OSFamily),
                                 targetDedicatedComputeNodes: 0);
-                            Bug1770942RetryPolicy retryPolicy = new Bug1770942RetryPolicy(this.testOutputHelper);
+                            Bug1770942RetryPolicy retryPolicy = new Bug1770942RetryPolicy(testOutputHelper);
 
                             // confirm there is a default retry policy
                             // EnforceThereIsOnlyOneRetry(unboundPool.CustomBehaviors);
@@ -1267,11 +1263,11 @@
                                 unboundPool.Commit();
                             }
 
-                            this.testOutputHelper.WriteLine("All pools: ");
+                            testOutputHelper.WriteLine("All pools: ");
 
                             var allPools = batchCli.PoolOperations.ListPools();
 
-                            TestUtilities.DisplayPools(this.testOutputHelper, allPools);
+                            TestUtilities.DisplayPools(testOutputHelper, allPools);
 
                             // get odd list, also test select
                             var oddIEnum =
@@ -1282,9 +1278,9 @@
                                 });
                             List<CloudPool> oddList = new List<CloudPool>(oddIEnum);
 
-                            this.testOutputHelper.WriteLine("Odd Pools:");
+                            testOutputHelper.WriteLine("Odd Pools:");
 
-                            TestUtilities.DisplayPools(this.testOutputHelper, oddIEnum);
+                            TestUtilities.DisplayPools(testOutputHelper, oddIEnum);
 
                             // get even list, also test select
                             var evenIEnum =
@@ -1295,9 +1291,9 @@
                                 });
                             List<CloudPool> evenList = new List<CloudPool>(evenIEnum);
 
-                            this.testOutputHelper.WriteLine("Even Pools:");
+                            testOutputHelper.WriteLine("Even Pools:");
 
-                            TestUtilities.DisplayPools(this.testOutputHelper, evenIEnum);
+                            TestUtilities.DisplayPools(testOutputHelper, evenIEnum);
 
                             Assert.Equal(numPoolsToCreate, (oddList.Count + evenList.Count));
 
@@ -1407,10 +1403,10 @@
                 TimeSpan retryInterval = TimeSpan.Zero;
 
                 // count up retries to prove test works
-                this.NumTimesCalled++;
+                NumTimesCalled++;
 
-                this.testOutputHelper.WriteLine("Bug1770942RetryPolicy exception:");
-                this.testOutputHelper.WriteLine(exception.ToString());
+                testOutputHelper.WriteLine("Bug1770942RetryPolicy exception:");
+                testOutputHelper.WriteLine(exception.ToString());
 
                 RetryDecision result;
                 if (operationContext.RequestResults.Count < 3)

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
@@ -68,7 +68,7 @@
                         Bug957878ReplacementInterceptorBox box0 = new Bug957878ReplacementInterceptorBox(this.testOutputHelper);
 
                         foreach (CloudTask curTask in theJob.ListTasks(additionalBehaviors: new[] {
-                            new Microsoft.Azure.Batch.Protocol.RequestReplacementInterceptor(box0.Bug957878RequestReplacementInterceptorOpContextFactory)}))
+                            new Protocol.RequestReplacementInterceptor(box0.Bug957878RequestReplacementInterceptorOpContextFactory)}))
                         {
                             numTasksSeen++;
 

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
@@ -41,61 +41,59 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                int numTasksCreated = 0;
+                string jobId = "bug957898Job-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    int numTasksCreated = 0;
-                    string jobId = "bug957898Job-" + TestUtilities.GetMyName();
+                    CloudJob jobCreate = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    jobCreate.Commit();
 
-                    try
+                    CloudJob theJob = batchCli.JobOperations.GetJob(jobId);
+
+                    for (int i = 0; i < 50; i++)
                     {
-                        CloudJob jobCreate = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        jobCreate.Commit();
+                        CloudTask curTask = new CloudTask("bug957878-task-" + i.ToString(), "hostname");
 
-                        CloudJob theJob = batchCli.JobOperations.GetJob(jobId);
+                        theJob.AddTask(curTask);
 
-                        for (int i = 0; i < 50; i++)
-                        {
-                            CloudTask curTask = new CloudTask("bug957878-task-" + i.ToString(), "hostname");
+                        numTasksCreated++;
+                    }
 
-                            theJob.AddTask(curTask);
+                    int numTasksSeen = 0;
 
-                            numTasksCreated++;
-                        }
+                    // test replacement interceptor and forces MaxResults to a low #
+                    Bug957878ReplacementInterceptorBox box0 = new Bug957878ReplacementInterceptorBox(testOutputHelper);
 
-                        int numTasksSeen = 0;
-
-                        // test replacement interceptor and forces MaxResults to a low #
-                        Bug957878ReplacementInterceptorBox box0 = new Bug957878ReplacementInterceptorBox(testOutputHelper);
-
-                        foreach (CloudTask curTask in theJob.ListTasks(additionalBehaviors: new[] {
+                    foreach (CloudTask curTask in theJob.ListTasks(additionalBehaviors: new[] {
                             new Protocol.RequestReplacementInterceptor(box0.Bug957878RequestReplacementInterceptorOpContextFactory)}))
-                        {
-                            numTasksSeen++;
-
-                            testOutputHelper.WriteLine("    Task_Id: " + curTask.Id);
-                        }
-
-                        // confirm we'v seen the correct # of tasks during enumeration
-                        Assert.Equal(numTasksCreated, numTasksSeen);
-
-                        // confirm we got the correct # of chunks...
-                        Assert.True(box0.NumTimesCalled >= 10);
-
-                        // >= because the server might hickup too and put in extra empty skiptokens
-
-                        testOutputHelper.WriteLine("total tasks created: " + numTasksCreated.ToString());
-                        testOutputHelper.WriteLine("total tasks enumerated: " + numTasksSeen.ToString());
-
-                        Assert.Equal(numTasksCreated, numTasksSeen);
-
-                        // tests performed elsewhere
-                        // list task files
-                        // list job schedules
-                    }
-                    finally
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        numTasksSeen++;
+
+                        testOutputHelper.WriteLine("    Task_Id: " + curTask.Id);
                     }
+
+                    // confirm we'v seen the correct # of tasks during enumeration
+                    Assert.Equal(numTasksCreated, numTasksSeen);
+
+                    // confirm we got the correct # of chunks...
+                    Assert.True(box0.NumTimesCalled >= 10);
+
+                    // >= because the server might hickup too and put in extra empty skiptokens
+
+                    testOutputHelper.WriteLine("total tasks created: " + numTasksCreated.ToString());
+                    testOutputHelper.WriteLine("total tasks enumerated: " + numTasksSeen.ToString());
+
+                    Assert.Equal(numTasksCreated, numTasksSeen);
+
+                    // tests performed elsewhere
+                    // list task files
+                    // list job schedules
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -109,33 +107,31 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string jobId = "Bug1568799Job-" + TestUtilities.GetMyName();
+                try
                 {
-                    string jobId = "Bug1568799Job-" + TestUtilities.GetMyName();
-                    try
-                    {
-                        CloudJob newJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
-                        newJob.Commit();
+                    CloudJob newJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
+                    newJob.Commit();
 
-                        // now we have at least one JS (and pool).  double-enumerate them
-                        IEnumerable<CloudJob> jobEnum = batchCli.JobOperations.ListJobs();
-                        // populating the List enumerates once
-                        List<CloudJob> jobList0 = new List<CloudJob>(jobEnum);
+                    // now we have at least one JS (and pool).  double-enumerate them
+                    IEnumerable<CloudJob> jobEnum = batchCli.JobOperations.ListJobs();
+                    // populating the List enumerates once
+                    List<CloudJob> jobList0 = new List<CloudJob>(jobEnum);
 
-                        // enumerate via the List's enumerator
-                        bool foundViaList0 = FoundJob(jobId, jobList0);
+                    // enumerate via the List's enumerator
+                    bool foundViaList0 = FoundJob(jobId, jobList0);
 
-                        Assert.True(foundViaList0);
+                    Assert.True(foundViaList0);
 
-                        // use original enumerator to find js again
-                        bool foundViaEnumeration = FoundJob(jobId, jobEnum);
+                    // use original enumerator to find js again
+                    bool foundViaEnumeration = FoundJob(jobId, jobEnum);
 
-                        Assert.True(foundViaEnumeration);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    Assert.True(foundViaEnumeration);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -149,17 +145,180 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                // pools tested in Bug1770942ExposeBatchRequestProperties
+                testOutputHelper.WriteLine("job schedule tests");
+
+                // create a bunch of job schedules
                 {
-                    // pools tested in Bug1770942ExposeBatchRequestProperties
-                    testOutputHelper.WriteLine("job schedule tests");
+                    const int numJobSchedulesToCreate = 10;
 
-                    // create a bunch of job schedules
+                    List<string> jobScheduleIds = new List<string>();
+                    for (int i = 0; i < numJobSchedulesToCreate; i++)
                     {
-                        const int numJobSchedulesToCreate = 10;
+                        string id;
 
-                        List<string> jobScheduleIds = new List<string>();
-                        for (int i = 0; i < numJobSchedulesToCreate; i++)
+                        if (1 == (i % 2))
+                        {
+                            id = "Odd-Bug1770942-";
+                        }
+                        else
+                        {
+                            id = "Even-Bug1770942-";
+                        }
+
+                        // add my name for visibile accounting
+                        id += i + "-" + TestUtilities.GetMyName();
+
+                        jobScheduleIds.Add(id);
+                    }
+
+                    try
+                    {
+                        foreach (string jobScheduleId in jobScheduleIds)
+                        {
+                            CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
+                            PoolInformation poolInformation = new PoolInformation();
+
+                            poolInformation.PoolId = poolFixture.PoolId;
+
+                            unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation);
+
+                            unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(5) };
+
+                            // create the job schedule
+                            unboundJobSchedule.Commit();
+                        }
+
+                        // first get a list of all wi's with all props
+                        IEnumerable<CloudJobSchedule> ienumJobScheduleAllProps = batchCli.JobScheduleOperations.ListJobSchedules();
+                        List<CloudJobSchedule> listAllJobScheduleProps = new List<CloudJobSchedule>(ienumJobScheduleAllProps);
+
+                        // get filtered lists using lower Detail Level
+                        IEnumerable<CloudJobSchedule> ienumOdd =
+                            batchCli.JobScheduleOperations.ListJobSchedules(detailLevel:
+                                new ODATADetailLevel() { FilterClause = "startswith(id, 'Odd')", SelectClause = "id,state" });
+                        List<CloudJobSchedule> listOdd = new List<CloudJobSchedule>(ienumOdd);
+
+                        IEnumerable<CloudJobSchedule> ienumEven =
+                            batchCli.JobScheduleOperations.ListJobSchedules(detailLevel:
+                                new ODATADetailLevel() { FilterClause = "startswith(id, 'Even')", SelectClause = "id,state" });
+                        List<CloudJobSchedule> listEven = new List<CloudJobSchedule>(ienumEven);
+
+                        // confirm detail level worked
+
+                        // pick one
+                        CloudJobSchedule lowDetailLevelJobSchedule = listEven[0];
+                        CloudJobSchedule matchingAllPropJobSchedule = null;
+
+                        // find it in the list that has full props
+                        foreach (CloudJobSchedule currJobSchedule in listAllJobScheduleProps)
+                        {
+                            // found it
+                            if (currJobSchedule.Id.Equals(lowDetailLevelJobSchedule.Id, StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                matchingAllPropJobSchedule = currJobSchedule;
+
+                                Assert.NotEqual(currJobSchedule.CreationTime, lowDetailLevelJobSchedule.CreationTime);
+                            }
+                        }
+
+                        // confirm that a match was found
+                        Assert.NotNull(matchingAllPropJobSchedule);
+
+                        // confirm that detail level works on jobScheduleOperations.GetJobSchedule()
+                        CloudJobSchedule directGetLowDetailLevel = batchCli.JobScheduleOperations.GetJobSchedule(matchingAllPropJobSchedule.Id,
+                            new ODATADetailLevel() { SelectClause = "id,state" });
+
+                        Assert.NotEqual(matchingAllPropJobSchedule.CreationTime, directGetLowDetailLevel.CreationTime);
+
+                        // confirm that detail level can be returned to normal via refresh()
+                        directGetLowDetailLevel.Refresh(); // no detail level returns to full properties
+
+                        Assert.Equal(matchingAllPropJobSchedule.CreationTime, directGetLowDetailLevel.CreationTime);
+                    }
+                    finally
+                    {
+                        List<Task> jobScheduleDeletions = new List<Task>();
+                        foreach (string id in jobScheduleIds)
+                        {
+                            Task t = TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, id);
+                            jobScheduleDeletions.Add(t);
+                        }
+
+                        Task.WhenAll(jobScheduleDeletions).Wait();
+                    }
+                }
+
+                testOutputHelper.WriteLine("job tests");
+
+                // jobs
+                string jobId = "Bug1770942Job-" + TestUtilities.GetMyName();
+
+                try
+                {
+                    {
+                        // create a job
+                        CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                        unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
+                        unboundJob.Commit();
+                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                        CloudTask unboundTask = new CloudTask("Bug1770942Taskname", "hostname");
+                        boundJob.AddTask(unboundTask);
+
+                        string filterString = string.Format("startswith(id, '{0}')", jobId);
+
+                        // first get a list with all props
+                        IEnumerable<CloudJob> ienumAllProps = batchCli.JobOperations.ListJobs(detailLevel: new ODATADetailLevel() { FilterClause = filterString });
+                        List<CloudJob> listAllProps = new List<CloudJob>(ienumAllProps);
+
+                        // get list using lower Detail Level.  choose a predicate that will return no jobs since there is only the one :(
+                        IEnumerable<CloudJob> iEnumFewerProps = batchCli.JobOperations.ListJobs(detailLevel: new ODATADetailLevel() { SelectClause = "id,state", FilterClause = filterString });
+                        List<CloudJob> listFewerProps = new List<CloudJob>(iEnumFewerProps);
+
+                        // the total must equal the sum of the parts
+                        Assert.Equal(listFewerProps.Count, listAllProps.Count);
+
+                        // confirm detail level worked
+
+                        // get the low detail level object
+                        CloudJob lowDetailLevel = listFewerProps.Single();
+
+                        // yes its the same and only
+                        Assert.Equal(listAllProps[0].Id, lowDetailLevel.Id);
+
+                        // confirm detail levels different
+                        Assert.NotEqual(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
+
+                        // confirm detail level returned to normal via refresh
+                        lowDetailLevel.Refresh();
+
+                        // now they both have all props
+                        Assert.Equal(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
+
+                        // confirm refresh can lower detail level
+                        lowDetailLevel = batchCli.JobOperations.GetJob(lowDetailLevel.Id);  // cant refresh 2 times or more because that pesky bug on refresh
+                        Assert.Equal(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);  // so all props are loaded
+
+                        // refresh and lower DL
+                        lowDetailLevel.Refresh(detailLevel: new ODATADetailLevel() { SelectClause = "id,state" });
+
+                        // now they must be different
+                        Assert.NotEqual(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
+                    }
+
+                    testOutputHelper.WriteLine("task tests");
+
+                    // tasks
+                    {
+                        // push tasks to this job
+                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+
+                        // add a bunch of tasks
+                        const int numToCreate = 10;
+
+                        for (int i = 0; i < numToCreate; i++)
                         {
                             string id;
 
@@ -175,290 +334,125 @@
                             // add my name for visibile accounting
                             id += i + "-" + TestUtilities.GetMyName();
 
-                            jobScheduleIds.Add(id);
-                        }
+                            CloudTask unboundTask = new CloudTask(id, "cmd /c hostname");
 
-                        try
-                        {
-                            foreach (string jobScheduleId in jobScheduleIds)
-                            {
-                                CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
-                                PoolInformation poolInformation = new PoolInformation();
-
-                                poolInformation.PoolId = poolFixture.PoolId;
-
-                                unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation);
-
-                                unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(5) };
-
-                                // create the job schedule
-                                unboundJobSchedule.Commit();
-                            }
-
-                            // first get a list of all wi's with all props
-                            IEnumerable<CloudJobSchedule> ienumJobScheduleAllProps = batchCli.JobScheduleOperations.ListJobSchedules();
-                            List<CloudJobSchedule> listAllJobScheduleProps = new List<CloudJobSchedule>(ienumJobScheduleAllProps);
-
-                            // get filtered lists using lower Detail Level
-                            IEnumerable<CloudJobSchedule> ienumOdd =
-                                batchCli.JobScheduleOperations.ListJobSchedules(detailLevel:
-                                    new ODATADetailLevel() { FilterClause = "startswith(id, 'Odd')", SelectClause = "id,state" });
-                            List<CloudJobSchedule> listOdd = new List<CloudJobSchedule>(ienumOdd);
-
-                            IEnumerable<CloudJobSchedule> ienumEven =
-                                batchCli.JobScheduleOperations.ListJobSchedules(detailLevel:
-                                    new ODATADetailLevel() { FilterClause = "startswith(id, 'Even')", SelectClause = "id,state" });
-                            List<CloudJobSchedule> listEven = new List<CloudJobSchedule>(ienumEven);
-
-                            // confirm detail level worked
-
-                            // pick one
-                            CloudJobSchedule lowDetailLevelJobSchedule = listEven[0];
-                            CloudJobSchedule matchingAllPropJobSchedule = null;
-
-                            // find it in the list that has full props
-                            foreach (CloudJobSchedule currJobSchedule in listAllJobScheduleProps)
-                            {
-                                // found it
-                                if (currJobSchedule.Id.Equals(lowDetailLevelJobSchedule.Id, StringComparison.InvariantCultureIgnoreCase))
-                                {
-                                    matchingAllPropJobSchedule = currJobSchedule;
-
-                                    Assert.NotEqual(currJobSchedule.CreationTime, lowDetailLevelJobSchedule.CreationTime);
-                                }
-                            }
-
-                            // confirm that a match was found
-                            Assert.NotNull(matchingAllPropJobSchedule);
-
-                            // confirm that detail level works on jobScheduleOperations.GetJobSchedule()
-                            CloudJobSchedule directGetLowDetailLevel = batchCli.JobScheduleOperations.GetJobSchedule(matchingAllPropJobSchedule.Id,
-                                new ODATADetailLevel() { SelectClause = "id,state" });
-
-                            Assert.NotEqual(matchingAllPropJobSchedule.CreationTime, directGetLowDetailLevel.CreationTime);
-
-                            // confirm that detail level can be returned to normal via refresh()
-                            directGetLowDetailLevel.Refresh(); // no detail level returns to full properties
-
-                            Assert.Equal(matchingAllPropJobSchedule.CreationTime, directGetLowDetailLevel.CreationTime);
-                        }
-                        finally
-                        {
-                            List<Task> jobScheduleDeletions = new List<Task>();
-                            foreach (string id in jobScheduleIds)
-                            {
-                                Task t = TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, id);
-                                jobScheduleDeletions.Add(t);
-                            }
-
-                            Task.WhenAll(jobScheduleDeletions).Wait();
-                        }
-                    }
-
-                    testOutputHelper.WriteLine("job tests");
-
-                    // jobs
-                    string jobId = "Bug1770942Job-" + TestUtilities.GetMyName();
-
-                    try
-                    {
-                        {
-                            // create a job
-                            CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                            unboundJob.PoolInformation.PoolId = poolFixture.PoolId;
-                            unboundJob.Commit();
-                            CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                            CloudTask unboundTask = new CloudTask("Bug1770942Taskname", "hostname");
+                            // add the task
                             boundJob.AddTask(unboundTask);
-
-                            string filterString = string.Format("startswith(id, '{0}')", jobId);
-
-                            // first get a list with all props
-                            IEnumerable<CloudJob> ienumAllProps = batchCli.JobOperations.ListJobs(detailLevel: new ODATADetailLevel(){ FilterClause = filterString });
-                            List<CloudJob> listAllProps = new List<CloudJob>(ienumAllProps);
-
-                            // get list using lower Detail Level.  choose a predicate that will return no jobs since there is only the one :(
-                            IEnumerable<CloudJob> iEnumFewerProps = batchCli.JobOperations.ListJobs(detailLevel: new ODATADetailLevel() { SelectClause = "id,state", FilterClause = filterString });
-                            List<CloudJob> listFewerProps = new List<CloudJob>(iEnumFewerProps);
-
-                            // the total must equal the sum of the parts
-                            Assert.Equal(listFewerProps.Count, listAllProps.Count);
-
-                            // confirm detail level worked
-
-                            // get the low detail level object
-                            CloudJob lowDetailLevel = listFewerProps.Single();
-
-                            // yes its the same and only
-                            Assert.Equal(listAllProps[0].Id, lowDetailLevel.Id);
-
-                            // confirm detail levels different
-                            Assert.NotEqual(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
-
-                            // confirm detail level returned to normal via refresh
-                            lowDetailLevel.Refresh();
-
-                            // now they both have all props
-                            Assert.Equal(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
-
-                            // confirm refresh can lower detail level
-                            lowDetailLevel = batchCli.JobOperations.GetJob(lowDetailLevel.Id);  // cant refresh 2 times or more because that pesky bug on refresh
-                            Assert.Equal(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);  // so all props are loaded
-
-                            // refresh and lower DL
-                            lowDetailLevel.Refresh(detailLevel: new ODATADetailLevel() { SelectClause = "id,state" });
-
-                            // now they must be different
-                            Assert.NotEqual(listAllProps[0].CreationTime, lowDetailLevel.CreationTime);
                         }
 
-                        testOutputHelper.WriteLine("task tests");
+                        // first get a list with all props
+                        IEnumerable<CloudTask> ienumAllProps = boundJob.ListTasks();
+                        List<CloudTask> listAllProps = new List<CloudTask>(ienumAllProps);
 
-                        // tasks
+                        // get filtered lists using lower Detail Level
+                        IEnumerable<CloudTask> ienumOdd = boundJob.ListTasks(detailLevel: new ODATADetailLevel() { FilterClause = "startswith(id, 'Odd')", SelectClause = "id,state" });
+                        List<CloudTask> listOdd = new List<CloudTask>(ienumOdd);
+
+                        IEnumerable<CloudTask> ienumEven = boundJob.ListTasks(detailLevel: new ODATADetailLevel() { FilterClause = "startswith(id, 'Even')", SelectClause = "id,state" });
+                        List<CloudTask> listEven = new List<CloudTask>(ienumEven);
+
+                        // the total must equal the sum of the parts
+                        Assert.Equal(listOdd.Count + listEven.Count + 1 /* 1 special task from above */, listAllProps.Count);
+
+                        // confirm detail level worked
+                        // pick one from lower detail level and compare it to the same one from the all-props collection
+
+                        CloudTask lowerDetailTask = listOdd[0];
+                        CloudTask matchingAllPropsTask = null;
+
+                        // now find it in the all-props list
+                        foreach (CloudTask curAllPropsTask in listAllProps)
                         {
-                            // push tasks to this job
-                            CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
-
-                            // add a bunch of tasks
-                            const int numToCreate = 10;
-
-                            for (int i = 0; i < numToCreate; i++)
+                            if (curAllPropsTask.Id.Equals(lowerDetailTask.Id))
                             {
-                                string id;
-
-                                if (1 == (i % 2))
-                                {
-                                    id = "Odd-Bug1770942-";
-                                }
-                                else
-                                {
-                                    id = "Even-Bug1770942-";
-                                }
-
-                                // add my name for visibile accounting
-                                id += i + "-" + TestUtilities.GetMyName();
-
-                                CloudTask unboundTask = new CloudTask(id, "cmd /c hostname");
-
-                                // add the task
-                                boundJob.AddTask(unboundTask);
+                                matchingAllPropsTask = curAllPropsTask;
                             }
-
-                            // first get a list with all props
-                            IEnumerable<CloudTask> ienumAllProps = boundJob.ListTasks();
-                            List<CloudTask> listAllProps = new List<CloudTask>(ienumAllProps);
-
-                            // get filtered lists using lower Detail Level
-                            IEnumerable<CloudTask> ienumOdd = boundJob.ListTasks(detailLevel: new ODATADetailLevel() { FilterClause = "startswith(id, 'Odd')", SelectClause = "id,state" });
-                            List<CloudTask> listOdd = new List<CloudTask>(ienumOdd);
-
-                            IEnumerable<CloudTask> ienumEven = boundJob.ListTasks(detailLevel: new ODATADetailLevel() { FilterClause = "startswith(id, 'Even')", SelectClause = "id,state" });
-                            List<CloudTask> listEven = new List<CloudTask>(ienumEven);
-
-                            // the total must equal the sum of the parts
-                            Assert.Equal(listOdd.Count + listEven.Count + 1 /* 1 special task from above */, listAllProps.Count);
-
-                            // confirm detail level worked
-                            // pick one from lower detail level and compare it to the same one from the all-props collection
-
-                            CloudTask lowerDetailTask = listOdd[0];
-                            CloudTask matchingAllPropsTask = null;
-
-                            // now find it in the all-props list
-                            foreach (CloudTask curAllPropsTask in listAllProps)
-                            {
-                                if (curAllPropsTask.Id.Equals(lowerDetailTask.Id))
-                                {
-                                    matchingAllPropsTask = curAllPropsTask;
-                                }
-                            }
-
-                            // we have a matching all-props instance... compare them.
-                            Assert.NotNull(matchingAllPropsTask);
-
-                            // see!  detail level works!
-                            Assert.NotEqual(matchingAllPropsTask.CreationTime, lowerDetailTask.CreationTime);
-
-                            // now confirm that refresh will raise detail level
-                            lowerDetailTask.Refresh();
-
-                            // they should be the same now
-                            Assert.Equal(matchingAllPropsTask.CreationTime, lowerDetailTask.CreationTime);
-
-                            // now confirm that refresh + detail level can lower detail level
-                            matchingAllPropsTask.Refresh(detailLevel: new ODATADetailLevel() { SelectClause = "id,state" });
-
-                            // confirm lower detail level
-                            Assert.NotEqual(lowerDetailTask.CreationTime, matchingAllPropsTask.CreationTime);
                         }
 
-                        // task files
-                        testOutputHelper.WriteLine("task file tests");
+                        // we have a matching all-props instance... compare them.
+                        Assert.NotNull(matchingAllPropsTask);
 
-                        {
-                            List<CloudTask> tasks = new List<CloudTask>(batchCli.JobOperations.GetJob(jobId).ListTasks());
-                            CloudTask task = tasks[0]; // just pick one it doesnt matter which
+                        // see!  detail level works!
+                        Assert.NotEqual(matchingAllPropsTask.CreationTime, lowerDetailTask.CreationTime);
 
-                            //Ensure that the task has run
-                            TaskStateMonitor tsm = batchCli.Utilities.CreateTaskStateMonitor();
-                            tsm.WaitAll(new List<CloudTask> { task }, TaskState.Completed, TimeSpan.FromSeconds(20));
+                        // now confirm that refresh will raise detail level
+                        lowerDetailTask.Refresh();
 
-                            // first get a list with all props
-                            IEnumerable<NodeFile> ienumAllProps = task.ListNodeFiles();
-                            List<NodeFile> listAllProps = new List<NodeFile>(ienumAllProps);
+                        // they should be the same now
+                        Assert.Equal(matchingAllPropsTask.CreationTime, lowerDetailTask.CreationTime);
 
-                            // get filtered lists using lower Detail Level
-                            IEnumerable<NodeFile> ienumStd = task.ListNodeFiles(detailLevel: new ODATADetailLevel() { FilterClause = "startswith(name, 'std')" });
-                            List<NodeFile> listStd = new List<NodeFile>(ienumStd);
+                        // now confirm that refresh + detail level can lower detail level
+                        matchingAllPropsTask.Refresh(detailLevel: new ODATADetailLevel() { SelectClause = "id,state" });
 
-                            // assert that filtering works
-                            Assert.Equal(2, listStd.Count);  // stdout/stderr
-                            Assert.True(listAllProps.Count > listStd.Count);
-
-                            // test nodefile refresh
-
-                            NodeFile stdoutFile = null;
-
-                            // find stdout
-                            listStd.ForEach(x => { if (x.Path.IndexOf("stdout", StringComparison.InvariantCultureIgnoreCase) >= 0) { stdoutFile = x; } });
-
-                            // save pre-refresh props
-                            FileProperties saveFilProps = stdoutFile.Properties;
-
-                            // refesh to see if the props come back
-                            stdoutFile.Refresh();
-
-                            NodeFile againViaList = null;
-
-                            new List<NodeFile>(task.ListNodeFiles()).ForEach(x => { if (x.Path.IndexOf("stdout", StringComparison.InvariantCultureIgnoreCase) >= 0) { againViaList = x; } });
-
-                            //"Bug1719609ODATADetailLevel: sometimes this can fail.  check out CreateTime"
-                            //This fails due to different time formats used in the header vs in the body of a request.  Since we expect that this will basically never pass
-                            //until the bug is fixed, we assert instead on only the upper-order digits of the DateTime
-
-                            //Assert.Equal(stdoutFile.Properties.CreationTime, saveFilProps.CreationTime);
-                            DateTime creationTime = saveFilProps.CreationTime.Value;
-                            DateTime refreshedCreationTime = stdoutFile.Properties.CreationTime.Value;
-
-                            Assert.Equal(DateTimeKind.Utc, refreshedCreationTime.Kind);
-
-                            Assert.Equal(creationTime.Year, refreshedCreationTime.Year);
-                            Assert.Equal(creationTime.Month, refreshedCreationTime.Month);
-                            Assert.Equal(creationTime.Day, refreshedCreationTime.Day);
-                            Assert.Equal(creationTime.Hour, refreshedCreationTime.Hour);
-                            Assert.Equal(creationTime.Minute, refreshedCreationTime.Minute);
-                            Assert.Equal(creationTime.Second, refreshedCreationTime.Second);
-                            Assert.Equal(creationTime.Kind, refreshedCreationTime.Kind);
-
-                            //Since the low order bits are lost in the GetFile (header based respose) assert that they are 0
-                            Assert.Equal(0, refreshedCreationTime.Millisecond);
-                        }
+                        // confirm lower detail level
+                        Assert.NotEqual(lowerDetailTask.CreationTime, matchingAllPropsTask.CreationTime);
                     }
-                    finally
+
+                    // task files
+                    testOutputHelper.WriteLine("task file tests");
+
                     {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
+                        List<CloudTask> tasks = new List<CloudTask>(batchCli.JobOperations.GetJob(jobId).ListTasks());
+                        CloudTask task = tasks[0]; // just pick one it doesnt matter which
+
+                        //Ensure that the task has run
+                        TaskStateMonitor tsm = batchCli.Utilities.CreateTaskStateMonitor();
+                        tsm.WaitAll(new List<CloudTask> { task }, TaskState.Completed, TimeSpan.FromSeconds(20));
+
+                        // first get a list with all props
+                        IEnumerable<NodeFile> ienumAllProps = task.ListNodeFiles();
+                        List<NodeFile> listAllProps = new List<NodeFile>(ienumAllProps);
+
+                        // get filtered lists using lower Detail Level
+                        IEnumerable<NodeFile> ienumStd = task.ListNodeFiles(detailLevel: new ODATADetailLevel() { FilterClause = "startswith(name, 'std')" });
+                        List<NodeFile> listStd = new List<NodeFile>(ienumStd);
+
+                        // assert that filtering works
+                        Assert.Equal(2, listStd.Count);  // stdout/stderr
+                        Assert.True(listAllProps.Count > listStd.Count);
+
+                        // test nodefile refresh
+
+                        NodeFile stdoutFile = null;
+
+                        // find stdout
+                        listStd.ForEach(x => { if (x.Path.IndexOf("stdout", StringComparison.InvariantCultureIgnoreCase) >= 0) { stdoutFile = x; } });
+
+                        // save pre-refresh props
+                        FileProperties saveFilProps = stdoutFile.Properties;
+
+                        // refesh to see if the props come back
+                        stdoutFile.Refresh();
+
+                        NodeFile againViaList = null;
+
+                        new List<NodeFile>(task.ListNodeFiles()).ForEach(x => { if (x.Path.IndexOf("stdout", StringComparison.InvariantCultureIgnoreCase) >= 0) { againViaList = x; } });
+
+                        //"Bug1719609ODATADetailLevel: sometimes this can fail.  check out CreateTime"
+                        //This fails due to different time formats used in the header vs in the body of a request.  Since we expect that this will basically never pass
+                        //until the bug is fixed, we assert instead on only the upper-order digits of the DateTime
+
+                        //Assert.Equal(stdoutFile.Properties.CreationTime, saveFilProps.CreationTime);
+                        DateTime creationTime = saveFilProps.CreationTime.Value;
+                        DateTime refreshedCreationTime = stdoutFile.Properties.CreationTime.Value;
+
+                        Assert.Equal(DateTimeKind.Utc, refreshedCreationTime.Kind);
+
+                        Assert.Equal(creationTime.Year, refreshedCreationTime.Year);
+                        Assert.Equal(creationTime.Month, refreshedCreationTime.Month);
+                        Assert.Equal(creationTime.Day, refreshedCreationTime.Day);
+                        Assert.Equal(creationTime.Hour, refreshedCreationTime.Hour);
+                        Assert.Equal(creationTime.Minute, refreshedCreationTime.Minute);
+                        Assert.Equal(creationTime.Second, refreshedCreationTime.Second);
+                        Assert.Equal(creationTime.Kind, refreshedCreationTime.Kind);
+
+                        //Since the low order bits are lost in the GetFile (header based respose) assert that they are 0
+                        Assert.Equal(0, refreshedCreationTime.Millisecond);
                     }
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -472,104 +466,102 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string testName = "Bug1996130_ResourceDoubleRefreshDoesntWork";
+                const string taskId = "Bug1996130_ResourceDoubleRefreshDoesntWork_Task1";
+
+                string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + testName;
+                try
                 {
-                    const string testName = "Bug1996130_ResourceDoubleRefreshDoesntWork";
-                    const string taskId = "Bug1996130_ResourceDoubleRefreshDoesntWork_Task1";
-
-                    string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + testName;
-                    try
+                    //
+                    // Create the job schedule
+                    //
+                    CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
+                    jobSchedule.JobSpecification = new JobSpecification(new PoolInformation()
                     {
-                        //
-                        // Create the job schedule
-                        //
-                        CloudJobSchedule jobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
-                        jobSchedule.JobSpecification = new JobSpecification(new PoolInformation()
-                            {
-                                PoolId = poolFixture.PoolId
-                            });
-                        jobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(1) };
+                        PoolId = poolFixture.PoolId
+                    });
+                    jobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(1) };
 
-                        testOutputHelper.WriteLine("Initial job schedule commit()");
-                        jobSchedule.Commit();
+                    testOutputHelper.WriteLine("Initial job schedule commit()");
+                    jobSchedule.Commit();
 
-                        //Get the bound job schedule
-                        CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(batchCli.JobScheduleOperations, jobScheduleId);
+                    //Get the bound job schedule
+                    CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(batchCli.JobScheduleOperations, jobScheduleId);
 
-                        //Get the job
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
-                        string jobId = boundJob.Id; //We have to store this because after we commit we can't access the name anymore...
+                    //Get the job
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
+                    string jobId = boundJob.Id; //We have to store this because after we commit we can't access the name anymore...
 
-                        CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
+                    CloudTask myTask = new CloudTask(taskId, "cmd /c echo hello world");
 
-                        //Add the task
-                        testOutputHelper.WriteLine("Adding task: {0}", taskId);
-                        boundJob.AddTask(myTask);
+                    //Add the task
+                    testOutputHelper.WriteLine("Adding task: {0}", taskId);
+                    boundJob.AddTask(myTask);
 
-                        //Get the task
-                        CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
+                    //Get the task
+                    CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
 
-                        //Wait for the task to complete
+                    //Wait for the task to complete
 
-                        TaskStateMonitor stateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
-                        stateMonitor.WaitAll(new List<CloudTask> { boundTask }, TaskState.Completed, TimeSpan.FromMinutes(2));
-                        
-                        //Try to refresh the job schedule multiple times
-                        testOutputHelper.WriteLine("Refreshing job schedule");
-                        boundJobSchedule.Refresh();
-                        testOutputHelper.WriteLine("Refreshing job schedule");
-                        boundJobSchedule.Refresh();
+                    TaskStateMonitor stateMonitor = batchCli.Utilities.CreateTaskStateMonitor();
+                    stateMonitor.WaitAll(new List<CloudTask> { boundTask }, TaskState.Completed, TimeSpan.FromMinutes(2));
 
-                        //Try to refresh the job multiple times
-                        testOutputHelper.WriteLine("Refreshing job");
-                        boundJob.Refresh();
-                        testOutputHelper.WriteLine("Refreshing job");
-                        boundJob.Refresh();
+                    //Try to refresh the job schedule multiple times
+                    testOutputHelper.WriteLine("Refreshing job schedule");
+                    boundJobSchedule.Refresh();
+                    testOutputHelper.WriteLine("Refreshing job schedule");
+                    boundJobSchedule.Refresh();
 
-                        //Try to refresh the task multiple times
-                        testOutputHelper.WriteLine("Refreshing task");
-                        boundTask.Refresh();
-                        testOutputHelper.WriteLine("Refreshing task");
-                        boundTask.Refresh();
+                    //Try to refresh the job multiple times
+                    testOutputHelper.WriteLine("Refreshing job");
+                    boundJob.Refresh();
+                    testOutputHelper.WriteLine("Refreshing job");
+                    boundJob.Refresh();
 
-                        //Try to refresh a file multiple times
-                        NodeFile nodeFile = boundTask.GetNodeFile("stdout.txt");
+                    //Try to refresh the task multiple times
+                    testOutputHelper.WriteLine("Refreshing task");
+                    boundTask.Refresh();
+                    testOutputHelper.WriteLine("Refreshing task");
+                    boundTask.Refresh();
 
-                        testOutputHelper.WriteLine("Refreshing task file");
-                        nodeFile.Refresh();
-                        testOutputHelper.WriteLine("Refreshing task file");
-                        nodeFile.Refresh();
+                    //Try to refresh a file multiple times
+                    NodeFile nodeFile = boundTask.GetNodeFile("stdout.txt");
 
-                        //Try to refresh the pool multiple times
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
+                    testOutputHelper.WriteLine("Refreshing task file");
+                    nodeFile.Refresh();
+                    testOutputHelper.WriteLine("Refreshing task file");
+                    nodeFile.Refresh();
 
-                        testOutputHelper.WriteLine("Refreshing pool");
-                        boundPool.Refresh();
-                        testOutputHelper.WriteLine("Refreshing pool");
-                        boundPool.Refresh();
-                        //Try to refresh a compute node multiple times
-                        ComputeNode computeNode = boundPool.ListComputeNodes().First();
+                    //Try to refresh the pool multiple times
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                        testOutputHelper.WriteLine("Refreshing compute node");
-                        computeNode.Refresh();
-                        testOutputHelper.WriteLine("Refreshing compute node");
-                        computeNode.Refresh();
+                    testOutputHelper.WriteLine("Refreshing pool");
+                    boundPool.Refresh();
+                    testOutputHelper.WriteLine("Refreshing pool");
+                    boundPool.Refresh();
+                    //Try to refresh a compute node multiple times
+                    ComputeNode computeNode = boundPool.ListComputeNodes().First();
 
-                        //Try to refresh a node file multiple times
-                        //NodeFile nodeFile = computeNode.GetNodeFile("startup/stdout.txt");
+                    testOutputHelper.WriteLine("Refreshing compute node");
+                    computeNode.Refresh();
+                    testOutputHelper.WriteLine("Refreshing compute node");
+                    computeNode.Refresh();
 
-                        //this.testOutputHelper.WriteLine("Refreshing vm file");
-                        //nodeFile.Refresh();
-                        //this.testOutputHelper.WriteLine("Refreshing vm file");
-                        //nodeFile.Refresh();
+                    //Try to refresh a node file multiple times
+                    //NodeFile nodeFile = computeNode.GetNodeFile("startup/stdout.txt");
 
-                        //TODO: Add certificate refreshes here
+                    //this.testOutputHelper.WriteLine("Refreshing vm file");
+                    //nodeFile.Refresh();
+                    //this.testOutputHelper.WriteLine("Refreshing vm file");
+                    //nodeFile.Refresh();
 
-                    }
-                    finally
-                    {
-                        batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
-                    }
+                    //TODO: Add certificate refreshes here
+
+                }
+                finally
+                {
+                    batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
                 }
             };
 
@@ -583,41 +575,38 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string testName = "PostCommitInvalidPropRouterTests";
+
+                JobScheduleOperations jobScheduleOperations = batchCli.JobScheduleOperations;
+                JobOperations jobOperations = batchCli.JobOperations;
+
+                // test bound job commit followed by refresh
+                string jobScheduleId = testName + "-" + TestUtilities.GetMyName();
+
+                try
                 {
-                    const string testName = "PostCommitInvalidPropRouterTests";
+                    CloudJobSchedule unboundJobSchedule = jobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
+                    PoolInformation poolInformation = new PoolInformation();
+                    poolInformation.PoolId = poolFixture.PoolId;
+                    unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation);
+                    unboundJobSchedule.Schedule = new Schedule() { DoNotRunAfter = DateTime.UtcNow.AddDays(1) };
+                    unboundJobSchedule.Commit();
 
-                    JobScheduleOperations jobScheduleOperations = batchCli.JobScheduleOperations;
-                    JobOperations jobOperations = batchCli.JobOperations;
+                    CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(jobScheduleOperations, jobScheduleId);
+                    CloudJob boundJob = jobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
 
-                    // test bound job commit followed by refresh
-                    string jobScheduleId = testName + "-" + TestUtilities.GetMyName();
+                    boundJob.Constraints = new JobConstraints(TimeSpan.FromDays(1), 99);
 
-                    try
-                    {
-                        CloudJobSchedule unboundJobSchedule = jobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
-                        PoolInformation poolInformation = new PoolInformation();
-                        poolInformation.PoolId = poolFixture.PoolId;
-                        unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation);
-                        unboundJobSchedule.Schedule = new Schedule() { DoNotRunAfter = DateTime.UtcNow.AddDays(1) };
-                        unboundJobSchedule.Commit();
+                    // we have a bound job, we made an unimportant change, now commit it to mark the object as read only
+                    boundJob.Commit();
 
-                        CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(jobScheduleOperations, jobScheduleId);
-                        CloudJob boundJob = jobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
-
-                        boundJob.Constraints = new JobConstraints(TimeSpan.FromDays(1), 99);
-
-                        // we have a bound job, we made an unimportant change, now commit it to mark the object as read only
-                        boundJob.Commit();
-
-                        // this used to throw
-                        boundJob.Refresh();
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
-                    }
-
+                    // this used to throw
+                    boundJob.Refresh();
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                 }
             };
 
@@ -631,90 +620,88 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string bug1959324JobId = null;
+                try
                 {
-                    string bug1959324JobId = null;
-                    try
+                    int interceptorCount = 0; // count the # of times the interceptor is executed
+
+                    // 2015.jul: in GA there is no SetOpCon interceptor and YieldInjector was removed and "the func" exposed
+                    //batchClient.CustomBehaviors.Add(new SetOperationContext(Bug1959324SetOperationContext));  // this does not exist in GA
+                    //batchClient.CustomBehaviors.Add(new YieldInjectionInterceptor(Bug1959324YieldInjectionInterceptor));  // this is now done by func replacement. see below
+                    batchCli.CustomBehaviors.Add(new Protocol.RequestInterceptor((o) => { interceptorCount++; testOutputHelper.WriteLine("Test: random interceptor"); }));
+
+                    string taskIdHello;
+
+                    // do some setup... get a job with a task that has files
                     {
-                        int interceptorCount = 0; // count the # of times the interceptor is executed
+                        int preSetupCount = interceptorCount;
 
-                        // 2015.jul: in GA there is no SetOpCon interceptor and YieldInjector was removed and "the func" exposed
-                        //batchClient.CustomBehaviors.Add(new SetOperationContext(Bug1959324SetOperationContext));  // this does not exist in GA
-                        //batchClient.CustomBehaviors.Add(new YieldInjectionInterceptor(Bug1959324YieldInjectionInterceptor));  // this is now done by func replacement. see below
-                        batchCli.CustomBehaviors.Add(new Protocol.RequestInterceptor((o) => { interceptorCount++; testOutputHelper.WriteLine("Test: random interceptor"); }));
+                        CloudPool sharedPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
 
-                        string taskIdHello;
+                        TestUtilities.HelloWorld(batchCli, testOutputHelper, sharedPool, out bug1959324JobId, out taskIdHello, deleteJob: false);
 
-                        // do some setup... get a job with a task that has files
-                        {
-                            int preSetupCount = interceptorCount;
+                        // confirm interceptor was executed
+                        Assert.True(interceptorCount > preSetupCount);
+                    }
 
-                            CloudPool sharedPool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
+                    // test jobOps.ListNodeFiles
+                    testOutputHelper.WriteLine("ListNodeFiles");
+                    int preListNodeFilesCount = interceptorCount;
+                    var files = batchCli.JobOperations.ListNodeFiles(bug1959324JobId, taskIdHello, recursive: true).ToList();
 
-                            TestUtilities.HelloWorld(batchCli, testOutputHelper, sharedPool, out bug1959324JobId, out taskIdHello, deleteJob: false);
+                    // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
+                    Assert.True(interceptorCount > preListNodeFilesCount);
 
-                            // confirm interceptor was executed
-                            Assert.True(interceptorCount > preSetupCount);
-                        }
+                    // test jobOps.ListJobs
+                    testOutputHelper.WriteLine("ListJobs");
+                    int preListJobsCount = interceptorCount;
+                    var jobs = batchCli.JobOperations.ListJobs().ToList();
 
-                        // test jobOps.ListNodeFiles
-                        testOutputHelper.WriteLine("ListNodeFiles");
-                        int preListNodeFilesCount = interceptorCount;
-                        var files = batchCli.JobOperations.ListNodeFiles(bug1959324JobId, taskIdHello, recursive: true).ToList();
+                    // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
+                    Assert.True(interceptorCount > preListJobsCount);
 
-                        // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
-                        Assert.True(interceptorCount > preListNodeFilesCount);
+                    // test poolOps.ListPools
+                    testOutputHelper.WriteLine("ListPools");
+                    int preListPoolsCount = interceptorCount;
+                    var pools = batchCli.PoolOperations.ListPools().ToList();
 
-                        // test jobOps.ListJobs
-                        testOutputHelper.WriteLine("ListJobs");
-                        int preListJobsCount = interceptorCount;
-                        var jobs = batchCli.JobOperations.ListJobs().ToList();
+                    // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
+                    Assert.True(interceptorCount > preListPoolsCount);
 
-                        // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
-                        Assert.True(interceptorCount > preListJobsCount);
+                    testOutputHelper.WriteLine("GetJob Yield Injector test");
 
-                        // test poolOps.ListPools
-                        testOutputHelper.WriteLine("ListPools");
-                        int preListPoolsCount = interceptorCount;
-                        var pools = batchCli.PoolOperations.ListPools().ToList();
+                    // this yield injector will mung the func to make a get job call
+                    // with real arguments.  the call made in the test has arguments that
+                    // would fail/throw.
+                    Protocol.BatchRequestModificationInterceptHandler yieldInjectionInterceptor = baseRequest =>
+                    {
+                        testOutputHelper.WriteLine("Yield Injector!");
 
-                        // assert the interceptor was honored in the list... lists can get skiptokens so there migth be more than one call
-                        Assert.True(interceptorCount > preListPoolsCount);
-
-                        testOutputHelper.WriteLine("GetJob Yield Injector test");
-
-                        // this yield injector will mung the func to make a get job call
-                        // with real arguments.  the call made in the test has arguments that
-                        // would fail/throw.
-                        Protocol.BatchRequestModificationInterceptHandler yieldInjectionInterceptor = baseRequest =>
-                        {
-                            testOutputHelper.WriteLine("Yield Injector!");
-
-                            var request =
-                                (JobGetBatchRequest)baseRequest;
+                        var request =
+                            (JobGetBatchRequest)baseRequest;
 
                             // replace the func with one that actually will work
                             request.ServiceRequestFunc = (token) => { return request.RestClient.Job.GetWithHttpMessagesAsync(bug1959324JobId, request.Options, cancellationToken: token); };
 
                             // the func has been replaced with one that will work.. and the caller will get a real job
                             testOutputHelper.WriteLine("Leaving Yield Injector!");
-                        };
+                    };
 
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(
-                                            "test value that can't possibly be found as a job id",
-                                            additionalBehaviors: new[] { new Protocol.RequestInterceptor(yieldInjectionInterceptor) });
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(
+                                        "test value that can't possibly be found as a job id",
+                                        additionalBehaviors: new[] { new Protocol.RequestInterceptor(yieldInjectionInterceptor) });
 
-                        testOutputHelper.WriteLine("Done. got job.");
+                    testOutputHelper.WriteLine("Done. got job.");
 
-                        // confirm the job has a real id from HelloWorld not the bad one passed in
+                    // confirm the job has a real id from HelloWorld not the bad one passed in
 
-                        Assert.Equal(bug1959324JobId, boundJob.Id);
-                    }
-                    finally
-                    {
-                        // cleanup
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, bug1959324JobId).Wait();
-                    }
+                    Assert.Equal(bug1959324JobId, boundJob.Id);
+                }
+                finally
+                {
+                    // cleanup
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, bug1959324JobId).Wait();
                 }
             };
 
@@ -728,223 +715,221 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string testName = "Bug1910530_ConcurrentChangeTrackedList";
+
+                PoolOperations poolOperations = batchCli.PoolOperations;
+                JobScheduleOperations jobScheduleOperations = batchCli.JobScheduleOperations;
+                JobOperations jobOperations = batchCli.JobOperations;
+
+                CloudJobSchedule boundJobSchedule = null;
+
                 {
-                    const string testName = "Bug1910530_ConcurrentChangeTrackedList";
-
-                    PoolOperations poolOperations = batchCli.PoolOperations;
-                    JobScheduleOperations jobScheduleOperations = batchCli.JobScheduleOperations;
-                    JobOperations jobOperations = batchCli.JobOperations;
-
-                    CloudJobSchedule boundJobSchedule = null;
-
+                    string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + testName;
+                    try
                     {
-                        string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-" + testName;
-                        try
+                        //
+                        //Test bound pool properties
+                        //
+                        CloudPool pool = poolOperations.GetPool(poolFixture.PoolId);
+                        pool.Metadata = new List<MetadataItem> { new MetadataItem("test", "test") };
+
+                        //Note: We rely on the certificate specific tests to validate certificate references work for us
+
+                        pool.Commit();
+
+                        pool = poolOperations.GetPool(poolFixture.PoolId);
+
+                        Assert.Equal(1, pool.Metadata.Count);
+
+                        //
+                        //Unbound job schedule properties
+                        //
+                        testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
+                        CloudJobSchedule unboundJobSchedule = jobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
+
+                        Assert.Null(unboundJobSchedule.Metadata);
+
+                        unboundJobSchedule.Metadata = new List<MetadataItem>() { new MetadataItem("test", "test") };
+
+                        //JobManagerTask
+                        JobManagerTask jm = new JobManagerTask(id: "JobManagerTask", commandLine: "cmd /c dir");
+
+                        Assert.Null(jm.ResourceFiles);
+                        Assert.Null(jm.EnvironmentSettings);
+
+                        jm.ResourceFiles = new List<ResourceFile> { ResourceFile.FromUrl("http://test", "test") };
+                        jm.EnvironmentSettings = new List<EnvironmentSetting> { new EnvironmentSetting("test", "Test") };
+
+                        //StartTask
+                        StartTask startTask = new StartTask("cmd /c dir");
+
+                        Assert.Null(startTask.ResourceFiles);
+                        Assert.Null(startTask.EnvironmentSettings);
+
+                        startTask.EnvironmentSettings = new List<EnvironmentSetting>() { new EnvironmentSetting("test", "test") };
+                        startTask.ResourceFiles = new List<ResourceFile>() { ResourceFile.FromUrl("http://test", "Test") };
+
+                        //Pool Specification
+                        PoolSpecification poolSpecification = new PoolSpecification()
                         {
-                            //
-                            //Test bound pool properties
-                            //
-                            CloudPool pool = poolOperations.GetPool(poolFixture.PoolId);
-                            pool.Metadata = new List<MetadataItem> { new MetadataItem("test", "test") };
+                            TargetDedicatedComputeNodes = 0,
+                            VirtualMachineSize = PoolFixture.VMSize,
+                            CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
+                            StartTask = startTask
+                        };
 
-                            //Note: We rely on the certificate specific tests to validate certificate references work for us
+                        Assert.Null(poolSpecification.Metadata);
+                        //Note: We rely on the certificate specific tests to validate certificate references work for us
 
-                            pool.Commit();
+                        poolSpecification.Metadata = new List<MetadataItem>() { new MetadataItem("test", "test") };
 
-                            pool = poolOperations.GetPool(poolFixture.PoolId);
-
-                            Assert.Equal(1, pool.Metadata.Count);
-
-                            //
-                            //Unbound job schedule properties
-                            //
-                            testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
-                            CloudJobSchedule unboundJobSchedule = jobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
-
-                            Assert.Null(unboundJobSchedule.Metadata);
-
-                            unboundJobSchedule.Metadata = new List<MetadataItem>() { new MetadataItem("test", "test") };
-
-                            //JobManagerTask
-                            JobManagerTask jm = new JobManagerTask(id: "JobManagerTask", commandLine: "cmd /c dir");
-
-                            Assert.Null(jm.ResourceFiles);
-                            Assert.Null(jm.EnvironmentSettings);
-
-                            jm.ResourceFiles = new List<ResourceFile> { ResourceFile.FromUrl("http://test", "test") };
-                            jm.EnvironmentSettings = new List<EnvironmentSetting> { new EnvironmentSetting("test", "Test") };
-
-                            //StartTask
-                            StartTask startTask = new StartTask("cmd /c dir");
-
-                            Assert.Null(startTask.ResourceFiles);
-                            Assert.Null(startTask.EnvironmentSettings);
-
-                            startTask.EnvironmentSettings = new List<EnvironmentSetting>() { new EnvironmentSetting("test", "test") };
-                            startTask.ResourceFiles = new List<ResourceFile>() { ResourceFile.FromUrl("http://test", "Test") };
-
-                            //Pool Specification
-                            PoolSpecification poolSpecification = new PoolSpecification()
-                            {
-                                TargetDedicatedComputeNodes = 0,
-                                VirtualMachineSize = PoolFixture.VMSize,
-                                CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily),
-                                StartTask = startTask
-                            };
-
-                            Assert.Null(poolSpecification.Metadata);
-                            //Note: We rely on the certificate specific tests to validate certificate references work for us
-
-                            poolSpecification.Metadata = new List<MetadataItem>() { new MetadataItem("test", "test") };
-
-                            PoolInformation poolInformation = new PoolInformation()
-                            {
-                                AutoPoolSpecification = new AutoPoolSpecification()
-                                {
-                                    KeepAlive = false,
-                                    PoolSpecification = poolSpecification,
-                                    PoolLifetimeOption = PoolLifetimeOption.JobSchedule
-                                }
-                            };
-
-                            unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation)
-                            {
-                                JobManagerTask = jm,
-                            };
-
-                            unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(6) };
-
-                            unboundJobSchedule.Commit();
-
-                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
-                            boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
-
-                            Assert.Equal(1, boundJobSchedule.Metadata.Count);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings.Count);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles.Count);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
-
-                            //
-                            // Bound job schedule properties
-                            //
-
-                            //Testing addition to existing lists now
-                            boundJobSchedule.Metadata.Add(new MetadataItem("abc", "abc"));
-                            boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles.Add(ResourceFile.FromUrl("http://abc", "abc"));
-                            boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings.Add(new EnvironmentSetting("abc", "abc"));
-                            boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Add(new MetadataItem("abc", "abc"));
-                            boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Add(new EnvironmentSetting("abc", "abc"));
-                            boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Add(ResourceFile.FromUrl("http://abc", "abc"));
-
-                            testOutputHelper.WriteLine("Commiting updated Job Schedule with more IList stuff added");
-                            boundJobSchedule.Commit();
-
-                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
-                            boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
-
-
-                            Assert.Equal(2, boundJobSchedule.Metadata.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
-
-                            //Choose some properties on the job schedule to set to null and ensure that works.
-
-                            boundJobSchedule.Metadata = null;
-                            boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles = null;
-                            boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings = null;
-
-                            testOutputHelper.WriteLine("Commiting updated Job Schedule with some IList stuff removed");
-                            boundJobSchedule.Commit();
-
-                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
-                            boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
-
-                            Assert.Null(boundJobSchedule.Metadata);
-                            Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings);
-                            Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
-
-                            //Choose some properties on the job schedule to remove an item from, and ensure that works
-                            boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.RemoveAt(0);
-                            boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.RemoveAt(1);
-
-                            boundJobSchedule.Commit();
-
-                            testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
-                            boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(jobScheduleOperations, jobScheduleId);
-
-                            Assert.Null(boundJobSchedule.Metadata);
-                            Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings);
-                            Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
-                            Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
-                            //Extra check to ensure we removed the right one
-                            Assert.Equal("abc", boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.First().Name);
-                            Assert.Equal("test", boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.First().Name);
-                            Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
-
-                            //Now take a snapshot and ensure it isn't modified by editing the list after the fact
-                            IList<ResourceFile> resourceFiles = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles;
-
-                            IEnumerator<ResourceFile> enumerator = resourceFiles.GetEnumerator();
-                            int resourceFileCountBeforeListModification = 0;
-                            int resourceFileCountAfterListModification = 0;
-                            while (enumerator.MoveNext())
-                            {
-                                ++resourceFileCountBeforeListModification;
-                            }
-
-                            //Remove a file
-                            ResourceFile resourceFile = resourceFiles[0];
-                            resourceFiles.Remove(resourceFile);
-
-                            enumerator.Reset();
-                            while (enumerator.MoveNext())
-                            {
-                                ++resourceFileCountAfterListModification;
-                            }
-
-                            Assert.Equal(resourceFileCountBeforeListModification, resourceFileCountAfterListModification);
-
-                            //
-                            // Get the job and add a task
-                            //
-                            CloudTask unboundTask = new CloudTask("test", "cmd /c dir");
-                            unboundTask.EnvironmentSettings = new List<EnvironmentSetting> { new EnvironmentSetting("foo", "baz") };
-
-                            unboundTask.ResourceFiles = new List<ResourceFile> { ResourceFile.FromUrl("http://foo", "baz") };
-
-                            CloudJob job = jobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
-                            job.AddTask(unboundTask);
-
-                            const string taskId = "test";
-
-                            //Get the bound task
-                            CloudTask boundTask = job.GetTask(taskId);
-
-                            Assert.NotNull(boundTask.ResourceFiles);
-                            Assert.NotNull(boundTask.EnvironmentSettings);
-
-                            //Ensure the task has the correct settings
-                            Assert.Equal(1, boundTask.EnvironmentSettings.Count);
-                            Assert.Equal(1, boundTask.ResourceFiles.Count);
-
-                            TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.EnvironmentSettings.Add(new EnvironmentSetting("test", "test")));
-                            TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.ResourceFiles.Add(ResourceFile.FromUrl("http://test", "test")));
-                            TestUtilities.AssertThrows<InvalidOperationException>(() => { IList<IFileStagingProvider> filesToStage = boundTask.FilesToStage; });
-                        }
-                        finally
+                        PoolInformation poolInformation = new PoolInformation()
                         {
-                            TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
+                            AutoPoolSpecification = new AutoPoolSpecification()
+                            {
+                                KeepAlive = false,
+                                PoolSpecification = poolSpecification,
+                                PoolLifetimeOption = PoolLifetimeOption.JobSchedule
+                            }
+                        };
+
+                        unboundJobSchedule.JobSpecification = new JobSpecification(poolInformation)
+                        {
+                            JobManagerTask = jm,
+                        };
+
+                        unboundJobSchedule.Schedule = new Schedule() { RecurrenceInterval = TimeSpan.FromMinutes(6) };
+
+                        unboundJobSchedule.Commit();
+
+                        testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
+                        boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
+
+                        Assert.Equal(1, boundJobSchedule.Metadata.Count);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings.Count);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles.Count);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
+
+                        //
+                        // Bound job schedule properties
+                        //
+
+                        //Testing addition to existing lists now
+                        boundJobSchedule.Metadata.Add(new MetadataItem("abc", "abc"));
+                        boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles.Add(ResourceFile.FromUrl("http://abc", "abc"));
+                        boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings.Add(new EnvironmentSetting("abc", "abc"));
+                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Add(new MetadataItem("abc", "abc"));
+                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Add(new EnvironmentSetting("abc", "abc"));
+                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Add(ResourceFile.FromUrl("http://abc", "abc"));
+
+                        testOutputHelper.WriteLine("Commiting updated Job Schedule with more IList stuff added");
+                        boundJobSchedule.Commit();
+
+                        testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were set correctly on server");
+                        boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
+
+
+                        Assert.Equal(2, boundJobSchedule.Metadata.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
+
+                        //Choose some properties on the job schedule to set to null and ensure that works.
+
+                        boundJobSchedule.Metadata = null;
+                        boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles = null;
+                        boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings = null;
+
+                        testOutputHelper.WriteLine("Commiting updated Job Schedule with some IList stuff removed");
+                        boundJobSchedule.Commit();
+
+                        testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
+                        boundJobSchedule = jobScheduleOperations.GetJobSchedule(jobScheduleId);
+
+                        Assert.Null(boundJobSchedule.Metadata);
+                        Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings);
+                        Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
+
+                        //Choose some properties on the job schedule to remove an item from, and ensure that works
+                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.RemoveAt(0);
+                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.RemoveAt(1);
+
+                        boundJobSchedule.Commit();
+
+                        testOutputHelper.WriteLine("Getting job schedule to ensure that IList properties were removed correctly on server");
+                        boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(jobScheduleOperations, jobScheduleId);
+
+                        Assert.Null(boundJobSchedule.Metadata);
+                        Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.EnvironmentSettings);
+                        Assert.Null(boundJobSchedule.JobSpecification.JobManagerTask.ResourceFiles);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.Count);
+                        Assert.Equal(1, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.Count);
+                        //Extra check to ensure we removed the right one
+                        Assert.Equal("abc", boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.Metadata.First().Name);
+                        Assert.Equal("test", boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.EnvironmentSettings.First().Name);
+                        Assert.Equal(2, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles.Count);
+
+                        //Now take a snapshot and ensure it isn't modified by editing the list after the fact
+                        IList<ResourceFile> resourceFiles = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.StartTask.ResourceFiles;
+
+                        IEnumerator<ResourceFile> enumerator = resourceFiles.GetEnumerator();
+                        int resourceFileCountBeforeListModification = 0;
+                        int resourceFileCountAfterListModification = 0;
+                        while (enumerator.MoveNext())
+                        {
+                            ++resourceFileCountBeforeListModification;
                         }
+
+                        //Remove a file
+                        ResourceFile resourceFile = resourceFiles[0];
+                        resourceFiles.Remove(resourceFile);
+
+                        enumerator.Reset();
+                        while (enumerator.MoveNext())
+                        {
+                            ++resourceFileCountAfterListModification;
+                        }
+
+                        Assert.Equal(resourceFileCountBeforeListModification, resourceFileCountAfterListModification);
+
+                        //
+                        // Get the job and add a task
+                        //
+                        CloudTask unboundTask = new CloudTask("test", "cmd /c dir");
+                        unboundTask.EnvironmentSettings = new List<EnvironmentSetting> { new EnvironmentSetting("foo", "baz") };
+
+                        unboundTask.ResourceFiles = new List<ResourceFile> { ResourceFile.FromUrl("http://foo", "baz") };
+
+                        CloudJob job = jobOperations.GetJob(boundJobSchedule.ExecutionInformation.RecentJob.Id);
+                        job.AddTask(unboundTask);
+
+                        const string taskId = "test";
+
+                        //Get the bound task
+                        CloudTask boundTask = job.GetTask(taskId);
+
+                        Assert.NotNull(boundTask.ResourceFiles);
+                        Assert.NotNull(boundTask.EnvironmentSettings);
+
+                        //Ensure the task has the correct settings
+                        Assert.Equal(1, boundTask.EnvironmentSettings.Count);
+                        Assert.Equal(1, boundTask.ResourceFiles.Count);
+
+                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.EnvironmentSettings.Add(new EnvironmentSetting("test", "test")));
+                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.ResourceFiles.Add(ResourceFile.FromUrl("http://test", "test")));
+                        TestUtilities.AssertThrows<InvalidOperationException>(() => { IList<IFileStagingProvider> filesToStage = boundTask.FilesToStage; });
+                    }
+                    finally
+                    {
+                        TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                     }
                 }
             };
@@ -959,174 +944,172 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                const string testName = "TestDisplayNameMutability";
+
+                string originalDisplayName = "OriginalDisplayName";
+                string updatedDisplayName = "UpdatedDisplayName";
+
+                // Create an unbound job schedule with a job specification containing a pool sepcification and a job manager task.
+                // Verify that their display names can be set.
+                string jobScheduleId = testName + "_schedule_" + TestUtilities.GetMyName();
+                CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
+                unboundJobSchedule.DisplayName = originalDisplayName;
+
+
+                Assert.Equal(originalDisplayName, unboundJobSchedule.DisplayName);
+
+                JobManagerTask jobManager = new JobManagerTask("JobManagerTask", "cmd /c echo hello");
+                jobManager.DisplayName = originalDisplayName;
+
+                Assert.Equal(originalDisplayName, jobManager.DisplayName);
+
+                PoolSpecification poolSpec = new PoolSpecification();
+
+                poolSpec.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily, "*");
+                poolSpec.TargetDedicatedComputeNodes = 0;
+                poolSpec.VirtualMachineSize = PoolFixture.VMSize;
+                poolSpec.DisplayName = originalDisplayName;
+
+                Assert.Equal(originalDisplayName, poolSpec.DisplayName);
+
+                AutoPoolSpecification autoPoolSpec = new AutoPoolSpecification();
+                string autoPoolPrefix = "DisplayName" + TestUtilities.GetMyName(); ;
+                autoPoolSpec.AutoPoolIdPrefix = autoPoolPrefix;
+                autoPoolSpec.KeepAlive = false;
+                autoPoolSpec.PoolLifetimeOption = PoolLifetimeOption.Job;
+                autoPoolSpec.PoolSpecification = poolSpec;
+                PoolInformation poolInfo = new PoolInformation();
+                poolInfo.AutoPoolSpecification = autoPoolSpec;
+
+                JobSpecification jobSpec = new JobSpecification(poolInfo);
+                jobSpec.DisplayName = originalDisplayName;
+
+                Assert.Equal(originalDisplayName, unboundJobSchedule.DisplayName);
+
+                jobSpec.JobManagerTask = jobManager;
+
+                unboundJobSchedule.JobSpecification = jobSpec;
+
+                Schedule schedule = new Schedule();
+                schedule.DoNotRunUntil = DateTime.Now.AddYears(1);
+                unboundJobSchedule.Schedule = schedule;
+
+                testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
+                unboundJobSchedule.Commit();
+
+                try
                 {
-                    const string testName = "TestDisplayNameMutability";
+                    // Verify that display names were set
+                    CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
 
-                    string originalDisplayName = "OriginalDisplayName";
-                    string updatedDisplayName = "UpdatedDisplayName";
+                    Assert.Equal(originalDisplayName, boundJobSchedule.DisplayName);
+                    Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.DisplayName);
+                    Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.JobManagerTask.DisplayName);
+                    Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName);
 
-                    // Create an unbound job schedule with a job specification containing a pool sepcification and a job manager task.
-                    // Verify that their display names can be set.
-                    string jobScheduleId = testName + "_schedule_" + TestUtilities.GetMyName();
-                    CloudJobSchedule unboundJobSchedule = batchCli.JobScheduleOperations.CreateJobSchedule(jobScheduleId, null, null);
-                    unboundJobSchedule.DisplayName = originalDisplayName;
+                    // Verify that job schedule display name cannot be set on bound, but sub property display names can
+                    testOutputHelper.WriteLine("Attempting to set display names on job schedule, job specification, pool specification, and job manager task");
 
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => boundJobSchedule.DisplayName = updatedDisplayName);
 
-                    Assert.Equal(originalDisplayName, unboundJobSchedule.DisplayName);
+                    boundJobSchedule.JobSpecification.DisplayName = updatedDisplayName;
+                    boundJobSchedule.JobSpecification.JobManagerTask.DisplayName = updatedDisplayName;
+                    boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName = updatedDisplayName;
 
-                    JobManagerTask jobManager = new JobManagerTask("JobManagerTask", "cmd /c echo hello");
-                    jobManager.DisplayName = originalDisplayName;
+                    Assert.Equal(updatedDisplayName, boundJobSchedule.JobSpecification.DisplayName);
+                    Assert.Equal(updatedDisplayName, boundJobSchedule.JobSpecification.JobManagerTask.DisplayName);
+                    Assert.Equal(updatedDisplayName, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName);
+                }
+                finally
+                {
+                    testOutputHelper.WriteLine("Deleting job schedule {0}", jobScheduleId);
+                    batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
+                }
 
-                    Assert.Equal(originalDisplayName, jobManager.DisplayName);
+                // Create an unbound job and verify that display name can be set
+                string jobId = testName + "_job_" + TestUtilities.GetMyName();
+                CloudJob unboundJob = batchCli.JobOperations.CreateJob();
+                unboundJob.Id = jobId;
+                unboundJob.DisplayName = originalDisplayName;
 
-                    PoolSpecification poolSpec = new PoolSpecification();
+                Assert.Equal(originalDisplayName, unboundJob.DisplayName);
 
-                    poolSpec.CloudServiceConfiguration = new CloudServiceConfiguration(PoolFixture.OSFamily, "*");
-                    poolSpec.TargetDedicatedComputeNodes = 0;
-                    poolSpec.VirtualMachineSize = PoolFixture.VMSize;
-                    poolSpec.DisplayName = originalDisplayName;
+                unboundJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
 
-                    Assert.Equal(originalDisplayName, poolSpec.DisplayName);
+                testOutputHelper.WriteLine("Creating job {0}", jobId);
+                unboundJob.Commit();
 
-                    AutoPoolSpecification autoPoolSpec = new AutoPoolSpecification();
-                    string autoPoolPrefix = "DisplayName" + TestUtilities.GetMyName(); ;
-                    autoPoolSpec.AutoPoolIdPrefix = autoPoolPrefix;
-                    autoPoolSpec.KeepAlive = false;
-                    autoPoolSpec.PoolLifetimeOption = PoolLifetimeOption.Job;
-                    autoPoolSpec.PoolSpecification = poolSpec;
-                    PoolInformation poolInfo = new PoolInformation();
-                    poolInfo.AutoPoolSpecification = autoPoolSpec;
+                try
+                {
+                    // Verify that display name was set
+                    CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                    JobSpecification jobSpec = new JobSpecification(poolInfo);
-                    jobSpec.DisplayName = originalDisplayName;
+                    Assert.Equal(originalDisplayName, boundJob.DisplayName);
 
-                    Assert.Equal(originalDisplayName, unboundJobSchedule.DisplayName);
+                    // Verify that display name can not be set when bound
+                    testOutputHelper.WriteLine("Attempting to set display name on job");
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => boundJob.DisplayName = updatedDisplayName);
 
-                    jobSpec.JobManagerTask = jobManager;
+                    // Create an unbound task and verify that display name can be set
+                    string taskId = testName + "_task_" + TestUtilities.GetMyName();
+                    CloudTask unboundTask = new CloudTask(taskId, "cmd /c echo hi");
+                    unboundTask.DisplayName = originalDisplayName;
 
-                    unboundJobSchedule.JobSpecification = jobSpec;
+                    Assert.Equal(originalDisplayName, unboundTask.DisplayName);
 
-                    Schedule schedule = new Schedule();
-                    schedule.DoNotRunUntil = DateTime.Now.AddYears(1);
-                    unboundJobSchedule.Schedule = schedule;
-
-                    testOutputHelper.WriteLine("Creating job schedule {0}", jobScheduleId);
-                    unboundJobSchedule.Commit();
-
-                    try
-                    {
-                        // Verify that display names were set
-                        CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
-
-                        Assert.Equal(originalDisplayName, boundJobSchedule.DisplayName);
-                        Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.DisplayName);
-                        Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.JobManagerTask.DisplayName);
-                        Assert.Equal(originalDisplayName, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName);
-
-                        // Verify that job schedule display name cannot be set on bound, but sub property display names can
-                        testOutputHelper.WriteLine("Attempting to set display names on job schedule, job specification, pool specification, and job manager task");
-
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundJobSchedule.DisplayName = updatedDisplayName);
-
-                        boundJobSchedule.JobSpecification.DisplayName = updatedDisplayName;
-                        boundJobSchedule.JobSpecification.JobManagerTask.DisplayName = updatedDisplayName;
-                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName = updatedDisplayName;
-
-                        Assert.Equal(updatedDisplayName, boundJobSchedule.JobSpecification.DisplayName);
-                        Assert.Equal(updatedDisplayName, boundJobSchedule.JobSpecification.JobManagerTask.DisplayName);
-                        Assert.Equal(updatedDisplayName, boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.DisplayName);
-                    }
-                    finally
-                    {
-                        testOutputHelper.WriteLine("Deleting job schedule {0}", jobScheduleId);
-                        batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
-                    }
-
-                    // Create an unbound job and verify that display name can be set
-                    string jobId = testName + "_job_" + TestUtilities.GetMyName();
-                    CloudJob unboundJob = batchCli.JobOperations.CreateJob();
-                    unboundJob.Id = jobId;
-                    unboundJob.DisplayName = originalDisplayName;
-
-                    Assert.Equal(originalDisplayName, unboundJob.DisplayName);
-
-                    unboundJob.PoolInformation = new PoolInformation() { PoolId = poolFixture.PoolId };
-
-                    testOutputHelper.WriteLine("Creating job {0}", jobId);
-                    unboundJob.Commit();
+                    testOutputHelper.WriteLine("Adding task {0} to job {1}", taskId, jobId);
+                    boundJob.AddTask(unboundTask);
 
                     try
                     {
                         // Verify that display name was set
-                        CloudJob boundJob = batchCli.JobOperations.GetJob(jobId);
+                        CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
 
-                        Assert.Equal(originalDisplayName, boundJob.DisplayName);
+                        Assert.Equal(originalDisplayName, boundTask.DisplayName);
 
                         // Verify that display name can not be set when bound
-                        testOutputHelper.WriteLine("Attempting to set display name on job");
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundJob.DisplayName = updatedDisplayName);
-
-                        // Create an unbound task and verify that display name can be set
-                        string taskId = testName + "_task_" + TestUtilities.GetMyName();
-                        CloudTask unboundTask = new CloudTask(taskId, "cmd /c echo hi");
-                        unboundTask.DisplayName = originalDisplayName;
-
-                        Assert.Equal(originalDisplayName, unboundTask.DisplayName);
-
-                        testOutputHelper.WriteLine("Adding task {0} to job {1}", taskId, jobId);
-                        boundJob.AddTask(unboundTask);
-
-                        try
-                        {
-                            // Verify that display name was set
-                            CloudTask boundTask = batchCli.JobOperations.GetTask(jobId, taskId);
-
-                            Assert.Equal(originalDisplayName, boundTask.DisplayName);
-
-                            // Verify that display name can not be set when bound
-                            testOutputHelper.WriteLine("Attempting to set display name on task");
-                            TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.DisplayName = updatedDisplayName);
-                        }
-                        finally
-                        {
-                            testOutputHelper.WriteLine("Deleting task {0}", taskId);
-                            batchCli.JobOperations.DeleteTask(jobId, taskId);
-                        }
+                        testOutputHelper.WriteLine("Attempting to set display name on task");
+                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundTask.DisplayName = updatedDisplayName);
                     }
                     finally
                     {
-                        testOutputHelper.WriteLine("Deleting job {0}", jobId);
-                        batchCli.JobOperations.DeleteJob(jobId);
+                        testOutputHelper.WriteLine("Deleting task {0}", taskId);
+                        batchCli.JobOperations.DeleteTask(jobId, taskId);
                     }
+                }
+                finally
+                {
+                    testOutputHelper.WriteLine("Deleting job {0}", jobId);
+                    batchCli.JobOperations.DeleteJob(jobId);
+                }
 
-                    // Create an unbound pool and verify that display name can be set
-                    string poolId = testName + "_pool_" + TestUtilities.GetMyName();
+                // Create an unbound pool and verify that display name can be set
+                string poolId = testName + "_pool_" + TestUtilities.GetMyName();
 
-                    CloudPool unboundPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), 0);
-                    unboundPool.DisplayName = originalDisplayName;
+                CloudPool unboundPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), 0);
+                unboundPool.DisplayName = originalDisplayName;
 
-                    Assert.Equal(originalDisplayName, unboundPool.DisplayName);
-                    testOutputHelper.WriteLine("Creating pool {0}", poolId);
-                    unboundPool.Commit();
+                Assert.Equal(originalDisplayName, unboundPool.DisplayName);
+                testOutputHelper.WriteLine("Creating pool {0}", poolId);
+                unboundPool.Commit();
 
-                    try
-                    {
-                        // Verify that display name was set
-                        CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
+                try
+                {
+                    // Verify that display name was set
+                    CloudPool boundPool = batchCli.PoolOperations.GetPool(poolId);
 
-                        Assert.Equal(originalDisplayName, boundPool.DisplayName);
+                    Assert.Equal(originalDisplayName, boundPool.DisplayName);
 
-                        // Verify that display name can not be set when bound
-                        testOutputHelper.WriteLine("Attempting to set display name on pool");
+                    // Verify that display name can not be set when bound
+                    testOutputHelper.WriteLine("Attempting to set display name on pool");
 
-                        TestUtilities.AssertThrows<InvalidOperationException>(() => boundPool.DisplayName = updatedDisplayName);
-                    }
-                    finally
-                    {
-                        testOutputHelper.WriteLine("Deleting pool {0}", poolId);
-                        batchCli.PoolOperations.DeletePool(poolId);
-                    }
+                    TestUtilities.AssertThrows<InvalidOperationException>(() => boundPool.DisplayName = updatedDisplayName);
+                }
+                finally
+                {
+                    testOutputHelper.WriteLine("Deleting pool {0}", poolId);
+                    batchCli.PoolOperations.DeletePool(poolId);
                 }
             };
 
@@ -1200,171 +1183,169 @@
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                List<string> poolIdsToCreate = new List<string>();
+                const int numPoolsToCreate = 10;
+
+                // create some pools that can be listed and filtered
+                for (int i = 0; i < numPoolsToCreate; i++)
                 {
-                    List<string> poolIdsToCreate = new List<string>();
-                    const int numPoolsToCreate = 10;
+                    string name;
 
-                    // create some pools that can be listed and filtered
-                    for (int i = 0; i < numPoolsToCreate; i++)
+                    if (1 == (i % 2))
                     {
-                        string name;
-
-                        if (1 == (i % 2))
-                        {
-                            name = "Odd-Bug1770942-";
-                        }
-                        else
-                        {
-                            name = "Even-Bug1770942-";
-                        }
-
-                        // add my name for visibile accounting
-                        name += i + "-" + TestUtilities.GetMyName();
-
-                        poolIdsToCreate.Add(name);
+                        name = "Odd-Bug1770942-";
+                    }
+                    else
+                    {
+                        name = "Even-Bug1770942-";
                     }
 
-                    try
-                    {
-                        // Pool tests
+                    // add my name for visibile accounting
+                    name += i + "-" + TestUtilities.GetMyName();
 
-                        // test custom retry policy per-call
+                    poolIdsToCreate.Add(name);
+                }
+
+                try
+                {
+                    // Pool tests
+
+                    // test custom retry policy per-call
+                    {
+                        CloudPool unboundPool = batchCli.PoolOperations.CreatePool(
+                            @"really/\bad+&*pool_^#name" + TestUtilities.GetMyName(),
+                            PoolFixture.VMSize,
+                            new CloudServiceConfiguration(PoolFixture.OSFamily),
+                            targetDedicatedComputeNodes: 0);
+                        Bug1770942RetryPolicy retryPolicy = new Bug1770942RetryPolicy(testOutputHelper);
+
+                        // confirm there is a default retry policy
+                        // EnforceThereIsOnlyOneRetry(unboundPool.CustomBehaviors);
+
+                        // test perCall RetryPolicy
+                        TestUtilities.AssertThrows<BatchException>(() => unboundPool.Commit(new[] { new RetryPolicyProvider(retryPolicy) }));
+
+                        // confirm retry policy was used
+                        Assert.Equal(3, retryPolicy.NumTimesCalled);
+                    }
+
+                    // test ListPools ODATA predicate
+                    {
+                        // create some pools that can be listed and filtered
+                        foreach (string poolId in poolIdsToCreate)
                         {
+                            // no compute nodes because this is only a list/predicate test
                             CloudPool unboundPool = batchCli.PoolOperations.CreatePool(
-                                @"really/\bad+&*pool_^#name" + TestUtilities.GetMyName(),
+                                poolId,
                                 PoolFixture.VMSize,
                                 new CloudServiceConfiguration(PoolFixture.OSFamily),
                                 targetDedicatedComputeNodes: 0);
-                            Bug1770942RetryPolicy retryPolicy = new Bug1770942RetryPolicy(testOutputHelper);
 
-                            // confirm there is a default retry policy
-                            // EnforceThereIsOnlyOneRetry(unboundPool.CustomBehaviors);
-
-                            // test perCall RetryPolicy
-                            TestUtilities.AssertThrows<BatchException>(() => unboundPool.Commit(new[] { new RetryPolicyProvider(retryPolicy) }));
-
-                            // confirm retry policy was used
-                            Assert.Equal(3, retryPolicy.NumTimesCalled);
+                            unboundPool.Commit();
                         }
 
-                        // test ListPools ODATA predicate
+                        testOutputHelper.WriteLine("All pools: ");
+
+                        var allPools = batchCli.PoolOperations.ListPools();
+
+                        TestUtilities.DisplayPools(testOutputHelper, allPools);
+
+                        // get odd list, also test select
+                        var oddIEnum =
+                            batchCli.PoolOperations.ListPools(new ODATADetailLevel()
+                            {
+                                FilterClause = "startswith(id, 'Odd')",
+                                SelectClause = "id,state"
+                            });
+                        List<CloudPool> oddList = new List<CloudPool>(oddIEnum);
+
+                        testOutputHelper.WriteLine("Odd Pools:");
+
+                        TestUtilities.DisplayPools(testOutputHelper, oddIEnum);
+
+                        // get even list, also test select
+                        var evenIEnum =
+                            batchCli.PoolOperations.ListPools(new ODATADetailLevel()
+                            {
+                                FilterClause = "startswith(id, 'Even')",
+                                SelectClause = "id,state"
+                            });
+                        List<CloudPool> evenList = new List<CloudPool>(evenIEnum);
+
+                        testOutputHelper.WriteLine("Even Pools:");
+
+                        TestUtilities.DisplayPools(testOutputHelper, evenIEnum);
+
+                        Assert.Equal(numPoolsToCreate, (oddList.Count + evenList.Count));
+
+                        // test that select worked
+
+                        // pick one
+                        CloudPool fewerDetails = oddList[0];
+                        CloudPool matchingPoolWithFullDetailLevel = null;
+
+                        // find in complete (which has no DetailLevel set and should have all props) list and compare detail level
+                        foreach (CloudPool curPool in allPools)
                         {
-                            // create some pools that can be listed and filtered
-                            foreach (string poolId in poolIdsToCreate)
+                            if (curPool.Id.Equals(fewerDetails.Id, StringComparison.InvariantCultureIgnoreCase))
                             {
-                                // no compute nodes because this is only a list/predicate test
-                                CloudPool unboundPool = batchCli.PoolOperations.CreatePool(
-                                    poolId,
-                                    PoolFixture.VMSize,
-                                    new CloudServiceConfiguration(PoolFixture.OSFamily),
-                                    targetDedicatedComputeNodes: 0);
+                                matchingPoolWithFullDetailLevel = curPool;
 
-                                unboundPool.Commit();
+                                // confirm detail level is different between instances
+                                Assert.NotEqual(curPool.AllocationState, fewerDetails.AllocationState);
+                                break;
                             }
-
-                            testOutputHelper.WriteLine("All pools: ");
-
-                            var allPools = batchCli.PoolOperations.ListPools();
-
-                            TestUtilities.DisplayPools(testOutputHelper, allPools);
-
-                            // get odd list, also test select
-                            var oddIEnum =
-                                batchCli.PoolOperations.ListPools(new ODATADetailLevel()
-                                {
-                                    FilterClause = "startswith(id, 'Odd')",
-                                    SelectClause = "id,state"
-                                });
-                            List<CloudPool> oddList = new List<CloudPool>(oddIEnum);
-
-                            testOutputHelper.WriteLine("Odd Pools:");
-
-                            TestUtilities.DisplayPools(testOutputHelper, oddIEnum);
-
-                            // get even list, also test select
-                            var evenIEnum =
-                                batchCli.PoolOperations.ListPools(new ODATADetailLevel()
-                                {
-                                    FilterClause = "startswith(id, 'Even')",
-                                    SelectClause = "id,state"
-                                });
-                            List<CloudPool> evenList = new List<CloudPool>(evenIEnum);
-
-                            testOutputHelper.WriteLine("Even Pools:");
-
-                            TestUtilities.DisplayPools(testOutputHelper, evenIEnum);
-
-                            Assert.Equal(numPoolsToCreate, (oddList.Count + evenList.Count));
-
-                            // test that select worked
-
-                            // pick one
-                            CloudPool fewerDetails = oddList[0];
-                            CloudPool matchingPoolWithFullDetailLevel = null;
-
-                            // find in complete (which has no DetailLevel set and should have all props) list and compare detail level
-                            foreach (CloudPool curPool in allPools)
-                            {
-                                if (curPool.Id.Equals(fewerDetails.Id, StringComparison.InvariantCultureIgnoreCase))
-                                {
-                                    matchingPoolWithFullDetailLevel = curPool;
-
-                                    // confirm detail level is different between instances
-                                    Assert.NotEqual(curPool.AllocationState, fewerDetails.AllocationState);
-                                    break;
-                                }
-                            }
-
-                            // confirm that a match was actually found.
-                            Assert.NotNull(matchingPoolWithFullDetailLevel);
-
-                            /////////////////////////////////////////////////////////////
-
-                            // test select works on poolMgr.GetPool
-                            // we have the matching instance with full props from list-all, and selected props from list+DetailLevel
-                            // now test poolMgr.GetPool + detailLevel
-
-                            CloudPool lowerDetailLevel = batchCli.PoolOperations.GetPool(matchingPoolWithFullDetailLevel.Id, new ODATADetailLevel() { SelectClause = "id,state" });
-
-                            // confirm that allocation state was not read in
-                            Assert.Null(lowerDetailLevel.AllocationState);
-
-                            matchingPoolWithFullDetailLevel.Refresh();
-
-                            // confirm full props have good prop value
-                            Assert.Equal(AllocationState.Steady, matchingPoolWithFullDetailLevel.AllocationState);
-
-                            //////////////////////////////////////////////////////
-                            //
-                            // test that pool.Refresh() can change the detail level
-                            // use "matching..." which has all props and "lowerDetailLevel" which has restricted props
-
-                            matchingPoolWithFullDetailLevel.Refresh(detailLevel: new ODATADetailLevel() { SelectClause = "id,state" });
-
-                            // confirm detail level is lower now
-                            Assert.Null(matchingPoolWithFullDetailLevel.AllocationState);
-
-                            // return to full props via refresh()
-
-                            matchingPoolWithFullDetailLevel.Refresh();
-
-                            Assert.Equal(AllocationState.Steady, matchingPoolWithFullDetailLevel.AllocationState);
-
                         }
+
+                        // confirm that a match was actually found.
+                        Assert.NotNull(matchingPoolWithFullDetailLevel);
+
+                        /////////////////////////////////////////////////////////////
+
+                        // test select works on poolMgr.GetPool
+                        // we have the matching instance with full props from list-all, and selected props from list+DetailLevel
+                        // now test poolMgr.GetPool + detailLevel
+
+                        CloudPool lowerDetailLevel = batchCli.PoolOperations.GetPool(matchingPoolWithFullDetailLevel.Id, new ODATADetailLevel() { SelectClause = "id,state" });
+
+                        // confirm that allocation state was not read in
+                        Assert.Null(lowerDetailLevel.AllocationState);
+
+                        matchingPoolWithFullDetailLevel.Refresh();
+
+                        // confirm full props have good prop value
+                        Assert.Equal(AllocationState.Steady, matchingPoolWithFullDetailLevel.AllocationState);
+
+                        //////////////////////////////////////////////////////
+                        //
+                        // test that pool.Refresh() can change the detail level
+                        // use "matching..." which has all props and "lowerDetailLevel" which has restricted props
+
+                        matchingPoolWithFullDetailLevel.Refresh(detailLevel: new ODATADetailLevel() { SelectClause = "id,state" });
+
+                        // confirm detail level is lower now
+                        Assert.Null(matchingPoolWithFullDetailLevel.AllocationState);
+
+                        // return to full props via refresh()
+
+                        matchingPoolWithFullDetailLevel.Refresh();
+
+                        Assert.Equal(AllocationState.Steady, matchingPoolWithFullDetailLevel.AllocationState);
+
                     }
-                    finally
+                }
+                finally
+                {
+                    // clean up
+                    List<Task> deletePoolTasks = new List<Task>();
+                    foreach (string poolId in poolIdsToCreate)
                     {
-                        // clean up
-                        List<Task> deletePoolTasks = new List<Task>();
-                        foreach (string poolId in poolIdsToCreate)
-                        {
-                            Task t = TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId);
-                            deletePoolTasks.Add(t);
-                        }
-
-                        Task.WhenAll(deletePoolTasks).Wait();
+                        Task t = TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId);
+                        deletePoolTasks.Add(t);
                     }
+
+                    Task.WhenAll(deletePoolTasks).Wait();
                 }
             };
 
@@ -1375,11 +1356,9 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task TestBatchClientWillErrorOnUnknownJsonProperties()
         {
-            using (BatchClient batchClient = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
-            {
-                Protocol.BatchServiceClient client = TestUtilities.GetServiceClient(batchClient);
-                Assert.Equal(MissingMemberHandling.Error, client.DeserializationSettings.MissingMemberHandling);
-            }
+            using BatchClient batchClient = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+            Protocol.BatchServiceClient client = TestUtilities.GetServiceClient(batchClient);
+            Assert.Equal(MissingMemberHandling.Error, client.DeserializationSettings.MissingMemberHandling);
         }
 
         #region Test helpers

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/TaskDependencyIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/TaskDependencyIntegrationTests.cs
@@ -41,26 +41,24 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
                 {
-                    using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                    using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                    string jobId = GenerateJobId();
+
+                    try
                     {
-                        string jobId = GenerateJobId();
-
-                        try
+                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                        cloudJob.PoolInformation = new PoolInformation()
                         {
-                            CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                            cloudJob.PoolInformation = new PoolInformation()
-                            {
-                                PoolId = poolFixture.PoolId
-                            };
-                            cloudJob.Commit();
+                            PoolId = poolFixture.PoolId
+                        };
+                        cloudJob.Commit();
 
-                            var boundJob = batchCli.JobOperations.GetJob(jobId);
-                            Assert.False(boundJob.UsesTaskDependencies);
-                        }
-                        finally
-                        {
-                            TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                        }
+                        var boundJob = batchCli.JobOperations.GetJob(jobId);
+                        Assert.False(boundJob.UsesTaskDependencies);
+                    }
+                    finally
+                    {
+                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                     }
                 };
 
@@ -74,27 +72,25 @@ namespace BatchClientIntegrationTests
         {
             Action test = () =>
             {
-                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+                using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+                string jobId = GenerateJobId();
+
+                try
                 {
-                    string jobId = GenerateJobId();
-
-                    try
+                    CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                    cloudJob.PoolInformation = new PoolInformation()
                     {
-                        CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                        cloudJob.PoolInformation = new PoolInformation()
-                        {
-                            PoolId = poolFixture.PoolId
-                        };
-                        cloudJob.UsesTaskDependencies = true;
-                        cloudJob.Commit();
+                        PoolId = poolFixture.PoolId
+                    };
+                    cloudJob.UsesTaskDependencies = true;
+                    cloudJob.Commit();
 
-                        var boundJob = batchCli.JobOperations.GetJob(jobId);
-                        Assert.True(boundJob.UsesTaskDependencies);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                    }
+                    var boundJob = batchCli.JobOperations.GetJob(jobId);
+                    Assert.True(boundJob.UsesTaskDependencies);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
             };
 
@@ -106,53 +102,51 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void CanSpecifyTaskDependencyIds()
         {
-            using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result)
+            using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+            string jobId = GenerateJobId();
+
+            try
             {
-                string jobId = GenerateJobId();
-
-                try
+                CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
+                unboundJob.PoolInformation = new PoolInformation()
                 {
-                    CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
-                    unboundJob.PoolInformation = new PoolInformation()
-                    {
-                        PoolId = poolFixture.PoolId
-                    };
+                    PoolId = poolFixture.PoolId
+                };
 
-                    unboundJob.UsesTaskDependencies = true;
-                    unboundJob.Commit();
-                    var taskId = Guid.NewGuid().ToString();
+                unboundJob.UsesTaskDependencies = true;
+                unboundJob.Commit();
+                var taskId = Guid.NewGuid().ToString();
 
-                    IList<TaskIdRange> taskIdRanges = new List<TaskIdRange>
+                IList<TaskIdRange> taskIdRanges = new List<TaskIdRange>
                     {
                         new TaskIdRange(1, 5),
                         new TaskIdRange(8, 8)
                     };
 
-                    IList<string> taskIds = new List<string> { "1" };
+                IList<string> taskIds = new List<string> { "1" };
 
-                    var boundJob = batchCli.JobOperations.GetJob(jobId);
+                var boundJob = batchCli.JobOperations.GetJob(jobId);
 
-                    CloudTask taskToAdd = new CloudTask(taskId, "cmd.exe")
-                        {
-                            DependsOn = new TaskDependencies(taskIds, taskIdRanges),
-                        };
-
-                    boundJob.AddTask(taskToAdd);
-
-                    CloudTask task = boundJob.GetTask(taskId);
-                    var dependedOnRange = task.DependsOn.TaskIdRanges.First();
-                    var dependedOnTaskId = task.DependsOn.TaskIds.First();
-
-                    Assert.Equal(1, dependedOnRange.Start);
-                    Assert.Equal(5, dependedOnRange.End);
-                    Assert.Equal("1", dependedOnTaskId);
-
-                    Assert.True(boundJob.UsesTaskDependencies);
-                }
-                finally
+                CloudTask taskToAdd = new CloudTask(taskId, "cmd.exe")
                 {
-                    TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
-                }
+                    DependsOn = new TaskDependencies(taskIds, taskIdRanges),
+                };
+
+                boundJob.AddTask(taskToAdd);
+
+                CloudTask task = boundJob.GetTask(taskId);
+                var dependedOnRange = task.DependsOn.TaskIdRanges.First();
+                var dependedOnTaskId = task.DependsOn.TaskIds.First();
+
+                Assert.Equal(1, dependedOnRange.Start);
+                Assert.Equal(5, dependedOnRange.End);
+                Assert.Equal("1", dependedOnTaskId);
+
+                Assert.True(boundJob.UsesTaskDependencies);
+            }
+            finally
+            {
+                TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
             }
         }
     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/TaskDependencyIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/TaskDependencyIntegrationTests.cs
@@ -50,7 +50,7 @@ namespace BatchClientIntegrationTests
                             CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
                             cloudJob.PoolInformation = new PoolInformation()
                             {
-                                PoolId = this.poolFixture.PoolId
+                                PoolId = poolFixture.PoolId
                             };
                             cloudJob.Commit();
 
@@ -83,7 +83,7 @@ namespace BatchClientIntegrationTests
                         CloudJob cloudJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
                         cloudJob.PoolInformation = new PoolInformation()
                         {
-                            PoolId = this.poolFixture.PoolId
+                            PoolId = poolFixture.PoolId
                         };
                         cloudJob.UsesTaskDependencies = true;
                         cloudJob.Commit();
@@ -115,7 +115,7 @@ namespace BatchClientIntegrationTests
                     CloudJob unboundJob = batchCli.JobOperations.CreateJob(jobId, new PoolInformation());
                     unboundJob.PoolInformation = new PoolInformation()
                     {
-                        PoolId = this.poolFixture.PoolId
+                        PoolId = poolFixture.PoolId
                     };
 
                     unboundJob.UsesTaskDependencies = true;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ApplicationPackageReferencesUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ApplicationPackageReferencesUnitTests.cs
@@ -27,42 +27,40 @@
             const string applicationId = "blender.exe";
             const string version = "blender";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                    {
-                        var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                {
+                    var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
 
-                        request.ServiceRequestFunc = (token) =>
+                    request.ServiceRequestFunc = (token) =>
+                    {
+                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
                         {
-                            var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
+                            Body = new Models.CloudPool
                             {
-                                Body = new Models.CloudPool
+                                ApplicationPackageReferences = new[]
                                 {
-                                    ApplicationPackageReferences = new[]
-                                    {
                                             new Protocol.Models.ApplicationPackageReference
                                             {
                                                  ApplicationId = applicationId,
                                                  Version = version
                                             }
-                                    },
-                                    CurrentDedicatedNodes = 4,
-                                    CloudServiceConfiguration = new Models.CloudServiceConfiguration(osFamily: "4", osVersion: "3"),
-                                    Id = "pool-id"
                                 },
-                            };
-
-                            return Task.FromResult(response);
+                                CurrentDedicatedNodes = 4,
+                                CloudServiceConfiguration = new Models.CloudServiceConfiguration(osFamily: "4", osVersion: "3"),
+                                Id = "pool-id"
+                            },
                         };
-                    });
 
-                Microsoft.Azure.Batch.CloudPool cloudPool = client.PoolOperations.GetPool("pool-id", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+                        return Task.FromResult(response);
+                    };
+                });
 
-                Assert.Equal(cloudPool.ApplicationPackageReferences.First().Version, version);
-                Assert.Equal(cloudPool.ApplicationPackageReferences.First().ApplicationId, applicationId);
-            }
+            Microsoft.Azure.Batch.CloudPool cloudPool = client.PoolOperations.GetPool("pool-id", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+
+            Assert.Equal(cloudPool.ApplicationPackageReferences.First().Version, version);
+            Assert.Equal(cloudPool.ApplicationPackageReferences.First().ApplicationId, applicationId);
         }
 
         [Fact]
@@ -74,35 +72,34 @@
             const string poolId = "mock-pool";
             const string osFamily = "3";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                    {
-                        Protocol.BatchRequests.PoolGetBatchRequest request = (Protocol.BatchRequests.PoolGetBatchRequest)baseRequest;
-
-                        request.ServiceRequestFunc = (token) =>
-                        {
-                            var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
-                            {
-                                Body = new Protocol.Models.CloudPool
-                                {
-                                    CurrentDedicatedNodes = 4,
-                                    CloudServiceConfiguration = new Models.CloudServiceConfiguration(osFamily),
-                                    Id = poolId
-                                }
-                            };
-                            return Task.FromResult(response);
-                        };
-                    });
-
-                Microsoft.Azure.Batch.CloudPool cloudPool = client.PoolOperations.GetPool("pool-id", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
-
-                // At this point the pool shouldn't have any application packages
-                Assert.Null(cloudPool.ApplicationPackageReferences);
-
-                cloudPool.ApplicationPackageReferences = new[]
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
                 {
+                    Protocol.BatchRequests.PoolGetBatchRequest request = (Protocol.BatchRequests.PoolGetBatchRequest)baseRequest;
+
+                    request.ServiceRequestFunc = (token) =>
+                    {
+                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
+                        {
+                            Body = new Protocol.Models.CloudPool
+                            {
+                                CurrentDedicatedNodes = 4,
+                                CloudServiceConfiguration = new Models.CloudServiceConfiguration(osFamily),
+                                Id = poolId
+                            }
+                        };
+                        return Task.FromResult(response);
+                    };
+                });
+
+            Microsoft.Azure.Batch.CloudPool cloudPool = client.PoolOperations.GetPool("pool-id", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+
+            // At this point the pool shouldn't have any application packages
+            Assert.Null(cloudPool.ApplicationPackageReferences);
+
+            cloudPool.ApplicationPackageReferences = new[]
+            {
                     new Microsoft.Azure.Batch.ApplicationPackageReference()
                     {
                         ApplicationId = applicationId,
@@ -110,22 +107,21 @@
                     }
                 };
 
-                interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                    {
-                        Protocol.BatchRequests.PoolUpdatePropertiesBatchRequest request =
-                            (Protocol.BatchRequests.PoolUpdatePropertiesBatchRequest)baseRequest;
+            interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                {
+                    Protocol.BatchRequests.PoolUpdatePropertiesBatchRequest request =
+                        (Protocol.BatchRequests.PoolUpdatePropertiesBatchRequest)baseRequest;
 
                         // Need to check to see if ApplicationPackageReferences is being populated.
                         Assert.Equal(applicationId, request.Parameters.ApplicationPackageReferences[0].ApplicationId);
-                        Assert.Equal(version, request.Parameters.ApplicationPackageReferences[0].Version);
+                    Assert.Equal(version, request.Parameters.ApplicationPackageReferences[0].Version);
 
-                        request.ServiceRequestFunc = token => Task.FromResult(new AzureOperationHeaderResponse<Models.PoolUpdatePropertiesHeaders>() { Response = new HttpResponseMessage(HttpStatusCode.NoContent) });
-                    });
+                    request.ServiceRequestFunc = token => Task.FromResult(new AzureOperationHeaderResponse<Models.PoolUpdatePropertiesHeaders>() { Response = new HttpResponseMessage(HttpStatusCode.NoContent) });
+                });
 
-                // Updating application pool to contain packages.
-                await cloudPool.CommitAsync(additionalBehaviors: new List<BatchClientBehavior> { interceptor });
-            }
+            // Updating application pool to contain packages.
+            await cloudPool.CommitAsync(additionalBehaviors: new List<BatchClientBehavior> { interceptor });
         }
 
         [Fact]
@@ -136,16 +132,15 @@
             const string version = "blender";
             const string jobId = "mock-job";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Microsoft.Azure.Batch.PoolInformation autoPoolSpecification = new Microsoft.Azure.Batch.PoolInformation
             {
-                Microsoft.Azure.Batch.PoolInformation autoPoolSpecification = new Microsoft.Azure.Batch.PoolInformation
+                AutoPoolSpecification = new Microsoft.Azure.Batch.AutoPoolSpecification
                 {
-                    AutoPoolSpecification = new Microsoft.Azure.Batch.AutoPoolSpecification
+                    KeepAlive = false,
+                    PoolSpecification = new Microsoft.Azure.Batch.PoolSpecification
                     {
-                        KeepAlive = false,
-                        PoolSpecification = new Microsoft.Azure.Batch.PoolSpecification
-                        {
-                            ApplicationPackageReferences = new List<Microsoft.Azure.Batch.ApplicationPackageReference>
+                        ApplicationPackageReferences = new List<Microsoft.Azure.Batch.ApplicationPackageReference>
                             {
                                 new Microsoft.Azure.Batch.ApplicationPackageReference
                                 {
@@ -153,16 +148,15 @@
                                     Version = version
                                 }
                             },
-                            AutoScaleEnabled = false
-                        }
+                        AutoScaleEnabled = false
                     }
-                };
+                }
+            };
 
-                Microsoft.Azure.Batch.CloudJob cloudJob = client.JobOperations.CreateJob(jobId, autoPoolSpecification);
+            Microsoft.Azure.Batch.CloudJob cloudJob = client.JobOperations.CreateJob(jobId, autoPoolSpecification);
 
-                Assert.Equal(cloudJob.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().ApplicationId, applicationId);
-                Assert.Equal(cloudJob.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().Version, version);
-            }
+            Assert.Equal(cloudJob.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().ApplicationId, applicationId);
+            Assert.Equal(cloudJob.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().Version, version);
         }
 
         [Fact]
@@ -173,52 +167,50 @@
             const string version = "blender";
             const string jobId = "mock-job";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                        {
-                            var request =
-                                (Protocol.BatchRequest<Models.JobScheduleGetOptions, AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>>)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                    {
+                        var request =
+                            (Protocol.BatchRequest<Models.JobScheduleGetOptions, AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>>)baseRequest;
 
-                            request.ServiceRequestFunc = (token) =>
+                        request.ServiceRequestFunc = (token) =>
+                            {
+                                var response = new AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>
                                 {
-                                    var response = new AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>
+                                    Body = new Models.CloudJobSchedule
                                     {
-                                        Body = new Models.CloudJobSchedule
+                                        JobSpecification = new Protocol.Models.JobSpecification
                                         {
-                                            JobSpecification = new Protocol.Models.JobSpecification
+                                            PoolInfo = new Models.PoolInformation
                                             {
-                                                PoolInfo = new Models.PoolInformation 
+                                                AutoPoolSpecification = new Models.AutoPoolSpecification
                                                 {
-                                                    AutoPoolSpecification = new Models.AutoPoolSpecification
+                                                    Pool = new Models.PoolSpecification
                                                     {
-                                                        Pool = new Models.PoolSpecification 
+                                                        ApplicationPackageReferences = new[]
                                                         {
-                                                            ApplicationPackageReferences = new[]
-                                                            {
                                                                 new Protocol.Models.ApplicationPackageReference
                                                                 {
                                                                         ApplicationId = applicationId,
                                                                         Version = version,
                                                                 }
-                                                            },
-                                                            TaskSlotsPerNode = 4
-                                                         }
+                                                        },
+                                                        TaskSlotsPerNode = 4
                                                     }
-                                                  }
-                                             }
+                                                }
+                                            }
                                         }
-                                    };
-                                    return Task.FromResult(response);
+                                    }
                                 };
-                        });
+                                return Task.FromResult(response);
+                            };
+                    });
 
-                Microsoft.Azure.Batch.CloudJobSchedule cloudJobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync(jobId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            Microsoft.Azure.Batch.CloudJobSchedule cloudJobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync(jobId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                Assert.Equal(cloudJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().ApplicationId, applicationId);
-                Assert.Equal(cloudJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().Version, version);
-            }
+            Assert.Equal(cloudJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().ApplicationId, applicationId);
+            Assert.Equal(cloudJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First().Version, version);
         }
 
         [Fact]
@@ -229,41 +221,39 @@
             const string version = "blender";
             const string poolName = "test-pool";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = async (token) =>
+                request.ServiceRequestFunc = async (token) =>
+                {
+                    var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
                     {
-                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
+                        Body = new Models.CloudPool
                         {
-                            Body = new Models.CloudPool
+                            ApplicationPackageReferences = new[]
                             {
-                                ApplicationPackageReferences = new[]
-                                {
                                     new Protocol.Models.ApplicationPackageReference
                                         {
                                             ApplicationId = applicationId,
                                             Version = version
                                         }
-                                },
-                            }
-                        };
-
-                        Task<AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>> task = Task.FromResult(response);
-                        return await task;
+                            },
+                        }
                     };
-                });
 
-                var pool = await client.PoolOperations.GetPoolAsync(poolName, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+                    Task<AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>> task = Task.FromResult(response);
+                    return await task;
+                };
+            });
 
-                var appRefs = pool.ApplicationPackageReferences;
+            var pool = await client.PoolOperations.GetPoolAsync(poolName, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                Assert.Equal(applicationId, appRefs[0].ApplicationId);
-                Assert.Equal(version, appRefs[0].Version);
-            }
+            var appRefs = pool.ApplicationPackageReferences;
+
+            Assert.Equal(applicationId, appRefs[0].ApplicationId);
+            Assert.Equal(version, appRefs[0].Version);
         }
 
         [Fact]
@@ -273,51 +263,49 @@
             const string applicationId = "app-1";
             const string version = "1.0";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.JobScheduleGetOptions, AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.JobScheduleGetOptions, AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = (token) =>
+                request.ServiceRequestFunc = (token) =>
+                {
+                    var response = new AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>
                     {
-                        var response = new AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>
+                        Body = new Models.CloudJobSchedule
                         {
-                            Body = new Models.CloudJobSchedule
+                            JobSpecification = new Protocol.Models.JobSpecification
                             {
-                                JobSpecification = new Protocol.Models.JobSpecification
+                                PoolInfo = new Models.PoolInformation
                                 {
-                                    PoolInfo = new Models.PoolInformation
+                                    AutoPoolSpecification = new Protocol.Models.AutoPoolSpecification
                                     {
-                                        AutoPoolSpecification = new Protocol.Models.AutoPoolSpecification
+                                        Pool = new Models.PoolSpecification
                                         {
-                                            Pool = new Models.PoolSpecification
+                                            ApplicationPackageReferences = new List<Protocol.Models.ApplicationPackageReference>
                                             {
-                                                ApplicationPackageReferences = new List<Protocol.Models.ApplicationPackageReference>
-                                                {
                                                     new Protocol.Models.ApplicationPackageReference
                                                     {
                                                         ApplicationId = applicationId,
                                                         Version = version
                                                     }
-                                                }
                                             }
                                         }
-                                     }
+                                    }
                                 }
-                           }
-                        };
-                        return Task.FromResult(response);
+                            }
+                        }
                     };
-                });
+                    return Task.FromResult(response);
+                };
+            });
 
-                Microsoft.Azure.Batch.CloudJobSchedule jobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync("test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            Microsoft.Azure.Batch.CloudJobSchedule jobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync("test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                Microsoft.Azure.Batch.ApplicationPackageReference apr = jobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
+            Microsoft.Azure.Batch.ApplicationPackageReference apr = jobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
 
-                Assert.Equal(apr.ApplicationId, applicationId);
-                Assert.Equal(apr.Version, version);
-            }
+            Assert.Equal(apr.ApplicationId, applicationId);
+            Assert.Equal(apr.Version, version);
         }
 
         [Fact]
@@ -329,26 +317,25 @@
             const string applicationId = "testApp";
             const string applicationVersion = "beta";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Models.CloudJob returnFakeJob = new Models.CloudJob(jobId);
+            var job = client.JobOperations.GetJob(jobId, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(returnFakeJob));
+
+            var verifyAPRs = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskAddParameter, Models.TaskAddOptions, AzureOperationHeaderResponse<Models.TaskAddHeaders>>(
+                (parameters, options) =>
             {
-                Models.CloudJob returnFakeJob = new Models.CloudJob(jobId);
-                var job = client.JobOperations.GetJob(jobId, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(returnFakeJob));
+                Assert.Equal(applicationId, parameters.ApplicationPackageReferences.First().ApplicationId);
+                Assert.Equal(applicationVersion, parameters.ApplicationPackageReferences.First().Version);
 
-                var verifyAPRs = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskAddParameter, Models.TaskAddOptions, AzureOperationHeaderResponse<Models.TaskAddHeaders>>(
-                    (parameters, options) =>
+                return new AzureOperationHeaderResponse<Models.TaskAddHeaders>
                 {
-                    Assert.Equal(applicationId, parameters.ApplicationPackageReferences.First().ApplicationId);
-                    Assert.Equal(applicationVersion, parameters.ApplicationPackageReferences.First().Version);
+                    Response = new HttpResponseMessage(HttpStatusCode.Accepted)
+                };
+            });
 
-                    return new AzureOperationHeaderResponse<Models.TaskAddHeaders>
-                    {
-                        Response = new HttpResponseMessage(HttpStatusCode.Accepted)
-                    };
-                });
-
-                var taskWithAPRs = new CloudTask(taskId, "cmd /c hostname")
-                {
-                    ApplicationPackageReferences = new List<ApplicationPackageReference>
+            var taskWithAPRs = new CloudTask(taskId, "cmd /c hostname")
+            {
+                ApplicationPackageReferences = new List<ApplicationPackageReference>
                     {
                         new ApplicationPackageReference
                         {
@@ -356,10 +343,9 @@
                             Version = applicationVersion
                         }
                     }
-                };
+            };
 
-                job.AddTask(taskWithAPRs, additionalBehaviors: verifyAPRs);  // assertions happen in the callback
-            }
+            job.AddTask(taskWithAPRs, additionalBehaviors: verifyAPRs);  // assertions happen in the callback
         }
 
         [Fact]
@@ -370,27 +356,25 @@
             const string applicationId = "foo";
             const string version = "beta";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Models.CloudJob protoJob = new Models.CloudJob
             {
-                Models.CloudJob protoJob = new Models.CloudJob
+                Id = jobId,
+                JobManagerTask = new Models.JobManagerTask
                 {
-                    Id = jobId,
-                    JobManagerTask = new Models.JobManagerTask
-                    {
-                        ApplicationPackageReferences = new List<Models.ApplicationPackageReference>
+                    ApplicationPackageReferences = new List<Models.ApplicationPackageReference>
                         {
                             new Models.ApplicationPackageReference
                             {
                                 Version = version, ApplicationId = applicationId
-                            } 
+                            }
                         }
-                    }
-                };
+                }
+            };
 
-                var job = client.JobOperations.GetJob(jobId, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
-                Assert.Equal(applicationId, job.JobManagerTask.ApplicationPackageReferences.First().ApplicationId);
-                Assert.Equal(version, job.JobManagerTask.ApplicationPackageReferences.First().Version);
-            }
+            var job = client.JobOperations.GetJob(jobId, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
+            Assert.Equal(applicationId, job.JobManagerTask.ApplicationPackageReferences.First().ApplicationId);
+            Assert.Equal(version, job.JobManagerTask.ApplicationPackageReferences.First().Version);
         }
 
         [Fact]
@@ -400,40 +384,38 @@
             const string applicationId = "blender.exe";
             const string version = "blender";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                    {
-                        var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                {
+                    var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
 
-                        request.ServiceRequestFunc = (token) =>
+                    request.ServiceRequestFunc = (token) =>
+                    {
+                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
                         {
-                            var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
+                            Body = new Models.CloudPool
                             {
-                                Body = new Models.CloudPool
+                                ApplicationPackageReferences = new[]
                                 {
-                                    ApplicationPackageReferences = new[]
-                                    {
                                          new Protocol.Models.ApplicationPackageReference
                                          {
                                               ApplicationId = applicationId,
                                               Version = version
                                          }
-                                    }
                                 }
-                            };
-
-                            return Task.FromResult(response);
+                            }
                         };
-                    });
 
-                Microsoft.Azure.Batch.CloudPool cloudPool = client.PoolOperations.GetPool("pool-id", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
-                Assert.Throws<InvalidOperationException>(() => cloudPool.ApplicationPackageReferences.First().ApplicationId = applicationId);
-                Assert.Throws<InvalidOperationException>(() => cloudPool.ApplicationPackageReferences.First().Version = version);
-                Assert.Equal(cloudPool.ApplicationPackageReferences.First().Version, version);
-                Assert.Equal(cloudPool.ApplicationPackageReferences.First().ApplicationId, applicationId);
-            }
+                        return Task.FromResult(response);
+                    };
+                });
+
+            Microsoft.Azure.Batch.CloudPool cloudPool = client.PoolOperations.GetPool("pool-id", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            Assert.Throws<InvalidOperationException>(() => cloudPool.ApplicationPackageReferences.First().ApplicationId = applicationId);
+            Assert.Throws<InvalidOperationException>(() => cloudPool.ApplicationPackageReferences.First().Version = version);
+            Assert.Equal(cloudPool.ApplicationPackageReferences.First().Version, version);
+            Assert.Equal(cloudPool.ApplicationPackageReferences.First().ApplicationId, applicationId);
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ApplicationPackageUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ApplicationPackageUnitTests.cs
@@ -29,41 +29,39 @@ namespace Azure.Batch.Unit.Tests
 
             IList<string> versions = new[] { "1.0", "1.5" };
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                    {
-                        var request = (Protocol.BatchRequest<Models.ApplicationListOptions, AzureOperationResponse<IPage<Models.ApplicationSummary>, Models.ApplicationListHeaders>>)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
+                {
+                    var request = (Protocol.BatchRequest<Models.ApplicationListOptions, AzureOperationResponse<IPage<Models.ApplicationSummary>, Models.ApplicationListHeaders>>)baseRequest;
 
-                        request.ServiceRequestFunc = (token) =>
+                    request.ServiceRequestFunc = (token) =>
+                        {
+                            var response = new AzureOperationResponse<IPage<Models.ApplicationSummary>, Models.ApplicationListHeaders>
                             {
-                                var response = new AzureOperationResponse<IPage<Models.ApplicationSummary>, Models.ApplicationListHeaders>
+                                Body = new FakePage<Models.ApplicationSummary>(new[]
                                 {
-                                    Body = new FakePage<Models.ApplicationSummary>(new[]
-                                    {
                                         new Models.ApplicationSummary
                                             {
                                                 Id = applicationId,
                                                 DisplayName = displayName,
                                                 Versions = versions
                                             },
-                                    })
-                                };
-
-                                return Task.FromResult(response);
+                                })
                             };
-                    });
 
-                IPagedEnumerable<Microsoft.Azure.Batch.ApplicationSummary> applicationSummaries = client.ApplicationOperations.ListApplicationSummaries(additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+                            return Task.FromResult(response);
+                        };
+                });
 
-                Assert.Single(applicationSummaries);
+            IPagedEnumerable<Microsoft.Azure.Batch.ApplicationSummary> applicationSummaries = client.ApplicationOperations.ListApplicationSummaries(additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                var applicationSummary = applicationSummaries.First();
-                Assert.Equal(applicationId, applicationSummary.Id);
-                Assert.Equal(displayName, applicationSummary.DisplayName);
-                Assert.Equal(versions.First(), applicationSummary.Versions.First());
-                Assert.Equal(versions.Count, applicationSummary.Versions.ToList().Count);
-            }
+            Assert.Single(applicationSummaries);
+
+            var applicationSummary = applicationSummaries.First();
+            Assert.Equal(applicationId, applicationSummary.Id);
+            Assert.Equal(displayName, applicationSummary.DisplayName);
+            Assert.Equal(versions.First(), applicationSummary.Versions.First());
+            Assert.Equal(versions.Count, applicationSummary.Versions.ToList().Count);
         }
 
         [Fact]
@@ -75,37 +73,35 @@ namespace Azure.Batch.Unit.Tests
 
             IList<string> versions = new[] { "1.0", "1.5" };
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                    {
-                        var request = (Protocol.BatchRequest<Models.ApplicationGetOptions, AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>>)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                {
+                    var request = (Protocol.BatchRequest<Models.ApplicationGetOptions, AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>>)baseRequest;
 
-                        request.ServiceRequestFunc = (token) =>
+                    request.ServiceRequestFunc = (token) =>
+                        {
+                            var response = new AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>
                             {
-                                var response = new AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>
+                                Body = new Models.ApplicationSummary
                                 {
-                                    Body = new Models.ApplicationSummary
-                                    {
-                                        Id = applicationId,
-                                        DisplayName = displayName,
-                                        Versions = versions
-                                    }
-                                };
-
-                                return Task.FromResult(response);
+                                    Id = applicationId,
+                                    DisplayName = displayName,
+                                    Versions = versions
+                                }
                             };
-                    });
+
+                            return Task.FromResult(response);
+                        };
+                });
 
 
-                Microsoft.Azure.Batch.ApplicationSummary applicationSummary = client.ApplicationOperations.GetApplicationSummaryAsync(applicationId, additionalBehaviors: new List<BatchClientBehavior> { interceptor }).Result;
-                Assert.Equal(applicationId, applicationSummary.Id);
-                Assert.Equal(displayName, applicationSummary.DisplayName);
+            Microsoft.Azure.Batch.ApplicationSummary applicationSummary = client.ApplicationOperations.GetApplicationSummaryAsync(applicationId, additionalBehaviors: new List<BatchClientBehavior> { interceptor }).Result;
+            Assert.Equal(applicationId, applicationSummary.Id);
+            Assert.Equal(displayName, applicationSummary.DisplayName);
 
 
-                Assert.Equal(versions.First(), applicationSummary.Versions.First());
-            }
+            Assert.Equal(versions.First(), applicationSummary.Versions.First());
         }
 
         [Fact]
@@ -117,34 +113,32 @@ namespace Azure.Batch.Unit.Tests
 
             IList<string> versions = new[] { "1.0", "1.5" };
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
+                var request = (Protocol.BatchRequest<Models.ApplicationGetOptions, AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>>)baseRequest;
+
+                request.ServiceRequestFunc = (token) =>
                 {
-                    var request = (Protocol.BatchRequest<Models.ApplicationGetOptions, AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>>)baseRequest;
-
-                    request.ServiceRequestFunc = (token) =>
+                    var response = new AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>
                     {
-                        var response = new AzureOperationResponse<Models.ApplicationSummary, Models.ApplicationGetHeaders>
+                        Body = new Models.ApplicationSummary
                         {
-                            Body = new Models.ApplicationSummary
-                            {
-                                Id = applicationId,
-                                DisplayName = displayName,
-                                Versions = versions
-                            }
-                        };
-
-                        return Task.FromResult(response);
+                            Id = applicationId,
+                            DisplayName = displayName,
+                            Versions = versions
+                        }
                     };
-                });
+
+                    return Task.FromResult(response);
+                };
+            });
 
 
-                Microsoft.Azure.Batch.ApplicationSummary applicationSummary = client.ApplicationOperations.GetApplicationSummary(applicationId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
-                Assert.Equal(applicationId, applicationSummary.Id);
-                Assert.Equal(displayName, applicationSummary.DisplayName);
-                Assert.Equal(versions.First(), applicationSummary.Versions.First());
-            }
+            Microsoft.Azure.Batch.ApplicationSummary applicationSummary = client.ApplicationOperations.GetApplicationSummary(applicationId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            Assert.Equal(applicationId, applicationSummary.Id);
+            Assert.Equal(displayName, applicationSummary.DisplayName);
+            Assert.Equal(versions.First(), applicationSummary.Versions.First());
         }
 
         [Fact]
@@ -214,12 +208,12 @@ namespace Azure.Batch.Unit.Tests
                 {
                     requests.Add(uri);
 
-                    switch (uri.AbsoluteUri)
+                    return uri.AbsoluteUri switch
                     {
-                        case "http://skip1/": return fakeResponse2;
-                        case "http://skip2/": return fakeResponse3;
-                        default: return fakeResponse1;
-                    }
+                        "http://skip1/" => fakeResponse2,
+                        "http://skip2/" => fakeResponse3,
+                        _ => fakeResponse1,
+                    };
                 };
 
             using (BatchClient client = BatchClient.Open(FakeClient.Create(HttpStatusCode.OK, responseBody)))

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BatchClientUnitTest.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BatchClientUnitTest.cs
@@ -46,10 +46,8 @@ namespace Azure.Batch.Unit.Tests
 
             using (var restClient = new BatchServiceClient(tokenCredentials, fakeHttpClientHandler) { BatchUrl = @"https://foo.microsoft.test" })
             {
-                using (var client = BatchClient.Open(restClient))
-                {
-                    await client.PoolOperations.DeletePoolAsync("bar", new List<BatchClientBehavior>());
-                }
+                using var client = BatchClient.Open(restClient);
+                await client.PoolOperations.DeletePoolAsync("bar", new List<BatchClientBehavior>());
             }
 
             Assert.Equal("foo", capturedRequest.Headers.Authorization.Parameter);
@@ -67,17 +65,16 @@ namespace Azure.Batch.Unit.Tests
                 return Task.FromResult("foo");
             }));
 
-            using (var restClient = new BatchServiceClient(
+            using var restClient = new BatchServiceClient(
                 tokenCredentials,
-                new FakeHttpClientHandler(req => new HttpResponseMessage(HttpStatusCode.Accepted))) { BatchUrl = @"https://foo.microsoft.test" })
-            {
-                var client = BatchClient.Open(restClient);
+                new FakeHttpClientHandler(req => new HttpResponseMessage(HttpStatusCode.Accepted)))
+            { BatchUrl = @"https://foo.microsoft.test" };
+            var client = BatchClient.Open(restClient);
 
-                await client.PoolOperations.DeletePoolAsync("bar", new List<BatchClientBehavior>());
-                Assert.Equal(1, count);
-                await client.PoolOperations.DeletePoolAsync("bar", new List<BatchClientBehavior>());
-                Assert.Equal(2, count);
-            }
+            await client.PoolOperations.DeletePoolAsync("bar", new List<BatchClientBehavior>());
+            Assert.Equal(1, count);
+            await client.PoolOperations.DeletePoolAsync("bar", new List<BatchClientBehavior>());
+            Assert.Equal(2, count);
         }
 
         [Fact]
@@ -95,10 +92,8 @@ namespace Azure.Batch.Unit.Tests
 
             using (var restClient = new BatchServiceClient(tokenCredentials, fakeHttpClientHandler) { BatchUrl = @"https://foo.microsoft.test" })
             {
-                using (var client = BatchClient.Open(restClient))
-                {
-                    await client.PoolOperations.DeletePoolAsync("bar");
-                }
+                using var client = BatchClient.Open(restClient);
+                await client.PoolOperations.DeletePoolAsync("bar");
             }
 
             Assert.Equal("foo", capturedRequest.Headers.Authorization.Parameter);

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BatchRequestUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BatchRequestUnitTests.cs
@@ -99,23 +99,21 @@
         public async Task TestDefaultBatchRequestTimeoutSet()
         {
             TimeSpan requestTimeout = TimeSpan.MinValue;
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(req =>
-                    {
-                        requestTimeout = req.Timeout;
-                        var castRequest = (Protocol.BatchRequest<
-                            Protocol.Models.JobGetOptions,
-                            AzureOperationResponse<Protocol.Models.CloudJob, Protocol.Models.JobGetHeaders>>)req;
-                        castRequest.ServiceRequestFunc = (token) =>
-                            {
-                                return Task.FromResult(new AzureOperationResponse<Protocol.Models.CloudJob, Protocol.Models.JobGetHeaders>() { Body = new Protocol.Models.CloudJob() });
-                            };
-                    });
-                await client.JobOperations.GetJobAsync("foo", additionalBehaviors: new List<BatchClientBehavior>{interceptor});
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(req =>
+                {
+                    requestTimeout = req.Timeout;
+                    var castRequest = (Protocol.BatchRequest<
+                        Protocol.Models.JobGetOptions,
+                        AzureOperationResponse<Protocol.Models.CloudJob, Protocol.Models.JobGetHeaders>>)req;
+                    castRequest.ServiceRequestFunc = (token) =>
+                        {
+                            return Task.FromResult(new AzureOperationResponse<Protocol.Models.CloudJob, Protocol.Models.JobGetHeaders>() { Body = new Protocol.Models.CloudJob() });
+                        };
+                });
+            await client.JobOperations.GetJobAsync("foo", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                Assert.Equal(Constants.DefaultSingleRestRequestClientTimeout, requestTimeout);
-            }
+            Assert.Equal(Constants.DefaultSingleRestRequestClientTimeout, requestTimeout);
         }
 
         [Fact]
@@ -136,9 +134,8 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task TestCancellationViaParameter()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                List<IInheritedBehaviors> objectsToExamineForMethods = new List<IInheritedBehaviors>()
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            List<IInheritedBehaviors> objectsToExamineForMethods = new List<IInheritedBehaviors>()
                     {
                         client.JobOperations,
                         client.JobScheduleOperations,
@@ -146,19 +143,18 @@
                         client.PoolOperations,
                     };
 
-                foreach (IInheritedBehaviors o in objectsToExamineForMethods)
+            foreach (IInheritedBehaviors o in objectsToExamineForMethods)
+            {
+                List<MethodInfo> methodsToCall = DiscoverCancellableMethods(o.GetType());
+                foreach (MethodInfo method in methodsToCall)
                 {
-                    List<MethodInfo> methodsToCall = DiscoverCancellableMethods(o.GetType());
-                    foreach (MethodInfo method in methodsToCall)
+                    foreach (IInheritedBehaviors behaviorContainer in objectsToExamineForMethods)
                     {
-                        foreach (IInheritedBehaviors behaviorContainer in objectsToExamineForMethods)
-                        {
-                            behaviorContainer.CustomBehaviors.Clear();
-                            behaviorContainer.CustomBehaviors.Add(CreateRequestInterceptorForCancellationMonitoring());
-                        }
-
-                        await this.BatchRequestCancellationViaParameterTestAsync(method, o, TimeSpan.FromSeconds(0));
+                        behaviorContainer.CustomBehaviors.Clear();
+                        behaviorContainer.CustomBehaviors.Add(CreateRequestInterceptorForCancellationMonitoring());
                     }
+
+                    await this.BatchRequestCancellationViaParameterTestAsync(method, o, TimeSpan.FromSeconds(0));
                 }
             }
         }
@@ -167,9 +163,8 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task TestCancellationViaParameterForLists()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                List<IInheritedBehaviors> objectsToExamineForMethods = new List<IInheritedBehaviors>()
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            List<IInheritedBehaviors> objectsToExamineForMethods = new List<IInheritedBehaviors>()
                     {
                         client.JobOperations,
                         client.JobScheduleOperations,
@@ -177,27 +172,26 @@
                         client.PoolOperations,
                     };
 
-                foreach (IInheritedBehaviors behaviorContainer in objectsToExamineForMethods)
+            foreach (IInheritedBehaviors behaviorContainer in objectsToExamineForMethods)
+            {
+                List<MethodInfo> listMethods = DiscoverListMethods(behaviorContainer.GetType());
+
+                //Call the list methods to build the enumerable
+                foreach (MethodInfo listMethod in listMethods)
                 {
-                    List<MethodInfo> listMethods = DiscoverListMethods(behaviorContainer.GetType());
+                    behaviorContainer.CustomBehaviors.Clear();
+                    behaviorContainer.CustomBehaviors.Add(CreateRequestInterceptorForCancellationMonitoring());
 
-                    //Call the list methods to build the enumerable
-                    foreach (MethodInfo listMethod in listMethods)
-                    {
-                        behaviorContainer.CustomBehaviors.Clear();
-                        behaviorContainer.CustomBehaviors.Add(CreateRequestInterceptorForCancellationMonitoring());
+                    object pagedEnumerable = ReflectionHelpers.InvokeMethodWithDefaultArguments(listMethod, behaviorContainer);
 
-                        object pagedEnumerable = ReflectionHelpers.InvokeMethodWithDefaultArguments(listMethod, behaviorContainer);
+                    //PagedEnumerable will have a method called: "GetPagedEnumerator"
+                    MethodInfo getEnumeratorMethod = pagedEnumerable.GetType().GetMethod("GetPagedEnumerator");
+                    object pagedEnumerator = getEnumeratorMethod.Invoke(pagedEnumerable, null);
 
-                        //PagedEnumerable will have a method called: "GetPagedEnumerator"
-                        MethodInfo getEnumeratorMethod = pagedEnumerable.GetType().GetMethod("GetPagedEnumerator");
-                        object pagedEnumerator = getEnumeratorMethod.Invoke(pagedEnumerable, null);
+                    //pagedEnumerator has the method to call "MoveNextAsync"
+                    MethodInfo moveNextAsyncMethod = pagedEnumerator.GetType().GetMethod("MoveNextAsync");
 
-                        //pagedEnumerator has the method to call "MoveNextAsync"
-                        MethodInfo moveNextAsyncMethod = pagedEnumerator.GetType().GetMethod("MoveNextAsync");
-
-                        await this.BatchRequestCancellationViaParameterTestAsync(moveNextAsyncMethod, pagedEnumerator, TimeSpan.FromSeconds(0));
-                    }
+                    await this.BatchRequestCancellationViaParameterTestAsync(moveNextAsyncMethod, pagedEnumerator, TimeSpan.FromSeconds(0));
                 }
             }
         }
@@ -262,28 +256,26 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task TestBatchRequestCannotBeModifiedAfterExecutionStarted()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(req =>
-                    {
-                        PoolAddBatchRequest addPoolRequest = req as PoolAddBatchRequest;
-                        addPoolRequest.ServiceRequestFunc = token =>
-                            {
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.CancellationToken = CancellationToken.None);
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.Options = null);
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.RetryPolicy = null);
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.ServiceRequestFunc = null);
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.Timeout = TimeSpan.FromSeconds(0));
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.ClientRequestIdProvider = null);
-                                Assert.Throws<InvalidOperationException>(() => addPoolRequest.Parameters = null);
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(req =>
+                {
+                    PoolAddBatchRequest addPoolRequest = req as PoolAddBatchRequest;
+                    addPoolRequest.ServiceRequestFunc = token =>
+                        {
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.CancellationToken = CancellationToken.None);
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.Options = null);
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.RetryPolicy = null);
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.ServiceRequestFunc = null);
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.Timeout = TimeSpan.FromSeconds(0));
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.ClientRequestIdProvider = null);
+                            Assert.Throws<InvalidOperationException>(() => addPoolRequest.Parameters = null);
 
-                                return Task.FromResult(new AzureOperationHeaderResponse<Protocol.Models.PoolAddHeaders>());
-                            };
-                    });
+                            return Task.FromResult(new AzureOperationHeaderResponse<Protocol.Models.PoolAddHeaders>());
+                        };
+                });
 
-                CloudPool pool = batchClient.PoolOperations.CreatePool("dummy", "small", default(CloudServiceConfiguration), targetDedicatedComputeNodes: 0);
-                await pool.CommitAsync(additionalBehaviors: new[] { interceptor });
-            }
+            CloudPool pool = batchClient.PoolOperations.CreatePool("dummy", "small", default(CloudServiceConfiguration), targetDedicatedComputeNodes: 0);
+            await pool.CommitAsync(additionalBehaviors: new[] { interceptor });
         }
 
         #endregion
@@ -316,107 +308,105 @@
 
             int observedRequestCount = 0;
             CancellationToken customToken = CancellationToken.None;
-            using (CancellationTokenSource source = new CancellationTokenSource(timeoutViaCancellationTokenValue))
+            using CancellationTokenSource source = new CancellationTokenSource(timeoutViaCancellationTokenValue);
+            if (clientRequestTimeoutViaCustomToken.HasValue)
             {
-                if (clientRequestTimeoutViaCustomToken.HasValue)
-                {
-                    customToken = source.Token;
-                }
+                customToken = source.Token;
+            }
 
-                //Determine which timeout should hit first and create the requestCancellationOptions object
-                if (clientRequestTimeoutViaCustomToken.HasValue && clientRequestTimeoutViaTimeout.HasValue)
-                {
-                    expectedCustomTokenTimeoutToHitFirst = clientRequestTimeoutViaCustomToken < clientRequestTimeoutViaTimeout;
-                }
-                else if (clientRequestTimeoutViaCustomToken.HasValue)
-                {
-                    expectedCustomTokenTimeoutToHitFirst = true;
-                }
-                else if (clientRequestTimeoutViaTimeout.HasValue)
-                {
-                    expectedCustomTokenTimeoutToHitFirst = false;
-                }
-                else
-                {
-                    Assert.True(false, "Both clientRequestTimeoutViaCustomToken and clientRequestTimeoutViaTimeout cannot be null");
-                }
+            //Determine which timeout should hit first and create the requestCancellationOptions object
+            if (clientRequestTimeoutViaCustomToken.HasValue && clientRequestTimeoutViaTimeout.HasValue)
+            {
+                expectedCustomTokenTimeoutToHitFirst = clientRequestTimeoutViaCustomToken < clientRequestTimeoutViaTimeout;
+            }
+            else if (clientRequestTimeoutViaCustomToken.HasValue)
+            {
+                expectedCustomTokenTimeoutToHitFirst = true;
+            }
+            else if (clientRequestTimeoutViaTimeout.HasValue)
+            {
+                expectedCustomTokenTimeoutToHitFirst = false;
+            }
+            else
+            {
+                Assert.True(false, "Both clientRequestTimeoutViaCustomToken and clientRequestTimeoutViaTimeout cannot be null");
+            }
 
-                using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-                {
-                    //Add a retry policy to the client if required
-                    if (retryPolicy != null)
-                    {
-                        client.CustomBehaviors.Add(new RetryPolicyProvider(retryPolicy));
-                    }
-
-                    //
-                    // Set the interceptor to catch the request before it really goes to the Batch service and hook the cancellation token to find when it times out
-                    //
-                    Protocol.RequestInterceptor requestInterceptor = new Protocol.RequestInterceptor(req =>
-                    {
-                        if (clientRequestTimeoutViaTimeout.HasValue)
-                        {
-                            req.Timeout = clientRequestTimeoutViaTimeout.Value;
-                        }
-
-                        req.CancellationToken = customToken;
-
-                        var castRequest = (Protocol.BatchRequests.JobGetBatchRequest)req;
-                        castRequest.ServiceRequestFunc = async (token) =>
-                        {
-                            TaskCompletionSource<TimeSpan> taskCompletionSource = new TaskCompletionSource<TimeSpan>();
-                            observedRequestCount++;
-                            if (!expectedCustomTokenTimeoutToHitFirst)
-                            {
-                                startTime = DateTime.UtcNow;
-                            }
-
-                            token.Register(() =>
-                            {
-                                DateTime endTime = DateTime.UtcNow;
-                                TimeSpan duration = endTime.Subtract(startTime);
-                                taskCompletionSource.SetResult(duration);
-                            });
-
-                            cancellationDuration = await taskCompletionSource.Task;
-
-                            token.ThrowIfCancellationRequested(); //Force an exception
-
-                            return new AzureOperationResponse<Protocol.Models.CloudJob, Protocol.Models.JobGetHeaders>() { Body = new Protocol.Models.CloudJob() };
-                        };
-                    });
-
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () => await client.JobOperations.GetJobAsync("dummy", additionalBehaviors: new List<BatchClientBehavior> { requestInterceptor }));
-                }
-                this.testOutputHelper.WriteLine("There were {0} requests executed", observedRequestCount);
-                this.testOutputHelper.WriteLine("Took {0} to cancel task", cancellationDuration);
-
-                Assert.NotNull(cancellationDuration);
-                if (expectedCustomTokenTimeoutToHitFirst)
-                {
-                    this.testOutputHelper.WriteLine("Expected custom token timeout to hit first");
-                    Assert.True(Math.Abs(clientRequestTimeoutViaCustomToken.Value.TotalSeconds - cancellationDuration.Value.TotalSeconds) < TimeTolerance,
-                        string.Format("Expected timeout: {0}, Observed timeout: {1}", clientRequestTimeoutViaCustomToken, cancellationDuration));
-                }
-                else
-                {
-                    this.testOutputHelper.WriteLine("Expected client side timeout to hit first");
-                    Assert.True(Math.Abs(clientRequestTimeoutViaTimeout.Value.TotalSeconds - cancellationDuration.Value.TotalSeconds) < TimeTolerance,
-                        string.Format("Expected timeout: {0}, Observed timeout: {1}", clientRequestTimeoutViaTimeout, cancellationDuration));
-                }
-
-                //Confirm the right number of retries were reached (if applicable)
+            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            {
+                //Add a retry policy to the client if required
                 if (retryPolicy != null)
                 {
-                    if (expectedCustomTokenTimeoutToHitFirst)
+                    client.CustomBehaviors.Add(new RetryPolicyProvider(retryPolicy));
+                }
+
+                //
+                // Set the interceptor to catch the request before it really goes to the Batch service and hook the cancellation token to find when it times out
+                //
+                Protocol.RequestInterceptor requestInterceptor = new Protocol.RequestInterceptor(req =>
+                {
+                    if (clientRequestTimeoutViaTimeout.HasValue)
                     {
-                        //This terminates the retry so there should just be 1 request (0 retries)
-                        Assert.Equal(0, observedRequestCount - 1);
+                        req.Timeout = clientRequestTimeoutViaTimeout.Value;
                     }
-                    else
+
+                    req.CancellationToken = customToken;
+
+                    var castRequest = (Protocol.BatchRequests.JobGetBatchRequest)req;
+                    castRequest.ServiceRequestFunc = async (token) =>
                     {
-                        Assert.Equal(expectedMaxRetries, observedRequestCount - 1);
-                    }
+                        TaskCompletionSource<TimeSpan> taskCompletionSource = new TaskCompletionSource<TimeSpan>();
+                        observedRequestCount++;
+                        if (!expectedCustomTokenTimeoutToHitFirst)
+                        {
+                            startTime = DateTime.UtcNow;
+                        }
+
+                        token.Register(() =>
+                        {
+                            DateTime endTime = DateTime.UtcNow;
+                            TimeSpan duration = endTime.Subtract(startTime);
+                            taskCompletionSource.SetResult(duration);
+                        });
+
+                        cancellationDuration = await taskCompletionSource.Task;
+
+                        token.ThrowIfCancellationRequested(); //Force an exception
+
+                            return new AzureOperationResponse<Protocol.Models.CloudJob, Protocol.Models.JobGetHeaders>() { Body = new Protocol.Models.CloudJob() };
+                    };
+                });
+
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await client.JobOperations.GetJobAsync("dummy", additionalBehaviors: new List<BatchClientBehavior> { requestInterceptor }));
+            }
+            this.testOutputHelper.WriteLine("There were {0} requests executed", observedRequestCount);
+            this.testOutputHelper.WriteLine("Took {0} to cancel task", cancellationDuration);
+
+            Assert.NotNull(cancellationDuration);
+            if (expectedCustomTokenTimeoutToHitFirst)
+            {
+                this.testOutputHelper.WriteLine("Expected custom token timeout to hit first");
+                Assert.True(Math.Abs(clientRequestTimeoutViaCustomToken.Value.TotalSeconds - cancellationDuration.Value.TotalSeconds) < TimeTolerance,
+                    string.Format("Expected timeout: {0}, Observed timeout: {1}", clientRequestTimeoutViaCustomToken, cancellationDuration));
+            }
+            else
+            {
+                this.testOutputHelper.WriteLine("Expected client side timeout to hit first");
+                Assert.True(Math.Abs(clientRequestTimeoutViaTimeout.Value.TotalSeconds - cancellationDuration.Value.TotalSeconds) < TimeTolerance,
+                    string.Format("Expected timeout: {0}, Observed timeout: {1}", clientRequestTimeoutViaTimeout, cancellationDuration));
+            }
+
+            //Confirm the right number of retries were reached (if applicable)
+            if (retryPolicy != null)
+            {
+                if (expectedCustomTokenTimeoutToHitFirst)
+                {
+                    //This terminates the retry so there should just be 1 request (0 retries)
+                    Assert.Equal(0, observedRequestCount - 1);
+                }
+                else
+                {
+                    Assert.Equal(expectedMaxRetries, observedRequestCount - 1);
                 }
             }
         }
@@ -466,22 +456,20 @@
         {
             Assert.NotNull(clientRequestTimeoutViaCustomToken);
 
-            using (CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(clientRequestTimeoutViaCustomToken.Value))
-            {
-                this.testOutputHelper.WriteLine("Invoking {0}", method.Name);
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(clientRequestTimeoutViaCustomToken.Value);
+            this.testOutputHelper.WriteLine("Invoking {0}", method.Name);
 
-                //Invoke the method with default parameters and a cancellationToken
-                BatchUnitTestCancellationException e = await Assert.ThrowsAsync<BatchUnitTestCancellationException>(
-                            async () => await InvokeCancellationTokenMethodAsync(method, o, cancellationTokenSource.Token));
+            //Invoke the method with default parameters and a cancellationToken
+            BatchUnitTestCancellationException e = await Assert.ThrowsAsync<BatchUnitTestCancellationException>(
+                        async () => await InvokeCancellationTokenMethodAsync(method, o, cancellationTokenSource.Token));
 
-                this.testOutputHelper.WriteLine("There were {0} requests executed", e.ObservedRequestCount);
-                this.testOutputHelper.WriteLine("Took {0} to cancel task", e.CancellationDuration);
+            this.testOutputHelper.WriteLine("There were {0} requests executed", e.ObservedRequestCount);
+            this.testOutputHelper.WriteLine("Took {0} to cancel task", e.CancellationDuration);
 
-                Assert.NotNull(e.CancellationDuration);
+            Assert.NotNull(e.CancellationDuration);
 
-                Assert.True(Math.Abs(clientRequestTimeoutViaCustomToken.Value.TotalSeconds - e.CancellationDuration.TotalSeconds) < TimeTolerance,
-                    string.Format("Expected timeout: {0}, Observed timeout: {1}", clientRequestTimeoutViaCustomToken, e.CancellationDuration));
-            }
+            Assert.True(Math.Abs(clientRequestTimeoutViaCustomToken.Value.TotalSeconds - e.CancellationDuration.TotalSeconds) < TimeTolerance,
+                string.Format("Expected timeout: {0}, Observed timeout: {1}", clientRequestTimeoutViaCustomToken, e.CancellationDuration));
         }
 
         /// <summary>

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BindingStateConstraintUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BindingStateConstraintUnitTests.cs
@@ -35,38 +35,36 @@ namespace Azure.Batch.Unit.Tests
             const string cloudPoolDisplayName = "pool-display-name-test";
             MetadataItem metadataItem = new MetadataItem("foo", "bar");
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudPool cloudPool = client.PoolOperations.CreatePool(cloudPoolId, virtualMachineSize, new CloudServiceConfiguration(osFamily));
-                cloudPool.DisplayName = cloudPoolDisplayName;
-                cloudPool.Metadata = new List<MetadataItem> { metadataItem };
-                
-                Assert.Equal(cloudPoolId, cloudPool.Id); // can set an unbound object
-                Assert.Equal(cloudPool.Metadata.First().Name, metadataItem.Name);
-                Assert.Equal(cloudPool.Metadata.First().Value, metadataItem.Value);
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudPool cloudPool = client.PoolOperations.CreatePool(cloudPoolId, virtualMachineSize, new CloudServiceConfiguration(osFamily));
+            cloudPool.DisplayName = cloudPoolDisplayName;
+            cloudPool.Metadata = new List<MetadataItem> { metadataItem };
 
-                cloudPool.Commit(additionalBehaviors: InterceptorFactory.CreateAddPoolRequestInterceptor());
+            Assert.Equal(cloudPoolId, cloudPool.Id); // can set an unbound object
+            Assert.Equal(cloudPool.Metadata.First().Name, metadataItem.Name);
+            Assert.Equal(cloudPool.Metadata.First().Value, metadataItem.Value);
 
-                // writing isn't allowed for a cloudPool that is in an readonly state.
-                Assert.Throws<InvalidOperationException>(() => cloudPool.AutoScaleFormula = "Foo");
-                Assert.Throws<InvalidOperationException>(() => cloudPool.DisplayName = "Foo");
-                Assert.Throws<InvalidOperationException>(() => cloudPool.CloudServiceConfiguration = null);
-                Assert.Throws<InvalidOperationException>(() => cloudPool.ResizeTimeout = TimeSpan.FromSeconds(10));
-                Assert.Throws<InvalidOperationException>(() => cloudPool.Metadata = null);
-                Assert.Throws<InvalidOperationException>(() => cloudPool.TargetDedicatedComputeNodes = 5);
-                Assert.Throws<InvalidOperationException>(() => cloudPool.VirtualMachineConfiguration = null);
-                Assert.Throws<InvalidOperationException>(() => cloudPool.VirtualMachineSize = "small");
+            cloudPool.Commit(additionalBehaviors: InterceptorFactory.CreateAddPoolRequestInterceptor());
 
-                //read is allowed though
-                Assert.Null(cloudPool.AutoScaleFormula);
-                Assert.Equal(cloudPoolDisplayName, cloudPool.DisplayName);
-                Assert.NotNull(cloudPool.CloudServiceConfiguration);
-                Assert.Null(cloudPool.ResizeTimeout);
-                Assert.Equal(1, cloudPool.Metadata.Count);
-                Assert.Null(cloudPool.TargetDedicatedComputeNodes);
-                Assert.Null(cloudPool.VirtualMachineConfiguration);
-                Assert.Equal(virtualMachineSize, cloudPool.VirtualMachineSize);
-            }
+            // writing isn't allowed for a cloudPool that is in an readonly state.
+            Assert.Throws<InvalidOperationException>(() => cloudPool.AutoScaleFormula = "Foo");
+            Assert.Throws<InvalidOperationException>(() => cloudPool.DisplayName = "Foo");
+            Assert.Throws<InvalidOperationException>(() => cloudPool.CloudServiceConfiguration = null);
+            Assert.Throws<InvalidOperationException>(() => cloudPool.ResizeTimeout = TimeSpan.FromSeconds(10));
+            Assert.Throws<InvalidOperationException>(() => cloudPool.Metadata = null);
+            Assert.Throws<InvalidOperationException>(() => cloudPool.TargetDedicatedComputeNodes = 5);
+            Assert.Throws<InvalidOperationException>(() => cloudPool.VirtualMachineConfiguration = null);
+            Assert.Throws<InvalidOperationException>(() => cloudPool.VirtualMachineSize = "small");
+
+            //read is allowed though
+            Assert.Null(cloudPool.AutoScaleFormula);
+            Assert.Equal(cloudPoolDisplayName, cloudPool.DisplayName);
+            Assert.NotNull(cloudPool.CloudServiceConfiguration);
+            Assert.Null(cloudPool.ResizeTimeout);
+            Assert.Equal(1, cloudPool.Metadata.Count);
+            Assert.Null(cloudPool.TargetDedicatedComputeNodes);
+            Assert.Null(cloudPool.VirtualMachineConfiguration);
+            Assert.Equal(virtualMachineSize, cloudPool.VirtualMachineSize);
         }
 
         [Fact]
@@ -77,10 +75,9 @@ namespace Azure.Batch.Unit.Tests
             const string cloudPoolDisplayName = "pool-display-name-test";
             MetadataItem metadataItem = new MetadataItem("foo", "bar");
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Models.CloudPool protoPool = new Models.CloudPool(id: cloudPoolId, displayName: cloudPoolDisplayName, metadata: new[]
             {
-                Models.CloudPool protoPool = new Models.CloudPool(id: cloudPoolId, displayName: cloudPoolDisplayName, metadata: new[]
-                {
                     new Models.MetadataItem
                     {
                         Name = metadataItem.Name,
@@ -88,20 +85,19 @@ namespace Azure.Batch.Unit.Tests
                     }
                 });
 
-                CloudPool boundPool = client.PoolOperations.GetPool(string.Empty, additionalBehaviors: InterceptorFactory.CreateGetPoolRequestInterceptor(protoPool));
+            CloudPool boundPool = client.PoolOperations.GetPool(string.Empty, additionalBehaviors: InterceptorFactory.CreateGetPoolRequestInterceptor(protoPool));
 
-                // Cannot change these bound properties.
-                Assert.Throws<InvalidOperationException>(() => boundPool.DisplayName = "cannot-change-display-name");
-                Assert.Throws<InvalidOperationException>(() => boundPool.Id = "cannot-change-id");
-                Assert.Throws<InvalidOperationException>(() => boundPool.TargetDedicatedComputeNodes = 1);
-                Assert.Throws<InvalidOperationException>(() => boundPool.VirtualMachineSize = "cannot-change-1");
+            // Cannot change these bound properties.
+            Assert.Throws<InvalidOperationException>(() => boundPool.DisplayName = "cannot-change-display-name");
+            Assert.Throws<InvalidOperationException>(() => boundPool.Id = "cannot-change-id");
+            Assert.Throws<InvalidOperationException>(() => boundPool.TargetDedicatedComputeNodes = 1);
+            Assert.Throws<InvalidOperationException>(() => boundPool.VirtualMachineSize = "cannot-change-1");
 
 
-                // Swap the value with the name and the name with the value.
-                boundPool.Metadata = new[] { new MetadataItem(metadataItem.Value, metadataItem.Name) };
-                Assert.Equal(metadataItem.Name, boundPool.Metadata.First().Value);
-                Assert.Equal(metadataItem.Value, boundPool.Metadata.First().Name);
-            }
+            // Swap the value with the name and the name with the value.
+            boundPool.Metadata = new[] { new MetadataItem(metadataItem.Value, metadataItem.Name) };
+            Assert.Equal(metadataItem.Name, boundPool.Metadata.First().Value);
+            Assert.Equal(metadataItem.Value, boundPool.Metadata.First().Name);
         }
 
         [Fact]
@@ -112,44 +108,42 @@ namespace Azure.Batch.Unit.Tests
             const string displayName = "DisplayNameFoo";
             MetadataItem metadataItem = new MetadataItem("foo", "bar");
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudJobSchedule jobSchedule = client.JobScheduleOperations.CreateJobSchedule();
+            jobSchedule.Id = jobScheduleId;
+            jobSchedule.DisplayName = displayName;
+            jobSchedule.Metadata = new List<MetadataItem> { metadataItem };
+            jobSchedule.JobSpecification = new JobSpecification
             {
-                CloudJobSchedule jobSchedule = client.JobScheduleOperations.CreateJobSchedule();
-                jobSchedule.Id = jobScheduleId;
-                jobSchedule.DisplayName = displayName;
-                jobSchedule.Metadata = new List<MetadataItem> { metadataItem };
-                jobSchedule.JobSpecification = new JobSpecification
-                {
-                    OnAllTasksComplete = OnAllTasksComplete.TerminateJob,
-                    OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction
-                };
+                OnAllTasksComplete = OnAllTasksComplete.TerminateJob,
+                OnTaskFailure = OnTaskFailure.PerformExitOptionsJobAction
+            };
 
-                Assert.Equal(jobSchedule.Id, jobScheduleId); // can set an unbound object
-                Assert.Equal(jobSchedule.Metadata.First().Name, metadataItem.Name);
-                Assert.Equal(jobSchedule.Metadata.First().Value, metadataItem.Value);
-                Assert.Equal(OnAllTasksComplete.TerminateJob, jobSchedule.JobSpecification.OnAllTasksComplete);
-                Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, jobSchedule.JobSpecification.OnTaskFailure);
+            Assert.Equal(jobSchedule.Id, jobScheduleId); // can set an unbound object
+            Assert.Equal(jobSchedule.Metadata.First().Name, metadataItem.Name);
+            Assert.Equal(jobSchedule.Metadata.First().Value, metadataItem.Value);
+            Assert.Equal(OnAllTasksComplete.TerminateJob, jobSchedule.JobSpecification.OnAllTasksComplete);
+            Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, jobSchedule.JobSpecification.OnTaskFailure);
 
-                jobSchedule.Commit(additionalBehaviors: InterceptorFactory.CreateAddJobScheduleRequestInterceptor());
+            jobSchedule.Commit(additionalBehaviors: InterceptorFactory.CreateAddJobScheduleRequestInterceptor());
 
-                // writing isn't allowed for a jobSchedule that is in an read only state.
-                Assert.Throws<InvalidOperationException>(() => jobSchedule.Id = "cannot-change-id");
-                Assert.Throws<InvalidOperationException>(() => jobSchedule.DisplayName = "cannot-change-display-name");
-                
-                //Can still read though
-                Assert.Equal(jobScheduleId, jobSchedule.Id);
-                Assert.Equal(displayName, jobSchedule.DisplayName);
+            // writing isn't allowed for a jobSchedule that is in an read only state.
+            Assert.Throws<InvalidOperationException>(() => jobSchedule.Id = "cannot-change-id");
+            Assert.Throws<InvalidOperationException>(() => jobSchedule.DisplayName = "cannot-change-display-name");
 
-                jobSchedule.Refresh(additionalBehaviors:
-                        InterceptorFactory.CreateGetJobScheduleRequestInterceptor(
-                            new Models.CloudJobSchedule()
-                                {
-                                    JobSpecification = new Models.JobSpecification()
-                                }));
+            //Can still read though
+            Assert.Equal(jobScheduleId, jobSchedule.Id);
+            Assert.Equal(displayName, jobSchedule.DisplayName);
 
-                jobSchedule.JobSpecification.OnAllTasksComplete = OnAllTasksComplete.NoAction;
-                jobSchedule.JobSpecification.OnTaskFailure = OnTaskFailure.NoAction;
-            }
+            jobSchedule.Refresh(additionalBehaviors:
+                    InterceptorFactory.CreateGetJobScheduleRequestInterceptor(
+                        new Models.CloudJobSchedule()
+                        {
+                            JobSpecification = new Models.JobSpecification()
+                        }));
+
+            jobSchedule.JobSpecification.OnAllTasksComplete = OnAllTasksComplete.NoAction;
+            jobSchedule.JobSpecification.OnTaskFailure = OnTaskFailure.NoAction;
         }
 
         [Fact]
@@ -160,45 +154,43 @@ namespace Azure.Batch.Unit.Tests
             const string displayName = "DisplayNameFoo";
             MetadataItem metadataItem = new MetadataItem("foo", "bar");
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                DateTime creationTime = DateTime.Now;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            DateTime creationTime = DateTime.Now;
 
-                var cloudJobSchedule = new Models.CloudJobSchedule
-                {
-                    Id = jobScheduleId,
-                    DisplayName = displayName,
-                    Metadata = new[]
-                            {
+            var cloudJobSchedule = new Models.CloudJobSchedule
+            {
+                Id = jobScheduleId,
+                DisplayName = displayName,
+                Metadata = new[]
+                        {
                                 new Models.MetadataItem { Name = metadataItem.Name, Value = metadataItem.Value }
                             },
-                    CreationTime = creationTime,
-                    JobSpecification = new Models.JobSpecification
-                            {
-                                OnAllTasksComplete = Models.OnAllTasksComplete.TerminateJob,
-                                OnTaskFailure = Models.OnTaskFailure.PerformExitOptionsJobAction
-                            }
-                };
+                CreationTime = creationTime,
+                JobSpecification = new Models.JobSpecification
+                {
+                    OnAllTasksComplete = Models.OnAllTasksComplete.TerminateJob,
+                    OnTaskFailure = Models.OnTaskFailure.PerformExitOptionsJobAction
+                }
+            };
 
-                CloudJobSchedule boundJobSchedule = client.JobScheduleOperations.GetJobSchedule(
-                    jobScheduleId,
-                    additionalBehaviors: InterceptorFactory.CreateGetJobScheduleRequestInterceptor(cloudJobSchedule));
+            CloudJobSchedule boundJobSchedule = client.JobScheduleOperations.GetJobSchedule(
+                jobScheduleId,
+                additionalBehaviors: InterceptorFactory.CreateGetJobScheduleRequestInterceptor(cloudJobSchedule));
 
-                Assert.Equal(jobScheduleId, boundJobSchedule.Id); // reading is allowed from a jobSchedule that is returned from the server.
-                Assert.Equal(creationTime, boundJobSchedule.CreationTime);
-                Assert.Equal(displayName, boundJobSchedule.DisplayName);
-                Assert.Equal(OnAllTasksComplete.TerminateJob, boundJobSchedule.JobSpecification.OnAllTasksComplete);
-                Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJobSchedule.JobSpecification.OnTaskFailure);
+            Assert.Equal(jobScheduleId, boundJobSchedule.Id); // reading is allowed from a jobSchedule that is returned from the server.
+            Assert.Equal(creationTime, boundJobSchedule.CreationTime);
+            Assert.Equal(displayName, boundJobSchedule.DisplayName);
+            Assert.Equal(OnAllTasksComplete.TerminateJob, boundJobSchedule.JobSpecification.OnAllTasksComplete);
+            Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJobSchedule.JobSpecification.OnTaskFailure);
 
-                Assert.Throws<InvalidOperationException>(() => boundJobSchedule.DisplayName = "cannot-change-display-name");
-                Assert.Throws<InvalidOperationException>(() => boundJobSchedule.Id = "cannot-change-id");
+            Assert.Throws<InvalidOperationException>(() => boundJobSchedule.DisplayName = "cannot-change-display-name");
+            Assert.Throws<InvalidOperationException>(() => boundJobSchedule.Id = "cannot-change-id");
 
-                boundJobSchedule.JobSpecification.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
-                boundJobSchedule.JobSpecification.OnTaskFailure = OnTaskFailure.NoAction;
+            boundJobSchedule.JobSpecification.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
+            boundJobSchedule.JobSpecification.OnTaskFailure = OnTaskFailure.NoAction;
 
-                Assert.Equal(OnAllTasksComplete.TerminateJob, boundJobSchedule.JobSpecification.OnAllTasksComplete);
-                Assert.Equal(OnTaskFailure.NoAction, boundJobSchedule.JobSpecification.OnTaskFailure);
-            }
+            Assert.Equal(OnAllTasksComplete.TerminateJob, boundJobSchedule.JobSpecification.OnAllTasksComplete);
+            Assert.Equal(OnTaskFailure.NoAction, boundJobSchedule.JobSpecification.OnTaskFailure);
         }
 
         [Fact]
@@ -212,40 +204,40 @@ namespace Azure.Batch.Unit.Tests
             const string applicationId = "testApp";
             const string applicationVersion = "beta";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudJob cloudJob = client.JobOperations.CreateJob(jobId, new PoolInformation { AutoPoolSpecification = new AutoPoolSpecification { KeepAlive = false } });
+            cloudJob.Id = jobId;
+            cloudJob.DisplayName = displayName;
+            cloudJob.Metadata = new List<MetadataItem> { metadataItem };
+            cloudJob.Priority = priority;
+            cloudJob.JobManagerTask = new JobManagerTask
             {
-                CloudJob cloudJob = client.JobOperations.CreateJob(jobId, new PoolInformation { AutoPoolSpecification = new AutoPoolSpecification { KeepAlive = false }});
-                cloudJob.Id = jobId;
-                cloudJob.DisplayName = displayName;
-                cloudJob.Metadata = new List<MetadataItem> { metadataItem };
-                cloudJob.Priority = priority;
-                cloudJob.JobManagerTask = new JobManagerTask { ApplicationPackageReferences = new List<ApplicationPackageReference>
+                ApplicationPackageReferences = new List<ApplicationPackageReference>
                 {
                     new ApplicationPackageReference { ApplicationId = applicationId, Version = applicationVersion }
                 },
-                    AuthenticationTokenSettings = new AuthenticationTokenSettings() { Access = AccessScope.Job }
-                };
+                AuthenticationTokenSettings = new AuthenticationTokenSettings() { Access = AccessScope.Job }
+            };
 
-                cloudJob.OnAllTasksComplete = OnAllTasksComplete.NoAction;
-                cloudJob.OnTaskFailure = OnTaskFailure.NoAction;
+            cloudJob.OnAllTasksComplete = OnAllTasksComplete.NoAction;
+            cloudJob.OnTaskFailure = OnTaskFailure.NoAction;
 
 
-                Assert.Throws<InvalidOperationException>(() => cloudJob.Url); // cannot read a Url since it's unbound at this point.
-                Assert.Equal(cloudJob.Id, jobId); // can set an unbound object
-                Assert.Equal(cloudJob.Metadata.First().Name, metadataItem.Name);
-                Assert.Equal(cloudJob.Metadata.First().Value, metadataItem.Value);
-                Assert.Equal(OnAllTasksComplete.NoAction, cloudJob.OnAllTasksComplete);
-                Assert.Equal(OnTaskFailure.NoAction, cloudJob.OnTaskFailure);
+            Assert.Throws<InvalidOperationException>(() => cloudJob.Url); // cannot read a Url since it's unbound at this point.
+            Assert.Equal(cloudJob.Id, jobId); // can set an unbound object
+            Assert.Equal(cloudJob.Metadata.First().Name, metadataItem.Name);
+            Assert.Equal(cloudJob.Metadata.First().Value, metadataItem.Value);
+            Assert.Equal(OnAllTasksComplete.NoAction, cloudJob.OnAllTasksComplete);
+            Assert.Equal(OnTaskFailure.NoAction, cloudJob.OnTaskFailure);
 
-                cloudJob.Commit(additionalBehaviors: InterceptorFactory.CreateAddJobRequestInterceptor());
+            cloudJob.Commit(additionalBehaviors: InterceptorFactory.CreateAddJobRequestInterceptor());
 
-                // writing isn't allowed for a job that is in an invalid state.
-                Assert.Throws<InvalidOperationException>(() => cloudJob.Id = "cannot-change-id");
-                Assert.Throws<InvalidOperationException>(() => cloudJob.DisplayName = "cannot-change-display-name");
+            // writing isn't allowed for a job that is in an invalid state.
+            Assert.Throws<InvalidOperationException>(() => cloudJob.Id = "cannot-change-id");
+            Assert.Throws<InvalidOperationException>(() => cloudJob.DisplayName = "cannot-change-display-name");
 
-                AuthenticationTokenSettings authenticationTokenSettings = new AuthenticationTokenSettings { Access = AccessScope.Job };
-                Assert.Throws<InvalidOperationException>(() => { cloudJob.JobManagerTask.AuthenticationTokenSettings = authenticationTokenSettings; });
-            }
+            AuthenticationTokenSettings authenticationTokenSettings = new AuthenticationTokenSettings { Access = AccessScope.Job };
+            Assert.Throws<InvalidOperationException>(() => { cloudJob.JobManagerTask.AuthenticationTokenSettings = authenticationTokenSettings; });
         }
 
         [Fact]
@@ -261,42 +253,40 @@ namespace Azure.Batch.Unit.Tests
             const int priority = 0;
             var onAllTasksComplete = OnAllTasksComplete.TerminateJob;
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                DateTime creationTime = DateTime.Now;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            DateTime creationTime = DateTime.Now;
 
-                Models.CloudJob protoJob = new Models.CloudJob(
-                    jobId,
-                    displayName,
-                    jobManagerTask: new Models.JobManagerTask()
-                    {
-                        ApplicationPackageReferences = new [] { new Models.ApplicationPackageReference(){ ApplicationId = applicationId, Version = applicationVersion } }
-                    }, 
-                    metadata: new[] { new Models.MetadataItem { Name = metadataItem.Name, Value = metadataItem.Value } },
-                    creationTime: creationTime,
-                    priority: priority,
-                    url: ClientUnitTestCommon.DummyBaseUrl, 
-                    onAllTasksComplete: Models.OnAllTasksComplete.NoAction);
+            Models.CloudJob protoJob = new Models.CloudJob(
+                jobId,
+                displayName,
+                jobManagerTask: new Models.JobManagerTask()
+                {
+                    ApplicationPackageReferences = new[] { new Models.ApplicationPackageReference() { ApplicationId = applicationId, Version = applicationVersion } }
+                },
+                metadata: new[] { new Models.MetadataItem { Name = metadataItem.Name, Value = metadataItem.Value } },
+                creationTime: creationTime,
+                priority: priority,
+                url: ClientUnitTestCommon.DummyBaseUrl,
+                onAllTasksComplete: Models.OnAllTasksComplete.NoAction);
 
-                CloudJob boundJob = client.JobOperations.GetJob(jobId, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
+            CloudJob boundJob = client.JobOperations.GetJob(jobId, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
 
-                Assert.Equal(jobId, boundJob.Id); // reading is allowed from a job that is returned from the server.
-                Assert.Equal(creationTime, boundJob.CreationTime);
-                Assert.Equal(displayName, boundJob.DisplayName);
-                Assert.Equal(applicationId, boundJob.JobManagerTask.ApplicationPackageReferences.First().ApplicationId);
-                Assert.Equal(applicationVersion, boundJob.JobManagerTask.ApplicationPackageReferences.First().Version);
+            Assert.Equal(jobId, boundJob.Id); // reading is allowed from a job that is returned from the server.
+            Assert.Equal(creationTime, boundJob.CreationTime);
+            Assert.Equal(displayName, boundJob.DisplayName);
+            Assert.Equal(applicationId, boundJob.JobManagerTask.ApplicationPackageReferences.First().ApplicationId);
+            Assert.Equal(applicationVersion, boundJob.JobManagerTask.ApplicationPackageReferences.First().Version);
 
-                AssertPatchableJobPropertiesCanBeWritten(boundJob, priority, metadataItem, onAllTasksComplete);
+            AssertPatchableJobPropertiesCanBeWritten(boundJob, priority, metadataItem, onAllTasksComplete);
 
-                // Can only read a url from a returned object.
-                Assert.Equal(ClientUnitTestCommon.DummyBaseUrl, boundJob.Url);
+            // Can only read a url from a returned object.
+            Assert.Equal(ClientUnitTestCommon.DummyBaseUrl, boundJob.Url);
 
-                // Cannot change a bound displayName, Id and any property on a JobManagerTask.
-                Assert.Throws<InvalidOperationException>(() => boundJob.DisplayName = "cannot-change-display-name");
-                Assert.Throws<InvalidOperationException>(() => boundJob.Id = "cannot-change-id");
-                Assert.Throws<InvalidOperationException>(() => boundJob.JobManagerTask.ApplicationPackageReferences = new List<ApplicationPackageReference>());
-                Assert.Throws<InvalidOperationException>(() => boundJob.JobManagerTask = new JobManagerTask());
-            }
+            // Cannot change a bound displayName, Id and any property on a JobManagerTask.
+            Assert.Throws<InvalidOperationException>(() => boundJob.DisplayName = "cannot-change-display-name");
+            Assert.Throws<InvalidOperationException>(() => boundJob.Id = "cannot-change-id");
+            Assert.Throws<InvalidOperationException>(() => boundJob.JobManagerTask.ApplicationPackageReferences = new List<ApplicationPackageReference>());
+            Assert.Throws<InvalidOperationException>(() => boundJob.JobManagerTask = new JobManagerTask());
         }
 
         [Fact]
@@ -315,37 +305,35 @@ namespace Azure.Batch.Unit.Tests
                 DependencyAction = Models.DependencyAction.Satisfy
             };
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Models.CloudTask cloudTask = new Models.CloudTask()
             {
-                Models.CloudTask cloudTask = new Models.CloudTask()
+                Id = jobId,
+                ExitConditions = new Models.ExitConditions()
                 {
-                    Id = jobId,
-                    ExitConditions = new Models.ExitConditions()
-                    {
-                        DefaultProperty = disableExitOption,
-                        ExitCodeRanges = new List<Models.ExitCodeRangeMapping>() { new Models.ExitCodeRangeMapping(exitCodeRangeStart, exitCodeRangeEnd, terminateExitOption) },
-                        ExitCodes = new List<Models.ExitCodeMapping>() { new Models.ExitCodeMapping(exitCode, terminateExitOption) },
-                        PreProcessingError = terminateExitOption,
-                        FileUploadError = disableExitOption
-                    }
-                };
+                    DefaultProperty = disableExitOption,
+                    ExitCodeRanges = new List<Models.ExitCodeRangeMapping>() { new Models.ExitCodeRangeMapping(exitCodeRangeStart, exitCodeRangeEnd, terminateExitOption) },
+                    ExitCodes = new List<Models.ExitCodeMapping>() { new Models.ExitCodeMapping(exitCode, terminateExitOption) },
+                    PreProcessingError = terminateExitOption,
+                    FileUploadError = disableExitOption
+                }
+            };
 
-                CloudTask boundTask = client.JobOperations.GetTask(
-                    jobId,
-                    taskId,
-                    additionalBehaviors: InterceptorFactory.CreateGetTaskRequestInterceptor(cloudTask));
+            CloudTask boundTask = client.JobOperations.GetTask(
+                jobId,
+                taskId,
+                additionalBehaviors: InterceptorFactory.CreateGetTaskRequestInterceptor(cloudTask));
 
-                Assert.Equal(taskId, boundTask.Id); // reading is allowed from a task that is returned from the server.
-                // These need to be compared as strings because they are different types but we are interested in the values being the same.
-                Assert.Equal(disableExitOption.JobAction.ToString(), boundTask.ExitConditions.Default.JobAction.ToString());
-                Assert.Equal(DependencyAction.Satisfy, boundTask.ExitConditions.Default.DependencyAction);
-                Assert.Equal(DependencyAction.Satisfy, boundTask.ExitConditions.FileUploadError.DependencyAction);
-                Assert.Throws<InvalidOperationException>(() => boundTask.ExitConditions = new ExitConditions());
-                Assert.Throws<InvalidOperationException>(() => boundTask.DependsOn = new TaskDependencies(new List<string>(), new List<TaskIdRange>()));
-                Assert.Throws<InvalidOperationException>(() => boundTask.UserIdentity = new UserIdentity("abc"));
-                Assert.Throws<InvalidOperationException>(() => boundTask.CommandLine = "Cannot change command line");
-                Assert.Throws<InvalidOperationException>(() => boundTask.ExitConditions.Default = new ExitOptions() { JobAction = JobAction.Terminate });
-            }
+            Assert.Equal(taskId, boundTask.Id); // reading is allowed from a task that is returned from the server.
+                                                // These need to be compared as strings because they are different types but we are interested in the values being the same.
+            Assert.Equal(disableExitOption.JobAction.ToString(), boundTask.ExitConditions.Default.JobAction.ToString());
+            Assert.Equal(DependencyAction.Satisfy, boundTask.ExitConditions.Default.DependencyAction);
+            Assert.Equal(DependencyAction.Satisfy, boundTask.ExitConditions.FileUploadError.DependencyAction);
+            Assert.Throws<InvalidOperationException>(() => boundTask.ExitConditions = new ExitConditions());
+            Assert.Throws<InvalidOperationException>(() => boundTask.DependsOn = new TaskDependencies(new List<string>(), new List<TaskIdRange>()));
+            Assert.Throws<InvalidOperationException>(() => boundTask.UserIdentity = new UserIdentity("abc"));
+            Assert.Throws<InvalidOperationException>(() => boundTask.CommandLine = "Cannot change command line");
+            Assert.Throws<InvalidOperationException>(() => boundTask.ExitConditions.Default = new ExitOptions() { JobAction = JobAction.Terminate });
         }
 
         private static void AssertPatchableJobPropertiesCanBeWritten(CloudJob boundJob, int priority, MetadataItem metadataItem, OnAllTasksComplete onAllTasksComplete)

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/CommitAndRefreshUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/CommitAndRefreshUnitTests.cs
@@ -27,117 +27,109 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundJobCommitAndRefreshWorks()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string id = "Bar";
+            const string displayName = "Baz";
+            var prepTask = new Protocol.Models.JobPreparationTask(id);
+
+            Protocol.Models.CloudJob protoJob = new Protocol.Models.CloudJob(
+                id: id,
+                displayName: displayName,
+                jobPreparationTask: prepTask);
+
+            CloudJob job = batchClient.JobOperations.CreateJob(id, new PoolInformation()
             {
-                const string id = "Bar";
-                const string displayName = "Baz";
-                var prepTask = new Protocol.Models.JobPreparationTask(id);
+                PoolId = "Foo"
+            });
 
-                Protocol.Models.CloudJob protoJob = new Protocol.Models.CloudJob(
-                    id: id,
-                    displayName: displayName,
-                    jobPreparationTask: prepTask);
+            await job.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddJobRequestInterceptor());
 
-                CloudJob job = batchClient.JobOperations.CreateJob(id, new PoolInformation()
-                    {
-                        PoolId = "Foo"
-                    });
+            await job.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
 
-                await job.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddJobRequestInterceptor());
-
-                await job.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
-
-                Assert.Equal(id, job.Id);
-                Assert.Equal(displayName, job.DisplayName);
-                Assert.Null(job.PoolInformation);
-                Assert.NotNull(job.JobPreparationTask);
-                Assert.Equal(prepTask.Id, job.JobPreparationTask.Id);
-            }
+            Assert.Equal(id, job.Id);
+            Assert.Equal(displayName, job.DisplayName);
+            Assert.Null(job.PoolInformation);
+            Assert.NotNull(job.JobPreparationTask);
+            Assert.Equal(prepTask.Id, job.JobPreparationTask.Id);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundPoolCommitAndRefreshWorks()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                const string id = "Bar";
-                const string displayName = "Baz";
-                var startTask = new Protocol.Models.StartTask("cmd /c dir");
-                var protoPool = new Protocol.Models.CloudPool(
-                    id: id,
-                    displayName: displayName,
-                    startTask: startTask);
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string id = "Bar";
+            const string displayName = "Baz";
+            var startTask = new Protocol.Models.StartTask("cmd /c dir");
+            var protoPool = new Protocol.Models.CloudPool(
+                id: id,
+                displayName: displayName,
+                startTask: startTask);
 
-                CloudPool pool = batchClient.PoolOperations.CreatePool(id, "Woo", new CloudServiceConfiguration("4"));
+            CloudPool pool = batchClient.PoolOperations.CreatePool(id, "Woo", new CloudServiceConfiguration("4"));
 
-                await pool.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddPoolRequestInterceptor());
+            await pool.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddPoolRequestInterceptor());
 
-                await pool.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetPoolRequestInterceptor(protoPool));
+            await pool.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetPoolRequestInterceptor(protoPool));
 
-                Assert.Equal(id, pool.Id);
-                Assert.Equal(displayName, pool.DisplayName);
-                Assert.Null(pool.CloudServiceConfiguration);
-                Assert.NotNull(pool.StartTask);
-                Assert.Equal(startTask.CommandLine, pool.StartTask.CommandLine);
-            }
+            Assert.Equal(id, pool.Id);
+            Assert.Equal(displayName, pool.DisplayName);
+            Assert.Null(pool.CloudServiceConfiguration);
+            Assert.NotNull(pool.StartTask);
+            Assert.Equal(startTask.CommandLine, pool.StartTask.CommandLine);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundJobScheduleCommitAndRefreshWorks()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string id = "Bar";
+            const string displayName = "Baz";
+            var jobSpecification = new Protocol.Models.JobSpecification()
             {
-                const string id = "Bar";
-                const string displayName = "Baz";
-                var jobSpecification = new Protocol.Models.JobSpecification()
-                    {
-                        DisplayName = displayName
-                    };
-                var protoJobSchedule = new Protocol.Models.CloudJobSchedule(
-                    id: id,
-                    displayName: displayName,
-                    jobSpecification: jobSpecification);
+                DisplayName = displayName
+            };
+            var protoJobSchedule = new Protocol.Models.CloudJobSchedule(
+                id: id,
+                displayName: displayName,
+                jobSpecification: jobSpecification);
 
-                CloudJobSchedule jobSchedule = batchClient.JobScheduleOperations.CreateJobSchedule(id, new Schedule(), null);
+            CloudJobSchedule jobSchedule = batchClient.JobScheduleOperations.CreateJobSchedule(id, new Schedule(), null);
 
-                await jobSchedule.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddJobScheduleRequestInterceptor());
+            await jobSchedule.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddJobScheduleRequestInterceptor());
 
-                await jobSchedule.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetJobScheduleRequestInterceptor(protoJobSchedule));
+            await jobSchedule.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetJobScheduleRequestInterceptor(protoJobSchedule));
 
-                Assert.Equal(id, jobSchedule.Id);
-                Assert.Equal(displayName, jobSchedule.DisplayName);
-                Assert.Null(jobSchedule.Schedule);
-                Assert.NotNull(jobSchedule.JobSpecification);
-                Assert.Equal(jobSpecification.DisplayName, jobSchedule.JobSpecification.DisplayName);
-            }
+            Assert.Equal(id, jobSchedule.Id);
+            Assert.Equal(displayName, jobSchedule.DisplayName);
+            Assert.Null(jobSchedule.Schedule);
+            Assert.NotNull(jobSchedule.JobSpecification);
+            Assert.Equal(jobSpecification.DisplayName, jobSchedule.JobSpecification.DisplayName);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundCertificateCommitAndRefreshWorks()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                const string expectedThumbprint = "ABC";
-                var protoCertificate = new Protocol.Models.Certificate(thumbprint: expectedThumbprint);
-                Certificate certificate = new Certificate(
-                    batchClient,
-                    null,
-                    string.Empty,
-                    expectedThumbprint,
-                    "SHA1");
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string expectedThumbprint = "ABC";
+            var protoCertificate = new Protocol.Models.Certificate(thumbprint: expectedThumbprint);
+            Certificate certificate = new Certificate(
+                batchClient,
+                null,
+                string.Empty,
+                expectedThumbprint,
+                "SHA1");
 
-                Assert.NotNull(certificate.ThumbprintAlgorithm);
+            Assert.NotNull(certificate.ThumbprintAlgorithm);
 
-                await certificate.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddCertificateRequestInterceptor());
+            await certificate.CommitAsync(additionalBehaviors: InterceptorFactory.CreateAddCertificateRequestInterceptor());
 
-                await certificate.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetCertificateRequestInterceptor(protoCertificate));
+            await certificate.RefreshAsync(additionalBehaviors: InterceptorFactory.CreateGetCertificateRequestInterceptor(protoCertificate));
 
-                Assert.Equal(expectedThumbprint, certificate.Thumbprint);
-                Assert.Null(certificate.ThumbprintAlgorithm);
-            }
+            Assert.Equal(expectedThumbprint, certificate.Thumbprint);
+            Assert.Null(certificate.ThumbprintAlgorithm);
         }
 
         [Fact]
@@ -152,52 +144,44 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundJobDirectRefreshFailsWithMissingPathVariables()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudJob job = batchClient.JobOperations.CreateJob(null, new PoolInformation());
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            CloudJob job = batchClient.JobOperations.CreateJob(null, new PoolInformation());
 
-                ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await job.RefreshAsync());
-                Assert.Contains("'jobId' cannot be null", e.Message);
-            }
+            ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await job.RefreshAsync());
+            Assert.Contains("'jobId' cannot be null", e.Message);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundPoolDirectRefreshFailsWithMissingPathVariables()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudPool pool = batchClient.PoolOperations.CreatePool();
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            CloudPool pool = batchClient.PoolOperations.CreatePool();
 
-                ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await pool.RefreshAsync());
-                Assert.Contains("'poolId' cannot be null", e.Message);
-            }
+            ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await pool.RefreshAsync());
+            Assert.Contains("'poolId' cannot be null", e.Message);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundJobScheduleDirectRefreshFailsWithMissingPathVariables()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudJobSchedule jobSchedule = batchClient.JobScheduleOperations.CreateJobSchedule();
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            CloudJobSchedule jobSchedule = batchClient.JobScheduleOperations.CreateJobSchedule();
 
-                ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await jobSchedule.RefreshAsync());
-                Assert.Contains("'jobScheduleId' cannot be null", e.Message);
-            }
+            ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await jobSchedule.RefreshAsync());
+            Assert.Contains("'jobScheduleId' cannot be null", e.Message);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UnboundCertificateDirectRefreshFailsWithMissingPathVariables()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Certificate certificate = new Certificate(batchClient, null, null, null, null);
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            Certificate certificate = new Certificate(batchClient, null, null, null, null);
 
-                ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await certificate.RefreshAsync());
-                Assert.Contains("'thumbprintAlgorithm' cannot be null", e.Message);
-            }
+            ValidationException e = await Assert.ThrowsAsync<ValidationException>(async () => await certificate.RefreshAsync());
+            Assert.Contains("'thumbprintAlgorithm' cannot be null", e.Message);
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ComputeNodeUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ComputeNodeUnitTests.cs
@@ -27,11 +27,10 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestComputeNodeCertificateReferencesAreReadOnly()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            var protoComputeNode = new Protocol.Models.ComputeNode()
             {
-                var protoComputeNode = new Protocol.Models.ComputeNode()
-                    {
-                        CertificateReferences = new List<Protocol.Models.CertificateReference>
+                CertificateReferences = new List<Protocol.Models.CertificateReference>
                             {
                                 new Protocol.Models.CertificateReference(
                                     thumbprint: "1234",
@@ -43,29 +42,28 @@
                                             Protocol.Models.CertificateVisibility.Task
                                         })
                             }
-                    };
+            };
 
-                ComputeNode computeNode = batchClient.PoolOperations.GetComputeNode(
-                    "dummy",
-                    "dummy",
-                    additionalBehaviors: InterceptorFactory.CreateGetComputeNodeRequestInterceptor(protoComputeNode));
+            ComputeNode computeNode = batchClient.PoolOperations.GetComputeNode(
+                "dummy",
+                "dummy",
+                additionalBehaviors: InterceptorFactory.CreateGetComputeNodeRequestInterceptor(protoComputeNode));
 
-                CertificateReference computeNodeCertificateReference = computeNode.CertificateReferences.First();
+            CertificateReference computeNodeCertificateReference = computeNode.CertificateReferences.First();
 
-                // reads are allowed
-                this.testOutputHelper.WriteLine(computeNodeCertificateReference.StoreLocation.ToString());
-                this.testOutputHelper.WriteLine(computeNodeCertificateReference.StoreName);
-                this.testOutputHelper.WriteLine(computeNodeCertificateReference.Thumbprint);
-                this.testOutputHelper.WriteLine(computeNodeCertificateReference.ThumbprintAlgorithm);
-                this.testOutputHelper.WriteLine(computeNodeCertificateReference.Visibility.ToString());
+            // reads are allowed
+            this.testOutputHelper.WriteLine(computeNodeCertificateReference.StoreLocation.ToString());
+            this.testOutputHelper.WriteLine(computeNodeCertificateReference.StoreName);
+            this.testOutputHelper.WriteLine(computeNodeCertificateReference.Thumbprint);
+            this.testOutputHelper.WriteLine(computeNodeCertificateReference.ThumbprintAlgorithm);
+            this.testOutputHelper.WriteLine(computeNodeCertificateReference.Visibility.ToString());
 
-                // writes are foribdden
-                Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.StoreLocation = CertStoreLocation.CurrentUser; });
-                Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.StoreName = "x"; });
-                Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.Thumbprint = "y"; });
-                Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.ThumbprintAlgorithm = "z"; });
-                Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.Visibility = CertificateVisibility.None; });
-            }
+            // writes are foribdden
+            Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.StoreLocation = CertStoreLocation.CurrentUser; });
+            Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.StoreName = "x"; });
+            Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.Thumbprint = "y"; });
+            Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.ThumbprintAlgorithm = "z"; });
+            Assert.Throws<InvalidOperationException>(() => { computeNodeCertificateReference.Visibility = CertificateVisibility.None; });
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/FileUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/FileUnitTests.cs
@@ -31,22 +31,18 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task GetFilePropertiesFromTaskDoesNotThrowOutOfMemoryException()
         {
-            using (BatchClient client = CreateBatchClientWithHandler())
-            {
-                NodeFile file = await client.JobOperations.GetNodeFileAsync("Foo", "Bar", "Baz");
-                Assert.Equal(StreamUnitTests.StreamLengthInBytes, file.Properties.ContentLength);
-            }
+            using BatchClient client = CreateBatchClientWithHandler();
+            NodeFile file = await client.JobOperations.GetNodeFileAsync("Foo", "Bar", "Baz");
+            Assert.Equal(StreamUnitTests.StreamLengthInBytes, file.Properties.ContentLength);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task GetFilePropertiesFromNodeDoesNotThrowOutOfMemoryException()
         {
-            using (BatchClient client = CreateBatchClientWithHandler())
-            {
-                NodeFile file = await client.PoolOperations.GetNodeFileAsync("Foo", "Bar", "Baz");
-                Assert.Equal(StreamUnitTests.StreamLengthInBytes, file.Properties.ContentLength);
-            }
+            using BatchClient client = CreateBatchClientWithHandler();
+            NodeFile file = await client.PoolOperations.GetNodeFileAsync("Foo", "Bar", "Baz");
+            Assert.Equal(StreamUnitTests.StreamLengthInBytes, file.Properties.ContentLength);
         }
 
         private static BatchClient CreateBatchClientWithHandler()

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/GetFileRequestByteRangeTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/GetFileRequestByteRangeTests.cs
@@ -124,17 +124,15 @@ namespace Azure.Batch.Unit.Tests
             // properties" call to the Batch service and instead builds a fake NodeFile.
             BatchClientBehavior getFakeNodeFile = CreateFakeNodeFileInterceptor<TPropertiesRequest, TPropertiesOptions, TPropertiesHeaders>();
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(confirmByteRangeIsSet);
-                client.CustomBehaviors.Add(getFakeNodeFile);
-                // Get a NodeFile object by invoking the "get file properties" API.
-                Microsoft.Azure.Batch.NodeFile nodeFile = await getNodeFilePropertiesFunc(client);
-                // The download func invokes the "get file" API where the OcpRange header is actually set
-                await downloadFileFunc(nodeFile, byteRange);
-                // Verify the OcpRange validation interceptor was actually invoked
-                Assert.True(invocationTracker.WasInvoked);
-            }
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(confirmByteRangeIsSet);
+            client.CustomBehaviors.Add(getFakeNodeFile);
+            // Get a NodeFile object by invoking the "get file properties" API.
+            Microsoft.Azure.Batch.NodeFile nodeFile = await getNodeFilePropertiesFunc(client);
+            // The download func invokes the "get file" API where the OcpRange header is actually set
+            await downloadFileFunc(nodeFile, byteRange);
+            // Verify the OcpRange validation interceptor was actually invoked
+            Assert.True(invocationTracker.WasInvoked);
         }
 
         private Protocol.RequestInterceptor CreateOcpRangeConfirmationInterceptor<TRequest, TOptions, THeaders>(

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/HttpClientBehaviorTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/HttpClientBehaviorTests.cs
@@ -36,16 +36,14 @@ namespace Azure.Batch.Unit.Tests
                 Authentication = { Schemes = AuthenticationSchemes.None },
                 UrlPrefixes = { url }
             };
-            using (WebListener listener = new WebListener(settings))
-            {
-                listener.Start();
-                Task listenTask = AcceptAndAssertAsync(httpMethod, listener, AssertRequestHasExpectedContentLength);
+            using WebListener listener = new WebListener(settings);
+            listener.Start();
+            Task listenTask = AcceptAndAssertAsync(httpMethod, listener, AssertRequestHasExpectedContentLength);
 
-                HttpClient client = new HttpClient();
-                await client.SendAsync(message);
+            HttpClient client = new HttpClient();
+            await client.SendAsync(message);
 
-                await listenTask;
-            }
+            await listenTask;
         }
 #endif
 
@@ -62,11 +60,9 @@ namespace Azure.Batch.Unit.Tests
 
         private static async Task AcceptAndAssertAsync(HttpMethod httpMethod, WebListener listener, Action<HttpMethod, RequestContext> assertLambda)
         {
-            using (RequestContext ctx = await listener.AcceptAsync())
-            {
-                assertLambda(httpMethod, ctx);
-                ctx.Response.StatusCode = 200;
-            }
+            using RequestContext ctx = await listener.AcceptAsync();
+            assertLambda(httpMethod, ctx);
+            ctx.Response.StatusCode = 200;
         }
 
         private static void AssertRequestHasExpectedContentLength(HttpMethod httpMethod, RequestContext ctx)

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/JobAutoTerminationUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/JobAutoTerminationUnitTests.cs
@@ -28,18 +28,16 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task UpdateBoundJobWithNewAutoTerminationPropertiesTest()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Models.CloudJob protoJob = new Models.CloudJob(id: "id", onAllTasksComplete: Models.OnAllTasksComplete.NoAction, onTaskFailure: Models.OnTaskFailure.PerformExitOptionsJobAction);
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Models.CloudJob protoJob = new Models.CloudJob(id: "id", onAllTasksComplete: Models.OnAllTasksComplete.NoAction, onTaskFailure: Models.OnTaskFailure.PerformExitOptionsJobAction);
 
-                CloudJob boundJob = await client.JobOperations.GetJobAsync(string.Empty, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
-                Assert.Equal(OnAllTasksComplete.NoAction, boundJob.OnAllTasksComplete);
-                Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJob.OnTaskFailure);
+            CloudJob boundJob = await client.JobOperations.GetJobAsync(string.Empty, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
+            Assert.Equal(OnAllTasksComplete.NoAction, boundJob.OnAllTasksComplete);
+            Assert.Equal(OnTaskFailure.PerformExitOptionsJobAction, boundJob.OnTaskFailure);
 
-                // Can update job's auto complete properties.
-                boundJob.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
-                Assert.Equal(OnAllTasksComplete.TerminateJob, boundJob.OnAllTasksComplete);
-            }
+            // Can update job's auto complete properties.
+            boundJob.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
+            Assert.Equal(OnAllTasksComplete.TerminateJob, boundJob.OnAllTasksComplete);
         }
 
         [Fact]
@@ -49,51 +47,49 @@ namespace Azure.Batch.Unit.Tests
             const string jobId = "id-123";
             const string taskId = "id-001";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Models.CloudJob protoJob = new Models.CloudJob(id: jobId, onAllTasksComplete: Models.OnAllTasksComplete.NoAction, onTaskFailure: Models.OnTaskFailure.PerformExitOptionsJobAction);
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Models.CloudJob protoJob = new Models.CloudJob(id: jobId, onAllTasksComplete: Models.OnAllTasksComplete.NoAction, onTaskFailure: Models.OnTaskFailure.PerformExitOptionsJobAction);
 
-                var fakeAddTaskResponse = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskAddParameter, Models.TaskAddOptions, AzureOperationHeaderResponse<Models.TaskAddHeaders>>((parameters, options) =>
-                {
-                    Assert.Equal((Models.JobAction?)JobAction.Terminate, parameters.ExitConditions.DefaultProperty.JobAction);
-                    Assert.Equal(0, parameters.ExitConditions.ExitCodeRanges.First().Start);
-                    Assert.Equal(4, parameters.ExitConditions.ExitCodeRanges.First().End);
-                    Assert.Equal((Models.JobAction?)JobAction.Disable, parameters.ExitConditions.ExitCodeRanges.First().ExitOptions.JobAction);
+            var fakeAddTaskResponse = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskAddParameter, Models.TaskAddOptions, AzureOperationHeaderResponse<Models.TaskAddHeaders>>((parameters, options) =>
+            {
+                Assert.Equal((Models.JobAction?)JobAction.Terminate, parameters.ExitConditions.DefaultProperty.JobAction);
+                Assert.Equal(0, parameters.ExitConditions.ExitCodeRanges.First().Start);
+                Assert.Equal(4, parameters.ExitConditions.ExitCodeRanges.First().End);
+                Assert.Equal((Models.JobAction?)JobAction.Disable, parameters.ExitConditions.ExitCodeRanges.First().ExitOptions.JobAction);
                     // These need to be compared as strings because they are different types but we are interested in the values being the same.
                     Assert.Equal(DependencyAction.Satisfy.ToString(), parameters.ExitConditions.ExitCodeRanges.First().ExitOptions.DependencyAction.ToString());
-                    Assert.Equal(3, parameters.ExitConditions.ExitCodes.First().Code);
-                    Assert.Equal((Models.JobAction?)JobAction.None, parameters.ExitConditions.ExitCodes.First().ExitOptions.JobAction);
-                    Assert.Equal((Models.JobAction?)JobAction.Terminate, parameters.ExitConditions.FileUploadError.JobAction);
+                Assert.Equal(3, parameters.ExitConditions.ExitCodes.First().Code);
+                Assert.Equal((Models.JobAction?)JobAction.None, parameters.ExitConditions.ExitCodes.First().ExitOptions.JobAction);
+                Assert.Equal((Models.JobAction?)JobAction.Terminate, parameters.ExitConditions.FileUploadError.JobAction);
 
-                    return new AzureOperationHeaderResponse<Models.TaskAddHeaders>()
-                    {
-                        Response = new HttpResponseMessage(HttpStatusCode.Accepted)
-                    };
-                });
-
-                CloudJob boundJob = await client.JobOperations.GetJobAsync(string.Empty, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
-
-                boundJob.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
-
-                CloudTask cloudTask = new CloudTask(taskId, "cmd /c echo hello world");
-
-                cloudTask.ExitConditions = new ExitConditions()
+                return new AzureOperationHeaderResponse<Models.TaskAddHeaders>()
                 {
-                    Default = new ExitOptions() { JobAction = JobAction.Terminate },
-                    ExitCodeRanges = new List<ExitCodeRangeMapping>()
+                    Response = new HttpResponseMessage(HttpStatusCode.Accepted)
+                };
+            });
+
+            CloudJob boundJob = await client.JobOperations.GetJobAsync(string.Empty, additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(protoJob));
+
+            boundJob.OnAllTasksComplete = OnAllTasksComplete.TerminateJob;
+
+            CloudTask cloudTask = new CloudTask(taskId, "cmd /c echo hello world");
+
+            cloudTask.ExitConditions = new ExitConditions()
+            {
+                Default = new ExitOptions() { JobAction = JobAction.Terminate },
+                ExitCodeRanges = new List<ExitCodeRangeMapping>()
                     {
                         new ExitCodeRangeMapping(0, 4, new ExitOptions() { DependencyAction = DependencyAction.Satisfy, JobAction = JobAction.Disable, })
                     },
-                    ExitCodes = new List<ExitCodeMapping>()
+                ExitCodes = new List<ExitCodeMapping>()
                     {
                         new ExitCodeMapping(3, new ExitOptions() {JobAction = JobAction.None})
                     },
-                    PreProcessingError = new ExitOptions() { JobAction = JobAction.Terminate },
-                    FileUploadError = new ExitOptions() { JobAction = JobAction.Terminate }
-                };
+                PreProcessingError = new ExitOptions() { JobAction = JobAction.Terminate },
+                FileUploadError = new ExitOptions() { JobAction = JobAction.Terminate }
+            };
 
-                boundJob.AddTask(cloudTask, additionalBehaviors: fakeAddTaskResponse);
-            }
+            boundJob.AddTask(cloudTask, additionalBehaviors: fakeAddTaskResponse);
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ODataUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ODataUnitTests.cs
@@ -27,102 +27,92 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnTaskListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.CloudTask,
-                        Protocol.Models.TaskListOptions,
-                        Protocol.Models.TaskListNextOptions,
-                        Protocol.Models.TaskListHeaders>(req, FullDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.CloudTask,
+                    Protocol.Models.TaskListOptions,
+                    Protocol.Models.TaskListNextOptions,
+                    Protocol.Models.TaskListHeaders>(req, FullDetailLevel)));
 
-                IEnumerable<CloudTask> tasks = client.JobOperations.ListTasks(
-                    "Foo",
-                    FullDetailLevel);
+            IEnumerable<CloudTask> tasks = client.JobOperations.ListTasks(
+                "Foo",
+                FullDetailLevel);
 
-                Assert.Empty(tasks.ToList());
-            }
+            Assert.Empty(tasks.ToList());
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnJobListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.CloudJob,
-                        Protocol.Models.JobListOptions,
-                        Protocol.Models.JobListNextOptions,
-                        Protocol.Models.JobListHeaders>(req, FullDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.CloudJob,
+                    Protocol.Models.JobListOptions,
+                    Protocol.Models.JobListNextOptions,
+                    Protocol.Models.JobListHeaders>(req, FullDetailLevel)));
 
-                IEnumerable<CloudJob> jobs = client.JobOperations.ListJobs(
-                    FullDetailLevel);
+            IEnumerable<CloudJob> jobs = client.JobOperations.ListJobs(
+                FullDetailLevel);
 
-                Assert.Empty(jobs.ToList());
-            }
+            Assert.Empty(jobs.ToList());
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnJobScheduleListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.CloudJobSchedule,
-                        Protocol.Models.JobScheduleListOptions,
-                        Protocol.Models.JobScheduleListNextOptions,
-                        Protocol.Models.JobScheduleListHeaders>(req, FullDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.CloudJobSchedule,
+                    Protocol.Models.JobScheduleListOptions,
+                    Protocol.Models.JobScheduleListNextOptions,
+                    Protocol.Models.JobScheduleListHeaders>(req, FullDetailLevel)));
 
-                IEnumerable<CloudJobSchedule> jobSchedules = client.JobScheduleOperations.ListJobSchedules(
-                    FullDetailLevel);
+            IEnumerable<CloudJobSchedule> jobSchedules = client.JobScheduleOperations.ListJobSchedules(
+                FullDetailLevel);
 
-                Assert.Empty(jobSchedules.ToList());
-            }
+            Assert.Empty(jobSchedules.ToList());
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnJobFromJobScheduleListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.CloudJob,
-                        Protocol.Models.JobListFromJobScheduleOptions,
-                        Protocol.Models.JobListFromJobScheduleNextOptions,
-                        Protocol.Models.JobListFromJobScheduleHeaders>(req, FullDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.CloudJob,
+                    Protocol.Models.JobListFromJobScheduleOptions,
+                    Protocol.Models.JobListFromJobScheduleNextOptions,
+                    Protocol.Models.JobListFromJobScheduleHeaders>(req, FullDetailLevel)));
 
-                IEnumerable<CloudJob> jobs = client.JobScheduleOperations.ListJobs(
-                    "Foo",
-                    FullDetailLevel);
+            IEnumerable<CloudJob> jobs = client.JobScheduleOperations.ListJobs(
+                "Foo",
+                FullDetailLevel);
 
-                Assert.Empty(jobs.ToList());
-            }
+            Assert.Empty(jobs.ToList());
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnPoolListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.CloudPool,
-                        Protocol.Models.PoolListOptions,
-                        Protocol.Models.PoolListNextOptions,
-                        Protocol.Models.PoolListHeaders>(req, FullDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.CloudPool,
+                    Protocol.Models.PoolListOptions,
+                    Protocol.Models.PoolListNextOptions,
+                    Protocol.Models.PoolListHeaders>(req, FullDetailLevel)));
 
-                IEnumerable<CloudPool> pools = client.PoolOperations.ListPools(
-                    FullDetailLevel);
+            IEnumerable<CloudPool> pools = client.PoolOperations.ListPools(
+                FullDetailLevel);
 
-                Assert.Empty(pools.ToList());
-            }
+            Assert.Empty(pools.ToList());
         }
 
 
@@ -130,62 +120,56 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnCertificateListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.Certificate,
-                        Protocol.Models.CertificateListOptions,
-                        Protocol.Models.CertificateListNextOptions,
-                        Protocol.Models.CertificateListHeaders>(req, FilterSelectDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.Certificate,
+                    Protocol.Models.CertificateListOptions,
+                    Protocol.Models.CertificateListNextOptions,
+                    Protocol.Models.CertificateListHeaders>(req, FilterSelectDetailLevel)));
 
-                IEnumerable<Certificate> certificates = client.CertificateOperations.ListCertificates(
-                    FilterSelectDetailLevel);
+            IEnumerable<Certificate> certificates = client.CertificateOperations.ListCertificates(
+                FilterSelectDetailLevel);
 
-                Assert.Empty(certificates.ToList());
-            }
+            Assert.Empty(certificates.ToList());
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnComputeNodeListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.ComputeNode,
-                        Protocol.Models.ComputeNodeListOptions,
-                        Protocol.Models.ComputeNodeListNextOptions,
-                        Protocol.Models.ComputeNodeListHeaders>(req, FilterSelectDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.ComputeNode,
+                    Protocol.Models.ComputeNodeListOptions,
+                    Protocol.Models.ComputeNodeListNextOptions,
+                    Protocol.Models.ComputeNodeListHeaders>(req, FilterSelectDetailLevel)));
 
-                IEnumerable<ComputeNode> nodes = client.PoolOperations.ListComputeNodes(
-                    "Foo",
-                    FilterSelectDetailLevel);
+            IEnumerable<ComputeNode> nodes = client.PoolOperations.ListComputeNodes(
+                "Foo",
+                FilterSelectDetailLevel);
 
-                Assert.Empty(nodes.ToList());
-            }
+            Assert.Empty(nodes.ToList());
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CanUseODataPredicatesOnJobPrepAndReleaseStatusListWithMultiplePages()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                client.JobOperations.CustomBehaviors.Add(new Protocol.RequestInterceptor(
-                    req => VerifyODataClausesAndReturnMultiplePages<
-                        Protocol.Models.JobPreparationAndReleaseTaskExecutionInformation,
-                        Protocol.Models.JobListPreparationAndReleaseTaskStatusOptions,
-                        Protocol.Models.JobListPreparationAndReleaseTaskStatusNextOptions,
-                        Protocol.Models.JobListPreparationAndReleaseTaskStatusHeaders>(req, FilterSelectDetailLevel)));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            client.JobOperations.CustomBehaviors.Add(new Protocol.RequestInterceptor(
+                req => VerifyODataClausesAndReturnMultiplePages<
+                    Protocol.Models.JobPreparationAndReleaseTaskExecutionInformation,
+                    Protocol.Models.JobListPreparationAndReleaseTaskStatusOptions,
+                    Protocol.Models.JobListPreparationAndReleaseTaskStatusNextOptions,
+                    Protocol.Models.JobListPreparationAndReleaseTaskStatusHeaders>(req, FilterSelectDetailLevel)));
 
-                IEnumerable<JobPreparationAndReleaseTaskExecutionInformation> jobPrepAndReleaseInfo = client.JobOperations.ListJobPreparationAndReleaseTaskStatus(
-                    "Foo",
-                    FilterSelectDetailLevel);
+            IEnumerable<JobPreparationAndReleaseTaskExecutionInformation> jobPrepAndReleaseInfo = client.JobOperations.ListJobPreparationAndReleaseTaskStatus(
+                "Foo",
+                FilterSelectDetailLevel);
 
-                Assert.Empty(jobPrepAndReleaseInfo.ToList());
-            }
+            Assert.Empty(jobPrepAndReleaseInfo.ToList());
         }
 
         private static void VerifyODataClausesAndReturnMultiplePages<TPage, TListOptions, TListNextOptions, THeaders>(Protocol.IBatchRequest req, ODATADetailLevel expectedDetailLevel)

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PagedCollectionUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PagedCollectionUnitTests.cs
@@ -130,12 +130,10 @@
             PagedAlphabet seq = new PagedAlphabet(4, 10);
 
             //Call with an already cancelled cancellation token
-            using (CancellationTokenSource source = new CancellationTokenSource())
-            {
-                source.Cancel();
+            using CancellationTokenSource source = new CancellationTokenSource();
+            source.Cancel();
 
-                await Assert.ThrowsAsync<OperationCanceledException>(async () => await seq.ToListAsync(source.Token));
-            }
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await seq.ToListAsync(source.Token));
         }
 
         [Fact]
@@ -145,12 +143,10 @@
             PagedAlphabet seq = new PagedAlphabet(4, 10);
 
             //Call with an already cancelled cancellation token
-            using (CancellationTokenSource source = new CancellationTokenSource())
-            {
-                source.Cancel();
+            using CancellationTokenSource source = new CancellationTokenSource();
+            source.Cancel();
 
-                await Assert.ThrowsAsync<OperationCanceledException>(async () => await seq.ForEachAsync(item => { }, source.Token));
-            }
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await seq.ForEachAsync(item => { }, source.Token));
         }
 
         [Fact]
@@ -160,13 +156,10 @@
             PagedAlphabet seq = new PagedAlphabet(4, 10);
 
             //Call with an already cancelled cancellation token
-            using (CancellationTokenSource source = new CancellationTokenSource())
-            {
+            using CancellationTokenSource source = new CancellationTokenSource();
+            source.Cancel();
 
-                source.Cancel();
-
-                await Assert.ThrowsAsync<OperationCanceledException>(async () => await seq.ForEachAsync(item => Task.Delay(0), source.Token));
-            }
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await seq.ForEachAsync(item => Task.Delay(0), source.Token));
         }
 
         private class PagedAlphabet : PagedEnumerable<string>

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PatchUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PatchUnitTests.cs
@@ -23,11 +23,9 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestPatchJob_ThrowsOnUnbound()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudJob job = client.JobOperations.CreateJob();
-                Assert.Throws<InvalidOperationException>(() => job.CommitChanges());
-            }
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudJob job = client.JobOperations.CreateJob();
+            Assert.Throws<InvalidOperationException>(() => job.CommitChanges());
         }
 
         [Fact]
@@ -243,11 +241,9 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestPatchPool_ThrowsOnUnbound()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudPool pool = client.PoolOperations.CreatePool();
-                Assert.Throws<InvalidOperationException>(() => pool.CommitChanges());
-            }
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudPool pool = client.PoolOperations.CreatePool();
+            Assert.Throws<InvalidOperationException>(() => pool.CommitChanges());
         }
 
         [Fact]
@@ -406,11 +402,9 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestPatchJobSchedule_ThrowsOnUnbound()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudJobSchedule jobSchedule = client.JobScheduleOperations.CreateJobSchedule();
-                Assert.Throws<InvalidOperationException>(() => jobSchedule.CommitChanges());
-            }
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudJobSchedule jobSchedule = client.JobScheduleOperations.CreateJobSchedule();
+            Assert.Throws<InvalidOperationException>(() => jobSchedule.CommitChanges());
         }
 
         [Fact]
@@ -574,23 +568,21 @@
             Action<CloudJob> modificationFunction,
             Action<Protocol.Models.JobPatchParameter> assertAction)
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudJob job = client.JobOperations.GetJob(
-                    string.Empty,
-                    additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(startEntity));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudJob job = client.JobOperations.GetJob(
+                string.Empty,
+                additionalBehaviors: InterceptorFactory.CreateGetJobRequestInterceptor(startEntity));
 
-                modificationFunction(job);
+            modificationFunction(job);
 
-                var patchInterceptor = ShimPatchJob(assertAction);
-                job.CommitChanges(additionalBehaviors: new[] { patchInterceptor });
+            var patchInterceptor = ShimPatchJob(assertAction);
+            job.CommitChanges(additionalBehaviors: new[] { patchInterceptor });
 
-                //Ensure that the job is in readable but unmodifiable state
-                var id = job.Id;
-                var priority = job.Priority;
+            //Ensure that the job is in readable but unmodifiable state
+            var id = job.Id;
+            var priority = job.Priority;
 
-                Assert.Throws<InvalidOperationException>(() => job.Priority = 5);
-            }
+            Assert.Throws<InvalidOperationException>(() => job.Priority = 5);
         }
 
         private static Protocol.RequestInterceptor ShimPatchJob(Action<Protocol.Models.JobPatchParameter> assertAction)
@@ -612,21 +604,19 @@
             Action<CloudPool> modificationFunction,
             Action<Protocol.Models.PoolPatchParameter> assertAction)
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudPool pool = client.PoolOperations.GetPool(
-                    string.Empty,
-                    additionalBehaviors: InterceptorFactory.CreateGetPoolRequestInterceptor(startEntity));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudPool pool = client.PoolOperations.GetPool(
+                string.Empty,
+                additionalBehaviors: InterceptorFactory.CreateGetPoolRequestInterceptor(startEntity));
 
-                modificationFunction(pool);
+            modificationFunction(pool);
 
-                var patchInterceptor = ShimPatchPool(assertAction);
-                pool.CommitChanges(additionalBehaviors: new[] { patchInterceptor });
+            var patchInterceptor = ShimPatchPool(assertAction);
+            pool.CommitChanges(additionalBehaviors: new[] { patchInterceptor });
 
-                //Ensure that the job is in readable but unmodifiable state
-                var id = pool.Id;
-                Assert.Throws<InvalidOperationException>(() => pool.Metadata = null);
-            }
+            //Ensure that the job is in readable but unmodifiable state
+            var id = pool.Id;
+            Assert.Throws<InvalidOperationException>(() => pool.Metadata = null);
         }
 
         private static Protocol.RequestInterceptor ShimPatchPool(Action<Protocol.Models.PoolPatchParameter> assertAction)
@@ -648,22 +638,20 @@
             Action<CloudJobSchedule> modificationFunction,
             Action<Protocol.Models.JobSchedulePatchParameter> assertAction)
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudJobSchedule jobSchedule = client.JobScheduleOperations.GetJobSchedule(
-                    string.Empty,
-                    additionalBehaviors: InterceptorFactory.CreateGetJobScheduleRequestInterceptor(startEntity));
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            CloudJobSchedule jobSchedule = client.JobScheduleOperations.GetJobSchedule(
+                string.Empty,
+                additionalBehaviors: InterceptorFactory.CreateGetJobScheduleRequestInterceptor(startEntity));
 
-                modificationFunction(jobSchedule);
+            modificationFunction(jobSchedule);
 
-                var patchInterceptor = ShimPatchJobSchedule(assertAction);
-                jobSchedule.CommitChanges(additionalBehaviors: new[] { patchInterceptor });
+            var patchInterceptor = ShimPatchJobSchedule(assertAction);
+            jobSchedule.CommitChanges(additionalBehaviors: new[] { patchInterceptor });
 
-                //Ensure that the job is in readable but unmodifiable state
-                var id = jobSchedule.Id;
+            //Ensure that the job is in readable but unmodifiable state
+            var id = jobSchedule.Id;
 
-                Assert.Throws<InvalidOperationException>(() => jobSchedule.Metadata = null);
-            }
+            Assert.Throws<InvalidOperationException>(() => jobSchedule.Metadata = null);
         }
 
         private static Protocol.RequestInterceptor ShimPatchJobSchedule(Action<Protocol.Models.JobSchedulePatchParameter> assertAction)

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PoolUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PoolUnitTests.cs
@@ -25,39 +25,37 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void GetPoolsListTest()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.PoolListOptions, AzureOperationResponse<IPage<Models.CloudPool>, Models.PoolListHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.PoolListOptions, AzureOperationResponse<IPage<Models.CloudPool>, Models.PoolListHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = async (token) =>
+                request.ServiceRequestFunc = async (token) =>
+                {
+                    var response = new AzureOperationResponse<IPage<Models.CloudPool>, Models.PoolListHeaders>
                     {
-                        var response = new AzureOperationResponse<IPage<Models.CloudPool>, Models.PoolListHeaders>
-                        {
-                            Body = new FakePage<Models.CloudPool>(new List<Models.CloudPool>
-                                        {
+                        Body = new FakePage<Models.CloudPool>(new List<Models.CloudPool>
+                                    {
                                             new Models.CloudPool { DisplayName = "batch-test"},
                                             new Models.CloudPool { DisplayName = "foobar", CloudServiceConfiguration = new Models.CloudServiceConfiguration("3"), AllocationState = Models.AllocationState.Steady},
-                                        })
-                        };
-
-                        Task<AzureOperationResponse<IPage<Models.CloudPool>, Models.PoolListHeaders>> task = Task.FromResult(response);
-                        return await task;
+                                    })
                     };
-                });
 
-                IPagedEnumerable<Microsoft.Azure.Batch.CloudPool> asyncPools = client.PoolOperations.ListPools(additionalBehaviors: new List<BatchClientBehavior> { interceptor });
-                var pools = new List<Microsoft.Azure.Batch.CloudPool>(asyncPools);
+                    Task<AzureOperationResponse<IPage<Models.CloudPool>, Models.PoolListHeaders>> task = Task.FromResult(response);
+                    return await task;
+                };
+            });
 
-                Assert.Equal(2, pools.Count);
-                Assert.Equal("batch-test", pools[0].DisplayName);
+            IPagedEnumerable<Microsoft.Azure.Batch.CloudPool> asyncPools = client.PoolOperations.ListPools(additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            var pools = new List<Microsoft.Azure.Batch.CloudPool>(asyncPools);
 
-                Assert.Equal("foobar", pools[1].DisplayName);
+            Assert.Equal(2, pools.Count);
+            Assert.Equal("batch-test", pools[0].DisplayName);
 
-                // enums are in the same namespace. 
-                Assert.Equal(AllocationState.Steady, pools[1].AllocationState);
-            }
+            Assert.Equal("foobar", pools[1].DisplayName);
+
+            // enums are in the same namespace. 
+            Assert.Equal(AllocationState.Steady, pools[1].AllocationState);
         }
 
         [Fact]
@@ -67,25 +65,24 @@ namespace Azure.Batch.Unit.Tests
             DateTime currentDateTime = DateTime.UtcNow;
             DateTime dateTimeMinusAnHour = currentDateTime.AddHours(-1);
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = async (token) =>
+                request.ServiceRequestFunc = async (token) =>
+                {
+                    var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
                     {
-                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
+                        Body = new Models.CloudPool
                         {
-                            Body = new Models.CloudPool
-                            {
-                                AllocationState = Models.AllocationState.Steady,
-                                AllocationStateTransitionTime = dateTimeMinusAnHour,
-                                AutoScaleFormula = string.Empty,
-                                AutoScaleRun = new Models.AutoScaleRun(),
-                                DisplayName = "batch-test",
-                                CertificateReferences = new[]
-                                                    {
+                            AllocationState = Models.AllocationState.Steady,
+                            AllocationStateTransitionTime = dateTimeMinusAnHour,
+                            AutoScaleFormula = string.Empty,
+                            AutoScaleRun = new Models.AutoScaleRun(),
+                            DisplayName = "batch-test",
+                            CertificateReferences = new[]
+                                                {
                                                         new Models.CertificateReference
                                                             {
                                                                 StoreLocation = Models.CertificateStoreLocation.CurrentUser,
@@ -99,53 +96,52 @@ namespace Azure.Batch.Unit.Tests
                                                                         Models.CertificateVisibility.Task
                                                                     }
                                                             }
-                                                    },
-                                CreationTime = dateTimeMinusAnHour,
-                                CloudServiceConfiguration = new Models.CloudServiceConfiguration(osFamily: "4", osVersion: "*"),
-                                CurrentDedicatedNodes = 3,
-                                ETag = "eTag=0x8D250D98B5D78AA",
-                                EnableAutoScale = false,
-                                LastModified = currentDateTime,
-                                TaskSlotsPerNode = 4,
-                                ResizeTimeout = new TimeSpan(),
-                                State = Models.PoolState.Active,
-                                StateTransitionTime = currentDateTime,
-                                TargetDedicatedNodes = 3,
-                                Url = "testbatch://batch-test.windows-int.net/pools/batch-test",
-                                TaskSchedulingPolicy = new Microsoft.Azure.Batch.Protocol.Models.TaskSchedulingPolicy { NodeFillType = Models.ComputeNodeFillType.Pack }
-                            }
-                        };
-                        
-                        var task = Task.FromResult(response);
-                        return await task;
+                                                },
+                            CreationTime = dateTimeMinusAnHour,
+                            CloudServiceConfiguration = new Models.CloudServiceConfiguration(osFamily: "4", osVersion: "*"),
+                            CurrentDedicatedNodes = 3,
+                            ETag = "eTag=0x8D250D98B5D78AA",
+                            EnableAutoScale = false,
+                            LastModified = currentDateTime,
+                            TaskSlotsPerNode = 4,
+                            ResizeTimeout = new TimeSpan(),
+                            State = Models.PoolState.Active,
+                            StateTransitionTime = currentDateTime,
+                            TargetDedicatedNodes = 3,
+                            Url = "testbatch://batch-test.windows-int.net/pools/batch-test",
+                            TaskSchedulingPolicy = new Microsoft.Azure.Batch.Protocol.Models.TaskSchedulingPolicy { NodeFillType = Models.ComputeNodeFillType.Pack }
+                        }
                     };
-                });
 
-                var pool = client.PoolOperations.GetPool("batch-test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+                    var task = Task.FromResult(response);
+                    return await task;
+                };
+            });
 
-                Assert.Equal("batch-test", pool.DisplayName);
-                Assert.Equal(AllocationState.Steady, pool.AllocationState);
-                Assert.Equal(dateTimeMinusAnHour, pool.AllocationStateTransitionTime);
-                Assert.Equal(dateTimeMinusAnHour, pool.CreationTime);
-                Assert.Equal("*", pool.CloudServiceConfiguration.OSVersion);
-                Assert.Equal(3, pool.CurrentDedicatedComputeNodes);
-                Assert.Equal(false, pool.AutoScaleEnabled);
-                Assert.Equal(currentDateTime, pool.LastModified);
-                Assert.Equal(4, pool.TaskSlotsPerNode);
-                Assert.Equal("4", pool.CloudServiceConfiguration.OSFamily);
-                Assert.Equal(PoolState.Active, pool.State);
-                Assert.Equal(currentDateTime, pool.StateTransitionTime);
-                Assert.Equal(ComputeNodeFillType.Pack, pool.TaskSchedulingPolicy.ComputeNodeFillType);
-                Assert.Equal(3, pool.TargetDedicatedComputeNodes);
-                Assert.Equal("testbatch://batch-test.windows-int.net/pools/batch-test", pool.Url);
+            var pool = client.PoolOperations.GetPool("batch-test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                var certs = pool.CertificateReferences;
+            Assert.Equal("batch-test", pool.DisplayName);
+            Assert.Equal(AllocationState.Steady, pool.AllocationState);
+            Assert.Equal(dateTimeMinusAnHour, pool.AllocationStateTransitionTime);
+            Assert.Equal(dateTimeMinusAnHour, pool.CreationTime);
+            Assert.Equal("*", pool.CloudServiceConfiguration.OSVersion);
+            Assert.Equal(3, pool.CurrentDedicatedComputeNodes);
+            Assert.Equal(false, pool.AutoScaleEnabled);
+            Assert.Equal(currentDateTime, pool.LastModified);
+            Assert.Equal(4, pool.TaskSlotsPerNode);
+            Assert.Equal("4", pool.CloudServiceConfiguration.OSFamily);
+            Assert.Equal(PoolState.Active, pool.State);
+            Assert.Equal(currentDateTime, pool.StateTransitionTime);
+            Assert.Equal(ComputeNodeFillType.Pack, pool.TaskSchedulingPolicy.ComputeNodeFillType);
+            Assert.Equal(3, pool.TargetDedicatedComputeNodes);
+            Assert.Equal("testbatch://batch-test.windows-int.net/pools/batch-test", pool.Url);
 
-                Assert.Equal(CertStoreLocation.CurrentUser, certs[0].StoreLocation);
-                Assert.Equal("My", certs[0].StoreName);
-                Assert.Equal(string.Empty, certs[0].Thumbprint);
-                Assert.Equal("sha1", certs[0].ThumbprintAlgorithm);
-            }
+            var certs = pool.CertificateReferences;
+
+            Assert.Equal(CertStoreLocation.CurrentUser, certs[0].StoreLocation);
+            Assert.Equal("My", certs[0].StoreName);
+            Assert.Equal(string.Empty, certs[0].Thumbprint);
+            Assert.Equal("sha1", certs[0].ThumbprintAlgorithm);
         }
         
         [Fact]
@@ -168,39 +164,37 @@ namespace Azure.Batch.Unit.Tests
 
             var autoScaleError = new Models.AutoScaleRun { Error = autoScaleRunError };
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = async (token) =>
+                request.ServiceRequestFunc = async (token) =>
+                    {
+                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
                         {
-                            var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
+                            Body = new Models.CloudPool
                             {
-                                Body = new Models.CloudPool
-                                {
-                                    DisplayName = "batch-test",
-                                    AutoScaleFormula = "$RunningTasks.GetSample(10 * TimeInterval_Second, 0 * TimeInterval_Second, 100);",
-                                    AutoScaleRun = autoScaleError,
-                                    EnableAutoScale = true,
-                                }
-                            };
+                                DisplayName = "batch-test",
+                                AutoScaleFormula = "$RunningTasks.GetSample(10 * TimeInterval_Second, 0 * TimeInterval_Second, 100);",
+                                AutoScaleRun = autoScaleError,
+                                EnableAutoScale = true,
+                            }
+                        };
 
                         var task = Task.FromResult(response);
                         return await task;
                     };
-                });
+            });
 
-                var pool = client.PoolOperations.GetPool("batch-test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            var pool = client.PoolOperations.GetPool("batch-test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                Assert.Equal("batch-test", pool.DisplayName);
-                Assert.Equal(true, pool.AutoScaleEnabled);
-                Assert.Equal("InsufficientSampleData", pool.AutoScaleRun.Error.Code);
-                Assert.Equal("Autoscale evaluation failed due to insufficient sample data", pool.AutoScaleRun.Error.Message);
-                Assert.Equal("Message", pool.AutoScaleRun.Error.Values.First().Name);
-                Assert.Equal("Line 1, Col 24: Insufficient data from data set: $RunningTasks wanted 100%, received 0%", pool.AutoScaleRun.Error.Values.First().Value);
-            }
+            Assert.Equal("batch-test", pool.DisplayName);
+            Assert.Equal(true, pool.AutoScaleEnabled);
+            Assert.Equal("InsufficientSampleData", pool.AutoScaleRun.Error.Code);
+            Assert.Equal("Autoscale evaluation failed due to insufficient sample data", pool.AutoScaleRun.Error.Message);
+            Assert.Equal("Message", pool.AutoScaleRun.Error.Values.First().Name);
+            Assert.Equal("Line 1, Col 24: Insufficient data from data set: $RunningTasks wanted 100%, received 0%", pool.AutoScaleRun.Error.Values.First().Value);
         }
 
 
@@ -218,34 +212,32 @@ namespace Azure.Batch.Unit.Tests
                                     WaitForSuccess = false
                                 };
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.PoolGetOptions, AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = async (token) =>
+                request.ServiceRequestFunc = async (token) =>
+                    {
+                        var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
                         {
-                            var response = new AzureOperationResponse<Models.CloudPool, Models.PoolGetHeaders>
-                            {
-                                Body = new Models.CloudPool { DisplayName = "batch-test", StartTask = startTask, }
-                            };
+                            Body = new Models.CloudPool { DisplayName = "batch-test", StartTask = startTask, }
+                        };
 
                         var task = Task.FromResult(response);
                         return await task;
                     };
-                });
+            });
 
-                var pool = client.PoolOperations.GetPool("batch-test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            var pool = client.PoolOperations.GetPool("batch-test", additionalBehaviors: new List<BatchClientBehavior> { interceptor });
 
-                Assert.Equal("batch-test", pool.DisplayName);
-                Assert.Equal("-start", pool.StartTask.CommandLine);
-                Assert.Equal("windows", pool.StartTask.EnvironmentSettings.FirstOrDefault().Name);
-                Assert.Equal("foo", pool.StartTask.EnvironmentSettings.FirstOrDefault().Value);
-                Assert.Equal(3, pool.StartTask.MaxTaskRetryCount);
-                Assert.Equal(ElevationLevel.NonAdmin, pool.StartTask.UserIdentity.AutoUser.ElevationLevel);
-                Assert.Equal(false, pool.StartTask.WaitForSuccess);
-            }
+            Assert.Equal("batch-test", pool.DisplayName);
+            Assert.Equal("-start", pool.StartTask.CommandLine);
+            Assert.Equal("windows", pool.StartTask.EnvironmentSettings.FirstOrDefault().Name);
+            Assert.Equal("foo", pool.StartTask.EnvironmentSettings.FirstOrDefault().Value);
+            Assert.Equal(3, pool.StartTask.MaxTaskRetryCount);
+            Assert.Equal(ElevationLevel.NonAdmin, pool.StartTask.UserIdentity.AutoUser.ElevationLevel);
+            Assert.Equal(false, pool.StartTask.WaitForSuccess);
         }
 
         [Fact]
@@ -254,39 +246,37 @@ namespace Azure.Batch.Unit.Tests
         {
             var dateTime = DateTime.UtcNow;
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
             {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(baseRequest =>
-                {
-                    var request = (Protocol.BatchRequest<Models.ComputeNodeListOptions, AzureOperationResponse<IPage<Models.ComputeNode>, Models.ComputeNodeListHeaders>>)baseRequest;
+                var request = (Protocol.BatchRequest<Models.ComputeNodeListOptions, AzureOperationResponse<IPage<Models.ComputeNode>, Models.ComputeNodeListHeaders>>)baseRequest;
 
-                    request.ServiceRequestFunc = async (token) =>
+                request.ServiceRequestFunc = async (token) =>
+                {
+                    var response = new AzureOperationResponse<IPage<Models.ComputeNode>, Models.ComputeNodeListHeaders>
                     {
-                        var response = new AzureOperationResponse<IPage<Models.ComputeNode>, Models.ComputeNodeListHeaders>
+                        Body = new FakePage<Models.ComputeNode>(new[]
                         {
-                            Body = new FakePage<Models.ComputeNode>(new[]
-                            {
                                 new Microsoft.Azure.Batch.Protocol.Models.ComputeNode
                                 {
                                     State = Models.ComputeNodeState.Running,
                                     LastBootTime = dateTime,
                                     Id = "computeNode1",
                                 },
-                            })
-                        };
-
-                        var task = Task.FromResult(response);
-                        return await task;
+                        })
                     };
-                });
 
-                List<Microsoft.Azure.Batch.ComputeNode> vms = client.PoolOperations.ListComputeNodes("foo", additionalBehaviors: new List<BatchClientBehavior> { interceptor }).ToList();
+                    var task = Task.FromResult(response);
+                    return await task;
+                };
+            });
 
-                Assert.Single(vms);
-                Assert.Equal("computeNode1", vms[0].Id);
-                Assert.Equal(ComputeNodeState.Running, vms[0].State);
-                Assert.Equal(vms[0].LastBootTime, dateTime);
-            }
+            List<Microsoft.Azure.Batch.ComputeNode> vms = client.PoolOperations.ListComputeNodes("foo", additionalBehaviors: new List<BatchClientBehavior> { interceptor }).ToList();
+
+            Assert.Single(vms);
+            Assert.Equal("computeNode1", vms[0].Id);
+            Assert.Equal(ComputeNodeState.Running, vms[0].State);
+            Assert.Equal(vms[0].LastBootTime, dateTime);
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PropertyUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PropertyUnitTests.cs
@@ -332,17 +332,15 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundCloudPoolProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.CloudPool poolModel =
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudPool>();
+                Protocol.Models.CloudPool poolModel =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudPool>();
 
-                    CloudPool boundPool = new CloudPool(client, poolModel, client.CustomBehaviors);
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundPool, poolModel);
-                    Assert.True(result.Equal, result.Message);
-                }
+                CloudPool boundPool = new CloudPool(client, poolModel, client.CustomBehaviors);
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundPool, poolModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -350,19 +348,16 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundCloudJobProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.CloudJob jobModel =
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudJob>();
+                Protocol.Models.CloudJob jobModel =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudJob>();
 
-                    CloudJob boundJob = new CloudJob(client.JobOperations.ParentBatchClient, jobModel, client.CustomBehaviors);
+                CloudJob boundJob = new CloudJob(client.JobOperations.ParentBatchClient, jobModel, client.CustomBehaviors);
 
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundJob, jobModel);
-                    Assert.True(result.Equal, result.Message);
-                }
-
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundJob, jobModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -370,18 +365,16 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundCloudJobScheduleProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.CloudJobSchedule jobScheduleModel =
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudJobSchedule>();
+                Protocol.Models.CloudJobSchedule jobScheduleModel =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudJobSchedule>();
 
-                    CloudJobSchedule boundJobSchedule = new CloudJobSchedule(client, jobScheduleModel, client.CustomBehaviors);
+                CloudJobSchedule boundJobSchedule = new CloudJobSchedule(client, jobScheduleModel, client.CustomBehaviors);
 
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundJobSchedule, jobScheduleModel);
-                    Assert.True(result.Equal, result.Message);
-                }
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundJobSchedule, jobScheduleModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -389,17 +382,15 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundCloudTaskProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.CloudTask taskModel = this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudTask>();
+                Protocol.Models.CloudTask taskModel = this.customizedObjectFactory.GenerateNew<Protocol.Models.CloudTask>();
 
-                    CloudTask boundTask = new CloudTask(client, "Foo", taskModel, client.CustomBehaviors);
+                CloudTask boundTask = new CloudTask(client, "Foo", taskModel, client.CustomBehaviors);
 
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundTask, taskModel);
-                    Assert.True(result.Equal, result.Message);
-                }
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundTask, taskModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -407,18 +398,16 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundComputeNodeProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.ComputeNode computeNodeModel =
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.ComputeNode>();
+                Protocol.Models.ComputeNode computeNodeModel =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.ComputeNode>();
 
-                    ComputeNode boundComputeNode = new ComputeNode(client, "Foo", computeNodeModel, client.CustomBehaviors);
+                ComputeNode boundComputeNode = new ComputeNode(client, "Foo", computeNodeModel, client.CustomBehaviors);
 
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundComputeNode, computeNodeModel);
-                    Assert.True(result.Equal, result.Message);
-                }
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundComputeNode, computeNodeModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -426,18 +415,16 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundCertificateProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.Certificate certificateModel =
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.Certificate>();
+                Protocol.Models.Certificate certificateModel =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.Certificate>();
 
-                    Certificate boundCertificate = new Certificate(client, certificateModel, client.CustomBehaviors);
+                Certificate boundCertificate = new Certificate(client, certificateModel, client.CustomBehaviors);
 
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundCertificate, certificateModel);
-                    Assert.True(result.Equal, result.Message);
-                }
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundCertificate, certificateModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -445,17 +432,15 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundImageInformationProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.ImageInformation imageModel = 
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.ImageInformation>();
+                Protocol.Models.ImageInformation imageModel =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.ImageInformation>();
 
-                    ImageInformation boundImageInfo = new ImageInformation(imageModel);
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundImageInfo, imageModel);
-                    Assert.True(result.Equal, result.Message);
-                }
+                ImageInformation boundImageInfo = new ImageInformation(imageModel);
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundImageInfo, imageModel);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -463,19 +448,17 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestRandomBoundPrepReleaseTaskExecutionInformationProperties()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            for (int i = 0; i < TestRunCount; i++)
             {
-                for (int i = 0; i < TestRunCount; i++)
-                {
-                    Protocol.Models.JobPreparationAndReleaseTaskExecutionInformation jobPrepReleaseExecutionInfo =
-                        this.customizedObjectFactory.GenerateNew<Protocol.Models.JobPreparationAndReleaseTaskExecutionInformation>();
+                Protocol.Models.JobPreparationAndReleaseTaskExecutionInformation jobPrepReleaseExecutionInfo =
+                    this.customizedObjectFactory.GenerateNew<Protocol.Models.JobPreparationAndReleaseTaskExecutionInformation>();
 
-                    JobPreparationAndReleaseTaskExecutionInformation boundJobPrepReleaseExecutionInfo =
-                        new JobPreparationAndReleaseTaskExecutionInformation(jobPrepReleaseExecutionInfo);
+                JobPreparationAndReleaseTaskExecutionInformation boundJobPrepReleaseExecutionInfo =
+                    new JobPreparationAndReleaseTaskExecutionInformation(jobPrepReleaseExecutionInfo);
 
-                    ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundJobPrepReleaseExecutionInfo, jobPrepReleaseExecutionInfo);
-                    Assert.True(result.Equal, result.Message);
-                }
+                ObjectComparer.CheckEqualityResult result = this.objectComparer.CheckEquality(boundJobPrepReleaseExecutionInfo, jobPrepReleaseExecutionInfo);
+                Assert.True(result.Equal, result.Message);
             }
         }
 
@@ -610,17 +593,15 @@ namespace Azure.Batch.Unit.Tests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void Bug1432987CloudTaskTaskConstraints()
         {
-            using (BatchClient batchCli = ClientUnitTestCommon.CreateDummyClient())
-            {
-                CloudTask badTask = new CloudTask("bug1432987TaskConstraints", "hostname");
+            using BatchClient batchCli = ClientUnitTestCommon.CreateDummyClient();
+            CloudTask badTask = new CloudTask("bug1432987TaskConstraints", "hostname");
 
-                TaskConstraints isThisBroken = badTask.Constraints;
-                TaskConstraints trySettingThem = new TaskConstraints(null, null, null);
+            TaskConstraints isThisBroken = badTask.Constraints;
+            TaskConstraints trySettingThem = new TaskConstraints(null, null, null);
 
-                badTask.Constraints = trySettingThem;
+            badTask.Constraints = trySettingThem;
 
-                TaskConstraints readThemBack = badTask.Constraints;
-            }
+            TaskConstraints readThemBack = badTask.Constraints;
         }
 
         [Fact]

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PropertyUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PropertyUnitTests.cs
@@ -524,8 +524,7 @@ namespace Azure.Batch.Unit.Tests
                         }
                         catch (TargetInvocationException e)
                         {
-                            var inner = e.InnerException as InvalidOperationException;
-                            if (inner != null)
+                            if (e.InnerException is InvalidOperationException inner)
                             {
                                 if (!inner.Message.Contains("while the object is in the Unbound state"))
                                 {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/RetryPolicyUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/RetryPolicyUnitTests.cs
@@ -605,33 +605,31 @@
 
             int callCount = 0;
 
-            using (var client = BatchClient.Open(this.credentials))
-            {
-                client.JobScheduleOperations.CustomBehaviors.Add(new RequestInterceptor(
-                    (req) =>
-                    {
+            using var client = BatchClient.Open(this.credentials);
+            client.JobScheduleOperations.CustomBehaviors.Add(new RequestInterceptor(
+                (req) =>
+                {
                         //I wish I didn't have to cast here
                         var stronglyTypedRequest = (BatchRequest<
-                            JobScheduleListOptions,
-                            AzureOperationResponse<IPage<ProxyModels.CloudJobSchedule>, JobScheduleListHeaders>>)req;
+                        JobScheduleListOptions,
+                        AzureOperationResponse<IPage<ProxyModels.CloudJobSchedule>, JobScheduleListHeaders>>)req;
 
-                        stronglyTypedRequest.ServiceRequestFunc = (token) =>
-                                                                  {
-                                                                      ++callCount;
-                                                                      throw new TimeoutException();
-                                                                  };
-                    }));
+                    stronglyTypedRequest.ServiceRequestFunc = (token) =>
+                                                              {
+                                                                  ++callCount;
+                                                                  throw new TimeoutException();
+                                                              };
+                }));
 
-                client.JobScheduleOperations.CustomBehaviors.Add(new RetryPolicyProvider(new LinearRetry(deltaBackoff, maxRetries)));
+            client.JobScheduleOperations.CustomBehaviors.Add(new RetryPolicyProvider(new LinearRetry(deltaBackoff, maxRetries)));
 
-                await Assert.ThrowsAsync<TimeoutException>(async () =>
-                                                     {
-                                                         IPagedEnumerable<CloudJobSchedule> schedules = client.JobScheduleOperations.ListJobSchedules();
-                                                         await schedules.GetPagedEnumerator().MoveNextAsync();
-                                                     });
+            await Assert.ThrowsAsync<TimeoutException>(async () =>
+                                                 {
+                                                     IPagedEnumerable<CloudJobSchedule> schedules = client.JobScheduleOperations.ListJobSchedules();
+                                                     await schedules.GetPagedEnumerator().MoveNextAsync();
+                                                 });
 
-                Assert.Equal(maxRetries + 1, callCount);
-            }
+            Assert.Equal(maxRetries + 1, callCount);
         }
 
         #endregion
@@ -640,27 +638,25 @@
         {
             int callCount = 0;
 
-            using (BatchClient client = BatchClient.Open(this.credentials))
-            {
-                client.CustomBehaviors.Add(new RequestInterceptor(
-                    (req) =>
+            using BatchClient client = BatchClient.Open(this.credentials);
+            client.CustomBehaviors.Add(new RequestInterceptor(
+                (req) =>
+                {
+                    var stronglyTypedRequest = (Microsoft.Azure.Batch.Protocol.BatchRequests.JobAddBatchRequest)req;
+
+                    stronglyTypedRequest.ServiceRequestFunc = (token) =>
                     {
-                        var stronglyTypedRequest = (Microsoft.Azure.Batch.Protocol.BatchRequests.JobAddBatchRequest)req;
+                        ++callCount;
+                        throw new Microsoft.Rest.ValidationException();
+                    };
+                }));
 
-                        stronglyTypedRequest.ServiceRequestFunc = (token) =>
-                        {
-                            ++callCount;
-                            throw new Microsoft.Rest.ValidationException();
-                        };
-                    }));
+            client.CustomBehaviors.Add(new RetryPolicyProvider(policy));
 
-                client.CustomBehaviors.Add(new RetryPolicyProvider(policy));
+            CloudJob job = client.JobOperations.CreateJob();
+            await Assert.ThrowsAsync<Microsoft.Rest.ValidationException>(async () => await job.CommitAsync());
 
-                CloudJob job = client.JobOperations.CreateJob();
-                await Assert.ThrowsAsync<Microsoft.Rest.ValidationException>(async () => await job.CommitAsync());
-
-                Assert.Equal(1, callCount);
-            }
+            Assert.Equal(1, callCount);
         }
 
     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/StreamUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/StreamUnitTests.cs
@@ -79,16 +79,12 @@
 
         private static async Task<long> InvokeActionWithDummyStreamBatchClientAsync(Func<BatchClient, Stream, Task> asyncAction, long streamSizeInBytes)
         {
-            using(Stream readStream = new DummyReadStream(streamSizeInBytes))
-            {
-                using (Protocol.BatchServiceClient protoClient = CreateBatchRestClientThatAlwaysRespondsWithStream(readStream))
-                using (DummyWriteStream writeStream = new DummyWriteStream())
-                using (BatchClient batchCli = BatchClient.Open(protoClient))
-                {
-                    await asyncAction(batchCli, writeStream);
-                    return writeStream.Length;
-                }
-            }
+            using Stream readStream = new DummyReadStream(streamSizeInBytes);
+            using Protocol.BatchServiceClient protoClient = CreateBatchRestClientThatAlwaysRespondsWithStream(readStream);
+            using DummyWriteStream writeStream = new DummyWriteStream();
+            using BatchClient batchCli = BatchClient.Open(protoClient);
+            await asyncAction(batchCli, writeStream);
+            return writeStream.Length;
         }
 
         private class AlwaysRespondWithStreamHandler : DelegatingHandler

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/SynchronousMethodExceptionBehaviorUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/SynchronousMethodExceptionBehaviorUnitTests.cs
@@ -15,80 +15,72 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void SynchronousMethodsPreserveProtocolLayerExceptions()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                const string dummyJobId = "Foo";
-                batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
-                    {
-                        throw new ArgumentException();
-                    }));
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string dummyJobId = "Foo";
+            batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
+                {
+                    throw new ArgumentException();
+                }));
 
-                Assert.Throws<ArgumentException>(() => batchClient.JobOperations.GetJob(dummyJobId));
-            }
+            Assert.Throws<ArgumentException>(() => batchClient.JobOperations.GetJob(dummyJobId));
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void SynchronousMethodsPreserveProtocolLayerAggregateExceptions()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
-            {
-                const string dummyJobId = "Foo";
-                batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
-                    {
-                        throw new AggregateException(new []
-                            {
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string dummyJobId = "Foo";
+            batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
+                {
+                    throw new AggregateException(new[]
+                        {
                                 new ArgumentException(),
                                 new ArgumentNullException()
-                            });
-                    }));
+                        });
+                }));
 
-                Assert.Throws<AggregateException>(() => batchClient.JobOperations.GetJob(dummyJobId));
-            }
+            Assert.Throws<AggregateException>(() => batchClient.JobOperations.GetJob(dummyJobId));
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void SynchronousMethodsCompatibilityHandlerThrowsAggregate()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string dummyJobId = "Foo";
+            batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
             {
-                const string dummyJobId = "Foo";
-                batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
-                {
-                    throw new ArgumentException();
-                }));
-                batchClient.CustomBehaviors.Add(SynchronousMethodExceptionBehavior.ThrowAggregateException);
+                throw new ArgumentException();
+            }));
+            batchClient.CustomBehaviors.Add(SynchronousMethodExceptionBehavior.ThrowAggregateException);
 
-                AggregateException aggregate = Assert.Throws<AggregateException>(() => batchClient.JobOperations.GetJob(dummyJobId));
-                Assert.IsAssignableFrom<ArgumentException>(aggregate.InnerException);
-            }
+            AggregateException aggregate = Assert.Throws<AggregateException>(() => batchClient.JobOperations.GetJob(dummyJobId));
+            Assert.IsAssignableFrom<ArgumentException>(aggregate.InnerException);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void SynchronousMethodsCompatibilityHandlerThrownAggregateIsWrapped()
         {
-            using (BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient())
+            using BatchClient batchClient = ClientUnitTestCommon.CreateDummyClient();
+            const string dummyJobId = "Foo";
+            batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
             {
-                const string dummyJobId = "Foo";
-                batchClient.CustomBehaviors.Add(new RequestInterceptor(req =>
-                {
-                    throw new AggregateException(new[]
-                            {
+                throw new AggregateException(new[]
+                        {
                                 new ArgumentException(),
                                 new ArgumentNullException()
-                            });
-                }));
-                batchClient.CustomBehaviors.Add(SynchronousMethodExceptionBehavior.ThrowAggregateException);
+                        });
+            }));
+            batchClient.CustomBehaviors.Add(SynchronousMethodExceptionBehavior.ThrowAggregateException);
 
-                AggregateException outerAggregate = Assert.Throws<AggregateException>(() => batchClient.JobOperations.GetJob(dummyJobId));
-                Assert.Single(outerAggregate.InnerExceptions);
-                
-                AggregateException innerAggregate = outerAggregate.InnerException as AggregateException;
-                Assert.NotNull(innerAggregate);
-                Assert.Equal(2, innerAggregate.InnerExceptions.Count);
-            }
+            AggregateException outerAggregate = Assert.Throws<AggregateException>(() => batchClient.JobOperations.GetJob(dummyJobId));
+            Assert.Single(outerAggregate.InnerExceptions);
+
+            AggregateException innerAggregate = outerAggregate.InnerException as AggregateException;
+            Assert.NotNull(innerAggregate);
+            Assert.Equal(2, innerAggregate.InnerExceptions.Count);
         }
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/TaskDependenciesUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/TaskDependenciesUnitTests.cs
@@ -29,27 +29,25 @@
             const bool usesTaskDependencies = true;
             // Bound
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                    {
-                        var request = (Protocol.BatchRequest<Models.JobGetOptions, AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>>)baseRequest;
-                                                request.ServiceRequestFunc = (token) =>
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                {
+                    var request = (Protocol.BatchRequest<Models.JobGetOptions, AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>>)baseRequest;
+                    request.ServiceRequestFunc = (token) =>
+{
+                        var response = new AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>
                         {
-                            var response = new AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>
-                            {
-                                Body = new Protocol.Models.CloudJob { UsesTaskDependencies = usesTaskDependencies }
-                            };
-
-                            return Task.FromResult(response);
+                            Body = new Protocol.Models.CloudJob { UsesTaskDependencies = usesTaskDependencies }
                         };
-                    });
 
-                var cloudJob = client.JobOperations.GetJob(jobId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
-                Assert.Equal(usesTaskDependencies, cloudJob.UsesTaskDependencies);
-                Assert.Throws<InvalidOperationException>(() => cloudJob.UsesTaskDependencies = false);
-            }
+                        return Task.FromResult(response);
+                    };
+                });
+
+            var cloudJob = client.JobOperations.GetJob(jobId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+            Assert.Equal(usesTaskDependencies, cloudJob.UsesTaskDependencies);
+            Assert.Throws<InvalidOperationException>(() => cloudJob.UsesTaskDependencies = false);
         }
 
         [Fact]
@@ -59,28 +57,26 @@
             const string jobId = "id-123";
             const bool usesTaskDependencies = true;
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                        {
-                            var request = (Protocol.BatchRequest<Models.JobScheduleGetOptions, AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>>)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                    {
+                        var request = (Protocol.BatchRequest<Models.JobScheduleGetOptions, AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>>)baseRequest;
 
-                            request.ServiceRequestFunc = token =>
+                        request.ServiceRequestFunc = token =>
+                            {
+                                var response = new AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>
                                 {
-                                    var response = new AzureOperationResponse<Models.CloudJobSchedule, Models.JobScheduleGetHeaders>
-                                    {
-                                        Body = new Protocol.Models.CloudJobSchedule(jobId, schedule: new Protocol.Models.Schedule(), jobSpecification: new Protocol.Models.JobSpecification(){ UsesTaskDependencies = true })
-                                    };
-
-                                    return Task.FromResult(response);
+                                    Body = new Protocol.Models.CloudJobSchedule(jobId, schedule: new Protocol.Models.Schedule(), jobSpecification: new Protocol.Models.JobSpecification() { UsesTaskDependencies = true })
                                 };
-                        });
 
-                Microsoft.Azure.Batch.CloudJobSchedule unboundCloudJob = client.JobScheduleOperations.GetJobSchedule(jobId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+                                return Task.FromResult(response);
+                            };
+                    });
 
-                Assert.Equal(usesTaskDependencies, unboundCloudJob.JobSpecification.UsesTaskDependencies);
-            }
+            Microsoft.Azure.Batch.CloudJobSchedule unboundCloudJob = client.JobScheduleOperations.GetJobSchedule(jobId, additionalBehaviors: new List<BatchClientBehavior> { interceptor });
+
+            Assert.Equal(usesTaskDependencies, unboundCloudJob.JobSpecification.UsesTaskDependencies);
         }
 
         [Fact]
@@ -90,29 +86,27 @@
             const bool usesTaskDependencies = true;
 
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
-                    baseRequest =>
-                        {
-                            var request = (Protocol.BatchRequests.JobScheduleAddBatchRequest)baseRequest;
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor(
+                baseRequest =>
+                    {
+                        var request = (Protocol.BatchRequests.JobScheduleAddBatchRequest)baseRequest;
 
-                            request.ServiceRequestFunc = token =>
-                                {
-                                    var response = new AzureOperationHeaderResponse<Models.JobScheduleAddHeaders> { Response = new HttpResponseMessage(HttpStatusCode.Created) };
+                        request.ServiceRequestFunc = token =>
+                            {
+                                var response = new AzureOperationHeaderResponse<Models.JobScheduleAddHeaders> { Response = new HttpResponseMessage(HttpStatusCode.Created) };
 
-                                    return Task.FromResult(response);
-                                };
-                        });
+                                return Task.FromResult(response);
+                            };
+                    });
 
-                Microsoft.Azure.Batch.CloudJobSchedule cloudJobSchedule = client.JobScheduleOperations.CreateJobSchedule();
-                Microsoft.Azure.Batch.JobSpecification jobSpec = new Microsoft.Azure.Batch.JobSpecification(poolInformation: null) { UsesTaskDependencies = usesTaskDependencies };
-                cloudJobSchedule.JobSpecification = jobSpec;
-                cloudJobSchedule.Commit(new List<BatchClientBehavior> { interceptor });
+            Microsoft.Azure.Batch.CloudJobSchedule cloudJobSchedule = client.JobScheduleOperations.CreateJobSchedule();
+            Microsoft.Azure.Batch.JobSpecification jobSpec = new Microsoft.Azure.Batch.JobSpecification(poolInformation: null) { UsesTaskDependencies = usesTaskDependencies };
+            cloudJobSchedule.JobSpecification = jobSpec;
+            cloudJobSchedule.Commit(new List<BatchClientBehavior> { interceptor });
 
-                // writing isn't allowed for a CloudJobSchedule.JobSpecification.UsesTaskDependencies that is in an invalid state. 
-                Assert.Throws<InvalidOperationException>(() => cloudJobSchedule.JobSpecification.UsesTaskDependencies = false);
-            }
+            // writing isn't allowed for a CloudJobSchedule.JobSpecification.UsesTaskDependencies that is in an invalid state. 
+            Assert.Throws<InvalidOperationException>(() => cloudJobSchedule.JobSpecification.UsesTaskDependencies = false);
         }
 
         [Fact]
@@ -121,38 +115,36 @@
         {
             const string jobId = "id-123";
 
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                var returnFakeJob = ClientUnitTestCommon.SimulateServiceResponse<Models.JobGetOptions, AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>>(_ =>
-                    new AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>
-                    {
-                        Body = new Protocol.Models.CloudJob { Id = jobId, UsesTaskDependencies = true }
-                    });
-
-                var verifyTaskDependencies = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskAddParameter, Models.TaskAddOptions, AzureOperationHeaderResponse<Models.TaskAddHeaders>>((parameters, options) =>
-                    {
-                        Assert.Equal((Int32.Parse(parameters.Id) - 10).ToString(), parameters.DependsOn.TaskIds.Single());
-                        Assert.Equal(5, parameters.DependsOn.TaskIdRanges.Single().Start);
-                        Assert.Equal(15, parameters.DependsOn.TaskIdRanges.Single().End);
-
-                        return new AzureOperationHeaderResponse<Models.TaskAddHeaders>()
-                        {
-                            Response = new HttpResponseMessage(HttpStatusCode.Accepted)
-                        };
-                    });
-
-
-                var job = client.JobOperations.GetJob(jobId, additionalBehaviors: returnFakeJob);
-
-                for (int j = 0; j < 5; j++)
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            var returnFakeJob = ClientUnitTestCommon.SimulateServiceResponse<Models.JobGetOptions, AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>>(_ =>
+                new AzureOperationResponse<Models.CloudJob, Models.JobGetHeaders>
                 {
-                    var taskWithDependencies = new Microsoft.Azure.Batch.CloudTask((10 + j).ToString(), "cmd /c hostname")
-                    {
-                        DependsOn = new Microsoft.Azure.Batch.TaskDependencies(new[] { j.ToString() }, new[] { new Microsoft.Azure.Batch.TaskIdRange(5, 15) }),
-                    };
+                    Body = new Protocol.Models.CloudJob { Id = jobId, UsesTaskDependencies = true }
+                });
 
-                    job.AddTask(taskWithDependencies, additionalBehaviors: verifyTaskDependencies);  // assertions happen in the callback
-                }
+            var verifyTaskDependencies = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskAddParameter, Models.TaskAddOptions, AzureOperationHeaderResponse<Models.TaskAddHeaders>>((parameters, options) =>
+                {
+                    Assert.Equal((Int32.Parse(parameters.Id) - 10).ToString(), parameters.DependsOn.TaskIds.Single());
+                    Assert.Equal(5, parameters.DependsOn.TaskIdRanges.Single().Start);
+                    Assert.Equal(15, parameters.DependsOn.TaskIdRanges.Single().End);
+
+                    return new AzureOperationHeaderResponse<Models.TaskAddHeaders>()
+                    {
+                        Response = new HttpResponseMessage(HttpStatusCode.Accepted)
+                    };
+                });
+
+
+            var job = client.JobOperations.GetJob(jobId, additionalBehaviors: returnFakeJob);
+
+            for (int j = 0; j < 5; j++)
+            {
+                var taskWithDependencies = new Microsoft.Azure.Batch.CloudTask((10 + j).ToString(), "cmd /c hostname")
+                {
+                    DependsOn = new Microsoft.Azure.Batch.TaskDependencies(new[] { j.ToString() }, new[] { new Microsoft.Azure.Batch.TaskIdRange(5, 15) }),
+                };
+
+                job.AddTask(taskWithDependencies, additionalBehaviors: verifyTaskDependencies);  // assertions happen in the callback
             }
         }
 
@@ -160,13 +152,12 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void WhenATaskIsRetrievedFromTheService_ItsDependenciesAreSurfacedCorrectly()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                var returnFakeTasks = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskListOptions, AzureOperationResponse<IPage<Models.CloudTask>, Models.TaskListHeaders>>(_ =>
-                    new AzureOperationResponse<IPage<Models.CloudTask>, Models.TaskListHeaders>
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            var returnFakeTasks = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskListOptions, AzureOperationResponse<IPage<Models.CloudTask>, Models.TaskListHeaders>>(_ =>
+                new AzureOperationResponse<IPage<Models.CloudTask>, Models.TaskListHeaders>
+                {
+                    Body = new FakePage<Models.CloudTask>(new[]
                     {
-                        Body = new FakePage<Models.CloudTask>(new []
-                        {
                             new Protocol.Models.CloudTask
                             {
                                 DependsOn = new Protocol.Models.TaskDependencies
@@ -177,45 +168,42 @@
                                 Id = "5",
                                 State = Models.TaskState.Active,
                             }
-                        })
-                    });
+                    })
+                });
 
-                var tasks = client.JobOperations.ListTasks("job", additionalBehaviors: returnFakeTasks).ToList();
+            var tasks = client.JobOperations.ListTasks("job", additionalBehaviors: returnFakeTasks).ToList();
 
-                var taskDependencies = tasks.First().DependsOn;
+            var taskDependencies = tasks.First().DependsOn;
 
-                Assert.Equal("5", taskDependencies.TaskIds.Single());
-                Assert.Equal(5, taskDependencies.TaskIdRanges.Single().Start);
-                Assert.Equal(15, taskDependencies.TaskIdRanges.Single().End);
-            }
+            Assert.Equal("5", taskDependencies.TaskIds.Single());
+            Assert.Equal(5, taskDependencies.TaskIdRanges.Single().Start);
+            Assert.Equal(15, taskDependencies.TaskIdRanges.Single().End);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void CannotModifyDependenciesOfABoundTask()
         {
-            using (BatchClient client = ClientUnitTestCommon.CreateDummyClient())
-            {
-                var returnFakeTasks = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskGetOptions, AzureOperationResponse<Models.CloudTask, Models.TaskGetHeaders>>(_ =>
-                    new AzureOperationResponse<Models.CloudTask, Models.TaskGetHeaders>
+            using BatchClient client = ClientUnitTestCommon.CreateDummyClient();
+            var returnFakeTasks = ClientUnitTestCommon.SimulateServiceResponse<Models.TaskGetOptions, AzureOperationResponse<Models.CloudTask, Models.TaskGetHeaders>>(_ =>
+                new AzureOperationResponse<Models.CloudTask, Models.TaskGetHeaders>
+                {
+                    Body = new Protocol.Models.CloudTask
                     {
-                        Body = new Protocol.Models.CloudTask
+                        DependsOn = new Protocol.Models.TaskDependencies
                         {
-                            DependsOn = new Protocol.Models.TaskDependencies
-                            {
-                                TaskIdRanges = new[] { new Protocol.Models.TaskIdRange(5, 15) },
-                                TaskIds = new List<string> { "5" }
-                            },
-                            Id = "5",
-                            State = Models.TaskState.Active,
-                        }
-                    });
+                            TaskIdRanges = new[] { new Protocol.Models.TaskIdRange(5, 15) },
+                            TaskIds = new List<string> { "5" }
+                        },
+                        Id = "5",
+                        State = Models.TaskState.Active,
+                    }
+                });
 
-                var task = client.JobOperations.GetTask("job", "5", additionalBehaviors: returnFakeTasks);
+            var task = client.JobOperations.GetTask("job", "5", additionalBehaviors: returnFakeTasks);
 
-                var newDependencies = Microsoft.Azure.Batch.TaskDependencies.OnId("hello");
-                Assert.Throws<InvalidOperationException>(() => task.DependsOn = newDependencies);
-            }
+            var newDependencies = Microsoft.Azure.Batch.TaskDependencies.OnId("hello");
+            Assert.Throws<InvalidOperationException>(() => task.DependsOn = newDependencies);
         }
 
         [Fact]

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/UtilitiesInternalUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/UtilitiesInternalUnitTests.cs
@@ -277,18 +277,16 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestStreamToStringAsciiEncoding()
         {
-            using (MemoryStream s = new MemoryStream())
-            using (StreamWriter streamWriter = new StreamWriter(s, Encoding.ASCII))
-            {
-                const string expectedText = "I am Foo!";
-                streamWriter.Write(expectedText);
-                streamWriter.Flush();
+            using MemoryStream s = new MemoryStream();
+            using StreamWriter streamWriter = new StreamWriter(s, Encoding.ASCII);
+            const string expectedText = "I am Foo!";
+            streamWriter.Write(expectedText);
+            streamWriter.Flush();
 
-                s.Seek(0, SeekOrigin.Begin);
-                
-                string text = UtilitiesInternal.StreamToString(s, Encoding.ASCII);
-                Assert.Equal(expectedText, text);
-            }
+            s.Seek(0, SeekOrigin.Begin);
+
+            string text = UtilitiesInternal.StreamToString(s, Encoding.ASCII);
+            Assert.Equal(expectedText, text);
         }
 
         [Theory, 
@@ -297,38 +295,34 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestStreamToStringUtf8NoByteOrderMarking(bool includeByteOrderMarking)
         {
-            using (MemoryStream s = new MemoryStream())
-            using (StreamWriter streamWriter = new StreamWriter(s, new UTF8Encoding(includeByteOrderMarking)))
-            {
-                const string expectedText = "㌎ 丧 가";
-                streamWriter.Write(expectedText);
-                streamWriter.Flush();
+            using MemoryStream s = new MemoryStream();
+            using StreamWriter streamWriter = new StreamWriter(s, new UTF8Encoding(includeByteOrderMarking));
+            const string expectedText = "㌎ 丧 가";
+            streamWriter.Write(expectedText);
+            streamWriter.Flush();
 
-                s.Seek(0, SeekOrigin.Begin);
+            s.Seek(0, SeekOrigin.Begin);
 
-                string text = UtilitiesInternal.StreamToString(s, Encoding.UTF8);
-                Assert.Equal(expectedText, text);
-            }
+            string text = UtilitiesInternal.StreamToString(s, Encoding.UTF8);
+            Assert.Equal(expectedText, text);
         }
 
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void TestStreamToStringDoesntReadWholeStream()
         {
-            using (MemoryStream s = new MemoryStream())
-            using (StreamWriter streamWriter = new StreamWriter(s, new UTF8Encoding(false)))
-            {
-                const string inputText = "This is a test";
-                streamWriter.Write(inputText);
-                streamWriter.Flush();
+            using MemoryStream s = new MemoryStream();
+            using StreamWriter streamWriter = new StreamWriter(s, new UTF8Encoding(false));
+            const string inputText = "This is a test";
+            streamWriter.Write(inputText);
+            streamWriter.Flush();
 
-                const int bytesToSkip = 4;
-                
-                s.Seek(bytesToSkip, SeekOrigin.Begin);
-                
-                string text = UtilitiesInternal.StreamToString(s, Encoding.UTF8);
-                Assert.Equal(" is a test", text);
-            }
+            const int bytesToSkip = 4;
+
+            s.Seek(bytesToSkip, SeekOrigin.Begin);
+
+            string text = UtilitiesInternal.StreamToString(s, Encoding.UTF8);
+            Assert.Equal(" is a test", text);
         }
 
     }


### PR DESCRIPTION
The async calls were hanging because they were lacking a ConfigureAwait(false). However, in some cases the synchronous version is sufficient for our purposes.