### PR TITLE
Fix deadlock in AzureCliCredential and other process based TokenCredential implementations

### DIFF
--- a/sdk/identity/Azure.Identity/src/DataReceivedEventArgsWrapper.cs
+++ b/sdk/identity/Azure.Identity/src/DataReceivedEventArgsWrapper.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace Azure.Identity
+{
+    internal class DataReceivedEventArgsWrapper
+    {
+        public DataReceivedEventArgsWrapper(string data)
+        {
+            Data = data;
+        }
+
+        public DataReceivedEventArgsWrapper(DataReceivedEventArgs args)
+        {
+            Data = args?.Data;
+        }
+
+        public string Data { get; }
+    }
+
+    internal delegate void DataReceivedEventWrapperHandler(object sender, DataReceivedEventArgsWrapper e);
+}

--- a/sdk/identity/Azure.Identity/src/IProcess.cs
+++ b/sdk/identity/Azure.Identity/src/IProcess.cs
@@ -16,6 +16,8 @@ namespace Azure.Identity
         ProcessStartInfo StartInfo { get; set; }
 
         event EventHandler Exited;
+        event DataReceivedEventWrapperHandler OutputDataReceived;
+        event DataReceivedEventWrapperHandler ErrorDataReceived;
 
         void Start();
         void Kill();

