### PR TITLE
[Identity] Fix token refresh issue for MSA accounts

### DIFF
--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -198,7 +198,7 @@ namespace Azure.Identity
                 {
                     try
                     {
-                        AuthenticationResult result = await Client.AcquireTokenSilentAsync(requestContext.Scopes, (AuthenticationAccount)Record, async, cancellationToken).ConfigureAwait(false);
+                        AuthenticationResult result = await Client.AcquireTokenSilentAsync(requestContext.Scopes, Record, async, cancellationToken).ConfigureAwait(false);
 
                         return scope.Succeeded(new AccessToken(result.AccessToken, result.ExpiresOn));
                     }

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
@@ -181,7 +181,7 @@ namespace Azure.Identity
                 {
                     try
                     {
-                        AuthenticationResult result = await Client.AcquireTokenSilentAsync(requestContext.Scopes, (AuthenticationAccount)Record, async, cancellationToken).ConfigureAwait(false);
+                        AuthenticationResult result = await Client.AcquireTokenSilentAsync(requestContext.Scopes, Record, async, cancellationToken).ConfigureAwait(false);
 
                         return scope.Succeeded(new AccessToken(result.AccessToken, result.ExpiresOn));
                     }

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -52,6 +52,11 @@ namespace Azure.Identity
             IPublicClientApplication client = await GetClientAsync(async, cancellationToken).ConfigureAwait(false);
             return await client.AcquireTokenSilent(scopes, account).ExecuteAsync(async, cancellationToken).ConfigureAwait(false);
         }
+        public virtual async ValueTask<AuthenticationResult> AcquireTokenSilentAsync(string[] scopes, AuthenticationRecord record, bool async, CancellationToken cancellationToken)
+        {
+            IPublicClientApplication client = await GetClientAsync(async, cancellationToken).ConfigureAwait(false);
+            return await client.AcquireTokenSilent(scopes, (AuthenticationAccount)record).WithAuthority(Pipeline.AuthorityHost.AbsoluteUri, record.TenantId).ExecuteAsync(async, cancellationToken).ConfigureAwait(false);
+        }
 
         public virtual async ValueTask<AuthenticationResult> AcquireTokenInteractiveAsync(string[] scopes, Prompt prompt, bool async, CancellationToken cancellationToken)
         {

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -55,7 +55,13 @@ namespace Azure.Identity
         public virtual async ValueTask<AuthenticationResult> AcquireTokenSilentAsync(string[] scopes, AuthenticationRecord record, bool async, CancellationToken cancellationToken)
         {
             IPublicClientApplication client = await GetClientAsync(async, cancellationToken).ConfigureAwait(false);
-            return await client.AcquireTokenSilent(scopes, (AuthenticationAccount)record).WithAuthority(Pipeline.AuthorityHost.AbsoluteUri, record.TenantId).ExecuteAsync(async, cancellationToken).ConfigureAwait(false);
+
+            // if the user specified a TenantId when they created the client we want to authenticate to that tenant.
+            // otherwise we should authenticate with the tenant specified by the authentication record since that's the tenant the
+            // user authenticated to originally.
+            return await client.AcquireTokenSilent(scopes, (AuthenticationAccount)record)
+                .WithAuthority(Pipeline.AuthorityHost.AbsoluteUri, TenantId ?? record.TenantId)
+                .ExecuteAsync(async, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual async ValueTask<AuthenticationResult> AcquireTokenInteractiveAsync(string[] scopes, Prompt prompt, bool async, CancellationToken cancellationToken)

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -85,5 +85,23 @@ namespace Azure.Identity.Tests
 
             Assert.NotNull(token.Token);
         }
+
+        [Test]
+        [Ignore("This test is an integration test which can only be run with user interaction")]
+        // This test should be run with an MSA account to validate that the refresh for MSA accounts works properly
+        public async Task AuthenticateWithMSAWithSubsequentSilentRefresh()
+        {
+            var cred = new InteractiveBrowserCredential();
+
+            // this should pop browser
+            var authRecord = await cred.AuthenticateAsync();
+
+            Assert.NotNull(authRecord);
+
+            // this should not pop browser
+            AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);
+
+            Assert.NotNull(token.Token);
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/Mock/MockMsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockMsalPublicClient.cs
@@ -73,6 +73,18 @@ namespace Azure.Identity.Tests.Mock
             throw new NotImplementedException();
         }
 
+        public override ValueTask<AuthenticationResult> AcquireTokenSilentAsync(string[] scopes, AuthenticationRecord record, bool async, CancellationToken cancellationToken)
+        {
+            Func<string[], AuthenticationResult> factory = SilentAuthFactory ?? AuthFactory;
+
+            if (factory != null)
+            {
+                return new ValueTask<AuthenticationResult>(factory(scopes));
+            }
+
+            throw new NotImplementedException();
+        }
+
         public override ValueTask<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(string[] scopes, Func<DeviceCodeResult, Task> deviceCodeCallback, bool async, CancellationToken cancellationToken)
         {
             Func<string[], AuthenticationResult> factory = DeviceCodeAuthFactory ?? AuthFactory;


### PR DESCRIPTION
This fixes an issue with token refresh on the `InteractiveBrowserCredential` and `DeviceCodeCredential` where they incorrectly authenticate to the home tenant when silently acquiring a token with a cache refresh token. 

Fixes #13801