### PR TITLE
[Communication] Remove suppressed warnings in the project files

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -138,7 +138,7 @@
     <PackageReference Update="System.Text.Json" Version="4.6.0" />
 
     <!-- Build time packages -->
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20200721.2" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20200929.2" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" />
 

--- a/sdk/communication/Azure.Communication.Administration/src/Azure.Communication.Administration.csproj
+++ b/sdk/communication/Azure.Communication.Administration/src/Azure.Communication.Administration.csproj
@@ -6,8 +6,6 @@
     <PackageTags>Microsoft Azure Communication Administration Service;Microsoft;Azure;Azure Communication Service;Azure Communication Administration Service;Administration;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>
-    <!-- These supressions should be removed in a production library -->
-    <NoWarn>$(NoWarn);AZC0001</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/communication/Azure.Communication.Chat/src/Azure.Communication.Chat.csproj
+++ b/sdk/communication/Azure.Communication.Chat/src/Azure.Communication.Chat.csproj
@@ -7,7 +7,6 @@
     <PackageTags>Microsoft Azure Communication Chat Service;Microsoft;Azure;Azure Communication Service;Azure Communication Chat Service;Chat;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>
-    <NoWarn>$(NoWarn);AZC0001</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
+++ b/sdk/communication/Azure.Communication.Common/src/Azure.Communication.Common.csproj
@@ -7,8 +7,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Azure.Communication</RootNamespace>
     <EnableApiCompat>false</EnableApiCompat>
-    <!-- These supressions should be removed in a production library -->
-    <NoWarn>$(NoWarn);CA1812;AZC0001</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/communication/Azure.Communication.Common/src/Identity/CommunicationUserCredential.cs
+++ b/sdk/communication/Azure.Communication.Common/src/Identity/CommunicationUserCredential.cs
@@ -42,14 +42,6 @@ namespace Azure.Communication.Identity
                 refreshProactively);
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="CommunicationUserCredential"/> class.
-        /// </summary>
-        ~CommunicationUserCredential()
-        {
-            Dispose();
-        }
-
-        /// <summary>
         /// Gets an <see cref="AccessToken"/> for the user.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for the task.</param>
@@ -84,7 +76,6 @@ namespace Azure.Communication.Identity
                 return;
 
             _userTokenCredential.Dispose();
-            GC.SuppressFinalize(this);
             _isDisposed = true;
         }
     }

--- a/sdk/communication/Azure.Communication.Common/src/Identity/CommunicationUserCredential.cs
+++ b/sdk/communication/Azure.Communication.Common/src/Identity/CommunicationUserCredential.cs
@@ -42,6 +42,14 @@ namespace Azure.Communication.Identity
                 refreshProactively);
 
         /// <summary>
+        /// Finalizes an instance of the <see cref="CommunicationUserCredential"/> class.
+        /// </summary>
+        ~CommunicationUserCredential()
+        {
+            Dispose();
+        }
+
+        /// <summary>
         /// Gets an <see cref="AccessToken"/> for the user.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token for the task.</param>
@@ -72,7 +80,11 @@ namespace Azure.Communication.Identity
         /// <inheritdoc />
         public void Dispose()
         {
+            if (_isDisposed)
+                return;
+
             _userTokenCredential.Dispose();
+            GC.SuppressFinalize(this);
             _isDisposed = true;
         }
     }

--- a/sdk/communication/Azure.Communication.Common/src/Identity/ThreadSafeRefreshableAccessTokenCache.cs
+++ b/sdk/communication/Azure.Communication.Common/src/Identity/ThreadSafeRefreshableAccessTokenCache.cs
@@ -17,7 +17,7 @@ namespace Azure.Communication.Identity
     /// <remarks>
     /// Proactive refreshing does not retry if it fails.
     /// </remarks>
