### PR TITLE
Add canary configuration to smoke test matrix

### DIFF
--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -11,21 +11,45 @@ jobs:
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Linux (AzureCloud Canary):
+          OSVmImage: "ubuntu-18.04"
+          TestTargetFramework: netcoreapp2.1
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "eastus2euap"
         Windows_NetCoreApp (AzureCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Windows_NetCoreApp (AzureCloud Canary):
+          OSVmImage: "windows-2019"
+          TestTargetFramework: netcoreapp2.1
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "eastus2euap"
         Windows_NetFramework (AzureCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Windows_NetFramework (AzureCloud Canary):
+          OSVmImage: "windows-2019"
+          TestTargetFramework: net461
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "eastus2euap"
         MacOs (AzureCloud):
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        MacOs (AzureCloud Canary):
+          OSVmImage: "macOS-10.15"
+          TestTargetFramework: netcoreapp2.1
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+          ArmTemplateParameters: $(azureCloudArmParameters)
+          Location: "eastus2euap"
         Windows_NetCoreApp (AzureUSGovernment):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1

--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -22,34 +22,16 @@ jobs:
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Windows_NetCoreApp (AzureCloud Canary):
-          OSVmImage: "windows-2019"
-          TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: "eastus2euap"
         Windows_NetFramework (AzureCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        Windows_NetFramework (AzureCloud Canary):
-          OSVmImage: "windows-2019"
-          TestTargetFramework: net461
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: "eastus2euap"
         MacOs (AzureCloud):
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
-        MacOs (AzureCloud Canary):
-          OSVmImage: "macOS-10.15"
-          TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-          ArmTemplateParameters: $(azureCloudArmParameters)
-          Location: "eastus2euap"
         Windows_NetCoreApp (AzureUSGovernment):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1


### PR DESCRIPTION
This PR adds a new entry to the smoke test matrix to add a public cloud test against a Canary/EUAP region (specifically eastus2euap).

Passing smoke test pipeline here (for new canary jobs, AzureChinaCloud seems to be having a transient issue but I'll keep an eye on it): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=572805&view=results

Azure/azure-sdk#1879