### PR TITLE
Allow use of refreshInterval for KV Secret Provider

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -1,24 +1,27 @@
 namespace Azure.Extensions.AspNetCore.Configuration.Secrets
 {
+    public partial class AzureKeyVaultConfigurationOptions
+    {
+        public AzureKeyVaultConfigurationOptions() { }
+        public AzureKeyVaultConfigurationOptions(System.Uri vaultUri, Azure.Core.TokenCredential credential) { }
+        public Azure.Security.KeyVault.Secrets.SecretClient Client { get { throw null; } set { } }
+        public Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager Manager { get { throw null; } set { } }
+        public System.TimeSpan? ReloadInterval { get { throw null; } set { } }
+    }
     public partial class KeyVaultSecretManager
     {
         public KeyVaultSecretManager() { }
         public virtual string GetKey(Azure.Security.KeyVault.Secrets.KeyVaultSecret secret) { throw null; }
         public virtual bool Load(Azure.Security.KeyVault.Secrets.SecretProperties secret) { throw null; }
     }
-    public partial class AzureKeyVaultConfigurationOptions
-    {
-        public AzureKeyVaultConfigurationOptions() { }
-        public AzureKeyVaultConfigurationOptions(System.Uri vultUri, Azure.Core.TokenCredential credential) { }
-    }
 }
 namespace Microsoft.Extensions.Configuration
 {
     public static partial class AzureKeyVaultConfigurationExtensions
     {
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
-        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -6,6 +6,11 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         public virtual string GetKey(Azure.Security.KeyVault.Secrets.KeyVaultSecret secret) { throw null; }
         public virtual bool Load(Azure.Security.KeyVault.Secrets.SecretProperties secret) { throw null; }
     }
+    public partial class AzureKeyVaultConfigurationOptions
+    {
+        public AzureKeyVaultConfigurationOptions() { }
+        public AzureKeyVaultConfigurationOptions(System.Uri vultUri, Azure.Core.TokenCredential credential) { }
+    }
 }
 namespace Microsoft.Extensions.Configuration
 {
@@ -14,5 +19,6 @@ namespace Microsoft.Extensions.Configuration
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -3,8 +3,6 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
     public partial class AzureKeyVaultConfigurationOptions
     {
         public AzureKeyVaultConfigurationOptions() { }
-        public AzureKeyVaultConfigurationOptions(System.Uri vaultUri, Azure.Core.TokenCredential credential) { }
-        public Azure.Security.KeyVault.Secrets.SecretClient Client { get { throw null; } set { } }
         public Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager Manager { get { throw null; } set { } }
         public System.TimeSpan? ReloadInterval { get { throw null; } set { } }
     }
@@ -19,9 +17,10 @@ namespace Microsoft.Extensions.Configuration
 {
     public static partial class AzureKeyVaultConfigurationExtensions
     {
-        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, Azure.Security.KeyVault.Secrets.SecretClient client, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Configuration
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to use.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        private static IConfigurationBuilder AddAzureKeyVault(this IConfigurationBuilder configurationBuilder, AzureKeyVaultConfigurationOptions options)
+        public static IConfigurationBuilder AddAzureKeyVault(this IConfigurationBuilder configurationBuilder, AzureKeyVaultConfigurationOptions options)
         {
             Argument.AssertNotNull(configurationBuilder, nameof(configurationBuilder));
             Argument.AssertNotNull(options, nameof(configurationBuilder));

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Extensions.Configuration
             TokenCredential credential,
             KeyVaultSecretManager manager)
         {
-            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions(vaultUri, credential)
+            return AddAzureKeyVault(configurationBuilder, new AzureKeyVaultConfigurationOptions
             {
+                Client = new SecretClient(vaultUri, credential),
                 Manager = manager
             });
         }
@@ -73,9 +74,42 @@ namespace Microsoft.Extensions.Configuration
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="vaultUri">Azure Key Vault uri.</param>
+        /// <param name="credential">The credential to to use for authentication.</param>
         /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to use.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
-        public static IConfigurationBuilder AddAzureKeyVault(this IConfigurationBuilder configurationBuilder, AzureKeyVaultConfigurationOptions options)
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            Uri vaultUri,
+            TokenCredential credential,
+            AzureKeyVaultConfigurationOptions options)
+        {
+            return configurationBuilder.AddAzureKeyVault(new SecretClient(vaultUri, credential), options);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="client">The <see cref="SecretClient"/> to use for retrieving values.</param>
+        /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to use.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddAzureKeyVault(
+            this IConfigurationBuilder configurationBuilder,
+            SecretClient client,
+            AzureKeyVaultConfigurationOptions options)
+        {
+            options.Client = client;
+            return configurationBuilder.AddAzureKeyVault(options);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Azure KeyVault.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="options">The <see cref="AzureKeyVaultConfigurationOptions"/> to use.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        internal static IConfigurationBuilder AddAzureKeyVault(this IConfigurationBuilder configurationBuilder, AzureKeyVaultConfigurationOptions options)
         {
             Argument.AssertNotNull(configurationBuilder, nameof(configurationBuilder));
             Argument.AssertNotNull(options, nameof(configurationBuilder));

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationOptions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
     /// <summary>
     /// Options class used by the <see cref="AzureKeyVaultConfigurationExtensions"/>.
     /// </summary>
-    internal class AzureKeyVaultConfigurationOptions
+    public class AzureKeyVaultConfigurationOptions
     {
         /// <summary>
         /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationOptions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 
@@ -22,21 +21,9 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="AzureKeyVaultConfigurationOptions"/>.
-        /// </summary>
-        /// <param name="vaultUri">Azure Key Vault uri.</param>
-        /// <param name="credential">The <see cref="TokenCredential"/> to use for authentication.</param>
-        public AzureKeyVaultConfigurationOptions(
-            Uri vaultUri,
-            TokenCredential credential) : this()
-        {
-            Client = new SecretClient(vaultUri, credential);
-        }
-
-        /// <summary>
         /// Gets or sets the <see cref="SecretClient"/> to use for retrieving values.
         /// </summary>
-        public SecretClient Client { get; set; }
+        internal SecretClient Client { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="KeyVaultSecretManager"/> instance used to control secret loading.


### PR DESCRIPTION
In the migration from the previous KeyVaultSecretProvider repo, the access
restriction on the KVSPO object became internal. This means that there's a
lack of any meaning to the refreshInterval-handling code in the package as
it will always be null.

This change re-exposes the options object so that users can take advantage
of the functionality to automatically refresh secret values.