### PR TITLE
[Storage][Webjobs] Hide blob name validation attribute.

### DIFF
--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/api/Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/api/Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.WebJobs
         public BlobAttribute(string blobPath, System.IO.FileAccess access) { }
         public System.IO.FileAccess? Access { get { throw null; } set { } }
         [Microsoft.Azure.WebJobs.Description.AutoResolveAttribute]
-        [Microsoft.Azure.WebJobs.Description.BlobNameValidationAttribute]
         public string BlobPath { get { throw null; } }
         public string Connection { get { throw null; } set { } }
     }
@@ -23,16 +22,6 @@ namespace Microsoft.Azure.WebJobs
         public BlobTriggerAttribute(string blobPath) { }
         public string BlobPath { get { throw null; } }
         public string Connection { get { throw null; } set { } }
-    }
-}
-namespace Microsoft.Azure.WebJobs.Description
-{
-    public partial class BlobNameValidationAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
-    {
-        public BlobNameValidationAttribute() { }
-        protected override System.ComponentModel.DataAnnotations.ValidationResult IsValid(object value, System.ComponentModel.DataAnnotations.ValidationContext validationContext) { throw null; }
-        public static bool IsValidBlobName(string blobName, out string errorMessage) { throw null; }
-        public static bool IsValidContainerName(string containerName) { throw null; }
     }
 }
 namespace Microsoft.Azure.WebJobs.Extensions.Storage

--- a/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/src/BlobNameValidationAttribute.cs
+++ b/sdk/storage/Azure.Storage.Webjobs.Extensions.Blobs/src/BlobNameValidationAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Description
     /// Validate this on the client side so that we can get a user-friendly error rather than a 400 from the service.
     /// See code here: http://social.msdn.microsoft.com/Forums/en-GB/windowsazuredata/thread/d364761b-6d9d-4c15-8353-46c6719a3392
     /// </summary>
-    public class BlobNameValidationAttribute : ValidationAttribute
+    internal sealed class BlobNameValidationAttribute : ValidationAttribute
     {
         // Tested against storage service on July 2016. All other unsafe and reserved characters work fine.
         private static readonly char[] UnsafeBlobNameCharacters = { '\\' };
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Description
         /// </summary>
         /// <param name="containerName"></param>
         /// <returns></returns>
-        public static bool IsValidContainerName(string containerName)
+        internal static bool IsValidContainerName(string containerName)
         {
             if (containerName == null)
             {
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Description
         /// <param name="blobName"></param>
         /// <param name="errorMessage"></param>
         /// <returns></returns>
-        public static bool IsValidBlobName(string blobName, out string errorMessage)
+        internal static bool IsValidBlobName(string blobName, out string errorMessage)
         {
             const string UnsafeCharactersMessage =
                 "The given blob name '{0}' contain illegal characters. A blob name cannot the following character(s): '\\'.";


### PR DESCRIPTION
In this PR:
- Further reduce public surface:
    - Hide blob validation attribute. This is working fine if made internal as the caller of it is resolving by super type.