### PR TITLE
Marking flaky tests and mitigating them somewhat

### DIFF
--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AddTaskCollectionIntegrationTests.cs
@@ -95,7 +95,7 @@
             const int countToFailAt = 102;
             const int taskCount = 407;
             HashSet<string> taskIdsExpectedToFail = new HashSet<string>();
-            Func<AddTaskResult, CancellationToken, AddTaskResultStatus> resultHandlerFunc = (result, token) =>
+            AddTaskResultStatus resultHandlerFunc(AddTaskResult result, CancellationToken token)
             {
                 testOutputHelper.WriteLine("Task: {0} got status code: {1}", result.TaskId, result.Status);
                 ++count;
@@ -121,7 +121,7 @@
                         return AddTaskResultStatus.Success;
                     }
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
@@ -157,7 +157,7 @@
             int numberOfTasksWhichHitClientError = 0;
             int numberOfTasksWhichWereForcedToRetry = 0;
 
-            Func<AddTaskResult, CancellationToken, AddTaskResultStatus> resultHandlerFunc = (result, token) =>
+            AddTaskResultStatus resultHandlerFunc(AddTaskResult result, CancellationToken token)
             {
                 testOutputHelper.WriteLine("Task: {0} got status code: {1}", result.TaskId, result.Status);
                 AddTaskResultStatus resultAction;
@@ -186,7 +186,7 @@
                 }
 
                 return resultAction;
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {
@@ -379,13 +379,13 @@
         {
             const string testName = "Bug1360227_ConfirmResultHandlerTaskReadOnly";
 
-            Func<AddTaskResult, CancellationToken, AddTaskResultStatus> resultHandlerFunc = (result, token) =>
+            AddTaskResultStatus resultHandlerFunc(AddTaskResult result, CancellationToken token)
             {
                 //Count everything as a success
                 AddTaskResultStatus resultAction = AddTaskResultStatus.Success;
 
                 //Try to set a property of the cloud task
-                InvalidOperationException e = TestUtilities.AssertThrows<InvalidOperationException>(() => 
+                InvalidOperationException e = TestUtilities.AssertThrows<InvalidOperationException>(() =>
                     result.Task.Constraints = new TaskConstraints(TimeSpan.FromSeconds(5), null, null));
 
                 Assert.Contains("Write access is not allowed.", e.Message);
@@ -404,7 +404,7 @@
                 //}
 
                 return resultAction;
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(async () =>
             {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationIntegrationCommon.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationIntegrationCommon.cs
@@ -1,18 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests.Application
+namespace BatchClientIntegrationTests.Application
 {
     using System;
     using System.Linq;
-    using System.Net;
     using System.Threading.Tasks;
-    using BatchTestCommon;
     using IntegrationTestCommon;
     using Microsoft.Azure.Management.Batch;
     using Microsoft.Azure.Management.Batch.Models;
     using Microsoft.Rest.Azure;
-    using Xunit;
 
     internal static class ApplicationIntegrationCommon
     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationManagementIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationManagementIntegrationTests.cs
@@ -40,50 +40,50 @@
         {
             string accountName = TestCommon.Configuration.BatchAccountName;
 
-            Func<Task> test = async () =>
+            async Task test()
+            {
+                var poolId = "app-ref-test" + Guid.NewGuid();
+                using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
+                using var mgmtClient = IntegrationTestCommon.OpenBatchManagementClient();
+                // Give the application a display name
+                await mgmtClient.Application.UpdateAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId, new UpdateApplicationParameters
                 {
-                    var poolId = "app-ref-test" + Guid.NewGuid();
-                    using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
-                    using var mgmtClient = IntegrationTestCommon.OpenBatchManagementClient();
-                    // Give the application a display name
-                    await mgmtClient.Application.UpdateAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId, new UpdateApplicationParameters
-                    {
-                        AllowUpdates = true,
-                        DefaultVersion = ApplicationIntegrationCommon.Version,
-                        DisplayName = DisplayName
-                    }).ConfigureAwait(false);
+                    AllowUpdates = true,
+                    DefaultVersion = ApplicationIntegrationCommon.Version,
+                    DisplayName = DisplayName
+                }).ConfigureAwait(false);
 
-                    List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
+                List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
 
-                    ApplicationSummary applicationSummary = applicationSummaries.First();
-                    Assert.Equal(ApplicationIntegrationCommon.Version, applicationSummary.Versions.First());
-                    Assert.Equal(ApplicationId, applicationSummary.Id);
-                    Assert.Equal(DisplayName, applicationSummary.DisplayName);
+                ApplicationSummary applicationSummary = applicationSummaries.First();
+                Assert.Equal(ApplicationIntegrationCommon.Version, applicationSummary.Versions.First());
+                Assert.Equal(ApplicationId, applicationSummary.Id);
+                Assert.Equal(DisplayName, applicationSummary.DisplayName);
 
 
-                    ApplicationSummary getApplicationSummary = await client.ApplicationOperations.GetApplicationSummaryAsync(applicationSummary.Id).ConfigureAwait(false);
+                ApplicationSummary getApplicationSummary = await client.ApplicationOperations.GetApplicationSummaryAsync(applicationSummary.Id).ConfigureAwait(false);
 
-                    Assert.Equal(getApplicationSummary.Id, applicationSummary.Id);
-                    Assert.Equal(getApplicationSummary.Versions.Count(), applicationSummary.Versions.Count());
-                    Assert.Equal(getApplicationSummary.DisplayName, applicationSummary.DisplayName);
+                Assert.Equal(getApplicationSummary.Id, applicationSummary.Id);
+                Assert.Equal(getApplicationSummary.Versions.Count(), applicationSummary.Versions.Count());
+                Assert.Equal(getApplicationSummary.DisplayName, applicationSummary.DisplayName);
 
-                    var appPackage = await mgmtClient.ApplicationPackage.GetAsync(
-                            TestCommon.Configuration.BatchAccountResourceGroup,
-                            accountName,
-                            ApplicationId,
-                            ApplicationIntegrationCommon.Version).ConfigureAwait(false);
+                var appPackage = await mgmtClient.ApplicationPackage.GetAsync(
+                        TestCommon.Configuration.BatchAccountResourceGroup,
+                        accountName,
+                        ApplicationId,
+                        ApplicationIntegrationCommon.Version).ConfigureAwait(false);
 
-                    Assert.Equal(PackageState.Active, appPackage.State);
-                    Assert.Equal(ApplicationIntegrationCommon.Version, appPackage.Version);
-                    Assert.Equal(ApplicationId, appPackage.Id);
+                Assert.Equal(PackageState.Active, appPackage.State);
+                Assert.Equal(ApplicationIntegrationCommon.Version, appPackage.Version);
+                Assert.Equal(ApplicationId, appPackage.Id);
 
-                    var application = await mgmtClient.Application.GetAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId).ConfigureAwait(false);
+                var application = await mgmtClient.Application.GetAsync(TestCommon.Configuration.BatchAccountResourceGroup, accountName, ApplicationId).ConfigureAwait(false);
 
-                    Assert.Equal(ApplicationIntegrationCommon.Version, application.DefaultVersion);
-                    Assert.Equal(ApplicationId, application.Id);
+                Assert.Equal(ApplicationIntegrationCommon.Version, application.DefaultVersion);
+                Assert.Equal(ApplicationId, application.Id);
 
-                    await AssertPoolWasCreatedWithApplicationReferences(client, poolId, ApplicationId).ConfigureAwait(false);
-                };
+                await AssertPoolWasCreatedWithApplicationReferences(client, poolId, ApplicationId).ConfigureAwait(false);
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, LongRunningTestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackageFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackageFixture.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests.Application
+namespace BatchClientIntegrationTests.Application
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using BatchTestCommon;
     using IntegrationTestCommon;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesIntegrationTests.cs
@@ -38,7 +38,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public async Task IfThereAreApplicationsInTheAccountThenListApplicationSummariesReturnsThem()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 List<ApplicationSummary> applicationSummaries = await client.ApplicationOperations.ListApplicationSummaries().ToListAsync().ConfigureAwait(false);
@@ -51,7 +51,7 @@
 
                 Assert.Equal(ApplicationId, getApplicationSummary.Id);
                 Assert.Equal(ApplicationIntegrationCommon.Version, getApplicationSummary.Versions.First());
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesIntegrationTests.cs
@@ -31,7 +31,7 @@
         {
             var poolId = "app-ref-test-1-" + Guid.NewGuid();
 
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
                 CloudPool newPool = null;
@@ -60,7 +60,7 @@
                 {
                     TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
         }
@@ -72,7 +72,7 @@
         {
             var poolId = "app-ref-test-2-" + Guid.NewGuid();
 
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync();
                 try
@@ -98,7 +98,7 @@
                 {
                     TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
         }
@@ -157,23 +157,23 @@
             using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
             CloudJobSchedule cloudJobSchedule = client.JobScheduleOperations.CreateJobSchedule(jobId, schedule, jobSpecification);
 
-            Func<Task> test = async () =>
+            async Task test()
+            {
+                CloudJobSchedule updatedBoundJobSchedule = null;
+
+                try
                 {
-                    CloudJobSchedule updatedBoundJobSchedule = null;
+                    await cloudJobSchedule.CommitAsync().ConfigureAwait(false);
 
-                    try
+                    CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(client.JobScheduleOperations, jobId);
+
+                    ApplicationPackageReference apr = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
+
+                    Assert.Equal(ApplicationId, apr.ApplicationId);
+                    Assert.Equal(Version, apr.Version);
+
+                    boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences = new[]
                     {
-                        await cloudJobSchedule.CommitAsync().ConfigureAwait(false);
-
-                        CloudJobSchedule boundJobSchedule = TestUtilities.WaitForJobOnJobSchedule(client.JobScheduleOperations, jobId);
-
-                        ApplicationPackageReference apr = boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences.First();
-
-                        Assert.Equal(ApplicationId, apr.ApplicationId);
-                        Assert.Equal(Version, apr.Version);
-
-                        boundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences = new[]
-                        {
                                 new ApplicationPackageReference()
                                 {
                                     ApplicationId = ApplicationId,
@@ -181,23 +181,23 @@
                                 }
                         };
 
-                        await boundJobSchedule.CommitAsync().ConfigureAwait(false);
-                        await boundJobSchedule.RefreshAsync().ConfigureAwait(false);
+                    await boundJobSchedule.CommitAsync().ConfigureAwait(false);
+                    await boundJobSchedule.RefreshAsync().ConfigureAwait(false);
 
-                        updatedBoundJobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync(jobId).ConfigureAwait(false);
+                    updatedBoundJobSchedule = await client.JobScheduleOperations.GetJobScheduleAsync(jobId).ConfigureAwait(false);
 
-                        ApplicationPackageReference updatedApr =
-                            updatedBoundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences
-                                                   .First();
+                    ApplicationPackageReference updatedApr =
+                        updatedBoundJobSchedule.JobSpecification.PoolInformation.AutoPoolSpecification.PoolSpecification.ApplicationPackageReferences
+                                               .First();
 
-                        Assert.Equal(ApplicationId, updatedApr.ApplicationId);
-                        Assert.Equal(newVersion, updatedApr.Version);
-                    }
-                    finally
-                    {
-                        TestUtilities.DeleteJobScheduleIfExistsAsync(client, jobId).Wait();
-                    }
-                };
+                    Assert.Equal(ApplicationId, updatedApr.ApplicationId);
+                    Assert.Equal(newVersion, updatedApr.Version);
+                }
+                finally
+                {
+                    TestUtilities.DeleteJobScheduleIfExistsAsync(client, jobId).Wait();
+                }
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
         }
@@ -230,7 +230,7 @@
                 }
             };
 
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 try
@@ -250,7 +250,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesOnTasksIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/ApplicationPackagesReferencesOnTasksIntegrationTests.cs
@@ -29,7 +29,7 @@
             const string applicationId = "blender";
             const string applicationVerson = "beta";
 
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 var poolInfo = new PoolInformation
@@ -75,7 +75,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -89,7 +89,7 @@
             const string applicationId = "blender";
             const string applicationVersion = "beta";
 
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 var poolInfo = new PoolInformation
@@ -131,7 +131,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/JobWithApplicationPackageReferencesIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Application/JobWithApplicationPackageReferencesIntegrationTests.cs
@@ -29,7 +29,7 @@
             var jobId = Guid.NewGuid().ToString();
             const string applicationId = "blender";
 
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient client = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 var poolInfo = new PoolInformation
@@ -70,7 +70,7 @@
                         TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                     }
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AuthenticationTest.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AuthenticationTest.cs
@@ -1,7 +1,6 @@
 ﻿
 namespace BatchClientIntegrationTests
 {
-    using System;
     using System.Threading.Tasks;
     using BatchTestCommon;
     using IntegrationTestCommon;
@@ -13,19 +12,12 @@ namespace BatchClientIntegrationTests
 
     public class AuthenticationTest
     {
-        private readonly ITestOutputHelper testOutputHelper;
-
-        public AuthenticationTest(ITestOutputHelper testOutputHelper)
-        {
-            this.testOutputHelper = testOutputHelper;
-        }
-
         [LiveTest]
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task CanAuthenticateToServiceWithAADToken()
         {
-            Func<Task<string>> tokenProvider = () => IntegrationTestCommon.GetAuthenticationTokenAsync("https://batch.core.windows.net/");
+            static Task<string> tokenProvider() => IntegrationTestCommon.GetAuthenticationTokenAsync("https://batch.core.windows.net/");
 
             using var client = BatchClient.Open(new BatchTokenCredentials(TestCommon.Configuration.BatchAccountUrl, tokenProvider));
             await client.JobOperations.ListJobs().ToListAsync();

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AutoScaleIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/AutoScaleIntegrationTests.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests
+namespace BatchClientIntegrationTests
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Batch.Common;
     using Microsoft.Azure.Batch.Integration.Tests.Infrastructure;
@@ -14,7 +11,6 @@
     using Xunit.Abstractions;
 
     using Microsoft.Azure.Batch;
-    using Protocol = Microsoft.Azure.Batch.Protocol;
     using BatchTestCommon;
     using IntegrationTestUtilities;
     using Fixtures;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/BatchRequestIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/BatchRequestIntegrationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests
+namespace BatchClientIntegrationTests
 {
     using System;
     using System.Collections.Generic;
@@ -16,20 +16,10 @@
     using IntegrationTestUtilities;
     using Microsoft.Rest.Azure;
     using Xunit;
-    using Xunit.Abstractions;
-    using CloudJob = Microsoft.Azure.Batch.CloudJob;
 
     public class BatchRequestIntegrationTests
     {
-        private readonly ITestOutputHelper testOutputHelper;
         private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
-
-        public BatchRequestIntegrationTests(ITestOutputHelper testOutputHelper)
-        {
-            this.testOutputHelper = testOutputHelper;
-        }
-
-        #region Cancellation
 
         [Fact]
         [LiveTest]
@@ -41,12 +31,14 @@
                 await SynchronizationContextHelper.RunTestAsync(async () =>
                 {
                     using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
-                    List<BatchClientBehavior> customBehaviors = new List<BatchClientBehavior>();
-                    customBehaviors.Add(new RequestInterceptor((req) =>
+                    List<BatchClientBehavior> customBehaviors = new List<BatchClientBehavior>
                     {
+                        new RequestInterceptor((req) =>
+                        {
                             //Set the timeout to something small so it is guaranteed to expire before the service has responded
                             req.Timeout = TimeSpan.FromMilliseconds(25);
-                    }));
+                        })
+                    };
 
                     await client.JobOperations.GetJobAsync("Foo", additionalBehaviors: customBehaviors).ConfigureAwait(false);
                 },
@@ -67,20 +59,22 @@
                 {
                     using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
                     client.CustomBehaviors.Add(RetryPolicyProvider.LinearRetryProvider(TimeSpan.FromMilliseconds(250), maxRetries));
-                    List<BatchClientBehavior> customBehaviors = new List<BatchClientBehavior>();
-                    customBehaviors.Add(new RequestInterceptor((req) =>
+                    List<BatchClientBehavior> customBehaviors = new List<BatchClientBehavior>
                     {
+                        new RequestInterceptor((req) =>
+                        {
                             //Set the timeout to something small so it is guaranteed to expire before the service has responded
                             req.Timeout = TimeSpan.FromMilliseconds(25);
 
-                        var castRequest = (JobGetBatchRequest)req;
-                        Func<CancellationToken, Task<AzureOperationResponse<Microsoft.Azure.Batch.Protocol.Models.CloudJob, JobGetHeaders>>> oldFunc = castRequest.ServiceRequestFunc;
-                        castRequest.ServiceRequestFunc = async (token) =>
-                                                               {
-                                                                   actualRequestCount++; //Count the number of calls to the func
+                            var castRequest = (JobGetBatchRequest)req;
+                            Func<CancellationToken, Task<AzureOperationResponse<Microsoft.Azure.Batch.Protocol.Models.CloudJob, JobGetHeaders>>> oldFunc = castRequest.ServiceRequestFunc;
+                            castRequest.ServiceRequestFunc = async (token) =>
+                                                                   {
+                                                                       actualRequestCount++; //Count the number of calls to the func
                                                                        return await oldFunc(token).ConfigureAwait(false);
-                                                               };
-                    }));
+                                                                   };
+                        })
+                    };
 
                     await client.JobOperations.GetJobAsync("Foo", additionalBehaviors: customBehaviors).ConfigureAwait(false);
                 },
@@ -99,18 +93,18 @@
                 //Set the timeout to something small so it is guaranteed to expire before the service has responded
                 using CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(25));
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
-                List<BatchClientBehavior> customBehaviors = new List<BatchClientBehavior>();
-                customBehaviors.Add(new RequestInterceptor((req) =>
+                List<BatchClientBehavior> customBehaviors = new List<BatchClientBehavior>
                 {
-                    req.CancellationToken = tokenSource.Token;
-                }));
+                    new RequestInterceptor((req) =>
+                    {
+                        req.CancellationToken = tokenSource.Token;
+                    })
+                };
 
                 await TestUtilities.AssertThrowsAsync<OperationCanceledException>(async () =>
                     await client.JobOperations.GetJobAsync("Foo", additionalBehaviors: customBehaviors).ConfigureAwait(false)).ConfigureAwait(false);
             },
             TestTimeout);
         }
-
-        #endregion
     }
 }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/BatchRequestIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/BatchRequestIntegrationTests.cs
