### PR TITLE
fix script Prepare-Release

### DIFF
--- a/eng/scripts/Prepare-Release.ps1
+++ b/eng/scripts/Prepare-Release.ps1
@@ -56,10 +56,10 @@ function Get-LevenshteinDistance {
 
     for ($i = 1; $i -le $d.GetUpperBound(0); $i++) {
         for ($j = 1; $j -le $d.GetUpperBound(1); $j++) {
-            $cost = [Convert]::ToInt32((-not($String1[$i–1] -ceq $String2[$j–1])))
-            $min1 = $d[($i–1),$j] + 1
-            $min2 = $d[$i,($j–1)] + 1
-            $min3 = $d[($i–1),($j–1)] + $cost
+            $cost = [Convert]::ToInt32((-not($String1[$i-1] -ceq $String2[$j-1])))
+            $min1 = $d[($i-1),$j] + 1
+            $min2 = $d[$i,($j-1)] + 1
+            $min3 = $d[($i-1),($j-1)] + $cost
             $d[$i,$j] = [Math]::Min([Math]::Min($min1,$min2),$min3)
         }
     }
@@ -67,7 +67,7 @@ function Get-LevenshteinDistance {
     $distance = ($d[$d.GetUpperBound(0),$d.GetUpperBound(1)])
 
     if ($NormalizeOutput) {
-        return (1 – ($distance) / ([Math]::Max($String1.Length,$String2.Length)))
+        return (1 - ($distance) / ([Math]::Max($String1.Length,$String2.Length)))
     }
 
     else {


### PR DESCRIPTION
The script `Prepare-Release.ps1` has invalid characters.


## Changes
- replaced "En Dash" (U+2013) with the normal dash character intended for arithmetic. 



## How I found this

When running this script, I get the following error:

```
PS D:\AzureSDK\eng\scripts> .\Prepare-Release.ps1 OpenTelemetry.Exporter.AzureMonitor
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:58
+             $cost = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $S ...
+                                                          ~
Missing ']' after array index expression.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:58
+ ...  = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $String2[$jâ€“1])))
+                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~
Unexpected token '€“1] -ceq $String2[$jâ€“1]' in expression or statement.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:58
+             $cost = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $S ...
+                                                          ~
Missing closing ')' in expression.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:58
+             $cost = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $S ...
+                                                          ~
Missing ')' in method call.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:58 char:56
+         for ($j = 1; $j -le $d.GetUpperBound(1); $j++) {
+                                                        ~
Missing closing '}' in statement block or type definition.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:57 char:52
+     for ($i = 1; $i -le $d.GetUpperBound(0); $i++) {
+                                                    ~
Missing closing '}' in statement block or type definition.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:8 char:34
+ function Get-LevenshteinDistance {
+                                  ~
Missing closing '}' in statement block or type definition.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:84
+ ...  = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $String2[$jâ€“1])))
+                                                                       ~
Unexpected token ')' in expression or statement.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:85
+ ...  = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $String2[$jâ€“1])))
+                                                                        ~
Unexpected token ')' in expression or statement.
At D:\AzureSDK\eng\scripts\Prepare-Release.ps1:59 char:86
+ ...  = [Convert]::ToInt32((-not($String1[$iâ€“1] -ceq $String2[$jâ€“1])))
+                                                                         ~
Unexpected token ')' in expression or statement.
Not all parse errors were reported.  Correct the reported errors and try again.
    + CategoryInfo          : ParserError: (:) [], ParseException
    + FullyQualifiedErrorId : MissingEndSquareBracket
```


I can see these characters using [Gremlins tracker for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=nhoizey.gremlins)

![image](https://user-images.githubusercontent.com/28785781/95383786-825f3800-08a0-11eb-986d-86db3dbd590f.png)
