### PR TITLE
Avoid using ${{ insert }} duplicate keys with un-rendered yaml validation

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -89,8 +89,10 @@ jobs:
               DOTNET_CLI_TELEMETRY_OPTOUT: 1
               DOTNET_MULTILEVEL_LOOKUP: 0
               AZURE_TEST_MODE: "${{ coalesce(platform.TestMode, 'None') }}"
-              ${{ insert }}: ${{ parameters.EnvVars }}
-              ${{ insert }}: ${{ cloudConfig.value.EnvVars }}
+              ${{ each var in parameters.EnvVars }}:
+                ${{ var.key }}: ${{ var.value }}
+              ${{ each var in cloudConfig.value.EnvVars }}:
+                ${{ var.key }}: ${{ var.value }}
 
           - template: /eng/common/TestResources/remove-test-resources.yml
             parameters:


### PR DESCRIPTION
The ${{ insert }} template syntax is used twice in one object, which produces valid yaml after render, but is interpreted as invalid yaml before rendering by some of our other validation scripts. This is a quick workaround to change the template syntax to produce the same result, but avoid breaking validation.

From the broken [aggregate-reports pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1399&_a=summary)
```
Verifying '/home/ben/sdk/azure-sdk-for-net/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml'
MethodInvocationException: /home/ben/.local/share/powershell/Modules/powershell-yaml/0.4.1/powershell-yaml.psm1:38
Line |
  38 |          $yamlStream.Load([YamlDotNet.Core.IParser] $parser)
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "Load" with "1" argument(s): "(Line: 93, Col: 15, Idx: 2994) - (Line: 93, Col: 28, Idx: 3007): Duplicate key"

InvalidOperation: /home/ben/sdk/azure-sdk-for-net/eng/common/scripts/Verify-Resource-Ref.ps1:12
```