### PR TITLE
Prevent template run for sync builds, Update SetTestPipelineVersion.ps1

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -12,6 +12,8 @@ jobs:
           pwsh: true
           workingDirectory: $(Build.SourcesDirectory)
           filePath: eng/scripts/SetTestPipelineVersion.ps1
+          arguments: >
+            -PreviewVersionNumber $(build.buildid)
       - pwsh: |
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -61,6 +61,8 @@ stages:
                         pwsh: true
                         workingDirectory: $(Build.SourcesDirectory)
                         filePath: eng/scripts/SetTestPipelineVersion.ps1
+                        arguments: >
+                          -PreviewVersionNumber $(build.buildid)
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}
@@ -216,6 +218,7 @@ stages:
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                           CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                           PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                          CloseAfterOpenForTesting: $(TestPipeline)
 
   - stage: Integration
     dependsOn: Signing

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -1,28 +1,18 @@
-# Overides the project file and CHANGELOG.md for the template project using the next publishable version
+# Overides the project file and CHANGELOG.md for the template project using a custom preview version
 # This is to help with testing the release pipeline.
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PreviewVersionNumber
+)
+
 . "${PSScriptRoot}\..\common\scripts\common.ps1"
-$latestTags = git tag -l "Azure.Template_*"
-$semVars = @()
 
 $changeLogFile = "${PSScriptRoot}\..\..\sdk\template\Azure.Template\CHANGELOG.md"
-
-Foreach ($tags in $latestTags)
-{
-  $semVars += $tags.Replace("Azure.Template_", "")
-}
-
-$semVarsSorted = [AzureEngSemanticVersion]::SortVersionStrings($semVars)
-LogDebug "Last Published Version $($semVarsSorted[0])"
-
-$newVersion = [AzureEngSemanticVersion]::ParseVersionString($semVarsSorted[0])
-$newVersion.IncrementAndSetToPrerelease()
-LogDebug "Version to publish [ $($newVersion.ToString()) ]"
+$newVersion = "1.0.3-beta.$PreviewVersionNumber"
 
 &"${PSScriptRoot}/Update-PkgVersion.ps1" -ServiceDirectory "template" `
--PackageName 'Azure.Template' -PackageDirName "Azure.Template" -NewVersionString $newVersion.ToString() `
+-PackageName 'Azure.Template' -PackageDirName "Azure.Template" -NewVersionString $newVersion `
 -ReleaseDate (Get-Date -f "yyyy-MM-dd")
-Set-Content -Path $changeLogFile -Value @"
-# Release History
-## $($newVersion.ToString()) ($(Get-Date -f "yyyy-MM-dd"))
-- Test Release Pipeline
-"@
+Set-TestChangeLog -TestVersion $newVersion -changeLogFile $changeLogFile -ReleaseEntry "Test Release Pipeline"

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -2,24 +2,25 @@
 trigger:
   branches:
     include:
-    - master
-    - hotfix/*
-    - release/*
+      - master
+      - hotfix/*
+      - release/*
   paths:
     include:
-    - sdk/template/
+      - sdk/template/
 
 pr:
   branches:
     include:
-    - master
-    - feature/*
-    - hotfix/*
-    - release/*
+      - master
+      - feature/*
+      - hotfix/*
+      - release/*
   paths:
     include:
-    - sdk/template/
-    - eng/common/
+      - sdk/template/
+    exclude:
+      - eng/common/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
Prevent template pipeline run triggered by eng/common changes.
Use BuildID as preview version in template runs.
Update SetTestPipelineVersion.ps1