### PR TITLE
ADT: Rename Model(s) to DtdlModel(s)

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -65,8 +65,8 @@ namespace Azure.DigitalTwins.Core
         public virtual Azure.Response<T> CreateDigitalTwin<T>(string digitalTwinId, T digitalTwin, Azure.DigitalTwins.Core.CreateDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response CreateEventRoute(string eventRouteId, Azure.DigitalTwins.Core.EventRoute eventRoute, Azure.DigitalTwins.Core.CreateEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> CreateEventRouteAsync(string eventRouteId, Azure.DigitalTwins.Core.EventRoute eventRoute, Azure.DigitalTwins.Core.CreateEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]> CreateModels(System.Collections.Generic.IEnumerable<string> models, Azure.DigitalTwins.Core.CreateModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]>> CreateModelsAsync(System.Collections.Generic.IEnumerable<string> models, Azure.DigitalTwins.Core.CreateModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]> CreateModels(System.Collections.Generic.IEnumerable<string> dtdlModels, Azure.DigitalTwins.Core.CreateModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]>> CreateModelsAsync(System.Collections.Generic.IEnumerable<string> dtdlModels, Azure.DigitalTwins.Core.CreateModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<T>> CreateRelationshipAsync<T>(string digitalTwinId, string relationshipId, T relationship, Azure.DigitalTwins.Core.CreateRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<T> CreateRelationship<T>(string digitalTwinId, string relationshipId, T relationship, Azure.DigitalTwins.Core.CreateRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DecommissionModel(string modelId, Azure.DigitalTwins.Core.DecomissionModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -126,8 +126,8 @@ namespace Azure.DigitalTwins.Core
         public bool? Decommissioned { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Description { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> DisplayName { get { throw null; } }
+        public string DtdlModel { get { throw null; } }
         public string Id { get { throw null; } }
-        public string Model { get { throw null; } }
         public System.DateTimeOffset? UploadTime { get { throw null; } }
     }
     public partial class EventRoute

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
@@ -10,14 +8,18 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsModelData")]
     public partial class DigitalTwinsModelData
     {
-        // This class declaration makes the generated class of the same name declare Model as a **string** rather than an **object**.
-        // It also changes the namespace and renames the type from "ModelData" to "DigitalTwinsModelData"
+        // This class declaration:
+        // - Changes the namespace and renames the type from "ModelData" to "DigitalTwinsModelData"
+        // - Makes the generated class of the same name declare Model as a **string** rather than an **object**.
+        // - Renames Model to DtdlModel.
         // Do not remove.
 
         /// <summary>
-        /// The model definition.
+        /// The model definition that conforms to the Digital Twins Definition Language (DTDL).
         /// </summary>
-        public string Model { get; }
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/digital-twins/concepts-models"/>
+        [CodeGenMember("Model")]
+        public string DtdlModel { get; }
 
         #region null overrides
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1283,7 +1283,7 @@ namespace Azure.DigitalTwins.Core
         /// <summary>
         /// Creates one or many models asynchronously.
         /// </summary>
-        /// <param name="models">The set of models to create. Each string corresponds to exactly one model.</param>
+        /// <param name="dtdlModels">The set of models conforming to the Digital Twins Definition Language (DTDL) to create. Each string corresponds to exactly one model.</param>
         /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created models and the http response <see cref="Response{T}"/>.</returns>
@@ -1301,22 +1301,23 @@ namespace Azure.DigitalTwins.Core
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
         /// </para>
         /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/digital-twins/concepts-models" />
         /// <example>
         /// <code snippet="Snippet:DigitalTwinsSampleCreateModels">
         /// await client.CreateModelsAsync(new[] { newComponentModelPayload, newModelPayload });
         /// Console.WriteLine($&quot;Created models &apos;{componentModelId}&apos; and &apos;{sampleModelId}&apos;.&quot;);
         /// </code>
         /// </example>
-        public virtual async Task<Response<DigitalTwinsModelData[]>> CreateModelsAsync(IEnumerable<string> models, CreateModelsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<DigitalTwinsModelData[]>> CreateModelsAsync(IEnumerable<string> dtdlModels, CreateModelsOptions options = null, CancellationToken cancellationToken = default)
         {
-            Response<IReadOnlyList<DigitalTwinsModelData>> response = await _dtModelsRestClient.AddAsync(models, options, cancellationToken).ConfigureAwait(false);
+            Response<IReadOnlyList<DigitalTwinsModelData>> response = await _dtModelsRestClient.AddAsync(dtdlModels, options, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(response.Value.ToArray(), response.GetRawResponse());
         }
 
         /// <summary>
         /// Creates one or many models synchronously.
         /// </summary>
-        /// <param name="models">The set of models to create. Each string corresponds to exactly one model.</param>
+        /// <param name="dtdlModels">The set of models conforming to the Digital Twins Definition Language (DTDL) to create. Each string corresponds to exactly one model.</param>
         /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created models and the http response <see cref="Response{T}"/>.</returns>
@@ -1331,15 +1332,16 @@ namespace Azure.DigitalTwins.Core
         /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
         /// </para>
         /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/digital-twins/concepts-models" />
         /// <exception cref="RequestFailedException">
         /// The exception that captures the errors from the service. Check the <see cref="RequestFailedException.ErrorCode"/> and <see cref="RequestFailedException.Status"/> properties for more details.
         /// </exception>
         /// <seealso cref="CreateModelsAsync(IEnumerable{string}, CreateModelsOptions, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response<DigitalTwinsModelData[]> CreateModels(IEnumerable<string> models, CreateModelsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response<DigitalTwinsModelData[]> CreateModels(IEnumerable<string> dtdlModels, CreateModelsOptions options = null, CancellationToken cancellationToken = default)
         {
-            Response<IReadOnlyList<DigitalTwinsModelData>> response = _dtModelsRestClient.Add(models, options, cancellationToken);
+            Response<IReadOnlyList<DigitalTwinsModelData>> response = _dtModelsRestClient.Add(dtdlModels, options, cancellationToken);
             return Response.FromValue(response.Value.ToArray(), response.GetRawResponse());
         }
 
@@ -2038,7 +2040,6 @@ namespace Azure.DigitalTwins.Core
 
             if (async)
             {
-
                 await objectSerializer.SerializeAsync(memoryStream, obj, typeof(T), cancellationToken).ConfigureAwait(false);
             }
             else

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
@@ -21,15 +21,15 @@ namespace Azure.DigitalTwins.Core
         /// <param name="id"> The id of the model as specified in the model definition. </param>
         /// <param name="uploadTime"> The time the model was uploaded to the service. </param>
         /// <param name="decommissioned"> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </param>
-        /// <param name="model"> The model definition. </param>
-        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayName, IReadOnlyDictionary<string, string> description, string id, DateTimeOffset? uploadTime, bool? decommissioned, string model)
+        /// <param name="dtdlModel"> The model definition. </param>
+        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayName, IReadOnlyDictionary<string, string> description, string id, DateTimeOffset? uploadTime, bool? decommissioned, string dtdlModel)
         {
             DisplayName = displayName;
             Description = description;
             Id = id;
             UploadTime = uploadTime;
             Decommissioned = decommissioned;
-            Model = model;
+            DtdlModel = dtdlModel;
         }
 
         /// <summary> A language map that contains the localized display names as specified in the model definition. </summary>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
@@ -44,7 +44,7 @@ namespace Azure.DigitalTwins.Core.Tests
 
                 // GET one created model
                 Response<DigitalTwinsModelData> buildingModel = await client.GetModelAsync(buildingModelId).ConfigureAwait(false);
-                Console.WriteLine($"Got {buildingModelId} as {buildingModel.Value.Model}");
+                Console.WriteLine($"Got {buildingModelId} as {buildingModel.Value.DtdlModel}");
 
                 // LIST all models
                 AsyncPageable<DigitalTwinsModelData> models = client.GetModelsAsync();


### PR DESCRIPTION
From Azure SDK board review: In methods like createModels(IEnumerable<String> models, ...) and in DigitalTwinsModelData.model we could be more descriptive