### PR TITLE
[Storage][Webjobs] Metapackage for easier upgrades.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests", "Microsoft.Azure.WebJobs.Extensions.Storage.Queues\samples\Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests.csproj", "{A7A937E4-F4E1-47B7-8D25-AA5FB6BDE010}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage", "Microsoft.Azure.WebJobs.Extensions.Storage\src\Microsoft.Azure.WebJobs.Extensions.Storage.csproj", "{022028DA-6134-4648-881C-9503E3034995}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +100,10 @@ Global
 		{A7A937E4-F4E1-47B7-8D25-AA5FB6BDE010}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7A937E4-F4E1-47B7-8D25-AA5FB6BDE010}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7A937E4-F4E1-47B7-8D25-AA5FB6BDE010}.Release|Any CPU.Build.0 = Release|Any CPU
+		{022028DA-6134-4648-881C-9503E3034995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{022028DA-6134-4648-881C-9503E3034995}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{022028DA-6134-4648-881C-9503E3034995}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{022028DA-6134-4648-881C-9503E3034995}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Release History
+
+## 5.0.0-beta.1 (Unreleased)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/README.md
@@ -45,6 +45,10 @@ Please refer to [Azure WebJobs Storage Queues](https://github.com/Azure/azure-sd
 
 Please refer to [Azure WebJobs Storage Blobs](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs).
 
+## Examples
+
+Please refer to [Azure WebJobs Storage Queues](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues) and [Azure WebJobs Storage Blobs](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs).
+
 ## Troubleshooting
 
 Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/README.md
@@ -1,0 +1,85 @@
+# Azure WebJobs Storage Blobs and Queues client library for .NET
+
+This extension provides functionality for accessing Azure Storage Blobs and Queues in Azure Functions. This package is a metapackage created for backwards compatibity. Using `Azure.WebJobs.Extensions.Storage.Blobs` and `Azure.WebJobs.Extensions.Storage.Queues` directly is recommended.
+
+## Getting started
+
+### Install the package
+
+Install the Storage Blobs and Queues extension with [NuGet][nuget]:
+
+```Powershell
+dotnet add package Azure.WebJobs.Extensions.Storage
+```
+
+### Prerequisites
+
+You need an [Azure subscription][azure_sub] and a
+[Storage Account][storage_account_docs] to use this package.
+
+To create a new Storage Account, you can use the [Azure Portal][storage_account_create_portal],
+[Azure PowerShell][storage_account_create_ps], or the [Azure CLI][storage_account_create_cli].
+Here's an example using the Azure CLI:
+
+```Powershell
+az storage account create --name <your-resource-name> --resource-group <your-resource-group-name> --location westus --sku Standard_LRS
+```
+
+### Authenticate the client
+
+In order for the extension to access Blobs, you will need the connection string which can be found in the [Azure Portal](https://portal.azure.com/) or by using the [Azure CLI](https://docs.microsoft.com/cli/azure) snippet below.
+
+```bash
+az storage account show-connection-string -g <your-resource-group-name> -n <your-resource-name>
+```
+
+The connection string can be supplied through [AzureWebJobsStorage app setting](https://docs.microsoft.com/azure/azure-functions/functions-app-settings).
+
+## Key concepts
+
+### Using Queues
+
+Please refer to [Azure WebJobs Storage Queues](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues).
+
+### Using Blobs
+
+Please refer to [Azure WebJobs Storage Blobs](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs).
+
+## Troubleshooting
+
+Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.
+
+## Next steps
+
+Read the [introduction to Azure Function](https://docs.microsoft.com/azure/azure-functions/functions-overview) or [creating an Azure Function guide](https://docs.microsoft.com/azure/azure-functions/functions-create-first-azure-function).
+
+## Contributing
+
+See the [Storage CONTRIBUTING.md][storage_contrib] for details on building,
+testing, and contributing to this library.
+
+This project welcomes contributions and suggestions.  Most contributions require
+you to agree to a Contributor License Agreement (CLA) declaring that you have
+the right to, and actually do, grant us the rights to use your contribution. For
+details, visit [cla.microsoft.com][cla].
+
+This project has adopted the [Microsoft Open Source Code of Conduct][coc].
+For more information see the [Code of Conduct FAQ][coc_faq]
+or contact [opencode@microsoft.com][coc_contact] with any
+additional questions or comments.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fstorage%2FAzure.Storage.Webjobs.Extensions.Blobs%2FREADME.png)
+
+<!-- LINKS -->
+[nuget]: https://www.nuget.org/
+[storage_account_docs]: https://docs.microsoft.com/azure/storage/common/storage-account-overview
+[storage_account_create_ps]: https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-powershell
+[storage_account_create_cli]: https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli
+[storage_account_create_portal]: https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal
+[azure_sub]: https://azure.microsoft.com/free/
+[RequestFailedException]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/core/Azure.Core/src/RequestFailedException.cs
+[storage_contrib]: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/CONTRIBUTING.md
+[cla]: https://cla.microsoft.com
+[coc]: https://opensource.microsoft.com/codeofconduct/
+[coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
+[coc_contact]: mailto:opencode@microsoft.com

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/src/Microsoft.Azure.WebJobs.Extensions.Storage.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Version>5.0.0-beta.1</Version>
+    <Description>This extension adds bindings for Storage</Description>
+    <!-- This package is a metapackage. The flag below makes sure it doesn't include any DLL-->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\src\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Azure.WebJobs.Extensions.Storage.Queues\src\Microsoft.Azure.WebJobs.Extensions.Storage.Queues.csproj" />
+  </ItemGroup>
+</Project>

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -41,6 +41,12 @@ extends:
       safeName: AzureStorageQueues
     - name: Azure.Storage.Blobs.ChangeFeed
       safeName: AzureStorageBlobsChangeFeed
+    - name: Microsoft.Azure.WebJobs.Extensions.Storage
+      safeName: MicrosoftAzureWebJobsExtensionsStorage
+    - name: Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
+      safeName: MicrosoftAzureWebJobsExtensionsStorageBlobs
+    - name: Microsoft.Azure.WebJobs.Extensions.Storage.Queues
+      safeName: MicrosoftAzureWebJobsExtensionsStorageQueues
     - name: Azure.ResourceManager.Storage
       safeName: AzureResourceManagerStorage
     TestSetupSteps:


### PR DESCRIPTION
**In this PR:**
- Add metapackage (no dll, just dependencies) to ease upgrade for users already using storage extensions.

**Testing**
I was running locally:
```
dotnet pack eng/service.proj -warnaserror /p:ServiceDirectory=storage /p:IncludeTests=false /p:PublicSign=false /p:OfficialBuildId=20201021.6 /p:SkipDevBuildNumber=false /p:Configuration=Release /p:CommitSHA=8b061b75d76cce3f93bb3741d622b26605ea36f0 /p:ArtifactsPackagesDir=C:\tmp\webjobs

```

The outcome is:
![image](https://user-images.githubusercontent.com/61715331/96938307-d9f3cb00-147e-11eb-9ffb-62a7a2a22653.png)


**Note**
I was running into https://github.com/NuGet/Home/issues/8583 while doing that. Hence the workaround I've copied from one of linked PRs in the csproj file.