@@ -86,6 +86,7 @@ namespace BatchClientIntegrationTests
         [Fact]
         [LiveTest]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
+        [Trait("Flaky", "true")]
         public async Task BatchRequestWithShortUserCancellationToken()
         {
             await SynchronizationContextHelper.RunTestAsync(async () =>

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CertificateUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CertificateUnitTests.cs
@@ -4,18 +4,14 @@
 namespace BatchClientIntegrationTests
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Security.Cryptography.X509Certificates;
     using BatchTestCommon;
     using Microsoft.Azure.Batch;
     using Microsoft.Azure.Batch.Auth;
-    using Microsoft.Azure.Batch.Common;
     using IntegrationTestCommon;
     using Xunit;
     using Xunit.Abstractions;
-    using Protocol = Microsoft.Azure.Batch.Protocol;
 
     //
     // NOTE: These are really unit tests but they cannot live in the unit tests project right now because the method we use to generate certificates is not

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudCertificateIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudCertificateIntegrationTests.cs
@@ -33,7 +33,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public async Task TestCertificateVerbs()
         {
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 //Generate the certificates
@@ -100,7 +100,7 @@
                         TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
                     }
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -110,7 +110,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongDuration)]
         public async Task TestPoolCertificateReferencesWithUpdate()
         {
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 //Generate the certificates
@@ -154,7 +154,7 @@
                         TestUtilities.DeleteCertMonitor(batchCli.CertificateOperations, testOutputHelper, certificate.ThumbprintAlgorithm, certificate.Thumbprint);
                     }
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -253,10 +253,11 @@
 
                 // mutate the cert refs: assign only one
                 {
-                    List<CertificateReference> listOfOne = new List<CertificateReference>();
-
-                    // just pick one cert
-                    listOfOne.Add(certificateReferences.ToArray()[1]);
+                    List<CertificateReference> listOfOne = new List<CertificateReference>
+                    {
+                        // just pick one cert
+                        certificateReferences.ToArray()[1]
+                    };
 
                     boundPool.CertificateReferences = listOfOne;
 
@@ -279,7 +280,6 @@
             }
             finally
             {
-                // cleanup
                 TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
             }
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobIntegrationTests.cs
@@ -36,7 +36,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongDuration)]
         public void Bug1665834TaskStateMonitor()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1665834Job-" + TestUtilities.GetMyName();
