### PR TITLE
Do NOT throw exceptions when PoductInfoHeaderValue has no Product

### DIFF
--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/ServiceClient.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/ServiceClient.cs
@@ -565,10 +565,26 @@ namespace Microsoft.Rest
             lock (lockUserAgent)
             {
                 if (!HttpClient.DefaultRequestHeaders.UserAgent.Contains<ProductInfoHeaderValue>(pInfoHeaderValue,
-                    new ObjectComparer<ProductInfoHeaderValue>((left, right) => left.Product.Name.Equals(right.Product.Name, StringComparison.OrdinalIgnoreCase))))
+                    new ObjectComparer<ProductInfoHeaderValue>(ProductInfoHeadersEqual)))
                 {
                     HttpClient.DefaultRequestHeaders.UserAgent.Add(pInfoHeaderValue);
                 }
+            }
+        }
+
+        private bool ProductInfoHeadersEqual(ProductInfoHeaderValue left, ProductInfoHeaderValue right)
+        {
+            if (left.Product != null && right.Product != null)
+            { 
+                return left.Product.Name.Equals(right.Product.Name, StringComparison.OrdinalIgnoreCase); 
+            }
+            else if(left.Product == null && right.Product == null && !string.IsNullOrEmpty(left.Comment) && !string.IsNullOrEmpty(right.Comment))
+            {
+                return left.Comment.Equals(right.Comment, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return false;
             }
         }
 

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/CustomClientWithHttpClientTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/CustomClientWithHttpClientTests.cs
@@ -206,6 +206,26 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Version.TryParse(fxVer.Product.Version, out defaultVersion);
             Assert.Equal(defaultVersion.ToString(), "1.0.0.0");
         }
+        
+        /// <summary>
+        /// This is to verify if a HttpClient is passed that contains ProductInfoHeaderValues with comments in
+        /// userAgent information, no exception occurs while merging
+        /// </summary>
+        [Fact]
+        public void ExistingCommentOnlyProductInfoHeaderValue()
+        {
+            const string comment = "(comment)";
+            HttpClient hc = new HttpClient(new ContosoMessageHandler());
+            hc.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(comment));
+            ContosoServiceClient contosoClient = new ContosoServiceClient(hc, false);
+            HttpResponseMessage response = contosoClient.DoSyncWork();
+
+            HttpHeaderValueCollection<ProductInfoHeaderValue> userAgentValueCollection = contosoClient.HttpClient.DefaultRequestHeaders.UserAgent;
+            contosoClient.Dispose();
+            var productInfos = userAgentValueCollection.Where<ProductInfoHeaderValue>((p) => p.Product == null && p.Comment.Equals(comment, StringComparison.OrdinalIgnoreCase));
+            Assert.Single(productInfos);
+            Assert.Equal(5, contosoClient.HttpClient.DefaultRequestHeaders.UserAgent.Count);
+        }
 
         private HttpResponseMessage SendAndReceiveResponse(HttpClient httpClient)
         {


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-net/issues/4086

Comment only ProductInfoHeaderValues should not be causing exceptions in this code.  Product is NOT required to construct a ProductInfoHeaderValue: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.headers.productinfoheadervalue.-ctor?view=netframework-4.7.2#System_Net_Http_Headers_ProductInfoHeaderValue__ctor_System_String_

The Bot Framework SDK uses a comment only ProductInfoHeaderValue:
![image](https://user-images.githubusercontent.com/11055362/97119664-f25a2480-16ce-11eb-83d4-335d16d298ee.png)
