### PR TITLE
Update digital twins versions and changelog in preparation for GA release

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Release History
 
-## 1.0.0-preview.4 (Unreleased)
+## 1.0.0 (Unreleased)
 
-### Breaking changes
-
--Renamed model type "ModelData" to "DigitalTwinsModelData"
--Renamed model type "RequestOptions" to "DigitalTwinsRequestOptions"
+- Regenerate protocol layer from GA service swagger
+- Update service API version to use GA service version
+- Add optional parameters for traceparent and tracestate to all service request APIs
+- Renamed model type "ModelData" to "DigitalTwinsModelData"
+- Renamed model type "RequestOptions" to "DigitalTwinsRequestOptions"
 
 ## 1.0.0-preview.3 (2020-07-13)
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 1.0.0 (Unreleased)
 
-- Regenerate protocol layer from GA service swagger
-- Update service API version to use GA service version
-- Add optional parameters for traceparent and tracestate to all service request APIs
-- Renamed model type "ModelData" to "DigitalTwinsModelData"
-- Renamed model type "RequestOptions" to "DigitalTwinsRequestOptions"
+- Regenerate protocol layer from service API version 2020-10-31
+- Update service API version to use service API version 2020-10-31 by default
+- Add optional parameters for traceparent and tracestate to all service request APIs to support distributed tracing
+- Renamed model type "ModelData" to "DigitalTwinsModelData" to make type less generic, and less likely to conflict with other libraries
+- Renamed model type "RequestOptions" to "DigitalTwinsRequestOptions" to make type less generic, and less likely to conflict with other libraries
 
 ## 1.0.0-preview.3 (2020-07-13)
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Azure.DigitalTwins.Core.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PackageTags>IoT;DigitalTwins;$(PackageCommonTags)</PackageTags>
     <Description>SDK for the Azure Digital Twins service</Description>
-    <Version>1.0.0-preview.4</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We'll be using this package in an internal-only bug bash, so we'll need to bump it to this version to avoid collision with the preview nugets that we've already publicly released