### PR TITLE
Fix AzureEventSourceListener initialization race

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - The `HttpClientTransport(HttpMessageHandler)` constructor overload.
 
+### Fixed
+- The race condition in `AzureEventSourceListener` class that sometimes resulted in a `NullReferenceException` in the `EventSource`.
+
 ## 1.5.1 (2020-10-01)
 
 ### Changed

--- a/sdk/core/Azure.Core/src/Diagnostics/AzureEventSourceListener.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/AzureEventSourceListener.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
-using System.Threading;
 using Azure.Core.Shared;
 
 namespace Azure.Core.Diagnostics
@@ -38,6 +37,7 @@ namespace Azure.Core.Diagnostics
         public AzureEventSourceListener(Action<EventWrittenEventArgs, string> log, EventLevel level)
         {
             _log = log ?? throw new ArgumentNullException(nameof(log));
+
             _level = level;
 
             foreach (EventSource eventSource in _eventSources)


### PR DESCRIPTION
Reproes with the following test:

``` C#

        [Test]
        public Task Race()
        {
            var t = Task.Run(() =>
            {
                while (true)
                {
                    AzureCoreEventSource.Singleton.Request("id", "GET", "http", "header", "Test-SDK");
                }
            });

            while (true)
            {
                if (t.IsCompleted)
                {
                    t.GetAwaiter().GetResult();
                }
                using var _ = new AzureEventSourceListener(
                    (args, s) =>
                    {
                    }, EventLevel.Verbose);
            }
        }

```