@@ -128,7 +128,7 @@
                     // cleanup
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -138,7 +138,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestBoundJobVerbs()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 //Create a job
@@ -229,7 +229,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -239,7 +239,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1433069TestBoundJobCommit()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobCommit";
@@ -311,7 +311,7 @@
                 {
                     batchCli.JobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -321,7 +321,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1996130_JobTaskVerbsFailAfterDoubleRefresh()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1996130Job-" + TestUtilities.GetMyName();
@@ -384,7 +384,7 @@
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
 
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -394,7 +394,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestJobCompletesWhenAllItsTasksComplete()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 //Create a job
@@ -427,7 +427,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -437,7 +437,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void IfJobSetsOnTaskFailed_JobCompletesWhenAnyTaskFails()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 //Create a job
@@ -476,7 +476,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -486,7 +486,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestExitConditionsAreBeingRoundTrippedCorrectly()
         {
-            Action test = () => 
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 //Create a job
@@ -534,7 +534,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -610,7 +610,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestJobUpdateWithAndWithoutPoolInfo()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string testName = "TestJobUpdateWithAndWithoutPoolInfo";
@@ -711,7 +711,7 @@
                         TestUtilities.DeletePoolIfExistsAsync(batchCli, pool.Id).Wait();
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -721,7 +721,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public void LongRunning_Bug1965363Wat7OSVersionFeaturesQuickJobWithAutoPool()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1965363Job-" + TestUtilities.GetMyName();
@@ -791,7 +791,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -801,7 +801,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void SetUpdateJobConditionalHeader()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string jobId = "JobConditionalHeaders-" + TestUtilities.GetMyName();
@@ -846,7 +846,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -856,7 +856,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task Job_CanAddJobWithJobManagerAndAllowLowPriorityTrue()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string jobId = "TestJobWithLowPriJobManager-" + TestUtilities.GetMyName();
@@ -881,7 +881,7 @@
                 {
                     await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -891,7 +891,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task Job_GetTaskCounts_ReturnsCorrectCount()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string jobId = "TestJobGetTaskCounts-" + TestUtilities.GetMyName();
@@ -922,7 +922,7 @@
                 {
                     await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -933,7 +933,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task Job_GetTaskCounts_ReturnsCorrectCountNonZeroTaskSlots()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string jobId = "NonZeroTaskSlots-" + TestUtilities.GetMyName();
@@ -972,7 +972,7 @@
                 {
                     await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId);
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobScheduleIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudJobScheduleIntegrationTests.cs
@@ -34,7 +34,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestBoundJobScheduleCommit()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundJobScheduleCommit";
@@ -71,7 +71,7 @@
                     CloudJobSchedule boundJobSchedule = batchCli.JobScheduleOperations.GetJobSchedule(jobScheduleId);
 
                     //Ensure the job schedule is structured as expected
-                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, firstRecurrenceInterval, metadata);
+                    AssertJobScheduleCorrectness(boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, firstRecurrenceInterval, metadata);
 
                     //Update the bound job schedule schedule
                     TimeSpan recurrenceInterval = TimeSpan.FromMinutes(5);
@@ -84,7 +84,7 @@
                     boundJobSchedule.Commit();
 
                     //Ensure the job schedule is correct after commit
-                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
+                    AssertJobScheduleCorrectness(boundJobSchedule, poolFixture.PoolId, jobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
 
                     //Update the bound job schedule priority
                     const int newJobSchedulePriority = 1;
@@ -94,7 +94,7 @@
                     boundJobSchedule.Commit();
 
                     //Ensure the job schedule is correct after commit
-                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
+                    AssertJobScheduleCorrectness(boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, jobManagerCommandLine, recurrenceInterval, metadata);
 
                     //Update the bound job schedule job manager commandline
                     const string newJobManagerCommandLine = "ping 127.0.0.1 -n 150";
@@ -104,7 +104,7 @@
                     boundJobSchedule.Commit();
 
                     //Ensure the job schedule is correct after commit
-                    AssertJobScheduleCorrectness(batchCli.JobScheduleOperations, boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, newJobManagerCommandLine, recurrenceInterval, metadata);
+                    AssertJobScheduleCorrectness(boundJobSchedule, poolFixture.PoolId, newJobSchedulePriority, jobManagerId, newJobManagerCommandLine, recurrenceInterval, metadata);
 
                     //Update the bound job schedule PoolInformation
                     const string newPoolId = "TestPool";
@@ -116,7 +116,6 @@
 
                     //Ensure the job schedule is correct after commit
                     AssertJobScheduleCorrectness(
-                        batchCli.JobScheduleOperations,
                         boundJobSchedule,
                         newPoolId,
                         newJobSchedulePriority,
@@ -134,7 +133,6 @@
 
                     //Ensure the job schedule is correct after commit
                     AssertJobScheduleCorrectness(
-                        batchCli.JobScheduleOperations,
                         boundJobSchedule,
                         newPoolId,
                         newJobSchedulePriority,
@@ -147,7 +145,7 @@
                 {
                     batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -155,7 +153,6 @@
         #region Test helpers
         
         private static void AssertJobScheduleCorrectness(
-            JobScheduleOperations jobScheduleOperations,
             CloudJobSchedule boundJobSchedule,
             string expectedPoolId,
             int expectedJobPriority,
@@ -208,7 +205,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task JobSchedulePatch()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string jobScheduleId = "TestPatchJobSchedule-" + TestUtilities.GetMyName();
@@ -252,7 +249,7 @@
                 {
                     await TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).ConfigureAwait(false);
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -262,7 +259,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void SampleCreateJobScheduleAutoPool()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jsId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-CreateWiAutoPoolTest";
@@ -360,7 +357,7 @@
                     // clean up
                     TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -370,7 +367,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1433008JobScheduleScheduleNewable()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jsId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-Bug1433008JobScheduleScheduleNewable";
@@ -434,7 +431,7 @@
                     // clean up
                     TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -444,7 +441,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public void TestListJobsByJobSchedule()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestListJobsByJobSchedule";
@@ -490,7 +487,7 @@
                     // clean up
                     TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -500,7 +497,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestJobScheduleVerbs()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobScheduleId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestEnableDisableDeleteJobSchedule";
@@ -570,7 +567,7 @@
                     // clean up
                     TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudPoolIntegrationTests.cs
@@ -22,8 +22,6 @@ namespace BatchClientIntegrationTests
     using Xunit;
     using Xunit.Abstractions;
     using Protocol = Microsoft.Azure.Batch.Protocol;
-    using Azure.Storage;
-    using Azure.Storage.Blobs.Models;
     using Microsoft.Azure.Batch.Integration.Tests.IntegrationTestUtilities;
 
     public class CloudPoolIntegrationTests
@@ -43,7 +41,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task PoolPatch()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string poolId = "TestPatchPool-" + TestUtilities.GetMyName();
@@ -80,7 +78,7 @@ namespace BatchClientIntegrationTests
                 {
                     await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -90,7 +88,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1505248SupportMultipleTasksPerComputeNodeOnPoolAndPoolUserSpec()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 // create a pool with the two new props
@@ -171,7 +169,7 @@ namespace BatchClientIntegrationTests
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -181,7 +179,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1587303StartTaskResourceFilesNotPushedToServer()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "Bug1587303Pool-" + TestUtilities.GetMyName();
@@ -269,10 +267,12 @@ namespace BatchClientIntegrationTests
                     {
                         CloudPool myPool = batchCli.PoolOperations.CreatePool(poolId, PoolFixture.VMSize, new CloudServiceConfiguration(PoolFixture.OSFamily), targetDedicatedComputeNodes: 0);
 
-                        StartTask st = new StartTask("dir");
-                        // use the empty collections from above
-                        st.ResourceFiles = emptyResfiles;
-                        st.EnvironmentSettings = emptyEnvSettings;
+                        StartTask st = new StartTask("dir")
+                        {
+                            // use the empty collections from above
+                            ResourceFiles = emptyResfiles,
+                            EnvironmentSettings = emptyEnvSettings
+                        };
 
                         // set the pool's start task so the collections get pushed
                         myPool.StartTask = st;
@@ -297,7 +297,7 @@ namespace BatchClientIntegrationTests
                     // cleanup
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -307,7 +307,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1433123PoolMissingResizeTimeout()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "Bug1433123PoolMissingResizeTimeout-" + TestUtilities.GetMyName();
@@ -341,7 +341,7 @@ namespace BatchClientIntegrationTests
                     // cleanup
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -351,7 +351,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1656475PoolLifetimeOption()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jsId = "Bug1656475PoolLifetimeOption-" + TestUtilities.GetMyName();
@@ -410,7 +410,7 @@ namespace BatchClientIntegrationTests
                     // cleanup
                     TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jsId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -420,7 +420,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongDuration)]
         public void Bug1432812SetAutoScaleMissingOnPoolPoolMgr()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "Bug1432812-" + TestUtilities.GetMyName();
@@ -480,7 +480,7 @@ namespace BatchClientIntegrationTests
                 {
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -490,7 +490,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1432819UpdateImplOnCloudPool()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "Bug1432819-" + TestUtilities.GetMyName();
@@ -520,7 +520,7 @@ namespace BatchClientIntegrationTests
                     // cleanup
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -530,7 +530,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestListPoolUsageMetrics()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 // test via faking data
@@ -576,7 +576,7 @@ namespace BatchClientIntegrationTests
                 }
 
                 List<PoolUsageMetrics> list = batchCli.PoolOperations.ListPoolUsageMetrics(DateTime.Now - TimeSpan.FromDays(1)).ToList();
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -586,7 +586,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestPoolObjectResizeStopResize()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "TestPoolObjectResizeStopResize" + TestUtilities.GetMyName();
@@ -622,7 +622,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -632,7 +632,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongDuration)]
         public void TestPoolAutoscaleVerbs()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = TestUtilities.GenerateResourceId();
@@ -718,7 +718,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -728,7 +728,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task TestServerRejectsNonExistantVNetWithCorrectError()
         {
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "TestPoolVNet" + TestUtilities.GetMyName();
@@ -758,7 +758,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -768,7 +768,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestPoolCreatedWithUserAccountsSucceeds()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string poolId = "TestPoolCreatedWithUserAccounts" + TestUtilities.GetMyName();
@@ -804,7 +804,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -814,7 +814,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestPoolCreatedOSDiskSucceeds()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string poolId = nameof(TestPoolCreatedOSDiskSucceeds) + TestUtilities.GetMyName();
@@ -845,7 +845,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -855,7 +855,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestPoolCreatedDataDiskSucceeds()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string poolId = nameof(TestPoolCreatedDataDiskSucceeds) + TestUtilities.GetMyName();
@@ -891,7 +891,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -901,9 +901,9 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestPoolCreatedCustomImageExpectedError()
         {
-            Action test = () =>
+            void test()
             {
-                Func<Task<string>> tokenProvider = () => IntegrationTestCommon.GetAuthenticationTokenAsync("https://batch.core.windows.net/");
+                static Task<string> tokenProvider() => IntegrationTestCommon.GetAuthenticationTokenAsync("https://batch.core.windows.net/");
 
                 using var client = BatchClient.Open(new BatchTokenCredentials(TestCommon.Configuration.BatchAccountUrl, tokenProvider));
                 string poolId = "TestPoolCreatedWithCustomImage" + TestUtilities.GetMyName();
@@ -933,7 +933,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(client, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -947,7 +947,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task ResizePool_AcceptedByServer(int? targetDedicated, int? targetLowPriority)
         {
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string poolId = TestUtilities.GenerateResourceId();
@@ -978,7 +978,7 @@ namespace BatchClientIntegrationTests
                 {
                     await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
-            };
+            }
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
 
@@ -987,7 +987,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void PoolStateCount_IsReturnedFromServer()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 var nodeCounts = batchCli.PoolOperations.ListPoolNodeCounts();
@@ -1008,7 +1008,7 @@ namespace BatchClientIntegrationTests
 
                 var filteredNodeCounts = batchCli.PoolOperations.ListPoolNodeCounts(new ODATADetailLevel(filterClause: $"poolId eq '{poolId}'")).ToList();
                 Assert.Single(filteredNodeCounts);
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -1018,7 +1018,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void ListSupportedImages()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 var supportedImages = batchCli.PoolOperations.ListSupportedImages().ToList();
@@ -1035,7 +1035,7 @@ namespace BatchClientIntegrationTests
                     testOutputHelper.WriteLine("   sku: " + imageInfo.ImageReference.Sku);
                     testOutputHelper.WriteLine("   version: " + imageInfo.ImageReference.Version);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, timeout: TimeSpan.FromSeconds(60));
         }
@@ -1045,7 +1045,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task CreatePool_WithBlobFuseMountConfiguration()
         {
-            Func<Task> test = async () =>
+            static async Task test()
             {
                 using BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync().ConfigureAwait(false);
                 string poolId = TestUtilities.GenerateResourceId();
@@ -1089,7 +1089,7 @@ namespace BatchClientIntegrationTests
                 {
                     await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
-            };
+            }
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
 
@@ -1098,7 +1098,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestCreatePoolEncryptionEnabled()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string poolId = nameof(TestCreatePoolEncryptionEnabled) + TestUtilities.GetMyName();
@@ -1128,7 +1128,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -1255,7 +1255,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public void LongRunning_RemovePoolComputeNodesResizeTimeout_ResizeErrorsPopulated()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "Bug2251050_TestRemoveComputeNodesResizeTimeout_LR" + TestUtilities.GetMyName();
@@ -1332,7 +1332,7 @@ namespace BatchClientIntegrationTests
                     //Delete the job schedule
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -1358,7 +1358,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public void LongRunning_TestRemovePoolComputeNodes()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "TestRemovePoolComputeNodes_LongRunning" + TestUtilities.GetMyName();
@@ -1458,7 +1458,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     batchCli.PoolOperations.DeletePool(poolId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -1484,7 +1484,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public async Task LongRunning_LowPriorityComputeNodeAllocated_IsDedicatedFalse()
         {
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "TestLowPri_LongRunning" + TestUtilities.GetMyName();
@@ -1522,7 +1522,7 @@ namespace BatchClientIntegrationTests
                     //Delete the pool
                     await TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).ConfigureAwait(false);
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, LongTestTimeout);
         }
@@ -1544,7 +1544,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongLongDuration)]
         public void LongRunning_Bug1771277_1771278_RebootReimageComputeNode()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "LongRunning_Bug1771277_1771278_RebootReimageComputeNode" + TestUtilities.GetMyName();
@@ -1658,7 +1658,7 @@ namespace BatchClientIntegrationTests
                         Assert.False(DateTime.UtcNow > timeoutAfterThisTimeUtc, "Timed out waiting for compute nodes in pool to reach idle state");
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskIntegrationTests.cs
@@ -112,7 +112,7 @@
         {
             TimeSpan checkSubtasksStateTimeout = TimeSpan.FromMinutes(1);
 
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string jobId = "MultiInstance-" + TestUtilities.GetMyName();
@@ -196,7 +196,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -208,7 +208,7 @@
         {
             TimeSpan checkSubtasksStateTimeout = TimeSpan.FromMinutes(1);
 
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string jobId = "MPI-" + TestUtilities.GetMyName();
@@ -284,7 +284,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -308,7 +308,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1432830TaskEnvSettings()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1432830Job-" + TestUtilities.GetMyName();
@@ -399,7 +399,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -409,7 +409,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1432973TaskAffinityInfoMissing()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1432973Job-" + TestUtilities.GetMyName();
@@ -439,7 +439,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -449,7 +449,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1447214TaskMissingExeInfoStatsAndConstraints()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1447214Job-" + TestUtilities.GetMyName();
@@ -550,7 +550,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -560,7 +560,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1535329JobOperationsMissingAddTaskMethods()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 StagingStorageAccount stagingStorageAccount = TestUtilities.GetStorageCredentialsFromEnvironment();
@@ -620,7 +620,7 @@
                     // clean up
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -630,7 +630,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1611592ComputeNodeInfoMissingOnTask()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1611592Job-" + TestUtilities.GetMyName();
@@ -671,7 +671,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -681,7 +681,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestBoundTaskTerminateAndDelete()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = Microsoft.Azure.Batch.Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + "-TestBoundTaskTerminateAndDelete";
@@ -792,7 +792,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -802,7 +802,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void FailedTaskCanBeReactivated()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
@@ -845,7 +845,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -855,7 +855,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void DependencyActionIsRoundTripped()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
@@ -891,7 +891,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
 
@@ -900,7 +900,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void AccessScopeCanBeRoundTripped()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
@@ -931,7 +931,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -941,7 +941,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1432996GetTaskOnJobOperationsAndJob()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = null;
@@ -961,7 +961,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -971,7 +971,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TaskRunsOnSharedUserAccount()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = Constants.DefaultConveniencePrefix + TestUtilities.GetMyName() + Guid.NewGuid();
@@ -982,15 +982,15 @@
                     CloudJob job = batchCli.JobOperations.CreateJob(jobId, new PoolInformation() { PoolId = poolFixture.PoolId });
                     job.Commit();
 
-                    Func<string, string, CloudTask> createTask = (taskId, userName) =>
+                    static CloudTask createTask(string taskId, string userName)
                     {
-                            //The magic command below will succeed on an admin account but fail for a non-admin account
-                            CloudTask task = new CloudTask(taskId, "cmd /c net session >nul 2>&1")
+                        //The magic command below will succeed on an admin account but fail for a non-admin account
+                        CloudTask task = new CloudTask(taskId, "cmd /c net session >nul 2>&1")
                         {
                             UserIdentity = new UserIdentity(userName)
                         };
                         return task;
-                    };
+                    }
 
                     var adminTask = createTask(adminTaskId, PoolFixture.AdminUserAccountName);
                     var nonAdminTask = createTask(nonAdminTaskId, PoolFixture.NonAdminUserAccountName);
@@ -1011,7 +1011,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -1032,7 +1032,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void UpdateTask_TaskIsUpdatedAsExpected()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string taskId = "task1";
@@ -1105,7 +1105,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -1115,7 +1115,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void SetTaskConditionalHeaders()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 string jobId = "TaskConditionalHeaders-" + TestUtilities.GetMyName();
@@ -1170,7 +1170,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -1179,7 +1179,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongDuration)]
         public void AddTaskOnContainerPool_TaskIsExecuted()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string taskId = "t1";
@@ -1216,7 +1216,7 @@
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/CloudTaskLinuxIntegrationTests.cs
@@ -13,10 +13,8 @@ namespace BatchClientIntegrationTests
     using Microsoft.Azure.Batch.Integration.Tests.Infrastructure;
     using IntegrationTestUtilities;
     using Xunit;
-    using Xunit.Abstractions;
     using Microsoft.Azure.Batch.Integration.Tests.IntegrationTestUtilities;
     using Azure.Storage.Blobs;
-    using Azure.Storage.Blobs.Models;
     using System.Threading.Tasks;
 
     [Collection("SharedLinuxPoolCollection")]
@@ -35,7 +33,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task RunTaskAndUploadFiles_FilesAreSuccessfullyUploaded()
         {
-            Func<Task> test = async () =>
+            async Task test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "RunTaskAndUploadFiles-" + TestUtilities.GetMyName();
@@ -83,17 +81,10 @@ namespace BatchClientIntegrationTests
                 }
                 finally
                 {
-                    try
-                    {
-                        await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).ConfigureAwait(false);
-                        containerClient.DeleteIfExists();
-                    }
-                    catch (Exception ex)
-                    {
-                        throw;
-                    }
+                    await TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).ConfigureAwait(false);
+                    containerClient.DeleteIfExists();
                 }
-            };
+            }
 
             await SynchronizationContextHelper.RunTestAsync(test, TestTimeout);
         }
