### PR TITLE
Fix Documentation comments

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/IReceiverClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/IReceiverClient.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
         /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
         /// registered. 
-        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
         /// </summary>
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.</param>
         Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout);
 
         /// <summary>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -907,8 +907,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
         /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
         /// registered. 
-        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
         /// </summary>
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.</param>
         public async Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout)
         {
             this.ThrowIfClosed();

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/IQueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/IQueueClient.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Azure.ServiceBus
         /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
         /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
         /// registered. 
-        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
         /// </summary>
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.</param>
         Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout);
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/ISubscriptionClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/ISubscriptionClient.cs
@@ -119,8 +119,8 @@ namespace Microsoft.Azure.ServiceBus
         /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
         /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
         /// registered. 
-        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
         /// </summary>
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.</param>
         Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout);
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ManagedIdentityTokenProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ManagedIdentityTokenProvider.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Azure.ServiceBus.Primitives
     {
         private readonly AzureServiceTokenProvider azureServiceTokenProvider;
 
-        /// <summary>Initializes new instance of <see cref="ManagedIdentityTokenProvider"/> class with default <see cref="AzureServiceTokenProvider"/> configuration.
+        /// <summary>Initializes new instance of <see cref="ManagedIdentityTokenProvider"/> class with default <see cref="AzureServiceTokenProvider"/> configuration.</summary>
         public ManagedIdentityTokenProvider() : this(new AzureServiceTokenProvider()){}
 
-        /// <summary>Initializes new instance of <see cref="ManagedIdentityTokenProvider"/> class with <see cref="AzureServiceTokenProvider"/>.
+        /// <summary>Initializes new instance of <see cref="ManagedIdentityTokenProvider"/> class with <see cref="AzureServiceTokenProvider"/>.</summary>
         /// <remarks>Call that constructore to set <see cref="AzureServiceTokenProvider"/> with required Managed Identity connection string.</remarks>
         public ManagedIdentityTokenProvider(AzureServiceTokenProvider azureServiceTokenProvider)
         {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/TokenProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/TokenProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         /// <param name="authCallback">The user defined authentication delegate to provide access token.</param>
         /// <param name="authority">URL of the Azure Active Directory instance to issue token.</param>
         /// <param name="state">Custom parameters that may be passed into the authentication delegate.</param>
-        /// <returns>The <see cref="Microsoft.ServiceBus.TokenProvider" /> for returning Json web token.</returns>
+        /// <returns>The <see cref="Microsoft.Azure.ServiceBus.Primitives.TokenProvider" /> for returning Json web token.</returns>
         public static TokenProvider CreateAzureActiveDirectoryTokenProvider(
             AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
             string authority,

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
@@ -450,8 +450,8 @@ namespace Microsoft.Azure.ServiceBus
         /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
         /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
         /// registered. 
-        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
         /// </summary>
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.</param>
         public async Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout)
         {
             this.ThrowIfClosed();
@@ -492,8 +492,8 @@ namespace Microsoft.Azure.ServiceBus
         /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
         /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
         /// registered. 
-        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
         /// </summary>
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.</param>
         public async Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout)
         {
             this.ThrowIfClosed();

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SubscriptionClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SubscriptionClient.cs
@@ -423,8 +423,8 @@ namespace Microsoft.Azure.ServiceBus
         /// Unregister message handler from the receiver if there is an active message handler registered. This operation waits for the completion
         /// of inflight receive and message handling operations to finish and unregisters future receives on the message handler which previously 
         /// registered. 
-        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.  
         /// </summary>
+        /// <param name="inflightMessageHandlerTasksWaitTimeout"> is the waitTimeout for inflight message handling tasks.</param>
         public async Task UnregisterMessageHandlerAsync(TimeSpan inflightMessageHandlerTasksWaitTimeout)
         {
             this.ThrowIfClosed();
@@ -465,8 +465,8 @@ namespace Microsoft.Azure.ServiceBus
         /// Unregister session handler from the receiver if there is an active session handler registered. This operation waits for the completion
         /// of inflight receive and session handling operations to finish and unregisters future receives on the session handler which previously 
         /// registered. 
-        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.  
         /// </summary>
+        /// <param name="inflightSessionHandlerTasksWaitTimeout"> is the waitTimeout for inflight session handling tasks.</param>
         public async Task UnregisterSessionHandlerAsync(TimeSpan inflightSessionHandlerTasksWaitTimeout)
         {
             this.ThrowIfClosed();


### PR DESCRIPTION
Fixes all errors that pop up if you enable `<GenerateDocumentationFile>true</GenerateDocumentationFile>` in `Microsoft.Azure.ServiceBus`.

I hope this contributes to #11798