### PR TITLE
[Event Hubs Client] Convert README Examples to Snippets

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/ReadMeSnippetsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/ReadMeSnippetsLiveTests.cs
@@ -1,0 +1,260 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Processor;
+using Azure.Messaging.EventHubs.Processor.Tests;
+using Azure.Storage.Blobs;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests defining the snippets used in the Event Hubs
+    ///   README.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    [SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value", Justification = "Example assignments needed for snippet output content.")]
+    public class ReadMeSnippetsLiveTests
+
+    {
+        /// <summary>The active Event Hub resource scope for the test fixture.</summary>
+        private EventHubScope _eventHubScope;
+        private StorageScope _storageScope;
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize the test fixture.  This
+        ///   method runs once for the entire fixture, prior to running any tests.
+        /// </summary>
+        ///
+        [OneTimeSetUp]
+        public async Task FixtureSetUp()
+        {
+            _eventHubScope = await EventHubScope.CreateAsync(2);
+            _storageScope = await StorageScope.CreateAsync();
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to cleanup the test fixture after all
+        ///   tests have run.  This method runs once for the entire fixture.
+        /// </summary>
+        ///
+        [OneTimeTearDown]
+        public async Task FixtureTearDown()
+        {
+            await Task.WhenAll
+            (
+                _eventHubScope.DisposeAsync().AsTask(),
+                _storageScope.DisposeAsync().AsTask()
+            );
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public void Create()
+        {
+            #region Snippet:EventHubs_Processor_ReadMe_Create
+
+            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+            var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+            /*@@*/
+            /*@@*/ storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            /*@@*/ blobContainerName = _storageScope.ContainerName;
+
+            var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+            /*@@*/
+            /*@@*/ eventHubsConnectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            /*@@*/ eventHubName = _eventHubScope.EventHubName;
+            /*@@*/ consumerGroup = _eventHubScope.ConsumerGroups.First();
+
+            BlobContainerClient storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+
+            EventProcessorClient processor = new EventProcessorClient
+            (
+                storageClient,
+                consumerGroup,
+                eventHubsConnectionString,
+                eventHubName
+            );
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public void ConfigureHandlers()
+        {
+            #region Snippet:EventHubs_Processor_ReadMe_ConfigureHandlers
+
+            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+            var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+            /*@@*/
+            /*@@*/ storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            /*@@*/ blobContainerName = _storageScope.ContainerName;
+
+            var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+            /*@@*/
+            /*@@*/ eventHubsConnectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            /*@@*/ eventHubName = _eventHubScope.EventHubName;
+            /*@@*/ consumerGroup = _eventHubScope.ConsumerGroups.First();
+
+            async Task processEventHandler(ProcessEventArgs eventArgs)
+            {
+                try
+                {
+                    // Perform the application-specific processing for an event.  This method
+                    // is intended for illustration and is not defined in this snippet.
+                    await DoSomethingWithTheEvent(eventArgs.Partition, eventArgs.Data);
+                }
+                catch
+                {
+                    // Handle the exception from handler code
+                }
+            }
+
+            async Task processErrorHandler(ProcessErrorEventArgs eventArgs)
+            {
+                try
+                {
+                    // Perform the application-specific processing for an error.  This method
+                    // is intended for illustration and is not defined in this snippet.
+                    await DoSomethingWithTheError(eventArgs.Exception);
+                }
+                catch
+                {
+                    // Handle the exception from handler code
+                }
+            }
+
+            var storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+            var processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName);
+
+            processor.ProcessEventAsync += processEventHandler;
+            processor.ProcessErrorAsync += processErrorHandler;
+
+            #endregion
+
+            Task DoSomethingWithTheEvent(PartitionContext partition, EventData data) => Task.CompletedTask;
+            Task DoSomethingWithTheError(Exception ex) => Task.CompletedTask;
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessUntilCanceled()
+        {
+            #region Snippet:EventHubs_Processor_ReadMe_ProcessUntilCanceled
+
+            var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+
+            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+            var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+            /*@@*/
+            /*@@*/ storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            /*@@*/ blobContainerName = _storageScope.ContainerName;
+
+            var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+            /*@@*/
+            /*@@*/ eventHubsConnectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            /*@@*/ eventHubName = _eventHubScope.EventHubName;
+            /*@@*/ consumerGroup = _eventHubScope.ConsumerGroups.First();
+
+            Task processEventHandler(ProcessEventArgs eventArgs) => Task.CompletedTask;
+            Task processErrorHandler(ProcessErrorEventArgs eventArgs) => Task.CompletedTask;
+
+            var storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+            var processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName);
+
+            processor.ProcessEventAsync += processEventHandler;
+            processor.ProcessErrorAsync += processErrorHandler;
+
+            await processor.StartProcessingAsync();
+
+            try
+            {
+                // The processor performs its work in the background; block until cancellation
+                // to allow processing to take place.
+                await Task.Delay(Timeout.Infinite, cancellationSource.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                // This is expected when the delay is canceled.
+            }
+
+            try
+            {
+                await processor.StopProcessingAsync();
+            }
+            finally
+            {
+                // To prevent leaks, the handlers should be removed when processing is complete.
+                processor.ProcessEventAsync -= processEventHandler;
+                processor.ProcessErrorAsync -= processErrorHandler;
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateWithIdentity()
+        {
+            #region Snippet:EventHubs_Processor_ReadMe_CreateWithIdentity
+
+            TokenCredential credential = new DefaultAzureCredential();
+            /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
+
+            string blobStorageUrl ="<< FULLY-QUALIFIED CONTAINER URL (like https://myaccount.blob.core.windows.net/mycontainer) >>";
+            /*@@*/ blobStorageUrl = $"https://{ StorageTestEnvironment.Instance.StorageAccountName }.{ StorageTestEnvironment.Instance.StorageEndpointSuffix }/{ _storageScope.ContainerName }";
+            /*@@*/
+            BlobContainerClient storageClient = new BlobContainerClient(new Uri(blobStorageUrl), credential);
+
+            var fullyQualifiedNamespace = "<< FULLY-QUALIFIED EVENT HUBS NAMESPACE (like something.servicebus.windows.net) >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+            /*@@*/
+            /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
+            /*@@*/ eventHubName = _eventHubScope.EventHubName;
+            /*@@*/ consumerGroup = _eventHubScope.ConsumerGroups.First();
+
+            EventProcessorClient processor = new EventProcessorClient
+            (
+                storageClient,
+                consumerGroup,
+                fullyQualifiedNamespace,
+                eventHubName,
+                credential
+            );
+
+            #endregion
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -66,7 +66,7 @@ For more concepts and deeper discussion, see: [Event Hubs Features](https://docs
 
 Many Event Hub operations take place within the scope of a specific partition.  Because partitions are owned by the Event Hub, their names are assigned at the time of creation.  To understand what partitions are available, you query the Event Hub using one of the Event Hub clients.
 
-```csharp
+```C# Snippet:EventHubs_ReadMe_Inspect
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
@@ -80,16 +80,16 @@ await using (var producer = new EventHubProducerClient(connectionString, eventHu
 
 In order to publish events, you'll need to create an `EventHubProducerClient`.  Producers publish events in batches and may request a specific partition, or allow the Event Hubs service to decide which partition events should be published to.  It is recommended to use automatic routing when the publishing of events needs to be highly available or when event data should be distributed evenly among the partitions.  Our example will take advantage of automatic routing.
 
-```csharp
+```C# Snippet:EventHubs_ReadMe_Publish
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
 await using (var producer = new EventHubProducerClient(connectionString, eventHubName))
 {
     using EventDataBatch eventBatch = await producer.CreateBatchAsync();
-    eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("First")));
-    eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("Second")));
-    
+    eventBatch.TryAdd(new EventData(new BinaryData("First")));
+    eventBatch.TryAdd(new EventData(new BinaryData("Second")));
+
     await producer.SendAsync(eventBatch);
 }
 ```
@@ -100,7 +100,7 @@ In order to read events from an Event Hub, you'll need to create an `EventHubCon
 
 **Note:** It is important to note that this approach to consuming is intended to improve the experience of exploring the Event Hubs client library and prototyping.  It is recommended that it not be used in production scenarios.   For production use, we recommend using the [Event Processor Client](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor), as it provides a more robust and performant experience.
 
-```csharp
+```C# Snippet:EventHubs_ReadMe_Read
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
@@ -125,7 +125,7 @@ await using (var consumer = new EventHubConsumerClient(consumerGroup, connection
 
 In order to read events for an Event Hub partition, you'll need to create an `EventHubConsumerClient` for a given consumer group.  When an Event Hub is created, it provides a default consumer group that can be used to get started with exploring Event Hubs.  To read from a specific partition, the consumer will also need to specify where in the event stream to begin receiving events; in our example, we will focus on reading all published events for the first partition of the Event Hub.
 
-```csharp
+```C# Snippet:EventHubs_ReadMe_Read
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
@@ -133,15 +133,12 @@ string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
 
 await using (var consumer = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName))
 {
-    EventPosition startingPosition = EventPosition.Earliest;
-    string partitionId = (await consumer.GetPartitionIdsAsync()).First();
-
     using var cancellationSource = new CancellationTokenSource();
     cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
 
-    await foreach (PartitionEvent receivedEvent in consumer.ReadEventsFromPartitionAsync(partitionId, startingPosition, cancellationSource.Token))
+    await foreach (PartitionEvent receivedEvent in consumer.ReadEventsAsync(cancellationSource.Token))
     {
-        // At this point, the loop will wait for events to be available in the partition.  When an event
+        // At this point, the loop will wait for events to be available in the Event Hub.  When an event
         // is available, the loop will iterate with the event that was received.  Because we did not
         // specify a maximum wait time, the loop will wait forever unless cancellation is requested using
         // the cancellation token.
@@ -155,7 +152,10 @@ For the majority of production scenarios, it is recommended that the [Event Proc
 
 Since the `EventProcessorClient` has a dependency on Azure Storage blobs for persistence of its state, you'll need to provide a `BlobContainerClient` for the processor, which has been configured for the storage account and container that should be used.
 
-```csharp
+```C# Snippet:EventHubs_Processor_ReadMe_ProcessUntilCanceled
+var cancellationSource = new CancellationTokenSource();
+cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+
 var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
 var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
 
@@ -163,15 +163,38 @@ var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPA
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
 
-BlobContainerClient storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+Task processEventHandler(ProcessEventArgs eventArgs) => Task.CompletedTask;
+Task processErrorHandler(ProcessErrorEventArgs eventArgs) => Task.CompletedTask;
 
-EventProcessorClient processor = new EventProcessorClient
-(
-    storageClient,
-    consumerGroup,
-    eventHubsConnectionString,
-    eventHubName
-);
+var storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+var processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName);
+
+processor.ProcessEventAsync += processEventHandler;
+processor.ProcessErrorAsync += processErrorHandler;
+
+await processor.StartProcessingAsync();
+
+try
+{
+    // The processor performs its work in the background; block until cancellation
+    // to allow processing to take place.
+    await Task.Delay(Timeout.Infinite, cancellationSource.Token);
+}
+catch (TaskCanceledException)
+{
+    // This is expected when the delay is canceled.
+}
+
+try
+{
+    await processor.StopProcessingAsync();
+}
+finally
+{
+    // To prevent leaks, the handlers should be removed when processing is complete.
+    processor.ProcessEventAsync -= processEventHandler;
+    processor.ProcessErrorAsync -= processErrorHandler;
+}
 ```
 
 More details can be found in the Event Processor Client [README](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md) and the accompanying [samples](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples).
@@ -182,15 +205,19 @@ The [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/mas
 
 To make use of an Active Directory principal, one of the available identity tokens from the `Azure.Identity` library is also provided when creating the Event Hub client.  In addition, the fully qualified Event Hubs namespace and the name of desired Event Hub are supplied in lieu of the Event Hubs connection string.
 
-```csharp
+```C# Snippet:EventHubs_ReadMe_PublishIdentity
+TokenCredential credential = new DefaultAzureCredential();
+
 var fullyQualifiedNamespace = "<< FULLY-QUALIFIED EVENT HUBS NAMESPACE (like something.servicebus.windows.net) >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
-TokenCredential credential = new DefaultAzureCredential();
-
 await using (var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential))
 {
-   // Publish events using the producer
+    using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+    eventBatch.TryAdd(new EventData(new BinaryData("First")));
+    eventBatch.TryAdd(new EventData(new BinaryData("Second")));
+
+    await producer.SendAsync(eventBatch);
 }
 ```
 
@@ -220,12 +247,13 @@ An `EventHubsException` is triggered when an operation specific to Event Hubs ha
   - **Resource Not Found**: An Event Hubs resource, such as an Event Hub, consumer group, or partition, could not be found by the Event Hubs service.  This may indicate that it has been deleted from the service or that there is an issue with the Event Hubs service itself.
   
 Reacting to a specific failure reason for the `EventHubException` can be accomplished in several ways, such as by applying an exception filter clause as part of the `catch` block:
-```csharp
+
+```C# Snippet:EventHubs_ReadMe_ExceptionFilter
 try
 {
     // Read events using the consumer client
 }
-catch (EventHubsException ex) when 
+catch (EventHubsException ex) when
     (ex.Reason == EventHubsException.FailureReason.ConsumerDisconnected)
 {
     // Take action based on a consumer being disconnected

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/ReadMeSnippetsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/ReadMeSnippetsLiveTests.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Producer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests defining the snippets used in the Event Hubs
+    ///   README.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    [SuppressMessage("Style", "IDE0059:Unnecessary assignment of a value", Justification = "Example assignments needed for snippet output content.")]
+    public class ReadMeSnippetsLiveTests
+
+    {
+        /// <summary>The active Event Hub resource scope for the test fixture.</summary>
+        private EventHubScope _scope;
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize the test fixture.  This
+        ///   method runs once for the entire fixture, prior to running any tests.
+        /// </summary>
+        ///
+        [OneTimeSetUp]
+        public async Task FixtureSetUp()
+        {
+            _scope = await EventHubScope.CreateAsync(2);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to cleanup the test fixture after all
+        ///   tests have run.  This method runs once for the entire fixture.
+        /// </summary>
+        ///
+        [OneTimeTearDown]
+        public async Task FixtureTearDown()
+        {
+            await _scope.DisposeAsync();
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task Inspect()
+        {
+            #region Snippet:EventHubs_ReadMe_Inspect
+
+            var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            /*@@*/
+            /*@@*/ connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            /*@@*/ eventHubName = _scope.EventHubName;
+
+            await using (var producer = new EventHubProducerClient(connectionString, eventHubName))
+            {
+                string[] partitionIds = await producer.GetPartitionIdsAsync();
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task Publish()
+        {
+            #region Snippet:EventHubs_ReadMe_Publish
+
+            var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            /*@@*/
+            /*@@*/ connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            /*@@*/ eventHubName = _scope.EventHubName;
+
+            await using (var producer = new EventHubProducerClient(connectionString, eventHubName))
+            {
+                using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+                eventBatch.TryAdd(new EventData(new BinaryData("First")));
+                eventBatch.TryAdd(new EventData(new BinaryData("Second")));
+
+                await producer.SendAsync(eventBatch);
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task Read()
+        {
+            try
+            {
+                #region Snippet:EventHubs_ReadMe_Read
+
+                var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+                var eventHubName = "<< NAME OF THE EVENT HUB >>";
+                /*@@*/
+                /*@@*/ connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+                /*@@*/ eventHubName = _scope.EventHubName;
+
+                string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
+
+                await using (var consumer = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName))
+                {
+                    using var cancellationSource = new CancellationTokenSource();
+                    cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+
+                    await foreach (PartitionEvent receivedEvent in consumer.ReadEventsAsync(cancellationSource.Token))
+                    {
+                        // At this point, the loop will wait for events to be available in the Event Hub.  When an event
+                        // is available, the loop will iterate with the event that was received.  Because we did not
+                        // specify a maximum wait time, the loop will wait forever unless cancellation is requested using
+                        // the cancellation token.
+                    }
+                }
+
+                #endregion
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected
+            }
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReadPartition()
+        {
+            try
+            {
+                #region Snippet:EventHubs_ReadMe_ReadPartition
+
+                var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+                var eventHubName = "<< NAME OF THE EVENT HUB >>";
+                /*@@*/
+                /*@@*/ connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+                /*@@*/ eventHubName = _scope.EventHubName;
+
+                string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
+
+                await using (var consumer = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName))
+                {
+                    EventPosition startingPosition = EventPosition.Earliest;
+                    string partitionId = (await consumer.GetPartitionIdsAsync()).First();
+
+                    using var cancellationSource = new CancellationTokenSource();
+                    cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+
+                    await foreach (PartitionEvent receivedEvent in consumer.ReadEventsFromPartitionAsync(partitionId, startingPosition, cancellationSource.Token))
+                    {
+                        // At this point, the loop will wait for events to be available in the partition.  When an event
+                        // is available, the loop will iterate with the event that was received.  Because we did not
+                        // specify a maximum wait time, the loop will wait forever unless cancellation is requested using
+                        // the cancellation token.
+                    }
+                }
+
+                #endregion
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected
+            }
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public async Task PublishIdentity()
+        {
+            #region Snippet:EventHubs_ReadMe_PublishIdentity
+
+            TokenCredential credential = new DefaultAzureCredential();
+            /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
+
+            var fullyQualifiedNamespace = "<< FULLY-QUALIFIED EVENT HUBS NAMESPACE (like something.servicebus.windows.net) >>";
+            var eventHubName = "<< NAME OF THE EVENT HUB >>";
+            /*@@*/
+            /*@@*/ fullyQualifiedNamespace = EventHubsTestEnvironment.Instance.FullyQualifiedNamespace;
+            /*@@*/ eventHubName = _scope.EventHubName;
+
+            await using (var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, credential))
+            {
+                using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+                eventBatch.TryAdd(new EventData(new BinaryData("First")));
+                eventBatch.TryAdd(new EventData(new BinaryData("Second")));
+
+                await producer.SendAsync(eventBatch);
+            }
+
+            #endregion
+        }
+
+        /// <summary>
+        ///   Performs basic smoke test validation of the contained snippet.
+        /// </summary>
+        ///
+        [Test]
+        public void ExceptionFilter()
+        {
+            #region Snippet:EventHubs_ReadMe_ExceptionFilter
+
+            try
+            {
+                // Read events using the consumer client
+            }
+            catch (EventHubsException ex) when
+                (ex.Reason == EventHubsException.FailureReason.ConsumerDisconnected)
+            {
+                // Take action based on a consumer being disconnected
+            }
+
+            #endregion
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to convert the examples in the READMEs to take advantage of code snippets, and ensure that those snippets are validated as smoke tests during Live runs.

# Last Upstream Rebase

Thursday, October 15, 5:42pm (EDT)