-    internal class ThreadSafeRefreshableAccessTokenCache : IDisposable
+    internal sealed class ThreadSafeRefreshableAccessTokenCache : IDisposable
     {
         internal const int ProactiveRefreshIntervalInMinutes = 10;
         internal const int OnDemandRefreshIntervalInMinutes = 2;
@@ -78,9 +78,9 @@ namespace Azure.Communication.Identity
 
             if (refreshProactively)
             {
-                var dueTime = IsCurrentTokenInRefreshZone()
+                TimeSpan dueTime = IsCurrentTokenInRefreshZone()
                        ? TimeSpan.Zero
-                       : _currentToken.ExpiresOn - this.UtcNow() - _proactiveRefreshingInterval;
+                       : _currentToken.ExpiresOn - UtcNow() - _proactiveRefreshingInterval;
                 _scheduledProactiveRefreshing = ScheduleProactiveRefreshing(dueTime);
             }
         }
@@ -179,7 +179,11 @@ namespace Azure.Communication.Identity
         private bool IsCurrentTokenInRefreshZone()
            => !_valueIsInitialized || UtcNow() >= _currentToken.ExpiresOn - _proactiveRefreshingInterval;
 
-        public void Dispose() => _scheduledProactiveRefreshing?.Dispose();
+        public void Dispose()
+        {
+            _scheduledProactiveRefreshing?.Dispose();
+            GC.SuppressFinalize(this);
+        }
 
         internal interface IScheduledAction : IDisposable { }
 

--- a/sdk/communication/Azure.Communication.Common/src/Identity/ThreadSafeRefreshableAccessTokenCache.cs
+++ b/sdk/communication/Azure.Communication.Common/src/Identity/ThreadSafeRefreshableAccessTokenCache.cs
@@ -180,10 +180,7 @@ namespace Azure.Communication.Identity
            => !_valueIsInitialized || UtcNow() >= _currentToken.ExpiresOn - _proactiveRefreshingInterval;
 
         public void Dispose()
-        {
-            _scheduledProactiveRefreshing?.Dispose();
-            GC.SuppressFinalize(this);
-        }
+            => _scheduledProactiveRefreshing?.Dispose();
 
         internal interface IScheduledAction : IDisposable { }
 

--- a/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
+++ b/sdk/communication/Azure.Communication.Sms/src/Azure.Communication.Sms.csproj
@@ -6,16 +6,12 @@
     <PackageTags>Microsoft Azure Communication Sms Service;Microsoft;Azure;Azure Communication Service;Azure Communication Sms Service;Sms;Communication;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>
-    <!-- These supressions should be removed in a production library -->
-    <NoWarn>$(NoWarn);CA1812;AZC0001</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
-
-  <!-- Shared source from Azure.Core -->
   <ItemGroup>
     <Compile Include="..\..\Shared\src\ClientOptionsExtensions.cs" Link="Shared\Communication\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="..\..\Shared\src\HMACAuthenticationPolicy.cs" Link="Shared\Communication\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/sdk/communication/Azure.ResourceManager.Communication/src/Azure.ResourceManager.Communication.csproj
+++ b/sdk/communication/Azure.ResourceManager.Communication/src/Azure.ResourceManager.Communication.csproj
@@ -5,11 +5,9 @@
     <Description>Azure management client SDK for Azure resource provider Microsoft.Communication</Description>
     <PackageTags>azure;management;communication</PackageTags>
     <Nullable>enable</Nullable>
-
     <!--
-    AZC0001 - Communication namespace needs to be registered in the analyzer
-    AZC0008 - ClientOptions complains about a missing nested enum
+    AZC0001 - Azure.ResourceManager.Communication namespace needs to be registered in the analyzer
     -->
-    <NoWarn>$(NoWarn);AZC0001;AZC0008</NoWarn>
+    <NoWarn>$(NoWarn);AZC0001</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Now that https://github.com/Azure/azure-sdk-tools/pull/1054 is merged, we can remove the warning suppression regarding "Azure.Communication" not being allowed as a public namespace.