--- a/sdk/identity/Azure.Identity/src/ProcessRunner.cs
+++ b/sdk/identity/Azure.Identity/src/ProcessRunner.cs
@@ -172,7 +172,6 @@ namespace Azure.Identity
         {
             if (_cancellationToken.IsCancellationRequested)
             {
-                DisposeProcess();
                 _stdOutCompletionSource.TrySetCanceled(_cancellationToken);
                 _stdErrCompletionSource.TrySetCanceled(_cancellationToken);
                 _processExitedCompletionSource.TrySetCanceled(_cancellationToken);

--- a/sdk/identity/Azure.Identity/src/ProcessRunner.cs
+++ b/sdk/identity/Azure.Identity/src/ProcessRunner.cs
@@ -15,7 +15,7 @@ namespace Azure.Identity
     {
         private readonly IProcess _process;
         private readonly TimeSpan _timeout;
-        private readonly TaskCompletionSource<bool> _processExitedComplectionSource;
+        private readonly TaskCompletionSource<bool> _processExitedCompletionSource;
         private readonly CancellationToken _cancellationToken;
         private readonly CancellationTokenSource _timeoutCts;
         private CancellationTokenRegistration _ctRegistration;
@@ -28,7 +28,7 @@ namespace Azure.Identity
         {
             _process = process;
             _timeout = timeout;
-            _processExitedComplectionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _processExitedCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _stdOutBuilder = new StringBuilder();
             _stdErrBuilder = new StringBuilder();
             _stdOutCompletionSource = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -51,7 +51,7 @@ namespace Azure.Identity
 
             try
             {
-                await _processExitedComplectionSource.Task.ConfigureAwait(false);
+                await _processExitedCompletionSource.Task.ConfigureAwait(false);
                 var output = await _stdOutCompletionSource.Task.ConfigureAwait(false);
                 await _stdErrCompletionSource.Task.ConfigureAwait(false);
                 return output;
@@ -68,7 +68,7 @@ namespace Azure.Identity
 #pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult().
             try
             {
-                _processExitedComplectionSource.Task.GetAwaiter().GetResult();
+                _processExitedCompletionSource.Task.GetAwaiter().GetResult();
                 var output = _stdOutCompletionSource.Task.GetAwaiter().GetResult();
                 _stdErrCompletionSource.Task.GetAwaiter().GetResult();
                 return output;
@@ -82,7 +82,7 @@ namespace Azure.Identity
 
         private void StartProcess()
         {
-            if (TrySetCanceled() || _processExitedComplectionSource.Task.IsCompleted)
+            if (TrySetCanceled() || _processExitedCompletionSource.Task.IsCompleted)
             {
                 return;
             }
@@ -106,11 +106,11 @@ namespace Azure.Identity
         {
             if (_process.ExitCode == 0)
             {
-                _processExitedComplectionSource.TrySetResult(true);
+                _processExitedCompletionSource.TrySetResult(true);
             }
             else
             {
-                _processExitedComplectionSource.TrySetResult(false);
+                _processExitedCompletionSource.TrySetResult(false);
             }
         }
         private void HandleStdErrDataReceived(object sender, DataReceivedEventArgsWrapper e)
@@ -147,7 +147,7 @@ namespace Azure.Identity
 
         private void HandleCancel()
         {
-            if (_processExitedComplectionSource.Task.IsCompleted)
+            if (_processExitedCompletionSource.Task.IsCompleted)
             {
                 return;
             }
@@ -160,7 +160,7 @@ namespace Azure.Identity
                 }
                 catch (Exception ex)
                 {
-                    _processExitedComplectionSource.TrySetException(ex);
+                    _processExitedCompletionSource.TrySetException(ex);
                     return;
                 }
             }
@@ -175,7 +175,7 @@ namespace Azure.Identity
                 DisposeProcess();
                 _stdOutCompletionSource.TrySetCanceled(_cancellationToken);
                 _stdErrCompletionSource.TrySetCanceled(_cancellationToken);
-                _processExitedComplectionSource.TrySetCanceled(_cancellationToken);
+                _processExitedCompletionSource.TrySetCanceled(_cancellationToken);
             }
 
             return _cancellationToken.IsCancellationRequested;

--- a/sdk/identity/Azure.Identity/tests/ProcessRunnerTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ProcessRunnerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -38,6 +39,17 @@ namespace Azure.Identity.Tests
         public async Task ProcessRunnerRealProcessSucceeded()
         {
             var output = "Test output";
+            var process = CreateRealProcess($"echo {output}", $"echo {output}");
+            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            var result = await Run(runner);
+
+            Assert.AreEqual(output, result.TrimEnd());
+        }
+
+        [Test]
+        public async Task ProcessRunnerRealProcessLargeOutputSucceeded()
+        {
+            var output = string.Concat(Enumerable.Repeat("ab", 3000));
             var process = CreateRealProcess($"echo {output}", $"echo {output}");
             var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
             var result = await Run(runner);

--- a/sdk/identity/Azure.Identity/tests/TestProcess.cs
+++ b/sdk/identity/Azure.Identity/tests/TestProcess.cs
@@ -70,6 +70,8 @@ namespace Azure.Identity.Tests
 
         public event EventHandler Exited;
         public event EventHandler Started;
+        public event DataReceivedEventWrapperHandler OutputDataReceived;
+        public event DataReceivedEventWrapperHandler ErrorDataReceived;
 
         public void Start()
         {
@@ -101,7 +103,18 @@ namespace Azure.Identity.Tests
         private void FinishProcessRun()
         {
             WriteToStream(Output, _outputStreamWriter);
+
+            if (Output != default)
+            {
+                OutputDataReceived?.Invoke(this, new DataReceivedEventArgsWrapper(Output));
+            }
+
             WriteToStream(Error, _errorStreamWriter);
+
+            if (Error != default)
+            {
+                ErrorDataReceived?.Invoke(this, new DataReceivedEventArgsWrapper(Error));
+            }
 
             _hasExited = true;
             _exitCode = CodeOnExit ?? (Error != default ? 1 : 0);

--- a/sdk/identity/Azure.Identity/tests/TestProcess.cs
+++ b/sdk/identity/Azure.Identity/tests/TestProcess.cs
@@ -116,6 +116,10 @@ namespace Azure.Identity.Tests
                 ErrorDataReceived?.Invoke(this, new DataReceivedEventArgsWrapper(Error));
             }
 
+            // signal completion
+            OutputDataReceived?.Invoke(this, new DataReceivedEventArgsWrapper((string)null));
+            ErrorDataReceived?.Invoke(this, new DataReceivedEventArgsWrapper((string)null));
+
             _hasExited = true;
             _exitCode = CodeOnExit ?? (Error != default ? 1 : 0);
             Exited?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
This PR fixes an issue where large tokens (e.g. due to being member of a lot of groups in AAD) caused all `TokenCredential` implementations which use the ProcessRunner to fail with a Timeout due to a deadlock when reading the StandardOut stream. 