### PR TITLE
Convert exception from AMQP layer to retriable EventHubsException.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpEventDataSender.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpEventDataSender.cs
@@ -81,6 +81,15 @@ namespace Microsoft.Azure.EventHubs.Amqp
                         {
                             throw AmqpExceptionHelper.ToMessagingContract(amqpException.Error);
                         }
+                        catch (Exception ex)
+                        {
+                            if (AmqpExceptionHelper.TryConvertToRetriableException(ex, out var retriableEx))
+                            {
+                                throw retriableEx;
+                            }
+
+                            throw;
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpEventDataSender.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpEventDataSender.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                         }
                         catch (Exception ex)
                         {
-                            if (AmqpExceptionHelper.TryConvertToRetriableException(ex, out var retriableEx))
+                            if (AmqpExceptionHelper.TryTranslateToRetriableException(ex, out var retriableEx))
                             {
                                 throw retriableEx;
                             }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpExceptionHelper.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
             return new EventHubsException(true, message);
         }
 
-        public static bool TryConvertToRetriableException(Exception exception, out EventHubsException retriableException)
+        public static bool TryTranslateToRetriableException(Exception exception, out EventHubsException retriableException)
         {
             retriableException = null;
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpExceptionHelper.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
             retriableException = null;
 
             // InvalidOperationException with 'connection is closing' message from AMQP layer is retriable.
-            if (exception is OperationCanceledException && exception.Message.IndexOf("connection is closing", StringComparison.OrdinalIgnoreCase) != - 1)
+            if (exception is InvalidOperationException && exception.Message.IndexOf("connection is closing", StringComparison.OrdinalIgnoreCase) != - 1)
             {
                 retriableException = new EventHubsException(true, exception);
             }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpExceptionHelper.cs
@@ -128,5 +128,18 @@ namespace Microsoft.Azure.EventHubs.Amqp
 
             return new EventHubsException(true, message);
         }
+
+        public static bool TryConvertToRetriableException(Exception exception, out EventHubsException retriableException)
+        {
+            retriableException = null;
+
+            // InvalidOperationException with 'connection is closing' message from AMQP layer is retriable.
+            if (exception is OperationCanceledException && exception.Message.IndexOf("connection is closing", StringComparison.OrdinalIgnoreCase) != - 1)
+            {
+                retriableException = new EventHubsException(true, exception);
+            }
+
+            return retriableException != null;
+        }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpPartitionReceiver.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpPartitionReceiver.cs
@@ -99,6 +99,15 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     {
                         throw AmqpExceptionHelper.ToMessagingContract(amqpException.Error);
                     }
+                    catch (Exception ex)
+                    {
+                        if (AmqpExceptionHelper.TryConvertToRetriableException(ex, out var retriableEx))
+                        {
+                            throw retriableEx;
+                        }
+
+                        throw;
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpPartitionReceiver.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Amqp/AmqpPartitionReceiver.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.EventHubs.Amqp
                     }
                     catch (Exception ex)
                     {
-                        if (AmqpExceptionHelper.TryConvertToRetriableException(ex, out var retriableEx))
+                        if (AmqpExceptionHelper.TryTranslateToRetriableException(ex, out var retriableEx))
                         {
                             throw retriableEx;
                         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Amqp/AmqpExceptionHandlerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Amqp/AmqpExceptionHandlerTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Tests.Amqp
+{
+    using System;
+    using Microsoft.Azure.EventHubs.Amqp;
+    using Xunit;
+
+    public class AmqpExceptionHandlerTests
+    {
+        /// <summary>
+        /// Validate TryTranslateToRetriableException doesn't translate mismatching error.
+        /// </summary>
+        [Fact]
+        [DisplayTestMethodName]
+        public void InvalidOperationExceptionWithoutClosingMessageNotTranslated()
+        {
+            var invalidOperationException = new InvalidOperationException("this is some other error");
+
+            EventHubsException newException;
+            var translated = AmqpExceptionHelper.TryTranslateToRetriableException(invalidOperationException, out newException);
+
+            Assert.False(translated, "TryTranslateToRetriableException returned true");
+        }
+
+        /// <summary>
+        /// Validate TryTranslateToRetriableException doesn't translate mismatching exception.
+        /// </summary>
+        [Fact]
+        [DisplayTestMethodName]
+        public void MismatchingExceptionNotTranslated()
+        {
+            var argumentException = new ArgumentException();
+
+            EventHubsException newException;
+            var translated = AmqpExceptionHelper.TryTranslateToRetriableException(argumentException, out newException);
+
+            Assert.False(translated, "TryTranslateToRetriableException returned true");
+        }
+
+        /// <summary>
+        /// Validate InvalidOperationException with 'connection is closing' message translates to retriable EventHubsException
+        /// </summary>
+        [Fact]
+        [DisplayTestMethodName]
+        public void InvalidOperationExceptionWithClosingMessageTranslated()
+        {
+            var invalidOperationException = new InvalidOperationException("Can't create session when the connection is closing.");
+            
+            EventHubsException newException;
+            var translated = AmqpExceptionHelper.TryTranslateToRetriableException(invalidOperationException, out newException);
+
+            Assert.True(translated, "TryTranslateToRetriableException returned false");
+            Assert.True(newException.IsTransient, "newException.IsTransient == false");
+            Assert.True(newException.InnerException == invalidOperationException, "newException.InnerException != invalidOperationException");
+        }
+    }
+}


### PR DESCRIPTION
Some exception cases from AMQP layer should be handled as retriable failure. "Invalid operation while connection is closing" error is one of them. This PR introduces changes for client to handle them as a retriable EventHubsException.

Fix is addressing the issue reported here https://github.com/Azure/azure-sdk-for-net/issues/8761