### PR TITLE
[Event Hubs Client] Disallow Cancellation after Publishing

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -457,7 +457,6 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                         var deliveryTag = new ArraySegment<byte>(BitConverter.GetBytes(Interlocked.Increment(ref _deliveryCount)));
                         var outcome = await link.SendMessageAsync(batchMessage, deliveryTag, AmqpConstants.NullBinary, tryTimeout.CalculateRemaining(stopWatch.GetElapsedTime())).ConfigureAwait(false);
-                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         if (outcome.DescriptorCode != Accepted.Code)
                         {


### PR DESCRIPTION
# Summary

The focus of these changes is to remove a cancellation token check at an inappropriate location; if the send operation completes, cancellation should not be honored.  Either the service exception or a success should be returned so that callers clearly understand that events were published.

# Last Upstream Rebase

Tuesday, October 6, 3:16pm (EDT)