@@ -103,7 +94,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.LongDuration)]
         public void TestContainerTask()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "ContainerJob" + TestUtilities.GetMyName();
@@ -136,7 +127,7 @@ namespace BatchClientIntegrationTests
                 {
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TimeSpan.FromMinutes(10));
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ComputeNodeIntegrationTests.cs
@@ -19,7 +19,6 @@ using Xunit.Abstractions;
 using Protocol = Microsoft.Azure.Batch.Protocol;
 using Azure.Storage.Blobs;
 using Microsoft.Azure.Batch.Integration.Tests.IntegrationTestUtilities;
-using Azure.Storage.Blobs.Models;
 
 namespace BatchClientIntegrationTests
 {
@@ -44,7 +43,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void BugComputeNodeMissingStartTaskInfo_RunAfterPoolIsUsed()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
@@ -59,7 +58,7 @@ namespace BatchClientIntegrationTests
                     Assert.NotNull(sti);
                     Assert.True(StartTaskState.Running == sti.State || StartTaskState.Completed == sti.State);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -69,7 +68,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1771163TestGetComputeNode_RefreshComputeNode()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 PoolOperations poolOperations = batchCli.PoolOperations;
@@ -109,7 +108,7 @@ namespace BatchClientIntegrationTests
                 //Refresh again with increased detail level
                 computeNodeToGet.Refresh();
                 CompareComputeNodeObjects(computeNodeToGet, computeNodeFromManager);
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -119,7 +118,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug2302907_TestComputeNodeDoesInheritBehaviors()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment(), addDefaultRetryPolicy: false);
                 Protocol.RequestInterceptor interceptor = new Protocol.RequestInterceptor();
@@ -131,7 +130,7 @@ namespace BatchClientIntegrationTests
 
                 Assert.Equal(2, computeNode.CustomBehaviors.Count);
                 Assert.Contains(interceptor, computeNode.CustomBehaviors);
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -141,7 +140,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug2329884_ComputeNodeRecentTasksAndComputeNodeError()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug2329884Job-" + TestUtilities.GetMyName();
@@ -227,36 +226,42 @@ namespace BatchClientIntegrationTests
                                 List<Protocol.Models.ComputeNodeError> errors =
                                     new List<Protocol.Models.ComputeNodeError>();
 
-                                    //Generate first Compute Node Error
-                                    List<Protocol.Models.NameValuePair> nvps = new List<Protocol.Models.NameValuePair>
+                                //Generate first Compute Node Error
+                                List<Protocol.Models.NameValuePair> nvps = new List<Protocol.Models.NameValuePair>
                                 {
                                         new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
                                 };
 
-                                Protocol.Models.ComputeNodeError error1 = new Protocol.Models.ComputeNodeError();
-                                error1.Code = expectedErrorCode;
-                                error1.Message = expectedErrorMessage;
-                                error1.ErrorDetails = nvps;
+                                Protocol.Models.ComputeNodeError error1 = new Protocol.Models.ComputeNodeError
+                                {
+                                    Code = expectedErrorCode,
+                                    Message = expectedErrorMessage,
+                                    ErrorDetails = nvps
+                                };
 
                                 errors.Add(error1);
 
-                                    //Generate second Compute Node Error
-                                    nvps = new List<Protocol.Models.NameValuePair>
+                                //Generate second Compute Node Error
+                                nvps = new List<Protocol.Models.NameValuePair>
                                 {
-                                        new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
+                                    new Protocol.Models.NameValuePair() { Name = nvpValue, Value = nvpValue }
                                 };
 
-                                Protocol.Models.ComputeNodeError error2 = new Protocol.Models.ComputeNodeError();
-                                error2.Code = expectedErrorCode;
-                                error2.Message = expectedErrorMessage;
-                                error2.ErrorDetails = nvps;
+                                Protocol.Models.ComputeNodeError error2 = new Protocol.Models.ComputeNodeError
+                                {
+                                    Code = expectedErrorCode,
+                                    Message = expectedErrorMessage,
+                                    ErrorDetails = nvps
+                                };
 
                                 errors.Add(error2);
 
-                                Protocol.Models.ComputeNode protoComputeNode = new Protocol.Models.ComputeNode();
-                                protoComputeNode.Id = computeNodeId;
-                                protoComputeNode.State = Protocol.Models.ComputeNodeState.Idle;
-                                protoComputeNode.Errors = errors;
+                                Protocol.Models.ComputeNode protoComputeNode = new Protocol.Models.ComputeNode
+                                {
+                                    Id = computeNodeId,
+                                    State = Protocol.Models.ComputeNodeState.Idle,
+                                    Errors = errors
+                                };
 
                                 response.Body = protoComputeNode;
 
