### PR TITLE
Add delay for replication for live Search test runs

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/Batching/BatchingTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Batching/BatchingTests.cs
@@ -598,38 +598,7 @@ namespace Azure.Search.Documents.Tests
             await WaitForDocumentCountAsync(resources.GetSearchClient(), data.Length);
         }
 
-        /*
-        System.InvalidOperationException : 'SearchClient.IndexDocuments' scope is not completed
-        Stack trace
-           at Azure.Core.Tests.ClientDiagnosticListener.Dispose() in D:\a\1\s\sdk\core\Azure.Core.TestFramework\src\ClientDiagnosticListener.cs:line 131
-           at Azure.Core.TestFramework.DiagnosticScopeValidatingInterceptor.Intercept(IInvocation invocation) in D:\a\1\s\sdk\core\Azure.Core.TestFramework\src\DiagnosticScopeValidatingInterceptor.cs:line 68
-           at Castle.DynamicProxy.AbstractInvocation.Proceed()
-           at Castle.Proxies.SearchClientProxy.GetDocumentCountAsync(CancellationToken cancellationToken)
-           at Azure.Search.Documents.Tests.SearchTestBase.<WaitForDocumentCountAsync>d__10.MoveNext() in D:\a\1\s\sdk\search\Azure.Search.Documents\tests\Utilities\SearchTestBase.cs:line 276
-        --- End of stack trace from previous location where exception was thrown ---
-           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
-           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
-           at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
-           at Azure.Search.Documents.Tests.BatchingTests.<AutoFlushInterval_FullBatch>d__25.MoveNext() in D:\a\1\s\sdk\search\Azure.Search.Documents\tests\Batching\BatchingTests.cs:line 624
-        --- End of stack trace from previous location where exception was thrown ---
-           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
-           at Azure.Search.Documents.Tests.BatchingTests.<AutoFlushInterval_FullBatch>d__25.MoveNext() in D:\a\1\s\sdk\search\Azure.Search.Documents\tests\Batching\BatchingTests.cs:line 624
-        --- End of stack trace from previous location where exception was thrown ---
-           at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
-           at Azure.Search.Documents.Tests.BatchingTests.<AutoFlushInterval_FullBatch>d__25.MoveNext() in D:\a\1\s\sdk\search\Azure.Search.Documents\tests\Batching\BatchingTests.cs:line 624
-        --- End of stack trace from previous location where exception was thrown ---
-           at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
-           at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
-           at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
-           at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaitable)
-           at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
-           at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
-           at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
-           at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
-           at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
-        */
         [Test]
-        [Ignore("TODO: Need to investigate why this the scope isn't completing")]
         public async Task AutoFlushInterval_FullBatch()
         {
             await using SearchResources resources = await SearchResources.CreateWithEmptyIndexAsync<SimpleDocument>(this);

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Sample05_IndexingDocuments.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Sample05_IndexingDocuments.cs
@@ -121,13 +121,6 @@ namespace Azure.Search.Documents.Tests.Samples
 
                 await WaitForDocumentCountAsync(searchClient, 1000);
 
-                // When using the free SKU, there may be enough load to prevent
-                // immediately replication to all replicas and we get back the
-                // wrong count. Wait another second before checking again. We
-                // may also upgrade to a basic SKU, but that will take longer
-                // to provision.
-                await DelayAsync(TimeSpan.FromSeconds(1));
-
                 // Check
                 #region Snippet:Azure_Search_Documents_Tests_Samples_Sample05_IndexingDocuments_SimpleIndexing2
                 Assert.AreEqual(1000, (int)await searchClient.GetDocumentCountAsync());

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchTestBase.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchTestBase.cs
@@ -254,7 +254,7 @@ namespace Azure.Search.Documents.Tests
         }
 
         /// <summary>
-        /// Wait until the document count for a given search index has crosssed
+        /// Wait until the document count for a given search index has crossed
         /// a minimum value.  This only does simple linear retries for a fixed
         /// number of attempts.
         /// </summary>
@@ -276,6 +276,13 @@ namespace Azure.Search.Documents.Tests
                 count = (int)await searchClient.GetDocumentCountAsync();
                 if (count >= minimumCount)
                 {
+                    // When using the free SKU, there may be enough load to prevent
+                    // immediately replication to all replicas and we get back the
+                    // wrong count. Wait a bit longer before checking again. We may
+                    // also upgrade to a basic SKU, but that will take longer to
+                    // provision.
+                    await DelayAsync(delay);
+
                     return;
                 }
                 await DelayAsync(delay);


### PR DESCRIPTION
I un-ignored a test that should be fixed after the changes to Azure.Core.TestFramework @pakrym and I worked on.

The extra delay was recommended by @brjohnstmsft to give the replicas time to replicate. A recent live run also resulted in an error in AutoFlushInterval_PartialBatch, and I believe the delay should help there as well. I believe a replica may still be getting doc updates (insertions) when a delete request is replicated.