@@ -286,7 +291,7 @@ namespace BatchClientIntegrationTests
                 {
                     batchCli.JobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -296,7 +301,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1770933_1770935_1771164_AddUserCRUDAndGetRDP()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 // names to create/delete
@@ -476,7 +481,7 @@ namespace BatchClientIntegrationTests
                         Assert.True(hitException, "Should have hit exception on user: " + curName + ", compute node: " + computeNode.Id + ".");
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -486,7 +491,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug2342986_StartTaskMissingOnComputeNode()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 CloudPool pool = batchCli.PoolOperations.GetPool(poolFixture.PoolId);
@@ -560,7 +565,7 @@ namespace BatchClientIntegrationTests
                         TestUtilities.AssertThrows<InvalidOperationException>(() => { computeNode.StartTask.ResourceFiles.Add(ResourceFile.FromUrl("test", "test")); });
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -719,7 +724,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestComputeNodeUserIaas()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 CloudPool sharedPool = poolFixture.Pool;
@@ -767,7 +772,7 @@ namespace BatchClientIntegrationTests
                         testOutputHelper.WriteLine("TestComputeNodeUserIAAS: exception deleting user account.  ex: " + ex.ToString());
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -777,7 +782,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public async Task ComputeNodeUploadLogs()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
                 const string containerName = "computenodelogscontainer";
@@ -826,7 +831,7 @@ namespace BatchClientIntegrationTests
                 {
                     containerClient.DeleteIfExists();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -836,7 +841,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestGetRemoteLoginSettings()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 CloudPool sharedPool = poolFixture.Pool;
@@ -872,7 +877,7 @@ namespace BatchClientIntegrationTests
                 {
                     // cleanup goes here
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/EndToEndIntegrationTests.cs
@@ -44,7 +44,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestSampleWithFilesAndPool()
         {
-            Action test = () =>
+            void test()
             {
                 StagingStorageAccount storageCreds = TestUtilities.GetStorageCredentialsFromEnvironment();
 
@@ -166,7 +166,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -176,11 +176,11 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void HelloWorld()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 TestUtilities.HelloWorld(batchCli, testOutputHelper, poolFixture.Pool, out string job, out string task);
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -220,7 +220,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1965363_2384616_Wat7OSVersionFeatures()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 PoolOperations poolOperations = batchCli.PoolOperations;
@@ -264,7 +264,7 @@
 
                     throw;
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -274,7 +274,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1771070_1771072_JobAndPoolLifetimeStats()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 JobStatistics jobStatistics = batchCli.JobOperations.GetAllLifetimeStatistics();
@@ -295,7 +295,7 @@
                 testOutputHelper.WriteLine("PoolStatistics.LastUpdateTime: {0}", poolStatistics.LastUpdateTime);
                 testOutputHelper.WriteLine("PoolStatistics.ResourceStatistics.AvgMemory: {0}", poolStatistics.ResourceStatistics.AverageMemoryGiB);
                 testOutputHelper.WriteLine("PoolStatistics.UsageStatistics.DedicatedCoreTime: {0}", poolStatistics.UsageStatistics.DedicatedCoreTime);
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -305,22 +305,22 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void ReadClientRequestIdAndRequestIdFromResponse()
         {
-            Action test = () =>
-                {
-                    using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
-                    string requestId = null;
-                    //Set up an interceptor to read RequestId from all responses
-                    ResponseInterceptor responseInterceptor = new ResponseInterceptor(
-                        (response, request) =>
-                            {
-                                requestId = response.RequestId;
-                                return Task.FromResult(response);
-                            });
+            void test()
+            {
+                using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
+                string requestId = null;
+                //Set up an interceptor to read RequestId from all responses
+                ResponseInterceptor responseInterceptor = new ResponseInterceptor(
+                    (response, request) =>
+                        {
+                            requestId = response.RequestId;
+                            return Task.FromResult(response);
+                        });
 
-                    batchCli.PoolOperations.ListPools(additionalBehaviors: new[] { responseInterceptor }).ToList(); //Force an enumeration to go to the server
+                batchCli.PoolOperations.ListPools(additionalBehaviors: new[] { responseInterceptor }).ToList(); //Force an enumeration to go to the server
 
-                    Assert.NotNull(requestId);
-                };
+                Assert.NotNull(requestId);
+            }
 
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
@@ -331,7 +331,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void ReadClientRequestIdAndRequestIdFromException()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 Guid myClientRequestid = Guid.NewGuid();
@@ -358,7 +358,7 @@
                 Assert.Equal(myClientRequestid, batchException.RequestInformation.ClientRequestId);
                 Assert.NotNull(batchException.RequestInformation.ServiceRequestId);
                 Assert.Equal("The specified job does not exist.", batchException.RequestInformation.HttpStatusMessage);
-            };
+            }
 
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/IaasLinuxPoolFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/IaasLinuxPoolFixture.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests.Fixtures
+namespace BatchClientIntegrationTests.Fixtures
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using IntegrationTestUtilities;
@@ -21,7 +20,7 @@
         {
             List<ImageInformation> imageInformation = client.PoolOperations.ListSupportedImages().ToList();
 
-            Func<ImageInformation, bool> ubuntuImageScanner = imageInfo =>
+            static bool ubuntuImageScanner(ImageInformation imageInfo) =>
                 imageInfo.ImageReference.Publisher == "canonical" &&
                 imageInfo.ImageReference.Offer == "ubuntuserver" &&
                 imageInfo.ImageReference.Sku.Contains("16.04");

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PaasWindowsPoolFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PaasWindowsPoolFixture.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests.Fixtures
+namespace BatchClientIntegrationTests.Fixtures
 {
     using System.Collections.Generic;
-    using BatchTestCommon;
     using IntegrationTestUtilities;
     using Microsoft.Azure.Batch;
     using Microsoft.Azure.Batch.Common;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PoolFixture.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/Fixtures/PoolFixture.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests.Fixtures
+namespace BatchClientIntegrationTests.Fixtures
 {
     using System;
     using System.Collections.Generic;
@@ -10,8 +10,6 @@
     using Microsoft.Azure.Batch;
     using Microsoft.Azure.Batch.Common;
     using IntegrationTestUtilities;
-    using Xunit;
-    using Xunit.Abstractions;
 
     public abstract class PoolFixture : IDisposable
     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/InboundEndpointIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/InboundEndpointIntegrationTests.cs
@@ -30,7 +30,7 @@ namespace BatchClientIntegrationTests
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void WhenPoolCreatedWithInboundEndpoints_EndpointsAreReturnedByPoolAndComputeNodes()
         {
-            Action test = () =>
+            static void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string poolId = "InboundEndpoints-" + TestUtilities.GetMyName();
@@ -59,7 +59,7 @@ namespace BatchClientIntegrationTests
                 {
                     TestUtilities.DeletePoolIfExistsAsync(batchCli, poolId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/BlobUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/BlobUtilities.cs
@@ -5,7 +5,6 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using BatchClientIntegrationTests.IntegrationTestUtilities;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Azure.Batch.Integration.Tests.IntegrationTestUtilities

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/FileUploadUtilities.cs
@@ -4,7 +4,6 @@
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using Microsoft.Azure.Batch;
 using Microsoft.Azure.Batch.FileStaging;
@@ -294,8 +293,7 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
             };
 
             sasBuilder.SetPermissions(permissions);
-            BlobUriBuilder builder = new BlobUriBuilder(containerClient.Uri);
-            builder.Sas = sasBuilder.ToSasQueryParameters(shardKeyCredentials);
+            BlobUriBuilder builder = new BlobUriBuilder(containerClient.Uri) { Sas = sasBuilder.ToSasQueryParameters(shardKeyCredentials) };
             string fullSas = builder.ToString();
             return fullSas;
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/TestUtilities.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/IntegrationTestUtilities/TestUtilities.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿
+
 namespace BatchClientIntegrationTests.IntegrationTestUtilities
 {
     using BatchTestCommon;
@@ -18,7 +18,6 @@ namespace BatchClientIntegrationTests.IntegrationTestUtilities
     using Microsoft.Azure.Batch;
     using Microsoft.Azure.Batch.Auth;
     using Microsoft.Azure.Batch.Common;
-    using Newtonsoft.Json;
     using Xunit;
     using Xunit.Abstractions;
     using Xunit.Sdk;

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/JobPrepReleaseIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/JobPrepReleaseIntegrationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests
+namespace BatchClientIntegrationTests
 {
     using System;
     using System.Collections.Generic;
@@ -16,7 +16,6 @@
     using Microsoft.Azure.Batch.Common;
     using Microsoft.Azure.Batch.FileStaging;
     using Microsoft.Azure.Batch.Integration.Tests.Infrastructure;
-    using Microsoft.Rest;
     using TestResources;
     using IntegrationTestUtilities;
     using Microsoft.Rest.Azure;
@@ -64,7 +63,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestOMJobSpecAndRelease()
         {
-            Action test = () =>
+            void test()
             {
                 StagingStorageAccount stagingCreds = TestUtilities.GetStorageCredentialsFromEnvironment();
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
@@ -104,8 +103,10 @@
                             JobPreparationTask prep = new JobPreparationTask(JobPrepCommandLine);
                             unboundJobSchedule.JobSpecification.JobPreparationTask = prep;
 
-                            List<EnvironmentSetting> prepEnvSettings = new List<EnvironmentSetting>();
-                            prepEnvSettings.Add(JobPrepEnvSettingOM);
+                            List<EnvironmentSetting> prepEnvSettings = new List<EnvironmentSetting>
+                            {
+                                JobPrepEnvSettingOM
+                            };
                             prep.EnvironmentSettings = prepEnvSettings;
 
                             prep.Id = JobPrepId;
@@ -133,8 +134,10 @@
                             JobReleaseTask relTask = new JobReleaseTask(JobReleaseTaskCommandLine);
                             unboundJobSchedule.JobSpecification.JobReleaseTask = relTask;
 
-                            List<EnvironmentSetting> relEnvSettings = new List<EnvironmentSetting>();
-                            relEnvSettings.Add(JobRelEnvSettingOM);
+                            List<EnvironmentSetting> relEnvSettings = new List<EnvironmentSetting>
+                            {
+                                JobRelEnvSettingOM
+                            };
                             relTask.EnvironmentSettings = relEnvSettings;
 
                             relTask.MaxWallClockTime = JobRelMaxWallClockTime;
@@ -157,9 +160,10 @@
 
                         // set JobCommonEnvSettings
                         {
-                            List<EnvironmentSetting> jobCommonES = new List<EnvironmentSetting>();
-
-                            jobCommonES.Add(JobCommonEnvSettingOM);
+                            List<EnvironmentSetting> jobCommonES = new List<EnvironmentSetting>
+                            {
+                                JobCommonEnvSettingOM
+                            };
 
                             unboundJobSchedule.JobSpecification.CommonEnvironmentSettings = jobCommonES;
                         }
@@ -235,7 +239,7 @@
                     TestUtilities.DeleteJobScheduleIfExistsAsync(client, jsId).Wait();
                 }
 
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -249,7 +253,7 @@
         public void TestOMJobPrepReleaseRunOnNaiveComputeNode()
         {
             string jobId = "TestOMJobPrepReleaseRunOnNaiveComputeNode-" + TestUtilities.GetMyName();
-            Action test = () =>
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 try
@@ -298,7 +302,7 @@
                     // cleanup
                     TestUtilities.DeleteJobIfExistsAsync(client, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -310,7 +314,7 @@
         {
             string jobId = "TestOMJobPrepSchedulingError-" + CraftTimeString() + "-" + TestUtilities.GetMyName();
 
-            Action test = () =>
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 try
@@ -381,7 +385,7 @@
                     // cleanup
                     client.JobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -392,7 +396,7 @@
         public void TestOMJobReleaseSchedulingError()
         {
             string jobId = "TestOMJobReleaseSchedulingError-" + CraftTimeString() + "-" + TestUtilities.GetMyName();
-            Action test = () =>
+            void test()
             {
                 using BatchClient client = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 try
@@ -502,7 +506,7 @@
                 {
                     client.JobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, LongTestTimeout);
         }
@@ -817,8 +821,10 @@
             FileToStage wordsDotText = new FileToStage(Resources.LocalWordsDotText, stagingCreds);                // use "default" mapping to base name of local file
 
             // add in the files to stage
-            myTask.FilesToStage = new List<IFileStagingProvider>();
-            myTask.FilesToStage.Add(wordsDotText);
+            myTask.FilesToStage = new List<IFileStagingProvider>
+            {
+                wordsDotText
+            };
 
             // trigger file staging
             myTask.StageFiles();

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/NodeFileIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/NodeFileIntegrationTests.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests
+namespace BatchClientIntegrationTests
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Text;
     using BatchTestCommon;
     using Fixtures;
     using Microsoft.Azure.Batch;
@@ -35,7 +34,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1480489NodeFileMissingIsDirectory()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1480489Job-" + TestUtilities.GetMyName();
@@ -97,7 +96,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -107,7 +106,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug230385SupportDeleteNodeFileByTask()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug230285Job-" + TestUtilities.GetMyName();
@@ -193,7 +192,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -203,7 +202,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestNode_GetListDeleteFiles()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "TestNodeGetListDeleteFiles-" + TestUtilities.GetMyName();
@@ -389,7 +388,7 @@
                 {
                     batchCli.JobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -399,7 +398,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug2338301_CheckStreamPositionAfterFileRead()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 JobOperations jobOperations = batchCli.JobOperations;
@@ -448,7 +447,7 @@
                         jobOperations.DeleteJob(jobId);
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -458,7 +457,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1480491NodeFileFileProperties()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1480491Job-" + TestUtilities.GetMyName();
@@ -540,7 +539,7 @@
                 {
                     batchCli.JobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -550,7 +549,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void TestGetNodeFileByTask()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 JobOperations jobOperations = batchCli.JobOperations;
@@ -616,7 +615,7 @@
                 {
                     jobOperations.DeleteJob(jobId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -669,21 +668,19 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestFilePropertiesFileMode()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = null;
                 try
                 {
-                    string taskId;
-
                     // create some files on the node
                     TestUtilities.HelloWorld(
                         batchCli,
                         testOutputHelper,
                         poolFixture.Pool,
                         out jobId,
-                        out taskId,
+                        out string taskId,
                         deleteJob: false,
                         isLinux: true);
 
@@ -712,7 +709,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests
+namespace BatchClientIntegrationTests
 {
     using System;
     using System.Collections.Generic;
@@ -15,7 +15,6 @@
     using IntegrationTestUtilities;
     using Microsoft.Azure.Batch.Integration.Tests.Infrastructure;
     using Microsoft.Azure.Batch.Protocol.BatchRequests;
-    using Microsoft.Rest.Azure;
     using Newtonsoft.Json;
     using Xunit;
     using Xunit.Abstractions;
@@ -39,7 +38,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug957878SkipTokenSupportMissing()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 int numTasksCreated = 0;
@@ -95,7 +94,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -105,7 +104,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1568799IEnumerableAsyncCannotBeIteratedAgain()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string jobId = "Bug1568799Job-" + TestUtilities.GetMyName();
@@ -133,7 +132,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -143,7 +142,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1719609ODATADetailLevel()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 // pools tested in Bug1770942ExposeBatchRequestProperties
@@ -454,7 +453,7 @@
                 {
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, jobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -464,7 +463,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1996130_ResourceDoubleRefreshDoesntWork()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string testName = "Bug1996130_ResourceDoubleRefreshDoesntWork";
@@ -563,7 +562,7 @@
                 {
                     batchCli.JobScheduleOperations.DeleteJobSchedule(jobScheduleId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -573,7 +572,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void CommitFollowedByRefreshTest()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string testName = "PostCommitInvalidPropRouterTests";
@@ -608,7 +607,7 @@
                 {
                     TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -618,7 +617,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1959324TestCustomBehaviorWorksOnLists()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 string bug1959324JobId = null;
@@ -674,19 +673,19 @@
                     // this yield injector will mung the func to make a get job call
                     // with real arguments.  the call made in the test has arguments that
                     // would fail/throw.
-                    Protocol.BatchRequestModificationInterceptHandler yieldInjectionInterceptor = baseRequest =>
+                    void yieldInjectionInterceptor(Protocol.IBatchRequest baseRequest)
                     {
                         testOutputHelper.WriteLine("Yield Injector!");
 
                         var request =
                             (JobGetBatchRequest)baseRequest;
 
-                            // replace the func with one that actually will work
-                            request.ServiceRequestFunc = (token) => { return request.RestClient.Job.GetWithHttpMessagesAsync(bug1959324JobId, request.Options, cancellationToken: token); };
+                        // replace the func with one that actually will work
+                        request.ServiceRequestFunc = (token) => { return request.RestClient.Job.GetWithHttpMessagesAsync(bug1959324JobId, request.Options, cancellationToken: token); };
 
-                            // the func has been replaced with one that will work.. and the caller will get a real job
-                            testOutputHelper.WriteLine("Leaving Yield Injector!");
-                    };
+                        // the func has been replaced with one that will work.. and the caller will get a real job
+                        testOutputHelper.WriteLine("Leaving Yield Injector!");
+                    }
 
                     CloudJob boundJob = batchCli.JobOperations.GetJob(
                                         "test value that can't possibly be found as a job id",
@@ -703,7 +702,7 @@
                     // cleanup
                     TestUtilities.DeleteJobIfExistsAsync(batchCli, bug1959324JobId).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -713,7 +712,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void Bug1910530_ConcurrentChangeTrackedList()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string testName = "Bug1910530_ConcurrentChangeTrackedList";
@@ -932,7 +931,7 @@
                         TestUtilities.DeleteJobScheduleIfExistsAsync(batchCli, jobScheduleId).Wait();
                     }
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -942,7 +941,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.ShortDuration)]
         public void TestDisplayNameMutability()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 const string testName = "TestDisplayNameMutability";
@@ -1111,7 +1110,7 @@
                     testOutputHelper.WriteLine("Deleting pool {0}", poolId);
                     batchCli.PoolOperations.DeletePool(poolId);
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }
@@ -1181,7 +1180,7 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
         public void Bug1770942ExposeBatchRequestProperties()
         {
-            Action test = () =>
+            void test()
             {
                 using BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment());
                 List<string> poolIdsToCreate = new List<string>();
@@ -1347,7 +1346,7 @@
 
                     Task.WhenAll(deletePoolTasks).Wait();
                 }
-            };
+            }
 
             SynchronizationContextHelper.RunTest(test, TestTimeout);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/ObjectModelFeatureIntegrationTests.cs
@@ -19,6 +19,7 @@ namespace BatchClientIntegrationTests
     using Xunit;
     using Xunit.Abstractions;
     using Protocol = Microsoft.Azure.Batch.Protocol;
+    using System.Threading;
 
     [Collection("SharedPoolCollection")]
     public class ObjectModelFeatureIntegrationTests
@@ -1178,6 +1179,7 @@ namespace BatchClientIntegrationTests
         [Fact]
         [LiveTest]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.MediumDuration)]
+        [Trait("Flaky", "true")]
         public void Bug1770942ExposeBatchRequestProperties()
         {
             void test()
@@ -1306,6 +1308,7 @@ namespace BatchClientIntegrationTests
                         // we have the matching instance with full props from list-all, and selected props from list+DetailLevel
                         // now test poolMgr.GetPool + detailLevel
 
+                        Thread.Sleep(10000); // TODO: Remove this band-aid. It's just to give the operation more time before the following line, but this is a bad, flaky solution.
                         CloudPool lowerDetailLevel = batchCli.PoolOperations.GetPool(matchingPoolWithFullDetailLevel.Id, new ODATADetailLevel() { SelectClause = "id,state" });
 
                         // confirm that allocation state was not read in

--- a/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/TestResources/Resources.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/IntegrationTests/TestResources/Resources.cs
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-﻿namespace BatchClientIntegrationTests.TestResources
+namespace BatchClientIntegrationTests.TestResources
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-
     public class Resources
     {
         public const string LocalWordsDotText = @"TestResources\localWords.txt";

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ApplicationPackageUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ApplicationPackageUnitTests.cs
@@ -156,12 +156,12 @@ namespace Azure.Batch.Unit.Tests
             var requests = new List<Uri>();
             var results = new List<Microsoft.Azure.Batch.ApplicationSummary>();
 
-            Func<Uri, string> responseBody = uri =>
+            string responseBody(Uri uri)
             {
                 requests.Add(uri);
 
                 return fakeResponse;
-            };
+            }
 
             using (BatchClient client = BatchClient.Open(FakeClient.Create(HttpStatusCode.OK, responseBody)))
             {
@@ -204,17 +204,17 @@ namespace Azure.Batch.Unit.Tests
             var requests = new List<Uri>();
             var results = new List<Microsoft.Azure.Batch.ApplicationSummary>();
 
-            Func<Uri, string> responseBody = uri =>
-                {
-                    requests.Add(uri);
+            string responseBody(Uri uri)
+            {
+                requests.Add(uri);
 
-                    return uri.AbsoluteUri switch
-                    {
-                        "http://skip1/" => fakeResponse2,
-                        "http://skip2/" => fakeResponse3,
-                        _ => fakeResponse1,
-                    };
+                return uri.AbsoluteUri switch
+                {
+                    "http://skip1/" => fakeResponse2,
+                    "http://skip2/" => fakeResponse3,
+                    _ => fakeResponse1,
                 };
+            }
 
             using (BatchClient client = BatchClient.Open(FakeClient.Create(HttpStatusCode.OK, responseBody)))
             {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BatchRequestUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/BatchRequestUnitTests.cs
@@ -522,44 +522,44 @@
 
         private static async Task InvokeCancellationTokenMethodAsync(MethodInfo method, object objectInstance, CancellationToken cancellationToken)
         {
-            Func<ParameterInfo, object> objectCreationFunc = (parameter) =>
+            object objectCreationFunc(ParameterInfo parameter)
+            {
+                object result;
+
+                if (parameter.ParameterType == typeof(CancellationToken))
                 {
-                    object result;
+                    result = cancellationToken;
+                }
+                else if (parameter.ParameterType.GetTypeInfo().IsValueType)
+                {
+                    result = Activator.CreateInstance(parameter.ParameterType);
+                }
+                //The below list is a list of types which are null-checked in some methods and so must not be null
+                //This is a bit of a hack but it's the easiest way currecntly...
+                else if (parameter.ParameterType == typeof(CloudTask))
+                {
+                    result = new CloudTask("bar", "baz");
+                }
+                else if (parameter.Name == "computeNodeIds")
+                {
+                    result = new List<string>();
+                }
+                else if (parameter.Name == "computeNodes")
+                {
+                    result = new List<ComputeNode>();
+                }
+                else if (parameter.Name == "rdpFileNameToCreate")
+                {
+                    result = "temp";
+                }
+                //Default to null if there is no special handling required
+                else
+                {
+                    result = null;
+                }
 
-                    if (parameter.ParameterType == typeof (CancellationToken))
-                    {
-                        result = cancellationToken;
-                    }
-                    else if (parameter.ParameterType.GetTypeInfo().IsValueType)
-                    {
-                        result = Activator.CreateInstance(parameter.ParameterType);
-                    }
-                    //The below list is a list of types which are null-checked in some methods and so must not be null
-                    //This is a bit of a hack but it's the easiest way currecntly...
-                    else if (parameter.ParameterType == typeof (CloudTask))
-                    {
-                        result = new CloudTask("bar", "baz");
-                    }
-                    else if (parameter.Name == "computeNodeIds")
-                    {
-                        result = new List<string>();
-                    }
-                    else if (parameter.Name == "computeNodes")
-                    {
-                        result = new List<ComputeNode>();
-                    }
-                    else if (parameter.Name == "rdpFileNameToCreate")
-                    {
-                        result = "temp";
-                    }
-                    //Default to null if there is no special handling required
-                    else
-                    {
-                        result = null;
-                    }
-
-                    return result;
-                };
+                return result;
+            }
 
             await (Task)ReflectionHelpers.InvokeMethodWithDefaultArguments(method, objectInstance, objectCreationFunc);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ConcurrentChangeTrackedListUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ConcurrentChangeTrackedListUnitTests.cs
@@ -42,13 +42,13 @@
             unboundJobSchedule.Metadata = new List<MetadataItem>();
 
             //Now it should be magically threadsafe
-            Action addAction = () =>
+            void addAction()
             {
                 this.testOutputHelper.WriteLine("Adding an item");
                 unboundJobSchedule.Metadata.Add(new MetadataItem("test", "test"));
-            };
+            }
 
-            Action removeAction = () =>
+            void removeAction()
             {
                 this.testOutputHelper.WriteLine("Removing an item");
                 try
@@ -58,7 +58,7 @@
                 catch (ArgumentOutOfRangeException)
                 {
                 }
-            };
+            }
 
             Random rand = new Random();
             object randLock = new object();
@@ -116,9 +116,10 @@
         public void ConcurrentChangeTrackedSimpleTypeListReadOnly()
         {
             const string item1 = "Foo";
-            var list = new ConcurrentChangeTrackedList<string>();
-
-            list.IsReadOnly = true;
+            var list = new ConcurrentChangeTrackedList<string>
+            {
+                IsReadOnly = true
+            };
             Assert.Throws<InvalidOperationException>(() => list.Add(item1));
             Assert.False(list.HasBeenModified);
         }
@@ -134,9 +135,10 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void ConcurrentChangeTrackedComplexTypeListReadOnly()
         {
-            var list = new ConcurrentChangeTrackedModifiableList<DummyComplexType>(new List<DummyComplexType> { new DummyComplexType() });
-
-            list.IsReadOnly = true;
+            var list = new ConcurrentChangeTrackedModifiableList<DummyComplexType>(new List<DummyComplexType> { new DummyComplexType() })
+            {
+                IsReadOnly = true
+            };
             Assert.Throws<InvalidOperationException>(() => list.Add(new DummyComplexType()));
             Assert.False(list.HasBeenModified);
             Assert.True(list.First().IsReadOnly);
@@ -146,9 +148,10 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void ConcurrentChangeTrackedComplexTypeListReadOnlyWithNull()
         {
-            var list = new ConcurrentChangeTrackedModifiableList<DummyComplexType>(new List<DummyComplexType> { null });
-
-            list.IsReadOnly = true;
+            var list = new ConcurrentChangeTrackedModifiableList<DummyComplexType>(new List<DummyComplexType> { null })
+            {
+                IsReadOnly = true
+            };
             Assert.Throws<InvalidOperationException>(() => list.Add(new DummyComplexType()));
         }
 
@@ -156,9 +159,10 @@
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public void ConcurrentChangeTrackedComplexTypeListHasBeenModifiedWithNull()
         {
-            var list = new ConcurrentChangeTrackedModifiableList<DummyComplexType>(new List<DummyComplexType> { null });
-
-            list.Add(null);
+            var list = new ConcurrentChangeTrackedModifiableList<DummyComplexType>(new List<DummyComplexType> { null })
+            {
+                null
+            };
             Assert.True(list.HasBeenModified);
         }
         

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/GetFileRequestByteRangeTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/GetFileRequestByteRangeTests.cs
@@ -18,15 +18,6 @@ namespace Azure.Batch.Unit.Tests
 
     public class GetFileRequestByteRangeTests
     {
-        private ITestOutputHelper testOutputHelper;
-        private const int DefaultServerTimeoutInSeconds = 30;
-        private static readonly TimeSpan DefaultClientTimeout = TimeSpan.FromSeconds(60);
-
-        public GetFileRequestByteRangeTests(ITestOutputHelper testOutputHelper)
-        {
-            this.testOutputHelper = testOutputHelper;
-        }
-
         [Fact]
         [Trait(TestTraits.Duration.TraitName, TestTraits.Duration.Values.VeryShortDuration)]
         public async Task WhenGettingTaskFileUsingReadAsString_OcpRangeHeaderIsSet()
@@ -145,8 +136,7 @@ namespace Azure.Batch.Unit.Tests
         {
             return new Protocol.RequestInterceptor(request =>
             {
-                TRequest getFileRequest = request as TRequest;
-                if (getFileRequest != null)
+                if (request is TRequest getFileRequest)
                 {
                     getFileRequest.ServiceRequestFunc = t =>
                     {
@@ -172,8 +162,7 @@ namespace Azure.Batch.Unit.Tests
         {
             return new Protocol.RequestInterceptor(request =>
             {
-                TRequest getFilePropertiesRequest = request as TRequest;
-                if (getFilePropertiesRequest != null)
+                if (request is TRequest getFilePropertiesRequest)
                 {
                     getFilePropertiesRequest.ServiceRequestFunc = t =>
                     {

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ODataUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/ODataUnitTests.cs
@@ -176,37 +176,34 @@
             where TListOptions : Protocol.Models.IOptions, new()
             where TListNextOptions : Protocol.Models.IOptions, new()
         {
-            var listRequest = req as Protocol.BatchRequest<TListOptions, AzureOperationResponse<IPage<TPage>, THeaders>>;
-            var listNextRequest = req as Protocol.BatchRequest<TListNextOptions, AzureOperationResponse<IPage<TPage>, THeaders>>;
-
-            if (listRequest != null)
+            if (req is Protocol.BatchRequest<TListOptions, AzureOperationResponse<IPage<TPage>, THeaders>> listRequest)
             {
                 listRequest.ServiceRequestFunc = token =>
+                {
+                    var filter = listRequest.Options as Protocol.Models.IODataFilter;
+                    var select = listRequest.Options as Protocol.Models.IODataSelect;
+                    var expand = listRequest.Options as Protocol.Models.IODataExpand;
+
+                    Assert.Equal(expectedDetailLevel.FilterClause, filter?.Filter);
+                    Assert.Equal(expectedDetailLevel.SelectClause, select?.Select);
+                    Assert.Equal(expectedDetailLevel.ExpandClause, expand?.Expand);
+
+                    return Task.FromResult(new AzureOperationResponse<IPage<TPage>, THeaders>()
                     {
-                        var filter = listRequest.Options as Protocol.Models.IODataFilter;
-                        var select = listRequest.Options as Protocol.Models.IODataSelect;
-                        var expand = listRequest.Options as Protocol.Models.IODataExpand;
-
-                        Assert.Equal(expectedDetailLevel.FilterClause, filter?.Filter);
-                        Assert.Equal(expectedDetailLevel.SelectClause, select?.Select);
-                        Assert.Equal(expectedDetailLevel.ExpandClause, expand?.Expand);
-
-                        return Task.FromResult(new AzureOperationResponse<IPage<TPage>, THeaders>()
-                        {
-                            Body = new FakePage<TPage>(new List<TPage>(), "Bar")
-                        });
-                    };
+                        Body = new FakePage<TPage>(new List<TPage>(), "Bar")
+                    });
+                };
             }
 
-            if (listNextRequest != null)
+            if (req is Protocol.BatchRequest<TListNextOptions, AzureOperationResponse<IPage<TPage>, THeaders>> listNextRequest)
             {
                 listNextRequest.ServiceRequestFunc = token =>
+                {
+                    return Task.FromResult(new AzureOperationResponse<IPage<TPage>, THeaders>()
                     {
-                        return Task.FromResult(new AzureOperationResponse<IPage<TPage>, THeaders>()
-                        {
-                            Body = new FakePage<TPage>(new List<TPage>())
-                        });
-                    };
+                        Body = new FakePage<TPage>(new List<TPage>())
+                    });
+                };
             }
         }
     }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PatchUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PatchUnitTests.cs
@@ -36,11 +36,11 @@
             var protoJob = new Protocol.Models.CloudJob(
                 id: jobId);
 
-            Action<CloudJob> modificationFunction = job => job.PoolInformation = null;
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
+            void modificationFunction(CloudJob job) => job.PoolInformation = null;
+            void assertAction(Protocol.Models.JobPatchParameter patchParameters)
             {
                 Assert.False(true, "Should have failed PATCH validation before issuing the request");
-            };
+            }
 
             //This should throw because we set a property to null which is not supported by PATCH
             Assert.Throws<InvalidOperationException>(() => CommonPatchJobTest(protoJob, modificationFunction, assertAction));
@@ -54,12 +54,12 @@
             const string newPoolId = "Bar";
             var protoJob = new Protocol.Models.CloudJob(id: jobId);
 
-            Action<CloudJob> modificationFunction = job =>
+            static void modificationFunction(CloudJob job)
             {
                 job.PoolInformation = new PoolInformation() { PoolId = newPoolId };
-            };
+            }
 
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
+            static void assertAction(Protocol.Models.JobPatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.Priority);
                 Assert.Null(patchParameters.Constraints);
@@ -68,7 +68,7 @@
 
                 Assert.NotNull(patchParameters.PoolInfo);
                 Assert.Equal(newPoolId, patchParameters.PoolInfo.PoolId);
-            };
+            }
 
             CommonPatchJobTest(protoJob, modificationFunction, assertAction);
         }
@@ -83,13 +83,13 @@
             var newOnAllTasksCompleted = Protocol.Models.OnAllTasksComplete.TerminateJob;
 
 
-            Action<CloudJob> modificationFunction = job =>
+            void modificationFunction(CloudJob job)
             {
                 job.Priority = newPriority;
                 job.OnAllTasksComplete = (Microsoft.Azure.Batch.Common.OnAllTasksComplete?)newOnAllTasksCompleted;
-            };
+            }
 
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
+            void assertAction(Protocol.Models.JobPatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.Constraints);
                 Assert.Null(patchParameters.Metadata);
@@ -100,7 +100,7 @@
 
                 Assert.NotNull(patchParameters.OnAllTasksComplete);
                 Assert.Equal(newOnAllTasksCompleted, patchParameters.OnAllTasksComplete);
-            };
+            }
 
             CommonPatchJobTest(protoJob, modificationFunction, assertAction);
         }
@@ -118,21 +118,21 @@
                         new Protocol.Models.MetadataItem("Foo", "Bar")
                     });
 
-            Action<CloudJob> modificationFunction = job =>
-                {
-                    job.Metadata.Add(new MetadataItem("Baz", "Qux"));
-                };
+            static void modificationFunction(CloudJob job)
+            {
+                job.Metadata.Add(new MetadataItem("Baz", "Qux"));
+            }
 
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.Priority);
-                    Assert.Null(patchParameters.Constraints);
-                    Assert.Null(patchParameters.PoolInfo);
-                    Assert.Null(patchParameters.OnAllTasksComplete);
+            static void assertAction(Protocol.Models.JobPatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.Priority);
+                Assert.Null(patchParameters.Constraints);
+                Assert.Null(patchParameters.PoolInfo);
+                Assert.Null(patchParameters.OnAllTasksComplete);
 
-                    Assert.NotNull(patchParameters.Metadata);
-                    Assert.Equal(2, patchParameters.Metadata.Count);
-                };
+                Assert.NotNull(patchParameters.Metadata);
+                Assert.Equal(2, patchParameters.Metadata.Count);
+            }
 
             CommonPatchJobTest(protoJob, modificationFunction, assertAction);
         }
@@ -148,22 +148,22 @@
                 id: jobId,
                 constraints: new Protocol.Models.JobConstraints(maxWallClockTime: TimeSpan.FromSeconds(10)));
 
-            Action<CloudJob> modificationFunction = job =>
-                {
-                    job.Constraints.MaxWallClockTime = newMaxWallClock;
-                };
+            void modificationFunction(CloudJob job)
+            {
+                job.Constraints.MaxWallClockTime = newMaxWallClock;
+            }
 
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.Priority);
-                    Assert.Null(patchParameters.Metadata);
-                    Assert.Null(patchParameters.PoolInfo);
-                    Assert.Null(patchParameters.OnAllTasksComplete);
+            void assertAction(Protocol.Models.JobPatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.Priority);
+                Assert.Null(patchParameters.Metadata);
+                Assert.Null(patchParameters.PoolInfo);
+                Assert.Null(patchParameters.OnAllTasksComplete);
 
-                    Assert.NotNull(patchParameters.Constraints);
-                    Assert.Equal(newMaxWallClock, patchParameters.Constraints.MaxWallClockTime);
-                    Assert.Null(patchParameters.Constraints.MaxTaskRetryCount);
-                };
+                Assert.NotNull(patchParameters.Constraints);
+                Assert.Equal(newMaxWallClock, patchParameters.Constraints.MaxWallClockTime);
+                Assert.Null(patchParameters.Constraints.MaxTaskRetryCount);
+            }
 
             CommonPatchJobTest(protoJob, modificationFunction, assertAction);
         }
@@ -180,19 +180,19 @@
                 metadata: new List<Protocol.Models.MetadataItem>() { new Protocol.Models.MetadataItem() },
                 poolInfo: new Protocol.Models.PoolInformation(poolId: "Test"));
 
-            Action<CloudJob> modificationFunction = job =>
-                {
-                    //Do nothing
-                };
+            static void modificationFunction(CloudJob job)
+            {
+                //Do nothing
+            }
 
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.Priority);
-                    Assert.Null(patchParameters.Metadata);
-                    Assert.Null(patchParameters.PoolInfo);
-                    Assert.Null(patchParameters.OnAllTasksComplete);
-                    Assert.Null(patchParameters.Constraints);
-                };
+            static void assertAction(Protocol.Models.JobPatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.Priority);
+                Assert.Null(patchParameters.Metadata);
+                Assert.Null(patchParameters.PoolInfo);
+                Assert.Null(patchParameters.OnAllTasksComplete);
+                Assert.Null(patchParameters.Constraints);
+            }
 
             CommonPatchJobTest(protoJob, modificationFunction, assertAction);
         }
@@ -216,19 +216,19 @@
                                     new Protocol.Models.ApplicationPackageReference("a")
                                 }))));
 
-            Action<CloudJob> modificationFunction = job =>
-                {
-                    //Do nothing
-                };
+            static void modificationFunction(CloudJob job)
+            {
+                //Do nothing
+            }
 
-            Action<Protocol.Models.JobPatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.Priority);
-                    Assert.Null(patchParameters.Metadata);
-                    Assert.Null(patchParameters.PoolInfo);
-                    Assert.Null(patchParameters.OnAllTasksComplete);
-                    Assert.Null(patchParameters.Constraints);
-                };
+            static void assertAction(Protocol.Models.JobPatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.Priority);
+                Assert.Null(patchParameters.Metadata);
+                Assert.Null(patchParameters.PoolInfo);
+                Assert.Null(patchParameters.OnAllTasksComplete);
+                Assert.Null(patchParameters.Constraints);
+            }
 
             CommonPatchJobTest(protoJob, modificationFunction, assertAction);
         }
@@ -253,11 +253,11 @@
             const string poolId = "Foo";
             var protoPool = new Protocol.Models.CloudPool(id: poolId);
 
-            Action<CloudPool> modificationFunction = pool => pool.StartTask = null;
-            Action<Protocol.Models.PoolPatchParameter> assertAction = patchParameters =>
+            void modificationFunction(CloudPool pool) => pool.StartTask = null;
+            void assertAction(Protocol.Models.PoolPatchParameter patchParameters)
             {
                 Assert.False(true, "Should have failed PATCH validation before issuing the request");
-            };
+            }
 
             //This should throw because we set a property to null which is not supported by PATCH
             Assert.Throws<InvalidOperationException>(() => CommonPatchPoolTest(protoPool, modificationFunction, assertAction));
@@ -272,8 +272,8 @@
 
             var protoPool = new Protocol.Models.CloudPool(id: poolId);
 
-            Action<CloudPool> modificationFunction = pool => pool.StartTask = new StartTask(newCommandLine);
-            Action<Protocol.Models.PoolPatchParameter> assertAction = patchParameters =>
+            static void modificationFunction(CloudPool pool) => pool.StartTask = new StartTask(newCommandLine);
+            static void assertAction(Protocol.Models.PoolPatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.Metadata);
                 Assert.Null(patchParameters.ApplicationPackageReferences);
@@ -281,7 +281,7 @@
 
                 Assert.NotNull(patchParameters.StartTask);
                 Assert.Equal(newCommandLine, patchParameters.StartTask.CommandLine);
-            };
+            }
 
             CommonPatchPoolTest(protoPool, modificationFunction, assertAction);
         }
@@ -299,8 +299,8 @@
                         new Protocol.Models.MetadataItem("Foo", "Bar")
                     });
 
-            Action<CloudPool> modificationFunction = pool => pool.Metadata.Add(new MetadataItem("Baz", "Qux"));
-            Action<Protocol.Models.PoolPatchParameter> assertAction = patchParameters =>
+            static void modificationFunction(CloudPool pool) => pool.Metadata.Add(new MetadataItem("Baz", "Qux"));
+            static void assertAction(Protocol.Models.PoolPatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.StartTask);
                 Assert.Null(patchParameters.ApplicationPackageReferences);
@@ -308,7 +308,7 @@
 
                 Assert.NotNull(patchParameters.Metadata);
                 Assert.Equal(2, patchParameters.Metadata.Count);
-            };
+            }
 
             CommonPatchPoolTest(protoPool, modificationFunction, assertAction);
         }
@@ -322,8 +322,8 @@
 
             var protoPool = new Protocol.Models.CloudPool(id: poolId, startTask: new Protocol.Models.StartTask(commandLine: "Foo"));
 
-            Action<CloudPool> modificationFunction = pool => pool.StartTask.CommandLine = newCommandLine;
-            Action<Protocol.Models.PoolPatchParameter> assertAction = patchParameters =>
+            static void modificationFunction(CloudPool pool) => pool.StartTask.CommandLine = newCommandLine;
+            static void assertAction(Protocol.Models.PoolPatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.Metadata);
                 Assert.Null(patchParameters.ApplicationPackageReferences);
@@ -331,7 +331,7 @@
 
                 Assert.NotNull(patchParameters.StartTask);
                 Assert.Equal(newCommandLine, patchParameters.StartTask.CommandLine);
-            };
+            }
 
             CommonPatchPoolTest(protoPool, modificationFunction, assertAction);
         }
@@ -347,18 +347,18 @@
                 startTask: new Protocol.Models.StartTask(commandLine: "Foo"),
                 metadata: new List<Protocol.Models.MetadataItem>() { new Protocol.Models.MetadataItem() });
 
-            Action<CloudPool> modificationFunction = pool =>
-                {
-                    //Do nothing
-                };
+            static void modificationFunction(CloudPool pool)
+            {
+                //Do nothing
+            }
 
-            Action<Protocol.Models.PoolPatchParameter> assertAction = patchParameters =>
+            static void assertAction(Protocol.Models.PoolPatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.Metadata);
                 Assert.Null(patchParameters.ApplicationPackageReferences);
                 Assert.Null(patchParameters.CertificateReferences);
                 Assert.Null(patchParameters.StartTask);
-            };
+            }
 
             CommonPatchPoolTest(protoPool, modificationFunction, assertAction);
         }
@@ -378,18 +378,18 @@
                             new Protocol.Models.ResourceFile("sas", "filepath")
                         }));
 
-            Action<CloudPool> modificationFunction = pool =>
-                {
-                    //Do nothing
-                };
+            static void modificationFunction(CloudPool pool)
+            {
+                //Do nothing
+            }
 
-            Action<Protocol.Models.PoolPatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.Metadata);
-                    Assert.Null(patchParameters.ApplicationPackageReferences);
-                    Assert.Null(patchParameters.CertificateReferences);
-                    Assert.Null(patchParameters.StartTask);
-                };
+            static void assertAction(Protocol.Models.PoolPatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.Metadata);
+                Assert.Null(patchParameters.ApplicationPackageReferences);
+                Assert.Null(patchParameters.CertificateReferences);
+                Assert.Null(patchParameters.StartTask);
+            }
 
             CommonPatchPoolTest(protoPool, modificationFunction, assertAction);
         }
@@ -414,11 +414,11 @@
             const string jobScheduleId = "Foo";
             var protoJobSchedule = new Protocol.Models.CloudJobSchedule(id: jobScheduleId);
 
-            Action<CloudJobSchedule> modificationFunction = jobSchedule => jobSchedule.JobSpecification = null;
-            Action<Protocol.Models.JobSchedulePatchParameter> assertAction = patchParameters =>
+            void modificationFunction(CloudJobSchedule jobSchedule) => jobSchedule.JobSpecification = null;
+            void assertAction(Protocol.Models.JobSchedulePatchParameter patchParameters)
             {
                 Assert.False(true, "Should have failed PATCH validation before issuing the request");
-            };
+            }
 
             //This should throw because we set a property to null which is not supported by PATCH
             Assert.Throws<InvalidOperationException>(() => CommonPatchJobScheduleTest(protoJobSchedule, modificationFunction, assertAction));
@@ -433,15 +433,15 @@
 
             var protoJobSchedule = new Protocol.Models.CloudJobSchedule(id: jobScheduleId);
 
-            Action<CloudJobSchedule> modificationFunction = jobSchedule => jobSchedule.JobSpecification = new JobSpecification() { Priority = newPriority };
-            Action<Protocol.Models.JobSchedulePatchParameter> assertAction = patchParameters =>
+            static void modificationFunction(CloudJobSchedule jobSchedule) => jobSchedule.JobSpecification = new JobSpecification() { Priority = newPriority };
+            static void assertAction(Protocol.Models.JobSchedulePatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.Metadata);
                 Assert.Null(patchParameters.Schedule);
 
                 Assert.NotNull(patchParameters.JobSpecification);
                 Assert.Equal(newPriority, patchParameters.JobSpecification.Priority);
-            };
+            }
 
             CommonPatchJobScheduleTest(protoJobSchedule, modificationFunction, assertAction);
         }
@@ -459,15 +459,15 @@
                         new Protocol.Models.MetadataItem("Foo", "Bar")
                     });
 
-            Action<CloudJobSchedule> modificationFunction = jobSchedule => jobSchedule.Metadata.Add(new MetadataItem("Baz", "Qux"));
-            Action<Protocol.Models.JobSchedulePatchParameter> assertAction = patchParameters =>
+            static void modificationFunction(CloudJobSchedule jobSchedule) => jobSchedule.Metadata.Add(new MetadataItem("Baz", "Qux"));
+            static void assertAction(Protocol.Models.JobSchedulePatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.JobSpecification);
                 Assert.Null(patchParameters.Schedule);
 
                 Assert.NotNull(patchParameters.Metadata);
                 Assert.Equal(2, patchParameters.Metadata.Count);
-            };
+            }
 
             CommonPatchJobScheduleTest(protoJobSchedule, modificationFunction, assertAction);
         }
@@ -483,15 +483,15 @@
                 id: jobScheduleId,
                 schedule: new Protocol.Models.Schedule(startWindow: TimeSpan.FromSeconds(10)));
 
-            Action<CloudJobSchedule> modificationFunction = jobSchedule => jobSchedule.Schedule.StartWindow = newStartWindow;
-            Action<Protocol.Models.JobSchedulePatchParameter> assertAction = patchParameters =>
+            void modificationFunction(CloudJobSchedule jobSchedule) => jobSchedule.Schedule.StartWindow = newStartWindow;
+            void assertAction(Protocol.Models.JobSchedulePatchParameter patchParameters)
             {
                 Assert.Null(patchParameters.JobSpecification);
                 Assert.Null(patchParameters.Metadata);
 
                 Assert.NotNull(patchParameters.Schedule);
                 Assert.Equal(newStartWindow, patchParameters.Schedule.StartWindow);
-            };
+            }
 
             CommonPatchJobScheduleTest(protoJobSchedule, modificationFunction, assertAction);
         }
@@ -509,17 +509,17 @@
                 jobSpecification: new Protocol.Models.JobSpecification(
                     poolInfo: new Protocol.Models.PoolInformation(poolId: "Test")));
 
-            Action<CloudJobSchedule> modificationFunction = jobSchedule =>
-                {
-                    //Do nothing
-                };
+            static void modificationFunction(CloudJobSchedule jobSchedule)
+            {
+                //Do nothing
+            }
 
-            Action<Protocol.Models.JobSchedulePatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.JobSpecification);
-                    Assert.Null(patchParameters.Metadata);
-                    Assert.Null(patchParameters.Schedule);
-                };
+            static void assertAction(Protocol.Models.JobSchedulePatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.JobSpecification);
+                Assert.Null(patchParameters.Metadata);
+                Assert.Null(patchParameters.Schedule);
+            }
 
             CommonPatchJobScheduleTest(protoJobSchedule, modificationFunction, assertAction);
         }
@@ -544,17 +544,17 @@
                                     new Protocol.Models.ApplicationPackageReference("a")
                                 })))));
 
-            Action<CloudJobSchedule> modificationFunction = jobSchedule =>
-                {
-                    //Do nothing
-                };
+            static void modificationFunction(CloudJobSchedule jobSchedule)
+            {
+                //Do nothing
+            }
 
-            Action<Protocol.Models.JobSchedulePatchParameter> assertAction = patchParameters =>
-                {
-                    Assert.Null(patchParameters.JobSpecification);
-                    Assert.Null(patchParameters.Metadata);
-                    Assert.Null(patchParameters.Schedule);
-                };
+            static void assertAction(Protocol.Models.JobSchedulePatchParameter patchParameters)
+            {
+                Assert.Null(patchParameters.JobSpecification);
+                Assert.Null(patchParameters.Metadata);
+                Assert.Null(patchParameters.Schedule);
+            }
 
             CommonPatchJobScheduleTest(protoJobSchedule, modificationFunction, assertAction);
         }

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PropertyUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/PropertyUnitTests.cs
@@ -160,25 +160,25 @@ namespace Azure.Batch.Unit.Tests
 
             Random rand = new Random();
 
-            Func<object> omTaskRangeBuilder = () =>
+            object omTaskRangeBuilder()
             {
                 int rangeLimit1 = rand.Next(0, int.MaxValue);
                 int rangeLimit2 = rand.Next(0, int.MaxValue);
 
                 return new TaskIdRange(Math.Min(rangeLimit1, rangeLimit2), Math.Max(rangeLimit1, rangeLimit2));
-            };
+            }
 
-            Func<object> iFileStagingProviderBuilder = () => null;
+            object iFileStagingProviderBuilder() => null;
 
-            Func<object> batchClientBehaviorBuilder = () => null;
+            object batchClientBehaviorBuilder() => null;
 
-            Func<object> taskRangeBuilder = () =>
+            object taskRangeBuilder()
             {
                 int rangeLimit1 = rand.Next(0, int.MaxValue);
                 int rangeLimit2 = rand.Next(0, int.MaxValue);
 
                 return new Protocol.Models.TaskIdRange(Math.Min(rangeLimit1, rangeLimit2), Math.Max(rangeLimit1, rangeLimit2));
-            };
+            }
 
             ObjectFactoryConstructionSpecification certificateReferenceSpecification = new ObjectFactoryConstructionSpecification(
                 typeof(Protocol.Models.CertificateReference),

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/RetryPolicyUnitTests.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/RetryPolicyUnitTests.cs
@@ -411,8 +411,8 @@
             request.ServiceRequestFunc = async (token) =>
             {
                 ++serviceRequestFuncCallCount;
-                
-                Action throwsAction = () => { throw new InvalidOperationException(); };
+
+                void throwsAction() { throw new InvalidOperationException(); }
                 Task throwsTask1 = Task.Factory.StartNew(throwsAction);
                 Task throwsTask2 = Task.Factory.StartNew(throwsAction);
                 await Task.WhenAll(throwsTask1, throwsTask2); //This will throw
@@ -463,7 +463,7 @@
             {
                 ++serviceRequestFuncCallCount;
 
-                Action throwsAction = () => { throw new ArgumentException(); };
+                void throwsAction() { throw new ArgumentException(); }
                 Task throwsTask1 = Task.Factory.StartNew(throwsAction);
                 Task throwsTask2 = Task.Factory.StartNew(throwsAction);
                 await Task.WhenAll(throwsTask1, throwsTask2); //This will throw

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/TestUtilities/InterceptorFactory.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/TestUtilities/InterceptorFactory.cs
@@ -114,7 +114,7 @@ namespace Azure.Batch.Unit.Tests.TestUtilities
                 });
         }
 
-        public static IEnumerable<Protocol.RequestInterceptor> CreateGetRequestInterceptor<TOptions, TResponse, TResponseHeaders>(TResponse valueToReturn, TResponseHeaders headersToReturn = default(TResponseHeaders))
+        public static IEnumerable<Protocol.RequestInterceptor> CreateGetRequestInterceptor<TOptions, TResponse, TResponseHeaders>(TResponse valueToReturn, TResponseHeaders headersToReturn = default)
             where TOptions : Protocol.Models.IOptions, new()
         {
             yield return new Protocol.RequestInterceptor(req =>

--- a/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/TestUtilities/ObjectComparer.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/tests/UnitTests/TestUtilities/ObjectComparer.cs
@@ -91,14 +91,14 @@
                 }
             }
             //Deal with collections
-            else if (o1 is IEnumerable)
+            else if (o1 is IEnumerable enumerable)
             {
                 if (!(o2 is IEnumerable))
                 {
                     return CheckEqualityResult.False("o2 was not IEnumerable");
                 }
 
-                IEnumerable o1Enumerable = (IEnumerable)o1;
+                IEnumerable o1Enumerable = enumerable;
                 IEnumerable o2Enumerable = (IEnumerable)o2;
 
                 return this.CompareEnumerables(o1Enumerable, o2Enumerable);
@@ -190,7 +190,7 @@
                 return CheckEqualityResult.False("Collection counts do not match");
             }
             var checkResult = list1.Select((item1, i) => this.CheckEquality(item1, list2[i])).FirstOrDefault(check => !check.Equal);
-            return checkResult != null ? checkResult : CheckEqualityResult.True;
+            return checkResult ?? CheckEqualityResult.True;
         }
 
         private string GetPropertyMappingOrNull(Type type, string propertyName)


### PR DESCRIPTION
Mostly a clean-up PR, but also marks 2 tests as flaky and puts in a delay which should help (but not eliminate, just a band-aid) the flakiness of one of them.